### PR TITLE
mpint: Zero the quotient buffer in r_mpint_div before the algorithm

### DIFF
--- a/rlib/data/rmpint.c
+++ b/rlib/data/rmpint.c
@@ -1175,6 +1175,14 @@ r_mpint_div (rmpint * q, rmpint * r, const rmpint * n, const rmpint * d)
   }
   qp->dig_used = nn - tt + 1;
   qp->sign = n->sign ^ d->sign;
+  /* Zero the quotient digits before the algorithm runs. The top digit
+   * is built up by `qp->data[nn - tt]++` below and the lower digits
+   * are filled in via `*qit` writes during Step 3, but neither path
+   * initialises the buffer first. r_mpint_ensure_digits only clears
+   * digits past the prior dig_used, so any stale content in [0..nn-tt]
+   * (notably when q aliases n and inherits n's representation) would
+   * leak into the result. */
+  r_memset (qp->data, 0, (nn - tt + 1) * sizeof (rmpint_digit));
 
   /* step 2 */
   r_mpint_shl_digit (&tmp1, &y, nn - tt);

--- a/test/rmpint.c
+++ b/test/rmpint.c
@@ -570,6 +570,47 @@ RTEST (rmpint, div, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rmpint, div_aliasing, RTEST_FAST)
+{
+  /* Calling r_mpint_div with q (or r) aliased to n must still produce
+   * the same (quotient, remainder) as the unaliased call. Pre-fix the
+   * quotient buffer wasn't zeroed before the algorithm wrote into it,
+   * so when q == n the top quotient digit inherited the corresponding
+   * digit of n's representation — the symptom that surfaced inside DSA
+   * keygen as a g that didn't actually have order q. */
+  rmpint n, d, expected_q, expected_r, got;
+  r_mpint_init_str (&n, "234845527586835683495634", NULL, 10);
+  r_mpint_init_str (&d, "1248358125842835824385", NULL, 10);
+  r_mpint_init (&expected_q);
+  r_mpint_init (&expected_r);
+  r_assert (r_mpint_div (&expected_q, &expected_r, &n, &d));
+
+  /* q == n */
+  r_mpint_init_copy (&got, &n);
+  r_assert (r_mpint_div (&got, NULL, &got, &d));
+  r_assert_cmpint (r_mpint_cmp (&got, &expected_q), ==, 0);
+  r_mpint_clear (&got);
+
+  /* r == n */
+  r_mpint_init_copy (&got, &n);
+  r_assert (r_mpint_div (NULL, &got, &got, &d));
+  r_assert_cmpint (r_mpint_cmp (&got, &expected_r), ==, 0);
+  r_mpint_clear (&got);
+
+  /* Also check the documented mod shortcut, which expands to
+   * r_mpint_div (NULL, dst, dst, mod). */
+  r_mpint_init_copy (&got, &n);
+  r_assert (r_mpint_mod (&got, &got, &d));
+  r_assert_cmpint (r_mpint_cmp (&got, &expected_r), ==, 0);
+  r_mpint_clear (&got);
+
+  r_mpint_clear (&n);
+  r_mpint_clear (&d);
+  r_mpint_clear (&expected_q);
+  r_mpint_clear (&expected_r);
+}
+RTEST_END;
+
 RTEST (rmpint, shl, RTEST_FAST)
 {
   rmpint a = R_MPINT_INIT, res;


### PR DESCRIPTION
\`r_mpint_div\` writes the top quotient digit via \`qp->data[nn - tt]++\` and the lower digits via \`*qit\` assignments inside the for loop, but the buffer is never explicitly initialised first. \`r_mpint_ensure_digits\` only zeros digits past the prior \`dig_used\`, so any existing content in \`[0..nn-tt]\` leaks into the result.

The bug is most visible when \`q\` aliases \`n\`: the quotient buffer inherits \`n\`'s digits, the increment at the top stage adds to a stale value, and the function returns a plausible-looking but wrong quotient (no obvious mismatch in size or sign). Surfaced from \`r_dsa_gen_generator\` calling \`r_mpint_div (&e, NULL, &e, q)\` to compute \`e = (p - 1) / q\` in place; the resulting \`g = h^e mod p\` didn't have order \`q\`, only caught by a \`g^q == 1\` sanity check downstream.

## Summary
- Add a single \`r_memset\` of the quotient buffer right after \`r_mpint_ensure_digits\`, so the algorithm starts from a clean slate regardless of how the caller prepared \`q\`.

## Test plan
- [x] \`meson test\` — all 1333 tests pass; ASAN build also clean.
- [x] New \`/rmpint/div_aliasing\` regression test covers \`q == n\`, \`r == n\`, and the \`r_mpint_mod (&got, &got, &d)\` shortcut that expands to \`r_mpint_div\` with the same aliasing. Verified the test fails (wrong quotient on \`q == n\`) when the fix is reverted via \`git restore --source=HEAD~1\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)