### PR TITLE
argparse: Support positional argument entries

### DIFF
--- a/example/rfile.c
+++ b/example/rfile.c
@@ -8,51 +8,50 @@ main (int argc, char ** argv)
   RArgParseCtx * ctx;
   RArgParseResult res;
   const RArgOptionEntry entries[] = {
-    { "hr", 0, R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "Human readable format", NULL, NULL },
+    { "hr",   0, R_ARG_OPTION_TYPE_NONE,     R_ARG_OPTION_FLAG_NONE,       "Human readable format", NULL, NULL },
+    { "file", 0, R_ARG_OPTION_TYPE_FILENAME, R_ARG_OPTION_FLAG_POSITIONAL, "Bitset file to read",   NULL, NULL },
   };
 
   r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries));
 
   if ((ctx = r_arg_parser_parse (parser, R_ARG_PARSE_FLAG_NONE,
           &argc, (const rchar ***)&argv, &res)) != NULL) {
-    if (argc == 1) {
-      if (r_arg_parse_ctx_has_option (ctx, "hr")) {
-        RBitset * bitset;
-        rsize bits;
-        if (!r_bitset_init_stack (bitset, 256)) {
-          r_print ("internal error\n");
-          return -1;
-        }
+    rchar * file = r_arg_parse_ctx_get_option_filename (ctx, "file");
 
-        if (r_bitset_set_from_human_readable_file (bitset, argv[0], &bits)) {
-          ruint i;
-          r_print ("Read %"RSIZE_FMT" from '%s'\n", bits, argv[0]);
-          for (i = 0; i < 256; i += 32)
-            r_print ("%.8"RINT32_MODIFIER"x\n", r_bitset_get_u32_at (bitset, i));
-        } else {
-          r_print ("Unable to read bitset from '%s'\n", argv[0]);
-        }
+    if (r_arg_parse_ctx_has_option (ctx, "hr")) {
+      RBitset * bitset;
+      rsize bits;
+      if (!r_bitset_init_stack (bitset, 256)) {
+        r_print ("internal error\n");
+        return -1;
+      }
+
+      if (r_bitset_set_from_human_readable_file (bitset, file, &bits)) {
+        ruint i;
+        r_print ("Read %"RSIZE_FMT" from '%s'\n", bits, file);
+        for (i = 0; i < 256; i += 32)
+          r_print ("%.8"RINT32_MODIFIER"x\n", r_bitset_get_u32_at (bitset, i));
       } else {
-        RFile * f;
-        if ((f = r_file_open (argv[0], "r")) != NULL) {
-          ruint32 val;
-          rsize tokens;
-
-          while (r_file_scanf (f, "%"RINT32_MODIFIER"x,", &tokens, &val) == R_FILE_ERROR_OK &&
-              tokens == 1) {
-            r_print ("%.8"RINT32_MODIFIER"x\n", val);
-          }
-
-          r_file_unref (f);
-        } else {
-          r_print ("'%s' not found\n", argv[0]);
-        }
+        r_print ("Unable to read bitset from '%s'\n", file);
       }
     } else {
-      r_print ("Missing file\n");
-      ret = r_arg_parser_print_help (parser, R_ARG_PARSE_FLAG_DONT_EXIT, NULL, 1);
+      RFile * f;
+      if ((f = r_file_open (file, "r")) != NULL) {
+        ruint32 val;
+        rsize tokens;
+
+        while (r_file_scanf (f, "%"RINT32_MODIFIER"x,", &tokens, &val) == R_FILE_ERROR_OK &&
+            tokens == 1) {
+          r_print ("%.8"RINT32_MODIFIER"x\n", val);
+        }
+
+        r_file_unref (f);
+      } else {
+        r_print ("'%s' not found\n", file);
+      }
     }
 
+    r_free (file);
     r_arg_parse_ctx_unref (ctx);
   } else {
     ret = r_arg_parser_print_help (parser, R_ARG_PARSE_FLAG_DONT_EXIT, NULL, -1);

--- a/include/rlib/rargparse.h
+++ b/include/rlib/rargparse.h
@@ -46,6 +46,13 @@ typedef enum {
   R_ARG_OPTION_FLAG_HIDDEN          = 1 << 0,
   R_ARG_OPTION_FLAG_INVERSE         = 1 << 1,
   R_ARG_OPTION_FLAG_REQUIRED        = 1 << 2,
+  /* Positional argument: bound by position in argv, not by --name.
+   * 'longarg' is the name used as the storage key and in help text;
+   * 'eqname' (or longarg uppercased) becomes the name in the Usage
+   * line. shortarg is ignored. Cannot be combined with TYPE_NONE
+   * since positionals always carry a value. REQUIRED is implied
+   * when defval is NULL. */
+  R_ARG_OPTION_FLAG_POSITIONAL      = 1 << 3,
 } RArgOptionFlags;
 
 typedef struct {

--- a/rlib/rargparse.c
+++ b/rlib/rargparse.c
@@ -169,6 +169,9 @@ r_arg_option_entry_ctx_init (RArgOptionEntry * entry, const RArgOptionEntry * op
     return FALSE;
   if (opt->type >= R_ARG_OPTION_TYPE_COUNT)
     return FALSE;
+  if ((opt->flags & R_ARG_OPTION_FLAG_POSITIONAL) &&
+      opt->type == R_ARG_OPTION_TYPE_NONE)
+    return FALSE;
 
   r_memcpy (entry, opt, sizeof (RArgOptionEntry));
 
@@ -176,6 +179,11 @@ r_arg_option_entry_ctx_init (RArgOptionEntry * entry, const RArgOptionEntry * op
   if (opt->shortarg == '-' || (opt->shortarg != 0 && !r_ascii_isprint (opt->shortarg))) {
     R_LOG_CAT_WARNING (&rlib_logcat,
         "ignoring incompatible short opt name for --%s", opt->longarg);
+    entry->shortarg = 0;
+  }
+  if ((opt->flags & R_ARG_OPTION_FLAG_POSITIONAL) && opt->shortarg != 0) {
+    R_LOG_CAT_WARNING (&rlib_logcat,
+        "ignoring short opt name on positional %s", opt->longarg);
     entry->shortarg = 0;
   }
   if (opt->type != R_ARG_OPTION_TYPE_NONE && (opt->flags & R_ARG_OPTION_FLAG_INVERSE)) {
@@ -193,6 +201,8 @@ r_arg_option_entry_ctx_init (RArgOptionEntry * entry, const RArgOptionEntry * op
         "clearing required flag for --%s because a default is set", opt->longarg);
     entry->flags &= ~R_ARG_OPTION_FLAG_REQUIRED;
   }
+  if ((opt->flags & R_ARG_OPTION_FLAG_POSITIONAL) && opt->defval == NULL)
+    entry->flags |= R_ARG_OPTION_FLAG_REQUIRED;
 
   return TRUE;
 }
@@ -379,12 +389,51 @@ r_arg_parser_get_epilog (RArgParser * parser)
   return parser->epilog;
 }
 
+static rchar *
+r_arg_positional_usage_name (const RArgOptionEntry * opt)
+{
+  rchar * ret;
+  rsize i;
+
+  if (opt->eqname != NULL && *opt->eqname != 0)
+    return r_strdup (opt->eqname);
+
+  ret = r_strdup (opt->longarg);
+  for (i = 0; ret[i] != 0; i++)
+    ret[i] = r_ascii_upper (ret[i]);
+  return ret;
+}
+
+static void
+r_arg_positional_entry_append_help (const RArgOptionEntry * opt, RString * str)
+{
+  rssize spacing = 32;
+  rchar * name;
+
+  if (opt->flags & R_ARG_OPTION_FLAG_HIDDEN)
+    return;
+
+  name = r_arg_positional_usage_name (opt);
+  spacing -= r_string_append_printf (str, "  %s", name);
+  r_free (name);
+
+  while (spacing > 0)
+    spacing -= r_string_append (str, " ");
+
+  r_string_append (str, opt->desc);
+  if (opt->defval != NULL)
+    r_string_append_printf (str, " [default: %s]", opt->defval);
+  r_string_append (str, "\n");
+}
+
 static void
 r_arg_option_entry_append_help (const RArgOptionEntry * opt, RString * str)
 {
   rssize spacing = 32;
 
   if (opt->flags & R_ARG_OPTION_FLAG_HIDDEN)
+    return;
+  if (opt->flags & R_ARG_OPTION_FLAG_POSITIONAL)
     return;
 
   spacing -= r_string_append (str, "  ");
@@ -464,6 +513,21 @@ r_arg_parser_get_help (RArgParser * parser, RArgParseFlags flags,
   str = r_string_new_sized (1024);
   r_string_append_printf (str, "Usage:\n  %s %s",
       appname != NULL ? appname : parser->appname, parser->options);
+  for (i = 0; i < parser->main->count; i++) {
+    const RArgOptionEntry * opt = &parser->main->entries[i];
+    rchar * name;
+
+    if (!(opt->flags & R_ARG_OPTION_FLAG_POSITIONAL))
+      continue;
+    if (opt->flags & R_ARG_OPTION_FLAG_HIDDEN)
+      continue;
+    name = r_arg_positional_usage_name (opt);
+    if (opt->defval != NULL)
+      r_string_append_printf (str, " [%s]", name);
+    else
+      r_string_append_printf (str, " %s", name);
+    r_free (name);
+  }
   if (r_kv_ptr_array_size (&parser->commands) > 0)
     r_string_append (str, " <command>");
   r_string_append (str, "\n");
@@ -480,6 +544,22 @@ r_arg_parser_get_help (RArgParser * parser, RArgParseFlags flags,
     r_arg_option_entry_append_help (&parser->main->entries[i], str);
 
   r_slist_foreach (parser->groups, (RFunc)r_arg_option_group_append_help, str);
+
+  {
+    rboolean any = FALSE;
+    for (i = 0; i < parser->main->count; i++) {
+      const RArgOptionEntry * opt = &parser->main->entries[i];
+      if (!(opt->flags & R_ARG_OPTION_FLAG_POSITIONAL))
+        continue;
+      if (opt->flags & R_ARG_OPTION_FLAG_HIDDEN)
+        continue;
+      if (!any) {
+        r_string_append (str, "\nArguments:\n");
+        any = TRUE;
+      }
+      r_arg_positional_entry_append_help (opt, str);
+    }
+  }
 
   if (r_kv_ptr_array_size (&parser->commands) > 0) {
     r_string_append (str, "\nCommands:\n");
@@ -803,12 +883,54 @@ r_arg_parser_parse_options (RArgParser * parser, RArgParseCtx * ctx,
     }
   }
 
-  if (ret == R_ARG_PARSE_OK) {
-    if (!r_arg_parser_check_required_options (parser, ctx))
-      ret = R_ARG_PARSE_MISSING_OPTION;
+  return ret;
+}
+
+static RArgParseResult
+r_arg_parser_parse_positionals (RArgParser * parser, RArgParseCtx * ctx,
+    int * argc, const rchar *** argv)
+{
+  rsize i;
+
+  for (i = 0; i < parser->main->count && *argc > 0; i++) {
+    RArgOptionEntry * entry = &parser->main->entries[i];
+    const rchar * str;
+    const rchar * end;
+    RArgParseResult parsed = R_ARG_PARSE_ERROR;
+
+    if (!(entry->flags & R_ARG_OPTION_FLAG_POSITIONAL))
+      continue;
+    if (r_dictionary_contains (ctx->options, entry->longarg))
+      continue;
+
+    str = (*argv)[0];
+    end = str;
+    switch (entry->type) {
+      case R_ARG_OPTION_TYPE_INT:
+        parsed = r_arg_option_parser_int (&end, NULL);
+        break;
+      case R_ARG_OPTION_TYPE_INT64:
+        parsed = r_arg_option_parser_int64 (&end, NULL);
+        break;
+      case R_ARG_OPTION_TYPE_DOUBLE:
+        parsed = r_arg_option_parser_double (&end, NULL);
+        break;
+      case R_ARG_OPTION_TYPE_STRING:
+      case R_ARG_OPTION_TYPE_FILENAME:
+        parsed = r_arg_option_parser_string (&end, NULL);
+        break;
+      default:
+        return R_ARG_PARSE_ERROR;
+    }
+    if (parsed != R_ARG_PARSE_OK)
+      return R_ARG_PARSE_VALUE_ERROR;
+
+    r_dictionary_insert (ctx->options, entry->longarg, (rpointer) str);
+    (*argv)++;
+    (*argc)--;
   }
 
-  return ret;
+  return R_ARG_PARSE_OK;
 }
 
 static RArgParser *
@@ -880,8 +1002,12 @@ r_arg_parser_parse_internal (RArgParser * parser, RArgParseFlags flags,
   RArgParseResult curres;
 
   if ((ret = r_arg_parse_ctx_new (parser, flags, appname)) != NULL) {
-    if ((curres = r_arg_parser_parse_options (parser, ret, argc, argv)) == R_ARG_PARSE_OK) {
-      curres = r_arg_parser_parse_command (parser, flags, ret, argc, argv);
+    if ((curres = r_arg_parser_parse_options (parser, ret, argc, argv)) == R_ARG_PARSE_OK &&
+        (curres = r_arg_parser_parse_positionals (parser, ret, argc, argv)) == R_ARG_PARSE_OK) {
+      if (!r_arg_parser_check_required_options (parser, ret))
+        curres = R_ARG_PARSE_MISSING_OPTION;
+      else
+        curres = r_arg_parser_parse_command (parser, flags, ret, argc, argv);
     }
 
     if (curres != R_ARG_PARSE_OK) {

--- a/test/rargparse.c
+++ b/test/rargparse.c
@@ -1116,6 +1116,260 @@ RTEST (rargparse, default_value_in_help, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rargparse, positional_bind, RTEST_FAST)
+{
+  static RArgOptionEntry entries[] = {
+    { "outfile", 0, R_ARG_OPTION_TYPE_FILENAME,
+      R_ARG_OPTION_FLAG_POSITIONAL, "Output file", "OUTFILE", NULL },
+  };
+  RArgParser * parser = r_arg_parser_new (NULL, NULL);
+  RArgParseCtx * ctx;
+  rchar ** strv = r_strv_new ("rlibtest", "/tmp/out.txt", NULL);
+  rchar ** argv = strv;
+  int argc = (int) r_strv_len (strv);
+  rchar * tmp;
+
+  r_assert (r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries)));
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, R_ARG_PARSE_FLAG_NONE,
+          &argc, (const rchar ***)&argv, NULL)), !=, NULL);
+  r_assert_cmpint (argc, ==, 0);
+  r_assert (r_arg_parse_ctx_has_option (ctx, "outfile"));
+  r_assert_cmpstr ((tmp = r_arg_parse_ctx_get_option_filename (ctx, "outfile")), ==, "/tmp/out.txt");
+  r_free (tmp);
+
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, positional_multiple_in_order, RTEST_FAST)
+{
+  static RArgOptionEntry entries[] = {
+    { "src",  0, R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_POSITIONAL, "Source", "SRC", NULL },
+    { "dst",  0, R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_POSITIONAL, "Destination", "DST", NULL },
+  };
+  RArgParser * parser = r_arg_parser_new (NULL, NULL);
+  RArgParseCtx * ctx;
+  rchar ** strv = r_strv_new ("rlibtest", "a.txt", "b.txt", NULL);
+  rchar ** argv = strv;
+  int argc = (int) r_strv_len (strv);
+  rchar * tmp;
+
+  r_assert (r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries)));
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, R_ARG_PARSE_FLAG_NONE,
+          &argc, (const rchar ***)&argv, NULL)), !=, NULL);
+  r_assert_cmpstr ((tmp = r_arg_parse_ctx_get_option_string (ctx, "src")), ==, "a.txt");
+  r_free (tmp);
+  r_assert_cmpstr ((tmp = r_arg_parse_ctx_get_option_string (ctx, "dst")), ==, "b.txt");
+  r_free (tmp);
+
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, positional_options_then_positional, RTEST_FAST)
+{
+  static RArgOptionEntry entries[] = {
+    { "verbose", 'v', R_ARG_OPTION_TYPE_NONE,     R_ARG_OPTION_FLAG_NONE, "Verbose", NULL, NULL },
+    { "n",        0,  R_ARG_OPTION_TYPE_INT,      R_ARG_OPTION_FLAG_NONE, "Count",   NULL, NULL },
+    { "outfile",  0,  R_ARG_OPTION_TYPE_FILENAME, R_ARG_OPTION_FLAG_POSITIONAL, "Output", "OUT", NULL },
+  };
+  RArgParser * parser = r_arg_parser_new (NULL, NULL);
+  RArgParseCtx * ctx;
+  rchar ** strv = r_strv_new ("rlibtest", "-v", "--n", "3", "out.txt", NULL);
+  rchar ** argv = strv;
+  int argc = (int) r_strv_len (strv);
+  rchar * tmp;
+
+  r_assert (r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries)));
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, R_ARG_PARSE_FLAG_NONE,
+          &argc, (const rchar ***)&argv, NULL)), !=, NULL);
+  r_assert (r_arg_parse_ctx_get_option_bool (ctx, "verbose"));
+  r_assert_cmpint (r_arg_parse_ctx_get_option_int (ctx, "n"), ==, 3);
+  r_assert_cmpstr ((tmp = r_arg_parse_ctx_get_option_filename (ctx, "outfile")), ==, "out.txt");
+  r_free (tmp);
+
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, positional_missing_required, RTEST_FAST)
+{
+  static RArgOptionEntry entries[] = {
+    { "outfile", 0, R_ARG_OPTION_TYPE_FILENAME,
+      R_ARG_OPTION_FLAG_POSITIONAL, "Output", "OUT", NULL },
+  };
+  RArgParser * parser = r_arg_parser_new (NULL, NULL);
+  RArgParseCtx * ctx;
+  rchar ** strv = r_strv_new ("rlibtest", NULL);
+  rchar ** argv = strv;
+  int argc = 1;
+  RArgParseResult res;
+
+  r_assert (r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries)));
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser,
+          R_ARG_PARSE_FLAG_DONT_EXIT | R_ARG_PARSE_FLAG_DONT_PRINT_STDOUT,
+          &argc, (const rchar ***)&argv, &res)), ==, NULL);
+  r_assert_cmpint (res, ==, R_ARG_PARSE_MISSING_OPTION);
+
+  r_strv_free (strv);
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, positional_default_used_when_absent, RTEST_FAST)
+{
+  static RArgOptionEntry entries[] = {
+    { "outfile", 0, R_ARG_OPTION_TYPE_FILENAME,
+      R_ARG_OPTION_FLAG_POSITIONAL, "Output", "OUT", "/tmp/default" },
+  };
+  RArgParser * parser = r_arg_parser_new (NULL, NULL);
+  RArgParseCtx * ctx;
+  rchar ** strv = r_strv_new ("rlibtest", NULL);
+  rchar ** argv = strv;
+  int argc = 1;
+  rchar * tmp;
+
+  r_assert (r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries)));
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, R_ARG_PARSE_FLAG_NONE,
+          &argc, (const rchar ***)&argv, NULL)), !=, NULL);
+  r_assert (!r_arg_parse_ctx_has_option (ctx, "outfile"));
+  r_assert_cmpstr ((tmp = r_arg_parse_ctx_get_option_filename (ctx, "outfile")), ==, "/tmp/default");
+  r_free (tmp);
+
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, positional_double_dash_terminator, RTEST_FAST)
+{
+  static RArgOptionEntry entries[] = {
+    { "verbose", 'v', R_ARG_OPTION_TYPE_NONE,   R_ARG_OPTION_FLAG_NONE, "Verbose", NULL, NULL },
+    { "name",     0,  R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_POSITIONAL, "Name", "NAME", NULL },
+  };
+  RArgParser * parser = r_arg_parser_new (NULL, NULL);
+  RArgParseCtx * ctx;
+  rchar ** strv = r_strv_new ("rlibtest", "-v", "--", "--something-that-looks-like-an-option", NULL);
+  rchar ** argv = strv;
+  int argc = (int) r_strv_len (strv);
+  rchar * tmp;
+
+  r_assert (r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries)));
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, R_ARG_PARSE_FLAG_NONE,
+          &argc, (const rchar ***)&argv, NULL)), !=, NULL);
+  r_assert (r_arg_parse_ctx_get_option_bool (ctx, "verbose"));
+  r_assert_cmpstr ((tmp = r_arg_parse_ctx_get_option_string (ctx, "name")),
+      ==, "--something-that-looks-like-an-option");
+  r_free (tmp);
+
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, positional_type_checked, RTEST_FAST)
+{
+  static RArgOptionEntry entries[] = {
+    { "count", 0, R_ARG_OPTION_TYPE_INT,
+      R_ARG_OPTION_FLAG_POSITIONAL, "Count", "N", NULL },
+  };
+  RArgParser * parser = r_arg_parser_new (NULL, NULL);
+  RArgParseCtx * ctx;
+  rchar ** strv;
+  rchar ** argv;
+  int argc;
+  RArgParseResult res;
+
+  r_assert (r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries)));
+
+  strv = argv = r_strv_new ("rlibtest", "42", NULL);
+  argc = (int) r_strv_len (strv);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, R_ARG_PARSE_FLAG_NONE,
+          &argc, (const rchar ***)&argv, &res)), !=, NULL);
+  r_assert_cmpint (res, ==, R_ARG_PARSE_OK);
+  r_assert_cmpint (r_arg_parse_ctx_get_option_int (ctx, "count"), ==, 42);
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+
+  strv = argv = r_strv_new ("rlibtest", "not-a-number", NULL);
+  argc = (int) r_strv_len (strv);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser,
+          R_ARG_PARSE_FLAG_DONT_EXIT | R_ARG_PARSE_FLAG_DONT_PRINT_STDOUT,
+          &argc, (const rchar ***)&argv, &res)), ==, NULL);
+  r_assert_cmpint (res, ==, R_ARG_PARSE_VALUE_ERROR);
+  r_strv_free (strv);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, positional_type_none_rejected, RTEST_FAST)
+{
+  static RArgOptionEntry bad[] = {
+    { "outfile", 0, R_ARG_OPTION_TYPE_NONE,
+      R_ARG_OPTION_FLAG_POSITIONAL, "Output", NULL, NULL },
+  };
+  RArgParser * parser = r_arg_parser_new (NULL, NULL);
+  r_assert (!r_arg_parser_add_option_entries (parser, bad, R_N_ELEMENTS (bad)));
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, positional_shortarg_warned, RTEST_FAST)
+{
+  static RArgOptionEntry entries[] = {
+    { "outfile", 'o', R_ARG_OPTION_TYPE_FILENAME,
+      R_ARG_OPTION_FLAG_POSITIONAL, "Output", "OUT", NULL },
+  };
+  RArgParser * parser = r_arg_parser_new (NULL, NULL);
+  rboolean res;
+  r_assert_logs_level (
+      res = r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries)),
+      R_LOG_LEVEL_WARNING);
+  r_assert (res);
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, positional_in_help, RTEST_FAST)
+{
+  static RArgOptionEntry entries[] = {
+    { "src", 0, R_ARG_OPTION_TYPE_STRING,
+      R_ARG_OPTION_FLAG_POSITIONAL, "Source file", "SRC", NULL },
+    { "dst", 0, R_ARG_OPTION_TYPE_STRING,
+      R_ARG_OPTION_FLAG_POSITIONAL, "Destination", "DST", "/tmp/d" },
+  };
+  static const rchar * help_tmpl =
+    "Usage:\n"
+    "  %s [options] SRC [DST]\n"
+    "\nOptions:\n"
+    "%s"
+    "\nArguments:\n"
+    "  SRC                           Source file\n"
+    "  DST                           Destination [default: /tmp/d]\n";
+  rchar * expected, * help, * exe;
+  RArgParser * parser = r_arg_parser_new (NULL, NULL);
+
+  r_assert_cmpptr ((exe = r_proc_get_exe_name ()), !=, NULL);
+  r_assert (r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries)));
+  expected = r_strprintf (help_tmpl, exe, rargparse_helpopt);
+  r_assert_cmpstr ((help = r_arg_parser_get_help (parser, R_ARG_PARSE_FLAG_NONE, NULL)), ==, expected);
+  r_free (expected);
+  r_free (help);
+  r_free (exe);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
 RTEST (rargparse, required_without_default_still_required, RTEST_FAST)
 {
   /* Sanity-check: defval=NULL + REQUIRED still rejects parses that miss


### PR DESCRIPTION
## Summary
- Add `R_ARG_OPTION_FLAG_POSITIONAL` to `RArgOptionEntry`: positionals are bound by argv index instead of `--name`, share the existing per-type value parsers, and become implicitly required unless a `defval` is set.
- Honour the `--` end-of-options terminator: subsequent tokens are bound to positional slots verbatim even when they look like options.
- Help output gains an `Arguments:` section and Usage-line placeholders (bracketed for optional, bare for required).
- Convert `example/rfile` from a hand-rolled `argv[0]` positional to a real one, with proper help text and missing-arg handling.

## Test plan
- [x] `meson test` — all 863 tests pass; 10 new positional cases cover single/multi bind, options-then-positional ordering, missing-required, defval fallback, `--` terminator, INT type validation (success and `VALUE_ERROR`), TYPE_NONE rejection at add time, shortarg warn-and-clear, and the full help format.
- [x] Manual smoke test of `example/rfile` with: `--help`, no args (help printed, exit -1), `rfile <path>`, and `rfile --hr <path>`.

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)