### PR TITLE
aes: Add CFB and OFB modes for 128/192/256-bit keys

### DIFF
--- a/include/rlib/crypto/raes.h
+++ b/include/rlib/crypto/raes.h
@@ -41,6 +41,12 @@ R_API RCryptoCipher * r_cipher_aes_256_cbc_new (const ruint8 * key) R_ATTR_MALLO
 R_API RCryptoCipher * r_cipher_aes_128_ctr_new (const ruint8 * key) R_ATTR_MALLOC;
 R_API RCryptoCipher * r_cipher_aes_192_ctr_new (const ruint8 * key) R_ATTR_MALLOC;
 R_API RCryptoCipher * r_cipher_aes_256_ctr_new (const ruint8 * key) R_ATTR_MALLOC;
+R_API RCryptoCipher * r_cipher_aes_128_cfb_new (const ruint8 * key) R_ATTR_MALLOC;
+R_API RCryptoCipher * r_cipher_aes_192_cfb_new (const ruint8 * key) R_ATTR_MALLOC;
+R_API RCryptoCipher * r_cipher_aes_256_cfb_new (const ruint8 * key) R_ATTR_MALLOC;
+R_API RCryptoCipher * r_cipher_aes_128_ofb_new (const ruint8 * key) R_ATTR_MALLOC;
+R_API RCryptoCipher * r_cipher_aes_192_ofb_new (const ruint8 * key) R_ATTR_MALLOC;
+R_API RCryptoCipher * r_cipher_aes_256_ofb_new (const ruint8 * key) R_ATTR_MALLOC;
 
 
 R_API rboolean r_cipher_aes_ecb_encrypt_block (const RCryptoCipher * cipher,
@@ -61,6 +67,15 @@ R_API RCryptoCipherResult r_cipher_aes_cbc_decrypt (const RCryptoCipher * cipher
 R_API RCryptoCipherResult r_cipher_aes_ctr_encrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
 #define r_cipher_aes_ctr_decrypt r_cipher_aes_ctr_encrypt
+
+R_API RCryptoCipherResult r_cipher_aes_cfb_encrypt (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
+R_API RCryptoCipherResult r_cipher_aes_cfb_decrypt (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
+
+R_API RCryptoCipherResult r_cipher_aes_ofb_encrypt (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
+#define r_cipher_aes_ofb_decrypt r_cipher_aes_ofb_encrypt
 
 R_END_DECLS
 

--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -100,6 +100,32 @@ const RCryptoCipherInfo g__r_crypto_cipher_aes_256_ctr = { "AES-256-CTR",
   r_cipher_aes_ctr_encrypt, r_cipher_aes_ctr_decrypt
 };
 
+const RCryptoCipherInfo g__r_crypto_cipher_aes_128_cfb = { "AES-128-CFB",
+  R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_CFB, 128, 16, 16,
+  r_cipher_aes_cfb_encrypt, r_cipher_aes_cfb_decrypt
+};
+const RCryptoCipherInfo g__r_crypto_cipher_aes_192_cfb = { "AES-192-CFB",
+  R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_CFB, 192, 16, 16,
+  r_cipher_aes_cfb_encrypt, r_cipher_aes_cfb_decrypt
+};
+const RCryptoCipherInfo g__r_crypto_cipher_aes_256_cfb = { "AES-256-CFB",
+  R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_CFB, 256, 16, 16,
+  r_cipher_aes_cfb_encrypt, r_cipher_aes_cfb_decrypt
+};
+
+const RCryptoCipherInfo g__r_crypto_cipher_aes_128_ofb = { "AES-128-OFB",
+  R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_OFB, 128, 16, 16,
+  r_cipher_aes_ofb_encrypt, r_cipher_aes_ofb_decrypt
+};
+const RCryptoCipherInfo g__r_crypto_cipher_aes_192_ofb = { "AES-192-OFB",
+  R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_OFB, 192, 16, 16,
+  r_cipher_aes_ofb_encrypt, r_cipher_aes_ofb_decrypt
+};
+const RCryptoCipherInfo g__r_crypto_cipher_aes_256_ofb = { "AES-256-OFB",
+  R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_OFB, 256, 16, 16,
+  r_cipher_aes_ofb_encrypt, r_cipher_aes_ofb_decrypt
+};
+
 static void
 r_cipher_aes_free (RAesCipher * cipher)
 {
@@ -278,6 +304,42 @@ r_cipher_aes_256_ctr_new (const ruint8 * key)
 }
 
 RCryptoCipher *
+r_cipher_aes_128_cfb_new (const ruint8 * key)
+{
+  return r_cipher_aes_new_with_info (&g__r_crypto_cipher_aes_128_cfb, key);
+}
+
+RCryptoCipher *
+r_cipher_aes_192_cfb_new (const ruint8 * key)
+{
+  return r_cipher_aes_new_with_info (&g__r_crypto_cipher_aes_192_cfb, key);
+}
+
+RCryptoCipher *
+r_cipher_aes_256_cfb_new (const ruint8 * key)
+{
+  return r_cipher_aes_new_with_info (&g__r_crypto_cipher_aes_256_cfb, key);
+}
+
+RCryptoCipher *
+r_cipher_aes_128_ofb_new (const ruint8 * key)
+{
+  return r_cipher_aes_new_with_info (&g__r_crypto_cipher_aes_128_ofb, key);
+}
+
+RCryptoCipher *
+r_cipher_aes_192_ofb_new (const ruint8 * key)
+{
+  return r_cipher_aes_new_with_info (&g__r_crypto_cipher_aes_192_ofb, key);
+}
+
+RCryptoCipher *
+r_cipher_aes_256_ofb_new (const ruint8 * key)
+{
+  return r_cipher_aes_new_with_info (&g__r_crypto_cipher_aes_256_ofb, key);
+}
+
+RCryptoCipher *
 r_cipher_aes_new (RCryptoCipherMode mode, ruint bits, const ruint8 * key)
 {
   switch (bits) {
@@ -289,6 +351,10 @@ r_cipher_aes_new (RCryptoCipherMode mode, ruint bits, const ruint8 * key)
           return r_cipher_aes_128_cbc_new (key);
         case R_CRYPTO_CIPHER_MODE_CTR:
           return r_cipher_aes_128_ctr_new (key);
+        case R_CRYPTO_CIPHER_MODE_CFB:
+          return r_cipher_aes_128_cfb_new (key);
+        case R_CRYPTO_CIPHER_MODE_OFB:
+          return r_cipher_aes_128_ofb_new (key);
         default:
           break;
       }
@@ -301,6 +367,10 @@ r_cipher_aes_new (RCryptoCipherMode mode, ruint bits, const ruint8 * key)
           return r_cipher_aes_192_cbc_new (key);
         case R_CRYPTO_CIPHER_MODE_CTR:
           return r_cipher_aes_192_ctr_new (key);
+        case R_CRYPTO_CIPHER_MODE_CFB:
+          return r_cipher_aes_192_cfb_new (key);
+        case R_CRYPTO_CIPHER_MODE_OFB:
+          return r_cipher_aes_192_ofb_new (key);
         default:
           break;
       }
@@ -313,6 +383,10 @@ r_cipher_aes_new (RCryptoCipherMode mode, ruint bits, const ruint8 * key)
           return r_cipher_aes_256_cbc_new (key);
         case R_CRYPTO_CIPHER_MODE_CTR:
           return r_cipher_aes_256_ctr_new (key);
+        case R_CRYPTO_CIPHER_MODE_CFB:
+          return r_cipher_aes_256_cfb_new (key);
+        case R_CRYPTO_CIPHER_MODE_OFB:
+          return r_cipher_aes_256_ofb_new (key);
         default:
           break;
       }
@@ -575,6 +649,111 @@ r_cipher_aes_ctr_encrypt (const RCryptoCipher * cipher,
       if (++iv[i - 1] != 0)
         break;
     }
+  }
+
+  return R_CRYPTO_CIPHER_OK;
+}
+
+RCryptoCipherResult
+r_cipher_aes_cfb_encrypt (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize)
+{
+  const ruint8 * ptr;
+  int i;
+  rsize bsize = size;
+  ruint8 scratch[R_AES_BLOCK_BYTES];
+
+  if (R_UNLIKELY (cipher == NULL)) return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (data == NULL)) return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (dst == NULL)) return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (ivsize != R_AES_BLOCK_BYTES)) return R_CRYPTO_CIPHER_INVAL;
+
+  size %= R_AES_BLOCK_BYTES;
+  bsize -= size;
+
+  for (ptr = data; ptr < ((ruint8 *)data) + bsize; ptr += R_AES_BLOCK_BYTES, dst += R_AES_BLOCK_BYTES) {
+    r_cipher_aes_ecb_encrypt_block (cipher, scratch, iv);
+    for (i = 0; i < R_AES_BLOCK_BYTES; i++)
+      dst[i] = scratch[i] ^ ptr[i];
+    /* CFB feedback: encrypt() input for the next block is the just-produced
+     * ciphertext, not the plaintext. */
+    r_memcpy (iv, dst, R_AES_BLOCK_BYTES);
+  }
+
+  if (size > 0) {
+    r_cipher_aes_ecb_encrypt_block (cipher, scratch, iv);
+    for (i = 0; i < (int)size; i++)
+      dst[i] = scratch[i] ^ ptr[i];
+  }
+
+  return R_CRYPTO_CIPHER_OK;
+}
+
+RCryptoCipherResult
+r_cipher_aes_cfb_decrypt (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize)
+{
+  const ruint8 * ptr;
+  int i;
+  rsize bsize = size;
+  ruint8 scratch[R_AES_BLOCK_BYTES];
+  ruint8 ctsave[R_AES_BLOCK_BYTES];
+
+  if (R_UNLIKELY (cipher == NULL)) return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (data == NULL)) return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (dst == NULL)) return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (ivsize != R_AES_BLOCK_BYTES)) return R_CRYPTO_CIPHER_INVAL;
+
+  size %= R_AES_BLOCK_BYTES;
+  bsize -= size;
+
+  for (ptr = data; ptr < ((ruint8 *)data) + bsize; ptr += R_AES_BLOCK_BYTES, dst += R_AES_BLOCK_BYTES) {
+    /* Save the consumed ciphertext before XOR in case dst == ptr (in-place). */
+    r_memcpy (ctsave, ptr, R_AES_BLOCK_BYTES);
+    r_cipher_aes_ecb_encrypt_block (cipher, scratch, iv);
+    for (i = 0; i < R_AES_BLOCK_BYTES; i++)
+      dst[i] = scratch[i] ^ ptr[i];
+    /* CFB-decrypt feedback uses the consumed ciphertext. */
+    r_memcpy (iv, ctsave, R_AES_BLOCK_BYTES);
+  }
+
+  if (size > 0) {
+    r_cipher_aes_ecb_encrypt_block (cipher, scratch, iv);
+    for (i = 0; i < (int)size; i++)
+      dst[i] = scratch[i] ^ ptr[i];
+  }
+
+  return R_CRYPTO_CIPHER_OK;
+}
+
+RCryptoCipherResult
+r_cipher_aes_ofb_encrypt (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize)
+{
+  const ruint8 * ptr;
+  int i;
+  rsize bsize = size;
+
+  if (R_UNLIKELY (cipher == NULL)) return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (data == NULL)) return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (dst == NULL)) return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (ivsize != R_AES_BLOCK_BYTES)) return R_CRYPTO_CIPHER_INVAL;
+
+  size %= R_AES_BLOCK_BYTES;
+  bsize -= size;
+
+  for (ptr = data; ptr < ((ruint8 *)data) + bsize; ptr += R_AES_BLOCK_BYTES, dst += R_AES_BLOCK_BYTES) {
+    /* OFB keystream: y_i = AES-encrypt(y_{i-1}), starting from IV.
+     * Encrypt in-place into iv so it carries forward. */
+    r_cipher_aes_ecb_encrypt_block (cipher, iv, iv);
+    for (i = 0; i < R_AES_BLOCK_BYTES; i++)
+      dst[i] = iv[i] ^ ptr[i];
+  }
+
+  if (size > 0) {
+    r_cipher_aes_ecb_encrypt_block (cipher, iv, iv);
+    for (i = 0; i < (int)size; i++)
+      dst[i] = iv[i] ^ ptr[i];
   }
 
   return R_CRYPTO_CIPHER_OK;

