### PR TITLE
argparse: Add default value support for option entries

### DIFF
--- a/example/rargparse.c
+++ b/example/rargparse.c
@@ -8,9 +8,9 @@ main (int argc, char ** argv)
   RArgParseResult res;
   int ret = 0;
   const RArgOptionEntry entries[] = {
-    { "foo",    'f', R_ARG_OPTION_TYPE_NONE,   R_ARG_OPTION_FLAG_NONE, "Do Foo", NULL },
-    { "input",  'i', R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_NONE, "Input string", NULL },
-    { "ret",    'r', R_ARG_OPTION_TYPE_INT,    R_ARG_OPTION_FLAG_NONE, "Return value program will return", NULL },
+    { "foo",    'f', R_ARG_OPTION_TYPE_NONE,   R_ARG_OPTION_FLAG_NONE, "Do Foo", NULL, NULL },
+    { "input",  'i', R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_NONE, "Input string", NULL, NULL },
+    { "ret",    'r', R_ARG_OPTION_TYPE_INT,    R_ARG_OPTION_FLAG_NONE, "Return value program will return", NULL, "0" },
   };
 
   r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries));

--- a/example/rfile.c
+++ b/example/rfile.c
@@ -8,7 +8,7 @@ main (int argc, char ** argv)
   RArgParseCtx * ctx;
   RArgParseResult res;
   const RArgOptionEntry entries[] = {
-    { "hr", 0, R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Human readable format", NULL },
+    { "hr", 0, R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Human readable format", NULL, NULL },
   };
 
   r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries));

--- a/include/rlib/rargparse.h
+++ b/include/rlib/rargparse.h
@@ -55,6 +55,13 @@ typedef struct {
   RArgOptionFlags flags;
   const rchar *   desc;
   const rchar *   eqname;
+  /* Default value returned by the getters when the option is absent
+   * from the command line. The string is parsed by the same per-type
+   * parser used for the on-cmdline value; NULL means "no default" and
+   * the getter returns the zero/empty value for the type, as before.
+   * Not meaningful for BOOL (presence is the value); ignored with a
+   * warning if combined with REQUIRED. */
+  const rchar *   defval;
 } RArgOptionEntry;
 
 typedef enum {

--- a/include/rlib/rtest.h
+++ b/include/rlib/rtest.h
@@ -192,15 +192,15 @@ int main (int argc, rchar ** argv) {                                            
                                                                                 \
   const RArgOptionEntry entries[] = {                                           \
     { "verbose",     'v', R_ARG_OPTION_TYPE_BOOL,     R_ARG_OPTION_FLAG_NONE,   \
-      "Print verbose info", NULL },                                             \
+      "Print verbose info", NULL, NULL },                                       \
     { "print",       'p', R_ARG_OPTION_TYPE_BOOL,     R_ARG_OPTION_FLAG_NONE,   \
-      "Print all tests which ran", NULL },                                      \
+      "Print all tests which ran", NULL, NULL },                                \
     { "ignore-skip", 'i', R_ARG_OPTION_TYPE_BOOL,     R_ARG_OPTION_FLAG_NONE,   \
-      "Run tests that default would be skipped", NULL },                        \
+      "Run tests that default would be skipped", NULL, NULL },                  \
     { "filter",      'f', R_ARG_OPTION_TYPE_STRING,   R_ARG_OPTION_FLAG_NONE,   \
-      "Filter on test path - default is * (\"/<suite>/<name>\")", NULL },       \
+      "Filter on test path - default is * (\"/<suite>/<name>\")", NULL, NULL }, \
     { "output",      'o', R_ARG_OPTION_TYPE_FILENAME, R_ARG_OPTION_FLAG_NONE,   \
-      "File to print results to, use - for stdout [default]", NULL },           \
+      "File to print results to, use - for stdout [default]", NULL, NULL },     \
   };                                                                            \
   r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries));    \
                                                                                 \

