### PR TITLE
crypto: Hash-then-sign helpers for DSA

### DIFF
--- a/include/rlib/crypto/rdsa.h
+++ b/include/rlib/crypto/rdsa.h
@@ -50,6 +50,19 @@ R_API rboolean r_dsa_pub_key_get_g (const RCryptoKey * key, rmpint * g);
 R_API rboolean r_dsa_pub_key_get_y (const RCryptoKey * key, rmpint * y);
 R_API rboolean r_dsa_priv_key_get_x (const RCryptoKey * key, rmpint * x);
 
+R_API RCryptoResult r_dsa_sign_msg (const RCryptoKey * key, RPrng * prng,
+    RMsgDigestType mdtype, rconstpointer msg, rsize msgsize,
+    rpointer sig, rsize * sigsize);
+R_API RCryptoResult r_dsa_sign_msg_hash (const RCryptoKey * key, RPrng * prng,
+    RMsgDigestType mdtype, rconstpointer hash, rsize hashsize,
+    rpointer sig, rsize * sigsize);
+R_API RCryptoResult r_dsa_verify_msg (const RCryptoKey * key,
+    RMsgDigestType mdtype, rconstpointer msg, rsize msgsize,
+    rconstpointer sig, rsize sigsize);
+R_API RCryptoResult r_dsa_verify_msg_with_hash (const RCryptoKey * key,
+    RMsgDigestType mdtype, rconstpointer hash, rsize hashsize,
+    rconstpointer sig, rsize sigsize);
+
 R_END_DECLS
 
 #endif /* __R_CRYPTO_DSA_H__ */

--- a/rlib/crypto/rdsa.c
+++ b/rlib/crypto/rdsa.c
@@ -572,3 +572,73 @@ r_dsa_priv_key_get_x (const RCryptoKey * key, rmpint * x)
   return TRUE;
 }
 
+/* Drive RMsgDigest from mdtype over (msg, msgsize), writing the digest
+ * to a caller-supplied buffer (64 bytes is enough for SHA-512).
+ * Returns the digest size on success, 0 on failure. */
+static rsize
+r_dsa_compute_hash (RMsgDigestType mdtype, rconstpointer msg, rsize msgsize,
+    ruint8 * hashbuf, rsize hashbuf_max)
+{
+  RMsgDigest * md;
+  rsize hashsize;
+
+  if ((md = r_msg_digest_new (mdtype)) == NULL)
+    return 0;
+  hashsize = r_msg_digest_size (md);
+  if (hashsize == 0 || hashsize > hashbuf_max ||
+      !r_msg_digest_update (md, msg, msgsize) ||
+      !r_msg_digest_get_data (md, hashbuf, hashsize, NULL)) {
+    r_msg_digest_free (md);
+    return 0;
+  }
+  r_msg_digest_free (md);
+  return hashsize;
+}
+
+RCryptoResult
+r_dsa_sign_msg_hash (const RCryptoKey * key, RPrng * prng,
+    RMsgDigestType mdtype, rconstpointer hash, rsize hashsize,
+    rpointer sig, rsize * sigsize)
+{
+  /* The algo->sign callback already accepts a pre-computed hash; this
+   * is just a name-symmetric shortcut to match the RSA shape. */
+  return r_crypto_key_sign (key, prng, mdtype, hash, hashsize, sig, sigsize);
+}
+
+RCryptoResult
+r_dsa_sign_msg (const RCryptoKey * key, RPrng * prng,
+    RMsgDigestType mdtype, rconstpointer msg, rsize msgsize,
+    rpointer sig, rsize * sigsize)
+{
+  ruint8 hash[64];
+  rsize hashsize;
+
+  if (R_UNLIKELY (msg == NULL || msgsize == 0))
+    return R_CRYPTO_INVAL;
+  if ((hashsize = r_dsa_compute_hash (mdtype, msg, msgsize, hash, sizeof (hash))) == 0)
+    return R_CRYPTO_HASH_FAILED;
+  return r_crypto_key_sign (key, prng, mdtype, hash, hashsize, sig, sigsize);
+}
+
+RCryptoResult
+r_dsa_verify_msg_with_hash (const RCryptoKey * key,
+    RMsgDigestType mdtype, rconstpointer hash, rsize hashsize,
+    rconstpointer sig, rsize sigsize)
+{
+  return r_crypto_key_verify (key, mdtype, hash, hashsize, sig, sigsize);
+}
+
+RCryptoResult
+r_dsa_verify_msg (const RCryptoKey * key,
+    RMsgDigestType mdtype, rconstpointer msg, rsize msgsize,
+    rconstpointer sig, rsize sigsize)
+{
+  ruint8 hash[64];
+  rsize hashsize;
+
+  if (R_UNLIKELY (msg == NULL || msgsize == 0))
+    return R_CRYPTO_INVAL;
+  if ((hashsize = r_dsa_compute_hash (mdtype, msg, msgsize, hash, sizeof (hash))) == 0)
+    return R_CRYPTO_HASH_FAILED;
+  return r_crypto_key_verify (key, mdtype, hash, hashsize, sig, sigsize);
+}