--- a/test/raes.c
+++ b/test/raes.c
@@ -18,8 +18,14 @@ RTEST (raes, new_args, RTEST_FAST)
   r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_CTR, 129, key), ==, NULL);
   r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_CTR, 255, key), ==, NULL);
 
-  r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_CFB, 128, key), ==, NULL);
-  r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_OFB, 128, key), ==, NULL);
+  r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_CFB, 0, key), ==, NULL);
+  r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_CFB, 129, key), ==, NULL);
+  r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_CFB, 255, key), ==, NULL);
+
+  r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_OFB, 0, key), ==, NULL);
+  r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_OFB, 129, key), ==, NULL);
+  r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_OFB, 255, key), ==, NULL);
+
   r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_GCM, 128, key), ==, NULL);
   r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_CCM, 128, key), ==, NULL);
 }
@@ -287,6 +293,94 @@ RTEST_LOOP (raes, ctr, RTEST_FAST, 0, R_N_ELEMENTS (CTR_test_data))
 
   r_assert_cmpuint (r_str_hex_to_binary (data->iv, iv, R_AES_BLOCK_BYTES), ==, R_AES_BLOCK_BYTES);
   r_assert_cmpint (r_cipher_aes_ctr_decrypt (cipher, out, plainsize, ciphertxt, iv, sizeof (iv)), ==, R_CRYPTO_CIPHER_OK);