--- a/rlib/rargparse.c
+++ b/rlib/rargparse.c
@@ -183,6 +183,16 @@ r_arg_option_entry_ctx_init (RArgOptionEntry * entry, const RArgOptionEntry * op
         "ignoring incompatible inverse flag for --%s", opt->longarg);
     entry->flags &= ~R_ARG_OPTION_FLAG_INVERSE;
   }
+  if (opt->defval != NULL && opt->type == R_ARG_OPTION_TYPE_NONE) {
+    R_LOG_CAT_WARNING (&rlib_logcat,
+        "ignoring default value for boolean --%s", opt->longarg);
+    entry->defval = NULL;
+  }
+  if (opt->defval != NULL && (opt->flags & R_ARG_OPTION_FLAG_REQUIRED)) {
+    R_LOG_CAT_WARNING (&rlib_logcat,
+        "clearing required flag for --%s because a default is set", opt->longarg);
+    entry->flags &= ~R_ARG_OPTION_FLAG_REQUIRED;
+  }
 
   return TRUE;
 }
@@ -290,16 +300,16 @@ r_arg_option_group_add_entry (RArgOptionGroup * group,
     RArgOptionType type, RArgOptionFlags flags,
     const rchar * desc, const rchar * eqname)
 {
-  const RArgOptionEntry entry = { longarg, shortarg, type, flags, desc, eqname };
+  const RArgOptionEntry entry = { longarg, shortarg, type, flags, desc, eqname, NULL };
   return r_arg_option_group_add_entries (group, &entry, 1);
 }
 
 static const RArgOptionEntry r_arg_version_args[] = {
-  { "version",  0, R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Show application version number and exit", NULL },
+  { "version",  0, R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Show application version number and exit", NULL, NULL },
 };
 static const RArgOptionEntry r_arg_help_args[] = {
-  { "help",   'h', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Show this help message and exit", NULL },
-  { "",       '?', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_HIDDEN, NULL, NULL },
+  { "help",   'h', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Show this help message and exit", NULL, NULL },
+  { "",       '?', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_HIDDEN, NULL, NULL, NULL },
 };
 
 static void
@@ -405,6 +415,8 @@ r_arg_option_entry_append_help (const RArgOptionEntry * opt, RString * str)
     spacing -= r_string_append (str, " ");
 
   r_string_append (str, opt->desc);
+  if (opt->defval != NULL)
+    r_string_append_printf (str, " [default: %s]", opt->defval);
   r_string_append (str, "\n");
 }
 
@@ -961,7 +973,11 @@ r_arg_parse_ctx_get_option_entry_value (RArgParseCtx * ctx, const RArgOptionEntr
 {
   const rchar * arg;
 
-  if ((arg = r_dictionary_lookup (ctx->options, entry->longarg)) != NULL) {
+  arg = r_dictionary_lookup (ctx->options, entry->longarg);
+  if (arg == NULL)
+    arg = entry->defval;
+
+  if (arg != NULL) {
     switch (entry->type) {
       case R_ARG_OPTION_TYPE_BOOL:
         r_arg_option_parse_none (&arg, val,

--- a/test/rargparse.c
+++ b/test/rargparse.c
@@ -82,8 +82,8 @@ RTEST (rargparse, group, RTEST_FAST)
 {
   RArgOptionGroup * group;
   static RArgOptionEntry entries[] = {
-    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE,    "Do foo", NULL },
-    { "bar", 'b', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_INVERSE, "Do bar", NULL },
+    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE,    "Do foo", NULL, NULL },
+    { "bar", 'b', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_INVERSE, "Do bar", NULL, NULL },
   };
 
   r_assert_cmpptr ((group = r_arg_option_group_new (NULL, NULL, NULL, NULL, NULL)), ==, NULL);
@@ -97,26 +97,26 @@ RTEST (rargparse, args_error, RTEST_FAST)
 {
   RArgParser * parser = r_arg_parser_new (NULL, NULL);
   static RArgOptionEntry missing_long[] = {
-    { "", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL },
+    { "", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL, NULL },
   };
   static RArgOptionEntry bad_type[] = {
-    { "foo", 0, R_ARG_OPTION_TYPE_COUNT, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL },
+    { "foo", 0, R_ARG_OPTION_TYPE_COUNT, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL, NULL },
   };
   static RArgOptionEntry duplicate_longarg[] = {
-    { "foo", 0, R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL },
-    { "foo", 0, R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Opps duplicate", NULL },
+    { "foo", 0, R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL, NULL },
+    { "foo", 0, R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Opps duplicate", NULL, NULL },
   };
   static RArgOptionEntry duplicate_shortarg[] = {
-    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL },
-    { "bar", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Opps duplicate", NULL },
+    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL, NULL },
+    { "bar", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Opps duplicate", NULL, NULL },
   };
   static RArgOptionEntry invalid_shortname[] = {
     { "foo", '-', R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_NONE,
-      "shortarg/name can't use '-', ignored", NULL },
+      "shortarg/name can't use '-', ignored", NULL, NULL },
   };
   static RArgOptionEntry inverse_string[] = {
     { "bar", 0, R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_INVERSE,
-      "There is no such thing as inverse string, but it will be ignored", NULL },
+      "There is no such thing as inverse string, but it will be ignored", NULL, NULL },
   };
   rboolean res;
 
@@ -143,7 +143,7 @@ RTEST (rargparse, no_val_works, RTEST_FAST)
 {
   RArgParser * parser = r_arg_parser_new (NULL, NULL);
   static RArgOptionEntry missing_val[] = {
-    { "foo", 0, R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL },
+    { "foo", 0, R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL, NULL },
   };
   r_assert (r_arg_parser_add_option_entries (parser, missing_val, 1));
   r_arg_parser_unref (parser);
@@ -153,9 +153,9 @@ RTEST_END;
 RTEST (rargparse, help_args, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {
-    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE,    "Do foo", NULL },
-    { "hidden", 0, R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_HIDDEN, "Not shown", NULL },
-    { "bar", 'b', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_INVERSE, "Do bar", NULL },
+    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE,    "Do foo", NULL, NULL },
+    { "hidden", 0, R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_HIDDEN, "Not shown", NULL, NULL },
+    { "bar", 'b', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_INVERSE, "Do bar", NULL, NULL },
   };
   const rchar * args_help =
     "  -f, --foo                     Do foo\n"
@@ -178,16 +178,16 @@ RTEST_END;
 RTEST (rargparse, help_argname, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {
-    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_INVERSE, "Do foo", "foo" },
-    { "bar", 'b', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_INVERSE, "Do bar", NULL },
-    { "num", 'n', R_ARG_OPTION_TYPE_INT, R_ARG_OPTION_FLAG_NONE, "Integer", "NUM" },
-    { "val", 0, R_ARG_OPTION_TYPE_INT, R_ARG_OPTION_FLAG_NONE, "Value", NULL },
-    { "num64", 0, R_ARG_OPTION_TYPE_INT64, R_ARG_OPTION_FLAG_NONE, "Integer 64bit", "NUM" },
-    { "double", 'd', R_ARG_OPTION_TYPE_DOUBLE, R_ARG_OPTION_FLAG_NONE, "Double", "NUM" },
-    { "output", 'o', R_ARG_OPTION_TYPE_FILENAME, R_ARG_OPTION_FLAG_NONE, "Output file", "FILE" },
-    { "input", 'i', R_ARG_OPTION_TYPE_FILENAME, R_ARG_OPTION_FLAG_NONE, "Input file", NULL },
-    { "outstr", 'u', R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_NONE, "Output string", "STR" },
-    { "instr", 's', R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_NONE, "Input string", NULL },
+    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_INVERSE, "Do foo", "foo", NULL },
+    { "bar", 'b', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_INVERSE, "Do bar", NULL, NULL },
+    { "num", 'n', R_ARG_OPTION_TYPE_INT, R_ARG_OPTION_FLAG_NONE, "Integer", "NUM", NULL },
+    { "val", 0, R_ARG_OPTION_TYPE_INT, R_ARG_OPTION_FLAG_NONE, "Value", NULL, NULL },
+    { "num64", 0, R_ARG_OPTION_TYPE_INT64, R_ARG_OPTION_FLAG_NONE, "Integer 64bit", "NUM", NULL },
+    { "double", 'd', R_ARG_OPTION_TYPE_DOUBLE, R_ARG_OPTION_FLAG_NONE, "Double", "NUM", NULL },
+    { "output", 'o', R_ARG_OPTION_TYPE_FILENAME, R_ARG_OPTION_FLAG_NONE, "Output file", "FILE", NULL },
+    { "input", 'i', R_ARG_OPTION_TYPE_FILENAME, R_ARG_OPTION_FLAG_NONE, "Input file", NULL, NULL },
+    { "outstr", 'u', R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_NONE, "Output string", "STR", NULL },
+    { "instr", 's', R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_NONE, "Input string", NULL, NULL },
   };
   const rchar * args_help =
     "  -f, --foo                     Do foo\n"
@@ -218,8 +218,8 @@ RTEST_END;
 RTEST (rargparse, parse_shortargs, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {
-    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE,    "Do foo", NULL },
-    { "bar", 'b', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_INVERSE, "Do bar", NULL },
+    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE,    "Do foo", NULL, NULL },
+    { "bar", 'b', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_INVERSE, "Do bar", NULL, NULL },
   };
   RArgParser * parser = r_arg_parser_new (NULL, NULL);
   RArgParseCtx * ctx;
@@ -247,8 +247,8 @@ RTEST_END;
 RTEST (rargparse, parse_shortargs_chain, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {
-    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE,    "Do foo", NULL },
-    { "bar", 'b', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_INVERSE, "Do bar", NULL },
+    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE,    "Do foo", NULL, NULL },
+    { "bar", 'b', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_INVERSE, "Do bar", NULL, NULL },
   };
   RArgParser * parser = r_arg_parser_new (NULL, NULL);
   RArgParseCtx * ctx;
@@ -275,8 +275,8 @@ RTEST_END;
 RTEST (rargparse, parse_longargs, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {
-    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE,    "Do foo", NULL },
-    { "bar", 'b', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_INVERSE, "Do bar", NULL },
+    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE,    "Do foo", NULL, NULL },
+    { "bar", 'b', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_INVERSE, "Do bar", NULL, NULL },
   };
   RArgParser * parser = r_arg_parser_new (NULL, NULL);
   RArgParseCtx * ctx;
@@ -378,8 +378,8 @@ RTEST_END;
 RTEST (rargparse, parse_partial, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {
-    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE,    "Do foo", NULL },
-    { "bar", 'b', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_INVERSE, "Do bar", NULL },
+    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE,    "Do foo", NULL, NULL },
+    { "bar", 'b', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_INVERSE, "Do bar", NULL, NULL },
   };
   RArgParser * parser = r_arg_parser_new (NULL, NULL);
   RArgParseCtx * ctx;
@@ -404,8 +404,8 @@ RTEST_END;
 RTEST (rargparse, parse_stop_after_dash_dash, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {
-    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE,    "Do foo", NULL },
-    { "bar", 'b', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_INVERSE, "Do bar", NULL },
+    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE,    "Do foo", NULL, NULL },
+    { "bar", 'b', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_INVERSE, "Do bar", NULL, NULL },
   };
   RArgParser * parser = r_arg_parser_new (NULL, NULL);
   RArgParseCtx * ctx;
@@ -429,7 +429,7 @@ RTEST_END;
 RTEST (rargparse, parse_int, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {
-    { "foo", 'f', R_ARG_OPTION_TYPE_INT, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL },
+    { "foo", 'f', R_ARG_OPTION_TYPE_INT, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL, NULL },
   };
   RArgParser * parser = r_arg_parser_new (NULL, NULL);
   RArgParseCtx * ctx;
@@ -513,7 +513,7 @@ RTEST_END;
 RTEST (rargparse, parse_int64, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {
-    { "foo", 'f', R_ARG_OPTION_TYPE_INT64, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL },
+    { "foo", 'f', R_ARG_OPTION_TYPE_INT64, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL, NULL },
   };
   RArgParser * parser = r_arg_parser_new (NULL, NULL);
   RArgParseCtx * ctx;
@@ -597,7 +597,7 @@ RTEST_END;
 RTEST (rargparse, parse_double, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {
-    { "foo", 'f', R_ARG_OPTION_TYPE_DOUBLE, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL },
+    { "foo", 'f', R_ARG_OPTION_TYPE_DOUBLE, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL, NULL },
   };
   RArgParser * parser = r_arg_parser_new (NULL, NULL);
   RArgParseCtx * ctx;
@@ -640,7 +640,7 @@ RTEST_END;
 RTEST (rargparse, parse_string, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {
-    { "foo", 'f', R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL },
+    { "foo", 'f', R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL, NULL },
   };
   RArgParser * parser = r_arg_parser_new (NULL, NULL);
   RArgParseCtx * ctx;
@@ -705,7 +705,7 @@ RTEST_END;
 RTEST (rargparse, parse_required, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {
-    { "foo", 'f', R_ARG_OPTION_TYPE_INT, R_ARG_OPTION_FLAG_REQUIRED, "Do foo", NULL },
+    { "foo", 'f', R_ARG_OPTION_TYPE_INT, R_ARG_OPTION_FLAG_REQUIRED, "Do foo", NULL, NULL },
   };
   RArgParser * parser = r_arg_parser_new (NULL, NULL);
   RArgParseCtx * ctx;
@@ -748,7 +748,7 @@ RTEST (rargparse, parse_unknown_option, RTEST_FAST)
 {
   RArgParser * parser = r_arg_parser_new (NULL, NULL);
   static RArgOptionEntry entries[] = {
-    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE,    "Do foo", NULL },
+    { "foo", 'f', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE,    "Do foo", NULL, NULL },
   };
   rchar ** strv, ** argv;
   RArgParseCtx * ctx;
@@ -798,8 +798,8 @@ RTEST_END;
 RTEST (rargparse, get_value, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {
-    { "foo", 'f', R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL },
-    { "bar", 'b', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Do bar", NULL },
+    { "foo", 'f', R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_NONE, "Do foo", NULL, NULL },
+    { "bar", 'b', R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Do bar", NULL, NULL },
   };
   RArgParser * parser = r_arg_parser_new (NULL, NULL);
   RArgParseCtx * ctx;
@@ -926,6 +926,218 @@ RTEST (rargparse, add_command_and_parse, RTEST_FAST)
   r_arg_parse_ctx_unref (ctx);
   r_arg_parser_unref (parser);
   r_strv_free (strv);
+}
+RTEST_END;
+
+
+RTEST (rargparse, default_value_used_when_absent, RTEST_FAST)
+{
+  static RArgOptionEntry entries[] = {
+    { "num",  0, R_ARG_OPTION_TYPE_INT,    R_ARG_OPTION_FLAG_NONE, "Integer",   NULL, "42" },
+    { "big",  0, R_ARG_OPTION_TYPE_INT64,  R_ARG_OPTION_FLAG_NONE, "Integer64", NULL, "1234567890123" },
+    { "d",    0, R_ARG_OPTION_TYPE_DOUBLE, R_ARG_OPTION_FLAG_NONE, "Double",    NULL, "3.14" },
+    { "s",    0, R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_NONE, "String",    NULL, "hello" },
+    { "f",    0, R_ARG_OPTION_TYPE_FILENAME, R_ARG_OPTION_FLAG_NONE, "Filename",NULL, "/tmp/x" },
+  };
+  RArgParser * parser = r_arg_parser_new (NULL, NULL);
+  RArgParseCtx * ctx;
+  rchar ** strv = r_strv_new ("rlibtest", NULL);
+  rchar ** argv = strv;
+  int argc = 1;
+  rchar * tmp;
+
+  r_assert (r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries)));
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, R_ARG_PARSE_FLAG_NONE,
+          &argc, (const rchar ***)&argv, NULL)), !=, NULL);
+
+  /* Nothing was actually provided on the command line. */
+  r_assert (!r_arg_parse_ctx_has_option (ctx, "num"));
+  r_assert (!r_arg_parse_ctx_has_option (ctx, "big"));
+  r_assert (!r_arg_parse_ctx_has_option (ctx, "d"));
+  r_assert (!r_arg_parse_ctx_has_option (ctx, "s"));
+  r_assert (!r_arg_parse_ctx_has_option (ctx, "f"));
+  r_assert_cmpint (r_arg_parse_ctx_option_count (ctx), ==, 0);
+
+  /* But the getters return the per-entry defval. */
+  r_assert_cmpint (r_arg_parse_ctx_get_option_int (ctx, "num"), ==, 42);
+  r_assert_cmpint (r_arg_parse_ctx_get_option_int64 (ctx, "big"), ==, RINT64_CONSTANT (1234567890123));
+  r_assert_cmpdouble (r_arg_parse_ctx_get_option_double (ctx, "d"), ==, 3.14);
+  r_assert_cmpstr ((tmp = r_arg_parse_ctx_get_option_string (ctx, "s")), ==, "hello");
+  r_free (tmp);
+  r_assert_cmpstr ((tmp = r_arg_parse_ctx_get_option_filename (ctx, "f")), ==, "/tmp/x");
+  r_free (tmp);
+
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, default_value_overridden_when_present, RTEST_FAST)
+{
+  static RArgOptionEntry entries[] = {
+    { "num", 'n', R_ARG_OPTION_TYPE_INT,    R_ARG_OPTION_FLAG_NONE, "Integer", NULL, "42" },
+    { "s",    0,  R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_NONE, "String",  NULL, "hello" },
+  };
+  RArgParser * parser = r_arg_parser_new (NULL, NULL);
+  RArgParseCtx * ctx;
+  rchar ** strv = r_strv_new ("rlibtest", "-n", "7", "--s", "world", NULL);
+  rchar ** argv = strv;
+  int argc = (int) r_strv_len (strv);
+  rchar * tmp;
+
+  r_assert (r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries)));
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, R_ARG_PARSE_FLAG_NONE,
+          &argc, (const rchar ***)&argv, NULL)), !=, NULL);
+
+  r_assert (r_arg_parse_ctx_has_option (ctx, "num"));
+  r_assert (r_arg_parse_ctx_has_option (ctx, "s"));
+  /* User value wins over defval. */
+  r_assert_cmpint (r_arg_parse_ctx_get_option_int (ctx, "num"), ==, 7);
+  r_assert_cmpstr ((tmp = r_arg_parse_ctx_get_option_string (ctx, "s")), ==, "world");
+  r_free (tmp);
+
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, no_default_returns_zero, RTEST_FAST)
+{
+  /* Pre-defval behaviour: missing options return the type's zero value.
+   * Verify defval = NULL preserves it. */
+  static RArgOptionEntry entries[] = {
+    { "num", 0, R_ARG_OPTION_TYPE_INT,    R_ARG_OPTION_FLAG_NONE, "Integer", NULL, NULL },
+    { "s",   0, R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_NONE, "String",  NULL, NULL },
+  };
+  RArgParser * parser = r_arg_parser_new (NULL, NULL);
+  RArgParseCtx * ctx;
+  rchar ** strv = r_strv_new ("rlibtest", NULL);
+  rchar ** argv = strv;
+  int argc = 1;
+
+  r_assert (r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries)));
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, R_ARG_PARSE_FLAG_NONE,
+          &argc, (const rchar ***)&argv, NULL)), !=, NULL);
+
+  r_assert_cmpint (r_arg_parse_ctx_get_option_int (ctx, "num"), ==, 0);
+  r_assert_cmpptr (r_arg_parse_ctx_get_option_string (ctx, "s"), ==, NULL);
+
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, default_value_ignored_for_bool, RTEST_FAST)
+{
+  /* BOOL ("NONE") options have no string value -- defval is meaningless and
+   * the entry init should warn and drop it. */
+  static RArgOptionEntry entries[] = {
+    { "foo", 0, R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Bool", NULL, "true" },
+  };
+  RArgParser * parser = r_arg_parser_new (NULL, NULL);
+  RArgParseCtx * ctx;
+  rchar ** strv = r_strv_new ("rlibtest", NULL);
+  rchar ** argv = strv;
+  int argc = 1;
+  rboolean res;
+
+  r_assert_logs_level (
+      res = r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries)),
+      R_LOG_LEVEL_WARNING);
+  r_assert (res);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, R_ARG_PARSE_FLAG_NONE,
+          &argc, (const rchar ***)&argv, NULL)), !=, NULL);
+
+  /* defval dropped: --foo absent -> FALSE, same as if no default had been set. */
+  r_assert (!r_arg_parse_ctx_get_option_bool (ctx, "foo"));
+
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, default_value_clears_required, RTEST_FAST)
+{
+  /* REQUIRED + defval is incoherent -- the defval makes the option not
+   * actually required. Entry init warns and clears REQUIRED so the
+   * required-options check at parse time passes even though the option
+   * wasn't on the command line. */
+  static RArgOptionEntry entries[] = {
+    { "num", 0, R_ARG_OPTION_TYPE_INT, R_ARG_OPTION_FLAG_REQUIRED, "Integer", NULL, "42" },
+  };
+  RArgParser * parser = r_arg_parser_new (NULL, NULL);
+  RArgParseCtx * ctx;
+  rchar ** strv = r_strv_new ("rlibtest", NULL);
+  rchar ** argv = strv;
+  int argc = 1;
+  rboolean res;
+
+  r_assert_logs_level (
+      res = r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries)),
+      R_LOG_LEVEL_WARNING);
+  r_assert (res);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, R_ARG_PARSE_FLAG_NONE,
+          &argc, (const rchar ***)&argv, NULL)), !=, NULL);
+  r_assert_cmpint (r_arg_parse_ctx_get_option_int (ctx, "num"), ==, 42);
+
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, default_value_in_help, RTEST_FAST)
+{
+  static RArgOptionEntry entries[] = {
+    { "num", 'n', R_ARG_OPTION_TYPE_INT,    R_ARG_OPTION_FLAG_NONE, "Integer", "NUM",  "42" },
+    { "s",   0,   R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_NONE, "String",  NULL,   "hi" },
+    { "plain", 0, R_ARG_OPTION_TYPE_INT,    R_ARG_OPTION_FLAG_NONE, "No default", NULL, NULL },
+  };
+  const rchar * args_help =
+    "  -n, --num=NUM                 Integer [default: 42]\n"
+    "  --s=STRING                    String [default: hi]\n"
+    "  --plain=VALUE                 No default\n";
+  rchar * expected, * help, * exe;
+  RArgParser * parser = r_arg_parser_new (NULL, NULL);
+
+  r_assert_cmpptr ((exe = r_proc_get_exe_name ()), !=, NULL);
+  r_assert (r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries)));
+  expected = r_strprintf (rargparse_help_tmpl, exe, "", rargparse_helpopt, args_help);
+  r_assert_cmpstr ((help = r_arg_parser_get_help (parser, R_ARG_PARSE_FLAG_NONE, NULL)), ==, expected);
+  r_free (expected);
+  r_free (help);
+  r_free (exe);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, required_without_default_still_required, RTEST_FAST)
+{
+  /* Sanity-check: defval=NULL + REQUIRED still rejects parses that miss
+   * the option, so we haven't accidentally weakened the required check. */
+  static RArgOptionEntry entries[] = {
+    { "num", 0, R_ARG_OPTION_TYPE_INT, R_ARG_OPTION_FLAG_REQUIRED, "Integer", NULL, NULL },
+  };
+  RArgParser * parser = r_arg_parser_new (NULL, NULL);
+  RArgParseCtx * ctx;
+  rchar ** strv = r_strv_new ("rlibtest", NULL);
+  rchar ** argv = strv;
+  int argc = 1;
+  RArgParseResult res;
+
+  r_assert (r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries)));
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser,
+          R_ARG_PARSE_FLAG_DONT_EXIT | R_ARG_PARSE_FLAG_DONT_PRINT_STDOUT,
+          &argc, (const rchar ***)&argv, &res)), ==, NULL);
+  r_assert_cmpint (res, ==, R_ARG_PARSE_MISSING_OPTION);
+
+  r_strv_free (strv);
+  r_arg_parser_unref (parser);
 }
 RTEST_END;
 