--- a/test/rdsa.c
+++ b/test/rdsa.c
@@ -489,3 +489,111 @@ RTEST_LOOP (rdsa, wycheproof_2048_256_sha256_verify, RTEST_SLOW,
   }
 }
 RTEST_END;
+
+RTEST (rdsa, sign_msg_verify_msg_roundtrip, RTEST_FAST)
+{
+  /* The _msg helpers hash internally and produce signatures verify-able
+   * both by the matching _msg verifier and by the pre-hashed verifier
+   * path. */
+  static const ruint8 message[] =
+      "The quick brown fox jumps over the lazy dog.";
+  rmpint p, q, g, y, x;
+  RCryptoKey * priv, * pub;
+  RPrng * prng;
+  ruint8 sig[64];
+  rsize sigsize = sizeof (sig);
+
+  init_dsa_mpints (&p, &q, &g, &y, &x);
+  r_assert_cmpptr ((priv = r_dsa_priv_key_new (&p, &q, &g, &y, &x)), !=, NULL);
+  r_assert_cmpptr ((pub  = r_dsa_pub_key_new_full (&p, &q, &g, &y)), !=, NULL);
+  r_assert_cmpptr ((prng = r_rand_prng_new ()), !=, NULL);
+
+  r_assert_cmpint (r_dsa_sign_msg (priv, prng, R_MSG_DIGEST_TYPE_SHA1,
+        message, sizeof (message) - 1, sig, &sigsize), ==, R_CRYPTO_OK);
+  r_assert_cmpuint (sigsize, >, 0);
+
+  r_assert_cmpint (r_dsa_verify_msg (pub, R_MSG_DIGEST_TYPE_SHA1,
+        message, sizeof (message) - 1, sig, sigsize), ==, R_CRYPTO_OK);
+
+  /* Cross-check: hashing manually and using verify_msg_with_hash must
+   * land on the same internal hash and so accept the same sig. */
+  {
+    RMsgDigest * md;
+    ruint8 hash[20];
+    rsize hashsize;
+    r_assert_cmpptr ((md = r_msg_digest_new (R_MSG_DIGEST_TYPE_SHA1)), !=, NULL);
+    hashsize = r_msg_digest_size (md);
+    r_assert_cmpuint (hashsize, ==, sizeof (hash));
+    r_assert (r_msg_digest_update (md, message, sizeof (message) - 1));
+    r_assert (r_msg_digest_get_data (md, hash, hashsize, NULL));
+    r_msg_digest_free (md);
+
+    r_assert_cmpint (r_dsa_verify_msg_with_hash (pub, R_MSG_DIGEST_TYPE_SHA1,
+          hash, hashsize, sig, sigsize), ==, R_CRYPTO_OK);
+  }
+
+  r_crypto_key_unref (priv);
+  r_crypto_key_unref (pub);
+  r_prng_unref (prng);
+  clear_dsa_mpints (&p, &q, &g, &y, &x);
+}
+RTEST_END;
+
+RTEST (rdsa, sign_msg_hash_matches_crypto_key_sign, RTEST_FAST)
+{
+  /* r_dsa_sign_msg_hash and r_dsa_verify_msg_with_hash are name-
+   * symmetric thin shells over r_crypto_key_sign / _verify. Confirm
+   * they round-trip and that tampered hashes are still rejected via
+   * the shortcut. */
+  rmpint p, q, g, y, x;
+  RCryptoKey * priv, * pub;
+  RPrng * prng;
+  ruint8 sig[64];
+  rsize sigsize = sizeof (sig);
+
+  init_dsa_mpints (&p, &q, &g, &y, &x);
+  r_assert_cmpptr ((priv = r_dsa_priv_key_new (&p, &q, &g, &y, &x)), !=, NULL);
+  r_assert_cmpptr ((pub  = r_dsa_pub_key_new_full (&p, &q, &g, &y)), !=, NULL);
+  r_assert_cmpptr ((prng = r_rand_prng_new ()), !=, NULL);
+
+  r_assert_cmpint (r_dsa_sign_msg_hash (priv, prng, R_MSG_DIGEST_TYPE_SHA1,
+        dsa_hash_a, sizeof (dsa_hash_a), sig, &sigsize), ==, R_CRYPTO_OK);
+  r_assert_cmpint (r_dsa_verify_msg_with_hash (pub, R_MSG_DIGEST_TYPE_SHA1,
+        dsa_hash_a, sizeof (dsa_hash_a), sig, sigsize), ==, R_CRYPTO_OK);
+  r_assert_cmpint (r_dsa_verify_msg_with_hash (pub, R_MSG_DIGEST_TYPE_SHA1,
+        dsa_hash_b, sizeof (dsa_hash_b), sig, sigsize),
+      ==, R_CRYPTO_VERIFY_FAILED);
+
+  r_crypto_key_unref (priv);
+  r_crypto_key_unref (pub);
+  r_prng_unref (prng);
+  clear_dsa_mpints (&p, &q, &g, &y, &x);
+}
+RTEST_END;
+
+RTEST (rdsa, sign_msg_rejects_empty, RTEST_FAST)
+{
+  /* msg == NULL / msgsize == 0 must be refused up front rather than
+   * silently signing the empty hash. */
+  rmpint p, q, g, y, x;
+  RCryptoKey * priv, * pub;
+  RPrng * prng;
+  ruint8 sig[64];
+  rsize sigsize = sizeof (sig);
+
+  init_dsa_mpints (&p, &q, &g, &y, &x);
+  r_assert_cmpptr ((priv = r_dsa_priv_key_new (&p, &q, &g, &y, &x)), !=, NULL);
+  r_assert_cmpptr ((pub  = r_dsa_pub_key_new_full (&p, &q, &g, &y)), !=, NULL);
+  r_assert_cmpptr ((prng = r_rand_prng_new ()), !=, NULL);
+
+  r_assert_cmpint (r_dsa_sign_msg (priv, prng, R_MSG_DIGEST_TYPE_SHA1,
+        NULL, 0, sig, &sigsize), ==, R_CRYPTO_INVAL);
+  r_assert_cmpint (r_dsa_verify_msg (pub, R_MSG_DIGEST_TYPE_SHA1,
+        NULL, 0, sig, sigsize), ==, R_CRYPTO_INVAL);
+
+  r_crypto_key_unref (priv);
+  r_crypto_key_unref (pub);
+  r_prng_unref (prng);
+  clear_dsa_mpints (&p, &q, &g, &y, &x);
+}
+RTEST_END;


