### PR TITLE
rrsa: Tighten private-key secret hygiene

### DIFF
--- a/rlib/crypto/rrsa.c
+++ b/rlib/crypto/rrsa.c
@@ -273,12 +273,12 @@ r_rsa_priv_key_new (const rmpint * n, const rmpint * e, const rmpint * d)
     if ((ret = r_mem_new0 (RRsaPrivKey)) != NULL) {
       r_mpint_init_copy (&ret->pub.n, n);
       r_mpint_init_copy (&ret->pub.e, e);
-      r_mpint_init_copy (&ret->d, d);
-      r_mpint_init (&ret->p);
-      r_mpint_init (&ret->q);
-      r_mpint_init (&ret->dp);
-      r_mpint_init (&ret->dq);
-      r_mpint_init (&ret->qp);
+      r_mpint_init_copy_secure (&ret->d, d);
+      r_mpint_init_secure (&ret->p);
+      r_mpint_init_secure (&ret->q);
+      r_mpint_init_secure (&ret->dp);
+      r_mpint_init_secure (&ret->dq);
+      r_mpint_init_secure (&ret->qp);
       ret->pub.padding = R_RSA_PADDING_PKCS1_V15;
       r_rsa_priv_key_init (&ret->pub.key, r_mpint_bits_used (&ret->pub.n));
     }
@@ -301,17 +301,17 @@ r_rsa_priv_key_new_full (rint32 ver, const rmpint * n, const rmpint * e,
       ret->ver = ver;
       r_mpint_init_copy (&ret->pub.n, n);
       r_mpint_init_copy (&ret->pub.e, e);
-      r_mpint_init_copy (&ret->d, d);
-      if (p != NULL)  r_mpint_init_copy (&ret->p, p);
-      else            r_mpint_init (&ret->p);
-      if (q != NULL)  r_mpint_init_copy (&ret->q, q);
-      else            r_mpint_init (&ret->q);
-      if (dp != NULL) r_mpint_init_copy (&ret->dp, dp);
-      else            r_mpint_init (&ret->dp);
-      if (dq != NULL) r_mpint_init_copy (&ret->dq, dq);
-      else            r_mpint_init (&ret->dq);
-      if (qp != NULL) r_mpint_init_copy (&ret->qp, qp);
-      else            r_mpint_init (&ret->qp);
+      r_mpint_init_copy_secure (&ret->d, d);
+      if (p != NULL)  r_mpint_init_copy_secure (&ret->p, p);
+      else            r_mpint_init_secure (&ret->p);
+      if (q != NULL)  r_mpint_init_copy_secure (&ret->q, q);
+      else            r_mpint_init_secure (&ret->q);
+      if (dp != NULL) r_mpint_init_copy_secure (&ret->dp, dp);
+      else            r_mpint_init_secure (&ret->dp);
+      if (dq != NULL) r_mpint_init_copy_secure (&ret->dq, dq);
+      else            r_mpint_init_secure (&ret->dq);
+      if (qp != NULL) r_mpint_init_copy_secure (&ret->qp, qp);
+      else            r_mpint_init_secure (&ret->qp);
       ret->pub.padding = R_RSA_PADDING_PKCS1_V15;
       r_rsa_priv_key_init (&ret->pub.key, r_mpint_bits_used (&ret->pub.n));
     }