### PR DESCRIPTION
Adds defval support to argparse, addressing #37. Implementation, semantics, tests, and a real consumer demonstrating it.

## API

New field on \`RArgOptionEntry\`:

\`\`\`c
typedef struct {
  const rchar *   longarg;
  rchar           shortarg;
  RArgOptionType  type;
  RArgOptionFlags flags;
  const rchar *   desc;
  const rchar *   eqname;
  const rchar *   defval;  /* new: parsed via the per-type parser when absent */
} RArgOptionEntry;
\`\`\`

Defval is a string; the existing per-type parser handles it the same way a cmdline value is handled — one field covers INT / INT64 / DOUBLE / STRING / FILENAME with no per-type plumbing. NULL preserves the previous \"return type-zero on missing\" behaviour exactly. The new field is the *last* one, so existing initialiser lists (\`{ \"foo\", 'f', TYPE, FLAGS, \"desc\", NULL }\`) stay source-compatible — C99 zero-initialises trailing fields.

## Semantic decisions

  * **BOOL + defval**: BOOL has no value beyond presence, so defval is meaningless. Entry init warns and clears it, matching the pre-existing \`INVERSE + non-NONE-type\` warning pattern.
  * **REQUIRED + defval**: incoherent — defval defeats the point of REQUIRED. Entry init warns and clears REQUIRED so the required-options check passes when the cmdline omits the option.
  * **has_option / option_count are unchanged**: they still reflect \"was this on the cmdline\". Callers that want the effective value just call the getter, which transparently falls back to defval.
  * **Help output self-documents the default**: \`r_arg_option_entry_append_help\` appends \`[default: <val>]\` after the description when defval is set; entries without defval render identically to before.

## Tests (suite 848 → 855)

  1. \`default_value_used_when_absent\` — every non-BOOL type returns its defval.
  2. \`default_value_overridden_when_present\` — user value wins over defval.
  3. \`no_default_returns_zero\` — defval=NULL preserves pre-feature zero-return behaviour.
  4. \`default_value_ignored_for_bool\` — BOOL+defval warns and the defval is dropped.
  5. \`default_value_clears_required\` — REQUIRED+defval warns, REQUIRED is cleared, parse succeeds.
  6. \`required_without_default_still_required\` — REQUIRED alone still rejects missing options.
  7. \`default_value_in_help\` — help formatter prints \`[default: ...]\` correctly and leaves no-default entries alone.

## Real-world demo

\`example/rargparse\` now sets \`defval = \"0\"\` on \`--ret\`, demonstrating the feature end-to-end:

\`\`\`
$ build/example/rargparse --help
Usage:
  rargparse [options]

Options:
  --version                     Show application version number and exit
  -h, --help                    Show this help message and exit
  -f, --foo                     Do Foo
  -i, --input=STRING            Input string
  -r, --ret=VALUE               Return value program will return [default: 0]
\`\`\`

\`-f\` alone exits 0 (defval), \`-f -r 7\` exits 7 (override).

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)