+  r_assert_cmpmem (out, ==, plaintxt, plainsize);
+
+  r_crypto_cipher_unref (cipher);
+  r_free (plaintxt);
+  r_free (ciphertxt);
+  r_free (out);
+}
+RTEST_END;
+
+
+RCryptoCipherTestData CFB_test_data[] = {
+  /* NIST SP 800-38A, F.3.13 / F.3.15 / F.3.17 -- CFB128 (full-block feedback) */
+  { 128, "2b7e151628aed2a6abf7158809cf4f3c", "000102030405060708090a0b0c0d0e0f",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
+    "3b3fd92eb72dad20333449f8e83cfb4ac8a64537a0b3a93fcde3cdad9f1ce58b26751f67a3cbb140b1808cf187a4f4dfc04b05357c5d1c0eeac4c66f9ff7f2e6" },
+  { 192, "8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b", "000102030405060708090a0b0c0d0e0f",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
+    "cdc80d6fddf18cab34c25909c99a417467ce7f7f81173621961a2b70171d3d7a2e1e8a1dd59b88b1c8e60fed1efac4c9c05f9f9ca9834fa042ae8fba584b09ff" },
+  { 256, "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", "000102030405060708090a0b0c0d0e0f",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
+    "dc7e84bfda79164b7ecd8486985d386039ffed143b28b1c832113c6331e5407bdf10132415e54b92a13ed0a8267ae2f975a385741ab9cef82031623d55b1e471" },
+};
+
+RTEST_LOOP (raes, cfb, RTEST_FAST, 0, R_N_ELEMENTS (CFB_test_data))
+{
+  RCryptoCipherTestData * data = &CFB_test_data[__i];
+  RCryptoCipher * cipher;
+  ruint8 * plaintxt, * ciphertxt, * out, iv[R_AES_BLOCK_BYTES];
+  rsize plainsize, ciphersize;
+
+  r_assert_cmpptr ((plaintxt = r_str_hex_mem (data->plaintxt, &plainsize)), !=, NULL);
+  r_assert_cmpptr ((ciphertxt = r_str_hex_mem (data->ciphertxt, &ciphersize)), !=, NULL);
+  r_assert_cmpuint (plainsize, ==, ciphersize);
+
+  r_assert_cmpptr ((cipher = r_cipher_aes_new_from_hex (R_CRYPTO_CIPHER_MODE_CFB, data->key)), !=, NULL);
+  r_assert_cmpuint (cipher->info->keybits, ==, data->keybits);
+
+  out = r_malloc (ciphersize);
+  r_assert_cmpuint (r_str_hex_to_binary (data->iv, iv, R_AES_BLOCK_BYTES), ==, R_AES_BLOCK_BYTES);
+  r_assert_cmpint (r_cipher_aes_cfb_encrypt (cipher, out, ciphersize, plaintxt, iv, sizeof (iv)), ==, R_CRYPTO_CIPHER_OK);
+  r_assert_cmpmem (out, ==, ciphertxt, ciphersize);
+
+  r_assert_cmpuint (r_str_hex_to_binary (data->iv, iv, R_AES_BLOCK_BYTES), ==, R_AES_BLOCK_BYTES);
+  r_assert_cmpint (r_cipher_aes_cfb_decrypt (cipher, out, plainsize, ciphertxt, iv, sizeof (iv)), ==, R_CRYPTO_CIPHER_OK);
+  r_assert_cmpmem (out, ==, plaintxt, plainsize);
+
+  r_crypto_cipher_unref (cipher);
+  r_free (plaintxt);
+  r_free (ciphertxt);
+  r_free (out);
+}
+RTEST_END;
+
+
+RCryptoCipherTestData OFB_test_data[] = {
+  /* NIST SP 800-38A, F.4.1 / F.4.3 / F.4.5 -- OFB */
+  { 128, "2b7e151628aed2a6abf7158809cf4f3c", "000102030405060708090a0b0c0d0e0f",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
+    "3b3fd92eb72dad20333449f8e83cfb4a7789508d16918f03f53c52dac54ed8259740051e9c5fecf64344f7a82260edcc304c6528f659c77866a510d9c1d6ae5e" },
+  { 192, "8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b", "000102030405060708090a0b0c0d0e0f",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
+    "cdc80d6fddf18cab34c25909c99a4174fcc28b8d4c63837c09e81700c11004018d9a9aeac0f6596f559c6d4daf59a5f26d9f200857ca6c3e9cac524bd9acc92a" },
+  { 256, "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", "000102030405060708090a0b0c0d0e0f",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
+    "dc7e84bfda79164b7ecd8486985d38604febdc6740d20b3ac88f6ad82a4fb08d71ab47a086e86eedf39d1c5bba97c4080126141d67f37be8538f5a8be740e484" },
+};
+
+RTEST_LOOP (raes, ofb, RTEST_FAST, 0, R_N_ELEMENTS (OFB_test_data))
+{
+  RCryptoCipherTestData * data = &OFB_test_data[__i];
+  RCryptoCipher * cipher;
+  ruint8 * plaintxt, * ciphertxt, * out, iv[R_AES_BLOCK_BYTES];
+  rsize plainsize, ciphersize;
+
+  r_assert_cmpptr ((plaintxt = r_str_hex_mem (data->plaintxt, &plainsize)), !=, NULL);
+  r_assert_cmpptr ((ciphertxt = r_str_hex_mem (data->ciphertxt, &ciphersize)), !=, NULL);
+  r_assert_cmpuint (plainsize, ==, ciphersize);
+
+  r_assert_cmpptr ((cipher = r_cipher_aes_new_from_hex (R_CRYPTO_CIPHER_MODE_OFB, data->key)), !=, NULL);
+  r_assert_cmpuint (cipher->info->keybits, ==, data->keybits);
+
+  out = r_malloc (ciphersize);
+  r_assert_cmpuint (r_str_hex_to_binary (data->iv, iv, R_AES_BLOCK_BYTES), ==, R_AES_BLOCK_BYTES);
+  r_assert_cmpint (r_cipher_aes_ofb_encrypt (cipher, out, ciphersize, plaintxt, iv, sizeof (iv)), ==, R_CRYPTO_CIPHER_OK);
+  r_assert_cmpmem (out, ==, ciphertxt, ciphersize);
+
+  r_assert_cmpuint (r_str_hex_to_binary (data->iv, iv, R_AES_BLOCK_BYTES), ==, R_AES_BLOCK_BYTES);
+  r_assert_cmpint (r_cipher_aes_ofb_decrypt (cipher, out, plainsize, ciphertxt, iv, sizeof (iv)), ==, R_CRYPTO_CIPHER_OK);
   r_assert_cmpmem (out, ==, plaintxt, plainsize);
 
   r_crypto_cipher_unref (cipher);


### PR DESCRIPTION
Adds the two non-AEAD AES stream modes called out in #29 — CFB-128 (full-block feedback) and OFB — at 128/192/256-bit keys. Both fit the existing `RCryptoCipherOperation` signature so no cipher-API change was needed.

## What's in

  * **CFB-128**: encrypt feeds the just-produced ciphertext forward; decrypt feeds the just-consumed ciphertext forward (saved before the XOR so `dst == ptr` in-place still works).
  * **OFB**: AES iterated on the IV produces the keystream; encrypt and decrypt are the same operation, so `r_cipher_aes_ofb_decrypt` is `#define`d to `_encrypt` (matching what CTR already does).
  * Six new `RCryptoCipherInfo` entries (128/192/256 × CFB/OFB), six new `r_cipher_aes_<bits>_<mode>_new` constructors, plus dispatch arms in `r_cipher_aes_new`.

## Tests

NIST SP 800-38A Appendix F.3 (CFB128) and F.4 (OFB) vectors for all three key sizes — six new entries in `test/raes.c`, each round-tripping encrypt then decrypt and matching the published ciphertext byte-for-byte. The obsolete \"returns NULL for CFB/OFB\" assertions in `raes/new_args` were swapped for the standard 0/129/255 invalid-key checks.

Suite goes from 842 → 848 tests, all green, local build clean across gcc/clang × debugoptimized/release.

## Out of scope

GCM and CCM are AEAD: they need AAD and an authentication tag, which the current cipher op signature doesn't carry. Split out to #64 for a separate API design pass.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)