@@ -332,12 +332,12 @@ r_rsa_priv_key_new_binary (rconstpointer n, rsize nsize,
     if ((ret = r_mem_new0 (RRsaPrivKey)) != NULL) {
       r_mpint_init_binary (&ret->pub.n, n, nsize);
       r_mpint_init_binary (&ret->pub.e, e, esize);
-      r_mpint_init_binary (&ret->d, d, dsize);
-      r_mpint_init (&ret->p);
-      r_mpint_init (&ret->q);
-      r_mpint_init (&ret->dp);
-      r_mpint_init (&ret->dq);
-      r_mpint_init (&ret->qp);
+      r_mpint_init_binary_secure (&ret->d, d, dsize);
+      r_mpint_init_secure (&ret->p);
+      r_mpint_init_secure (&ret->q);
+      r_mpint_init_secure (&ret->dp);
+      r_mpint_init_secure (&ret->dq);
+      r_mpint_init_secure (&ret->qp);
       ret->pub.padding = R_RSA_PADDING_PKCS1_V15;
       r_rsa_priv_key_init (&ret->pub.key, r_mpint_bits_used (&ret->pub.n));
     }
@@ -357,12 +357,12 @@ r_rsa_priv_key_new_from_asn1 (RAsn1BinDecoder * dec, RAsn1BinTLV * tlv)
 
     r_mpint_init (&ret->pub.n);
     r_mpint_init (&ret->pub.e);
-    r_mpint_init (&ret->d);
-    r_mpint_init (&ret->p);
-    r_mpint_init (&ret->q);
-    r_mpint_init (&ret->dp);
-    r_mpint_init (&ret->dq);
-    r_mpint_init (&ret->qp);
+    r_mpint_init_secure (&ret->d);
+    r_mpint_init_secure (&ret->p);
+    r_mpint_init_secure (&ret->q);
+    r_mpint_init_secure (&ret->dp);
+    r_mpint_init_secure (&ret->dq);
+    r_mpint_init_secure (&ret->qp);
 
     if (r_asn1_bin_decoder_into (dec, tlv) != R_ASN1_DECODER_OK ||
         r_asn1_bin_tlv_parse_integer_i32 (tlv, &ret->ver) != R_ASN1_DECODER_OK ||
@@ -410,13 +410,16 @@ r_rsa_priv_key_new_gen (rsize bits, ruint64 e, RPrng * prng)
     r_mpint_init (&ret->pub.e);
     r_mpint_set_u64 (&ret->pub.e, e);
     r_mpint_init (&ret->pub.n);
-    r_mpint_init (&ret->p);
-    r_mpint_init (&ret->q);
+    r_mpint_init_secure (&ret->p);
+    r_mpint_init_secure (&ret->q);
 
-    r_mpint_init (&g);
-    r_mpint_init (&p_1);
-    r_mpint_init (&q_1);
-    r_mpint_init (&p_1mulq_1);
+    /* g, p_1, q_1, p_1mulq_1 are derived from the primes p / q and so
+     * are themselves secret. Mark them so the data buffers don't end
+     * up in freed heap after this function returns. */
+    r_mpint_init_secure (&g);
+    r_mpint_init_secure (&p_1);
+    r_mpint_init_secure (&q_1);
+    r_mpint_init_secure (&p_1mulq_1);
 
     if (prng != NULL)
       r_prng_ref (prng);
@@ -453,10 +456,10 @@ r_rsa_priv_key_new_gen (rsize bits, ruint64 e, RPrng * prng)
     } while (!(pq_gcd = (r_mpint_cmp_i32 (&g, 1) == 0)));
 
     if (pq_gcd) {
-      r_mpint_init (&ret->d);
-      r_mpint_init (&ret->dp);
-      r_mpint_init (&ret->dq);
-      r_mpint_init (&ret->qp);
+      r_mpint_init_secure (&ret->d);
+      r_mpint_init_secure (&ret->dp);
+      r_mpint_init_secure (&ret->dq);
+      r_mpint_init_secure (&ret->qp);
 
       r_mpint_invmod (&ret->qp, &ret->q, &ret->p);        /* qp = q^-1 mod p */
       r_mpint_invmod (&ret->d, &ret->pub.e, &p_1mulq_1);  /* d  = e^-1 mod ((p - 1) * (q - 1)) */

--- a/rlib/crypto/rrsa.c
+++ b/rlib/crypto/rrsa.c
@@ -711,10 +711,14 @@ r_rsa_raw_decrypt_internal (const RRsaPrivKey * key, RPrng * prng,
     own_prng = TRUE;
   }
 
+  /* m ends up holding the plaintext; r / r_inv / r_e are the blinding
+   * factor and its variants. None of those should linger in freed
+   * heap after this function returns. */
   r_mpint_init_size (&m, r_mpint_digits_used (&key->pub.n));
-  r_mpint_init (&r);
-  r_mpint_init (&r_inv);
-  r_mpint_init (&r_e);
+  r_mpint_set_secure_clear (&m);
+  r_mpint_init_secure (&r);
+  r_mpint_init_secure (&r_inv);
+  r_mpint_init_secure (&r_e);
   rbuf = r_alloca (size);
 
   /* RSA blinding: instead of computing m = c^d mod n directly — whose
@@ -741,6 +745,9 @@ r_rsa_raw_decrypt_internal (const RRsaPrivKey * key, RPrng * prng,
 done:
   ret = ok ? R_CRYPTO_OK : R_CRYPTO_DECRYPT_FAILED;
 
+  /* rbuf held raw PRNG output used to seed the blinding factor; the
+   * blinding mpint itself is wiped via secure-clear above. */
+  r_memclear_secure (rbuf, size);
   r_mpint_clear (&c);
   r_mpint_clear (&m);
   r_mpint_clear (&r);
@@ -811,6 +818,7 @@ r_rsa_pkcs1v1_5_decrypt (const RCryptoKey * key,
 {
   RCryptoResult ret;
   ruint8 * buffer;
+  rboolean scratch;
 
   if (R_UNLIKELY (key == NULL)) return R_CRYPTO_INVAL;
   if (R_UNLIKELY (key->algo->algo != R_CRYPTO_ALGO_RSA)) return R_CRYPTO_WRONG_TYPE;
@@ -821,28 +829,44 @@ r_rsa_pkcs1v1_5_decrypt (const RCryptoKey * key,
   if (size != r_mpint_digits_used (&((const RRsaPrivKey*)key)->pub.n) * sizeof (rmpint_digit))
     return R_CRYPTO_WRONG_SIZE;
 
-  buffer = (*outsize >= size) ? out : r_alloca (size);
+  /* When out is big enough we decrypt straight into it; otherwise a
+   * scratch alloca holds the padded plaintext until we strip the
+   * PS / 0x00 separator and copy the message out. The scratch case
+   * gets a secure wipe at the end - it's a full RSA plaintext (TLS
+   * premaster secrets in particular) and shouldn't linger on the
+   * popped stack frame. */
+  scratch = (*outsize < size);
+  buffer = scratch ? r_alloca (size) : out;
 
   if ((ret = r_rsa_raw_decrypt_internal ((const RRsaPrivKey*)key, NULL, data, buffer, size)) == R_CRYPTO_OK) {
     ruint8 * ptr;
 
-    if (size < 11 || buffer[0] != 0x00 || buffer[1] != R_RSA_EME_PKCS1)
-      return R_CRYPTO_INVALID_PADDING;
+    if (size < 11 || buffer[0] != 0x00 || buffer[1] != R_RSA_EME_PKCS1) {
+      ret = R_CRYPTO_INVALID_PADDING;
+      goto out_wipe;
+    }
 
     ptr = buffer + 2;
     while (ptr < buffer + size && *ptr != 0) ptr++;
 
-    if (ptr - buffer < 10 || ptr >= buffer + size)
-      return R_CRYPTO_INVALID_PADDING;
+    if (ptr - buffer < 10 || ptr >= buffer + size) {
+      ret = R_CRYPTO_INVALID_PADDING;
+      goto out_wipe;
+    }
     ptr++;
 
-    if (*outsize < size - (ptr - buffer))
-      return R_CRYPTO_BUFFER_TOO_SMALL;
+    if (*outsize < size - (ptr - buffer)) {
+      ret = R_CRYPTO_BUFFER_TOO_SMALL;
+      goto out_wipe;
+    }
 
     *outsize = size - (ptr - buffer);
     r_memmove (out, ptr, *outsize);
   }
 
+out_wipe:
+  if (scratch)
+    r_memclear_secure (buffer, size);
   return ret;
 }
 

--- a/rlib/crypto/rrsa.c
+++ b/rlib/crypto/rrsa.c
@@ -421,10 +421,20 @@ r_rsa_priv_key_new_gen (rsize bits, ruint64 e, RPrng * prng)
     r_mpint_init_secure (&q_1);
     r_mpint_init_secure (&p_1mulq_1);
 
-    if (prng != NULL)
+    if (prng != NULL) {
       r_prng_ref (prng);
-    else
-      prng = r_rand_prng_new ();
+    } else if ((prng = r_rand_prng_new ()) == NULL) {
+      /* No usable PRNG and the caller didn't supply one. Bail out
+       * cleanly - the rest of the gen path relies on prng being
+       * non-NULL, and proceeding with a NULL would just crash
+       * inside r_mpint_gen_prime. */
+      r_mpint_clear (&p_1mulq_1);
+      r_mpint_clear (&q_1);
+      r_mpint_clear (&p_1);
+      r_mpint_clear (&g);
+      r_crypto_key_unref ((RCryptoKey *)ret);
+      return NULL;
+    }
 
     /* Find two primes p and q where;
      * GCD (e, (p - 1) * (q - 1)) == 1

--- a/test/rrsa.c
+++ b/test/rrsa.c
@@ -108,6 +108,39 @@ RTEST (rrsa, decrypt_pkcs, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rrsa, pkcs1v1_5_decrypt_buffer_too_small, RTEST_FAST)
+{
+  rmpint n, e, d;
+  RCryptoKey * key;
+  ruint8 dst[1];
+  rsize size = 0;
+
+  r_mpint_init_str (&n,
+      "0x00aa18aba43b50deef38598faf87d2ab634e4571c130a9bca7b878267414faab8b47"
+      "1bd8965f5c9fc3818485eaf529c26246f3055064a8de19c8c338be5496cbaeb059dc0b"
+      "358143b44a35449eb264113121a455bd7fde3fac919e94b56fb9bb4f651cdb23ead439"
+      "d6cd523eb08191e75b35fd13a7419b3090f24787bd4f4e1967", NULL, 16);
+  r_mpint_init_str (&d,
+      "0x1628e4a39ebea86c8df0cd11572691017cfefb14ea1c12e1dedc7856032dad0f9612"
+      "00a38684f0a36dca30102e2464989d19a805933794c7d329ebc890089d3c4c6f602766"
+      "e5d62add74e82e490bbf92f6a482153853031be2844a700557b97673e727cd1316d3e6"
+      "fa7fc991d4227366ec552cbe90d367ef2e2e79fe66d26311", NULL, 16);
+  r_mpint_init_str (&e, "65537", NULL, 10);
+
+  r_assert_cmpptr ((key = r_rsa_priv_key_new (&n, &e, &d)), !=, NULL);
+  /* outsize=0 forces the scratch-buffer path; padding strips fine but
+   * the output buffer can't hold the plaintext, so the function must
+   * still reach the out_wipe label and return BUFFER_TOO_SMALL. */
+  r_assert_cmpuint (r_rsa_pkcs1v1_5_decrypt (key, rsa_encrypted, sizeof (rsa_encrypted),
+        dst, &size), ==, R_CRYPTO_BUFFER_TOO_SMALL);
+
+  r_mpint_clear (&n);
+  r_mpint_clear (&d);
+  r_mpint_clear (&e);
+  r_crypto_key_unref (key);
+}
+RTEST_END;
+
 RTEST (rrsa, priv_key_new_marks_d_secure, RTEST_FAST)
 {
   rmpint n, e, d, out;

--- a/test/rrsa.c
+++ b/test/rrsa.c
@@ -108,6 +108,36 @@ RTEST (rrsa, decrypt_pkcs, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rrsa, priv_key_new_marks_d_secure, RTEST_FAST)
+{
+  rmpint n, e, d, out;
+  RCryptoKey * key;
+
+  r_mpint_init_str (&n,
+      "0x00aa18aba43b50deef38598faf87d2ab634e4571c130a9bca7b878267414faab8b47"
+      "1bd8965f5c9fc3818485eaf529c26246f3055064a8de19c8c338be5496cbaeb059dc0b"
+      "358143b44a35449eb264113121a455bd7fde3fac919e94b56fb9bb4f651cdb23ead439"
+      "d6cd523eb08191e75b35fd13a7419b3090f24787bd4f4e1967", NULL, 16);
+  r_mpint_init_str (&d,
+      "0x1628e4a39ebea86c8df0cd11572691017cfefb14ea1c12e1dedc7856032dad0f9612"
+      "00a38684f0a36dca30102e2464989d19a805933794c7d329ebc890089d3c4c6f602766"
+      "e5d62add74e82e490bbf92f6a482153853031be2844a700557b97673e727cd1316d3e6"
+      "fa7fc991d4227366ec552cbe90d367ef2e2e79fe66d26311", NULL, 16);
+  r_mpint_init_str (&e, "65537", NULL, 10);
+  r_mpint_init (&out);
+
+  r_assert_cmpptr ((key = r_rsa_priv_key_new (&n, &e, &d)), !=, NULL);
+  r_assert (r_rsa_priv_key_get_d (key, &out));
+  r_assert_cmpuint (out.flags & R_MPINT_FLAG_SECURE_CLEAR, !=, 0);
+
+  r_mpint_clear (&out);
+  r_mpint_clear (&n);
+  r_mpint_clear (&d);
+  r_mpint_clear (&e);
+  r_crypto_key_unref (key);
+}
+RTEST_END;
+
 RTEST (rrsa, encrypt_decrypt_1024, RTEST_FAST)
 {
   rchar before[] = "foobar\n";
@@ -456,6 +486,18 @@ RTEST (rrsa, gen_key, RTEST_SLOW)
     r_assert (r_rsa_priv_key_get_dp (key, &dp));
     r_assert (r_rsa_priv_key_get_dq (key, &dq));
     r_assert (r_rsa_priv_key_get_qp (key, &qp));
+
+    /* Sticky-propagation: secret components from the gen'd key carry
+     * the secure-clear flag, so r_mpint_set into a plain caller mpint
+     * inherits it. Public components must not. */
+    r_assert_cmpuint (n.flags & R_MPINT_FLAG_SECURE_CLEAR, ==, 0);
+    r_assert_cmpuint (e.flags & R_MPINT_FLAG_SECURE_CLEAR, ==, 0);
+    r_assert_cmpuint (d.flags  & R_MPINT_FLAG_SECURE_CLEAR, !=, 0);
+    r_assert_cmpuint (p.flags  & R_MPINT_FLAG_SECURE_CLEAR, !=, 0);
+    r_assert_cmpuint (q.flags  & R_MPINT_FLAG_SECURE_CLEAR, !=, 0);
+    r_assert_cmpuint (dp.flags & R_MPINT_FLAG_SECURE_CLEAR, !=, 0);
+    r_assert_cmpuint (dq.flags & R_MPINT_FLAG_SECURE_CLEAR, !=, 0);
+    r_assert_cmpuint (qp.flags & R_MPINT_FLAG_SECURE_CLEAR, !=, 0);
 
     r_assert_cmpuint (r_mpint_isprime (&q), >=, R_MPINT_CERTAIN_PRIME);
     r_assert_cmpuint (r_mpint_isprime (&p), >=, R_MPINT_CERTAIN_PRIME);


### PR DESCRIPTION
## Summary

Three RSA-side hygiene fixes uncovered by the crypto audit, each with regression coverage in the same commit:

- **Mark private-key mpints as secure-clear** (closes #111) — every constructor (`new`, `new_full`, `new_binary`, `new_from_asn1`, `new_gen`) routes `d/p/q/dp/dq/qp` through `r_mpint_init*_secure` so the buffers are wiped on release. `new_gen` also wipes the secret-derived intermediates `g`, `p-1`, `q-1`, `(p-1)(q-1)`. Tested via the sticky-flag propagation through `r_rsa_priv_key_get_*`.
- **Wipe blinding scratch and decrypted plaintext on every exit** (closes #110) — `r_rsa_raw_decrypt_internal` marks `r`/`r_inv`/`r_e`/`m` secure and zeroes the raw output buffer at `done:`. `r_rsa_pkcs1v1_5_decrypt` routes all error returns through a single `out_wipe:` label so the scratch alloca cannot leak a TLS premaster on the popped stack. Regression-tested by forcing the buffer-too-small path.
- **NULL-check `r_rand_prng_new` in `r_rsa_priv_key_new_gen`** (closes #112) — the previous code would deref a NULL PRNG when allocation failed. Now unwinds cleanly.

## Test plan

- [x] `build-debug-test/test/rlibtest -f '/rrsa/*'` — 79 pass (was 77; two new regressions added)
- [x] `build-debug-test/test/rlibtest --heavy -f '/rrsa/gen_key'` — passes with the new secure-flag assertions
- [x] `build-asan/test/rlibtest` — full suite green
- [x] Each commit builds and tests pass in isolation (bisect-safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)