### PR DESCRIPTION
DSA exposed only the hash-already-computed entry points via \`r_crypto_key_sign\` / \`r_crypto_key_verify\`; every caller had to drive \`RMsgDigest\` themselves to actually sign / verify a message. Add the four shape-symmetric helpers RSA has had since the PKCS#1 v1.5 work.

## Summary
- \`r_dsa_sign_msg (key, prng, mdtype, msg, msgsize, sig, sigsize)\` — drive \`RMsgDigest\` from \`mdtype\` over the message, then sign the resulting hash.
- \`r_dsa_sign_msg_hash\` — name-symmetric shortcut over \`r_crypto_key_sign\` for the pre-hashed input.
- \`r_dsa_verify_msg\` / \`r_dsa_verify_msg_with_hash\` — matching verify side, same shape.

Implementation is a small wrapper around \`r_crypto_key_sign\` / \`_verify\` plus an internal helper that runs \`RMsgDigest\` on a 64-byte stack buffer (enough for SHA-512).

## Test plan
- [x] \`meson test\` — all 1330 tests pass (+3 in \`/rdsa/sign_msg*\`); ASAN build also clean.
- [x] Tests cover \`sign_msg\` -> \`verify_msg\` round-trip plus cross-validation against \`verify_msg_with_hash\` on a manually-computed hash, the pre-hashed shortcut round-trip, tampered-hash rejection through the shortcut, and \`msg == NULL || msgsize == 0\` refusal.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)