### PR TITLE
crypto: Wipe secret-bearing state before release across raes/rhmac/rmsgdigest/rpem

### DIFF
--- a/include/rlib/rmem.h
+++ b/include/rlib/rmem.h
@@ -80,6 +80,13 @@ typedef struct {
 } RMemVTable;
 
 R_API void r_mem_set_vtable (RMemVTable * vtable);
+/* Copy the current vtable into *out. Pairs with r_mem_set_vtable so a
+ * caller (typically a test) can save the active vtable, swap in its
+ * own, then restore exactly the pointers it saw. Restoring via
+ * r_mem_set_vtable with locally-typed { malloc, calloc, realloc, free }
+ * is not safe across DLL boundaries on Windows - the test binary's
+ * import thunks resolve to different addresses than the rlib DLL's. */
+R_API void r_mem_get_vtable (RMemVTable * out);
 R_API rboolean r_mem_using_system_default (void);
 
 

--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -20,6 +20,7 @@
 #include <rlib/crypto/raes.h>
 #include <rlib/crypto/raes-data.inc>
 
+#include <rlib/rmem.h>
 #include <rlib/rstr.h>
 
 #define R_AES_MAX_KEY_BYTES   32
@@ -129,6 +130,9 @@ const RCryptoCipherInfo g__r_crypto_cipher_aes_256_ofb = { "AES-256-OFB",
 static void
 r_cipher_aes_free (RAesCipher * cipher)
 {
+  /* key + round-key schedules are key-equivalent; wipe before
+   * release so heap reuse, swap, or core dumps don't expose them. */
+  r_memclear_secure (cipher, sizeof (*cipher));
   r_free (cipher);
 }
 
@@ -611,6 +615,7 @@ r_cipher_aes_cbc_decrypt (const RCryptoCipher * cipher,
     r_memcpy (iv, scratch, R_AES_BLOCK_BYTES);
   }
 
+  r_memclear_secure (scratch, sizeof (scratch));
   return R_CRYPTO_CIPHER_OK;
 }
 
@@ -651,6 +656,7 @@ r_cipher_aes_ctr_encrypt (const RCryptoCipher * cipher,
     }
   }
 
+  r_memclear_secure (scratch, sizeof (scratch));
   return R_CRYPTO_CIPHER_OK;
 }
 
@@ -686,6 +692,7 @@ r_cipher_aes_cfb_encrypt (const RCryptoCipher * cipher,
       dst[i] = scratch[i] ^ ptr[i];
   }
 
+  r_memclear_secure (scratch, sizeof (scratch));
   return R_CRYPTO_CIPHER_OK;
 }
 
@@ -723,6 +730,8 @@ r_cipher_aes_cfb_decrypt (const RCryptoCipher * cipher,
       dst[i] = scratch[i] ^ ptr[i];
   }
 
+  r_memclear_secure (scratch, sizeof (scratch));
+  r_memclear_secure (ctsave, sizeof (ctsave));
   return R_CRYPTO_CIPHER_OK;
 }
 

--- a/rlib/crypto/rhmac.c
+++ b/rlib/crypto/rhmac.c
@@ -68,7 +68,11 @@ r_hmac_free (RHmac * hmac)
   if (hmac != NULL) {
     r_msg_digest_free (hmac->inner);
     r_msg_digest_free (hmac->outer);
-    r_free (hmac->keyblock);
+    if (hmac->keyblock != NULL) {
+      /* keyblock holds the post-hash or zero-padded HMAC key. */
+      r_memclear_secure (hmac->keyblock, hmac->blocksize);
+      r_free (hmac->keyblock);
+    }
     r_free (hmac);
   }
 }
@@ -96,6 +100,10 @@ r_hmac_reset (RHmac * hmac)
   for (i = 0; i < hmac->blocksize / sizeof (ruint32); i++)
     block[i] = hmac->keyblock[i] ^ 0x5c5c5c5c;
   r_msg_digest_update (hmac->outer, block, hmac->blocksize);
+
+  /* block carried the keyed ipad/opad expansions; wipe before the
+   * stack frame is popped. */
+  r_memclear_secure (block, hmac->blocksize);
 }
 
 

--- a/rlib/crypto/rpem.c
+++ b/rlib/crypto/rpem.c
@@ -606,9 +606,15 @@ r_pem_decrypt_legacy (RPemBlock * block, const ruint8 * passphrase, rsize ppsize
 RCryptoKey *
 r_pem_block_get_key (RPemBlock * block, const rchar * passphrase, rsize ppsize)
 {
-  RCryptoKey * ret;
+  RCryptoKey * ret = NULL;
   RAsn1BinDecoder * dec;
   RAsn1BinTLV tlv = R_ASN1_BIN_TLV_INIT;
+  /* When non-NULL, this buffer holds the DER-encoded private key
+   * plaintext from r_pem_decrypt_legacy and must be wiped on every
+   * return path (the ASN.1 decoder uses a borrowed reference here
+   * via the const-data variant). */
+  ruint8 * decrypted = NULL;
+  rsize decrypted_size = 0;
 
   if (R_UNLIKELY (block == NULL))
     return NULL;
@@ -625,22 +631,23 @@ r_pem_block_get_key (RPemBlock * block, const rchar * passphrase, rsize ppsize)
       return NULL;
     if (r_pem_decrypt_legacy (block, (const ruint8 *) passphrase, ppsize,
             decoded, decoded_size, &plain_size) == NULL) {
+      /* Wrong-passphrase residue: failed AES-CBC output, not the
+       * plaintext, but still wipe before release. */
+      r_memclear_secure (decoded, decoded_size);
       r_free (decoded);
       return NULL;
     }
-    if ((dec = r_asn1_bin_decoder_new_with_data (R_ASN1_BER, decoded,
-            plain_size)) == NULL) {
-      r_free (decoded);
-      return NULL;
-    }
+    decrypted = decoded;
+    decrypted_size = decoded_size;
+    if ((dec = r_asn1_bin_decoder_new (R_ASN1_BER, decoded, plain_size)) == NULL)
+      goto out_wipe;
   } else if ((dec = r_pem_block_get_asn1_decoder (block)) == NULL) {
     return NULL;
   }
 
-  if (r_asn1_bin_decoder_next (dec, &tlv) != R_ASN1_DECODER_OK) {
-    r_asn1_bin_decoder_unref (dec);
-    return NULL;
-  }
+  if (r_asn1_bin_decoder_next (dec, &tlv) != R_ASN1_DECODER_OK)
+    goto out_unref;
+
   switch (r_pem_block_get_type (block)) {
     case R_PEM_TYPE_PUBLIC_KEY:
       ret = r_crypto_key_from_asn1_public_key (dec, &tlv);
@@ -656,9 +663,16 @@ r_pem_block_get_key (RPemBlock * block, const rchar * passphrase, rsize ppsize)
       break;
     /* TODO: PKCS#8 EncryptedPrivateKeyInfo */
     default:
-      ret = NULL;
+      break;
   }
+
+out_unref:
   r_asn1_bin_decoder_unref (dec);
+out_wipe:
+  if (decrypted != NULL) {
+    r_memclear_secure (decrypted, decrypted_size);
+    r_free (decrypted);
+  }
 
   return ret;
 }

--- a/rlib/rmem.c
+++ b/rlib/rmem.c
@@ -73,6 +73,13 @@ r_realloc (rpointer ptr, rsize size)
 }
 
 void
+r_mem_get_vtable (RMemVTable * out)
+{
+  if (R_UNLIKELY (out == NULL)) return;
+  *out = r_memvtable;
+}
+
+void
 r_mem_set_vtable (RMemVTable * vtable)
 {
   /* Reject vtables that would set any callback to NULL: every allocation

--- a/rlib/rmsgdigest.c
+++ b/rlib/rmsgdigest.c
@@ -138,7 +138,16 @@ r_msg_digest_new (RMsgDigestType type)
 void
 r_msg_digest_free (RMsgDigest * md)
 {
-  r_free (md);
+  if (md != NULL) {
+    /* The trailing per-algorithm state (RMd5 / RSha* compression
+     * variables and partial-block buffer) is allocated in one block
+     * with the header - md->mdsize covers the lot. For HMAC and the
+     * legacy-PEM KDF the state mid-stream is key-dependent, so we
+     * wipe unconditionally rather than trying to track which callers
+     * fed secret data. */
+    r_memclear_secure (md, md->mdsize);
+    r_free (md);
+  }
 }
 
 rsize
@@ -253,11 +262,16 @@ r_msg_digest_get_data (const RMsgDigest * md, ruint8 * data, rsize size, rsize *
 {
   if (!md->is_final) {
     RMsgDigest * h = (RMsgDigest *) r_alloca (md->mdsize);
+    rboolean ret;
 
     r_memcpy (h, md, md->mdsize);
     r_msg_digest_finish (h);
 
-    return md->get (h, data, size, out);
+    ret = md->get (h, data, size, out);
+    /* h cloned the compression-variable state to finalise without
+     * touching md; wipe before the stack frame is popped. */
+    r_memclear_secure (h, md->mdsize);
+    return ret;
   }
 
   return md->get (md, data, size, out);

--- a/test/raes.c
+++ b/test/raes.c
@@ -1,5 +1,7 @@
 #include <rlib/rcrypto.h>
 
+#include "wipewitness.h"
+
 RTEST (raes, new_args, RTEST_FAST)
 {
   ruint8 key[32] = { 0 };
@@ -387,6 +389,28 @@ RTEST_LOOP (raes, ofb, RTEST_FAST, 0, R_N_ELEMENTS (OFB_test_data))
   r_free (plaintxt);
   r_free (ciphertxt);
   r_free (out);
+}
+RTEST_END;
+
+RTEST (raes, free_wipes_cipher_state, RTEST_FAST)
+{
+  /* Sentinel-tagged AES key: if r_cipher_aes_free fails to wipe the
+   * RAesCipher (key + round-key schedules) before r_free, the bytes
+   * survive in the freed-buffer pile the allocator hook captured. */
+  static const ruint8 sentinel_key[32] = {
+    0xCA, 0xFE, 0xBA, 0xBE, 0xDE, 0xAD, 0xBE, 0xEF,
+    0xFE, 0xED, 0xFA, 0xCE, 0xBA, 0xAD, 0xF0, 0x0D,
+    0x13, 0x37, 0xC0, 0xDE, 0xB1, 0x05, 0xF0, 0x0D,
+    0x8B, 0xAD, 0xF0, 0x0D, 0x0F, 0xF1, 0xCE, 0x42
+  };
+  RCryptoCipher * cipher;
+
+  r_wipe_witness_install ();
+  r_assert_cmpptr ((cipher = r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_CBC, 256, sentinel_key)), !=, NULL);
+  r_crypto_cipher_unref (cipher);
+  r_wipe_witness_uninstall ();
+
+  r_assert (!r_wipe_witness_freed_contains (sentinel_key, sizeof (sentinel_key)));
 }
 RTEST_END;
 

--- a/test/rcryptohmac.c
+++ b/test/rcryptohmac.c
@@ -1,5 +1,7 @@
 #include <rlib/rcrypto.h>
 
+#include "wipewitness.h"
+
 RTEST (rcryptomac, hmac_md5, R_TEST_TYPE_FAST)
 {
   RHmac * hmac;
@@ -72,6 +74,30 @@ RTEST (rcryptomac, hmac_unsupported_type, R_TEST_TYPE_FAST)
   r_assert_cmpptr ((hmac = r_hmac_new (R_MSG_DIGEST_TYPE_SHA384, "k", 1)),
       !=, NULL);
   r_hmac_free (hmac);
+}
+RTEST_END;
+
+RTEST (rcryptomac, free_wipes_keyblock, R_TEST_TYPE_FAST)
+{
+  /* Sentinel-tagged HMAC key: shorter than the SHA-256 block size
+   * so r_hmac_new takes the zero-padding branch into keyblock, then
+   * r_hmac_reset folds it into the inner/outer pads. Both code
+   * paths must wipe before release; otherwise the sentinel survives
+   * in the freed-buffer pile. */
+  static const ruint8 sentinel_key[24] = {
+    0xCA, 0xFE, 0xBA, 0xBE, 0xDE, 0xAD, 0xBE, 0xEF,
+    0xFE, 0xED, 0xFA, 0xCE, 0xBA, 0xAD, 0xF0, 0x0D,
+    0x13, 0x37, 0xC0, 0xDE, 0xB1, 0x05, 0xF0, 0x0D
+  };
+  RHmac * hmac;
+
+  r_wipe_witness_install ();
+  r_assert_cmpptr ((hmac = r_hmac_new (R_MSG_DIGEST_TYPE_SHA256, sentinel_key,
+          sizeof (sentinel_key))), !=, NULL);
+  r_hmac_free (hmac);
+  r_wipe_witness_uninstall ();
+
+  r_assert (!r_wipe_witness_freed_contains (sentinel_key, sizeof (sentinel_key)));
 }
 RTEST_END;
 

--- a/test/rcryptopem.c
+++ b/test/rcryptopem.c
@@ -1,5 +1,7 @@
 #include <rlib/rcrypto.h>
 
+#include "wipewitness.h"
+
 static const rchar pem_invalid[] =
   "---BEGIN PRIVATE KEY-----\n"
   "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0\n"
@@ -731,6 +733,52 @@ RTEST (rcryptopem, legacy_encrypted_rsa_aes256, RTEST_FAST)
 {
   verify_legacy_pem (pem_legacy_enc_aes256, sizeof (pem_legacy_enc_aes256),
       "test123");
+}
+RTEST_END;
+
+RTEST (rcryptopem, legacy_decrypted_plaintext_wiped, RTEST_FAST)
+{
+  /* Decrypt a legacy-encrypted PEM and verify that the DER-encoded
+   * plaintext (the buffer r_pem_decrypt_legacy returned) does not
+   * survive in any freed allocation. The modulus bytes are a
+   * convenient long-enough needle that lives inside the decrypted
+   * DER but not in any non-secret intermediate. */
+  RPemParser * parser;
+  RPemBlock * block;
+  RCryptoKey * key;
+  rmpint n;
+  ruint8 modulus[128];
+
+  /* Pull the modulus bytes from the unencrypted reference key first,
+   * outside the hook so the allocation noise doesn't end up in the
+   * captured pile. */
+  r_assert_cmpptr (
+      (parser = r_pem_parser_new (pem_legacy_unenc, sizeof (pem_legacy_unenc))),
+      !=, NULL);
+  r_assert_cmpptr ((block = r_pem_parser_next_block (parser)), !=, NULL);
+  r_assert_cmpptr ((key = r_pem_block_get_key (block, NULL, 0)), !=, NULL);
+  r_mpint_init (&n);
+  r_assert (r_rsa_pub_key_get_n (key, &n));
+  r_assert (r_mpint_to_binary_with_size (&n, modulus, sizeof (modulus)));
+  r_mpint_clear (&n);
+  r_crypto_key_unref (key);
+  r_pem_block_unref (block);
+  r_pem_parser_unref (parser);
+
+  r_wipe_witness_install ();
+  r_assert_cmpptr ((parser = r_pem_parser_new (pem_legacy_enc_aes128,
+          sizeof (pem_legacy_enc_aes128))), !=, NULL);
+  r_assert_cmpptr ((block = r_pem_parser_next_block (parser)), !=, NULL);
+  r_assert_cmpptr ((key = r_pem_block_get_key (block, "test123", 7)), !=, NULL);
+  r_crypto_key_unref (key);
+  r_pem_block_unref (block);
+  r_pem_parser_unref (parser);
+  r_wipe_witness_uninstall ();
+
+  /* A 32-byte run of the modulus is uniquely identifying and gives a
+   * clean signal: present in the DER plaintext, absent from every
+   * non-secret intermediate that flowed through the allocator. */
+  r_assert (!r_wipe_witness_freed_contains (modulus + 16, 32));
 }
 RTEST_END;
 

--- a/test/rmem.c
+++ b/test/rmem.c
@@ -26,6 +26,28 @@ RTEST (rmem, set_vtable_validation, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rmem, get_set_vtable_roundtrip, RTEST_FAST)
+{
+  /* r_mem_get_vtable returns the exact pointers the rlib TU sees, so
+   * save + restore through it leaves r_mem_using_system_default
+   * intact even across DLL boundaries where locally-typed
+   * { malloc, calloc, realloc, free } resolve to different thunks. */
+  RMemVTable saved;
+  RMemVTable hook = { malloc, calloc, realloc, free };
+
+  r_assert (r_mem_using_system_default ());
+  r_mem_get_vtable (&saved);
+
+  r_mem_set_vtable (&hook);
+  /* hook is well-formed so the install takes effect; whether the
+   * resulting vtable equals the system default depends on DLL-thunk
+   * identity, so don't assert on it here. */
+
+  r_mem_set_vtable (&saved);
+  r_assert (r_mem_using_system_default ());
+}
+RTEST_END;
+
 RTEST (rmem, cmp, RTEST_FAST)
 {
   ruint8 foo[]    = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };

--- a/test/rmsgdigest.c
+++ b/test/rmsgdigest.c
@@ -1,5 +1,7 @@
 #include <rlib/rlib.h>
 
+#include "wipewitness.h"
+
 RTEST (rmsgdigest, type_string, R_TEST_TYPE_FAST)
 {
   r_assert_cmpstr (r_msg_digest_type_string (R_MSG_DIGEST_TYPE_MD5), ==, "md5");
@@ -280,6 +282,30 @@ RTEST (rmsgdigest, sha512_fill_block, R_TEST_TYPE_FAST)
       "27e08ffc73ae538d581b65a2eb706459817ff51172742a9e1cf832b0727cc66");
   r_free (hex);
   r_msg_digest_free (md);
+}
+RTEST_END;
+
+RTEST (rmsgdigest, free_wipes_state, R_TEST_TYPE_FAST)
+{
+  /* Sentinel-tagged input shorter than the MD5 block: with no
+   * finalise call the trailing per-algorithm partial-block buffer
+   * still holds the raw input bytes verbatim. r_msg_digest_free
+   * must wipe the whole md (mdsize covers the trailing state)
+   * before r_free, or the sentinel survives in the freed pile. */
+  static const ruint8 sentinel[24] = {
+    0xCA, 0xFE, 0xBA, 0xBE, 0xDE, 0xAD, 0xBE, 0xEF,
+    0xFE, 0xED, 0xFA, 0xCE, 0xBA, 0xAD, 0xF0, 0x0D,
+    0x13, 0x37, 0xC0, 0xDE, 0xB1, 0x05, 0xF0, 0x0D
+  };
+  RMsgDigest * md;
+
+  r_wipe_witness_install ();
+  r_assert_cmpptr ((md = r_msg_digest_new (R_MSG_DIGEST_TYPE_MD5)), !=, NULL);
+  r_assert (r_msg_digest_update (md, sentinel, sizeof (sentinel)));
+  r_msg_digest_free (md);
+  r_wipe_witness_uninstall ();
+
+  r_assert (!r_wipe_witness_freed_contains (sentinel, sizeof (sentinel)));
 }
 RTEST_END;
 

--- a/test/wipewitness.h
+++ b/test/wipewitness.h
@@ -1,0 +1,130 @@
+/* RLIB test helper: allocator hook that snapshots each freed buffer
+ * before it reaches system free, so a test can scan the pile for a
+ * sentinel byte sequence afterwards. Used to witness "did the
+ * destructor wipe its secrets before r_free?" — if the wipe is in
+ * place, the sentinel won't appear in the captured pile; if a
+ * regression removes the wipe, the sentinel survives in the buffer
+ * we copied out, and the test fails. */
+#ifndef __R_TEST_WIPE_WITNESS_H__
+#define __R_TEST_WIPE_WITNESS_H__
+
+#include <rlib/rlib.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define R_WIPE_WITNESS_MAX_ALLOCS 4096
+#define R_WIPE_WITNESS_MAX_FREED  (1024 * 1024)
+
+typedef struct {
+  rpointer ptr;
+  rsize    size;
+} r_wipe_witness_alloc;
+
+static r_wipe_witness_alloc r_wipe_witness_live[R_WIPE_WITNESS_MAX_ALLOCS];
+static rsize r_wipe_witness_live_count;
+static ruint8 r_wipe_witness_freed[R_WIPE_WITNESS_MAX_FREED];
+static rsize r_wipe_witness_freed_used;
+static RMemVTable r_wipe_witness_saved_vtable;
+
+static rpointer
+r_wipe_witness_malloc (rsize sz)
+{
+  rpointer p = malloc (sz);
+  if (p != NULL && r_wipe_witness_live_count < R_WIPE_WITNESS_MAX_ALLOCS) {
+    r_wipe_witness_live[r_wipe_witness_live_count].ptr = p;
+    r_wipe_witness_live[r_wipe_witness_live_count].size = sz;
+    r_wipe_witness_live_count++;
+  }
+  return p;
+}
+
+static rpointer
+r_wipe_witness_calloc (rsize n, rsize sz)
+{
+  rpointer p = calloc (n, sz);
+  if (p != NULL && r_wipe_witness_live_count < R_WIPE_WITNESS_MAX_ALLOCS) {
+    r_wipe_witness_live[r_wipe_witness_live_count].ptr = p;
+    r_wipe_witness_live[r_wipe_witness_live_count].size = n * sz;
+    r_wipe_witness_live_count++;
+  }
+  return p;
+}
+
+static rpointer
+r_wipe_witness_realloc (rpointer p, rsize sz)
+{
+  rsize i;
+  rpointer np = realloc (p, sz);
+  for (i = 0; i < r_wipe_witness_live_count; i++) {
+    if (r_wipe_witness_live[i].ptr == p) {
+      r_wipe_witness_live[i].ptr = np;
+      r_wipe_witness_live[i].size = sz;
+      return np;
+    }
+  }
+  if (np != NULL && r_wipe_witness_live_count < R_WIPE_WITNESS_MAX_ALLOCS) {
+    r_wipe_witness_live[r_wipe_witness_live_count].ptr = np;
+    r_wipe_witness_live[r_wipe_witness_live_count].size = sz;
+    r_wipe_witness_live_count++;
+  }
+  return np;
+}
+
+static void
+r_wipe_witness_free (rpointer p)
+{
+  rsize i;
+  if (p == NULL) { free (p); return; }
+  for (i = 0; i < r_wipe_witness_live_count; i++) {
+    if (r_wipe_witness_live[i].ptr == p) {
+      rsize sz = r_wipe_witness_live[i].size;
+      if (r_wipe_witness_freed_used + sz <= R_WIPE_WITNESS_MAX_FREED) {
+        memcpy (r_wipe_witness_freed + r_wipe_witness_freed_used, p, sz);
+        r_wipe_witness_freed_used += sz;
+      }
+      r_wipe_witness_live[i] = r_wipe_witness_live[--r_wipe_witness_live_count];
+      break;
+    }
+  }
+  free (p);
+}
+
+static void
+r_wipe_witness_install (void)
+{
+  RMemVTable v;
+  r_wipe_witness_live_count = 0;
+  r_wipe_witness_freed_used = 0;
+  /* Snapshot the active vtable so uninstall restores the exact
+   * pointers rlib was using - locally-typed { malloc, ... } would
+   * pick up the test binary's import thunks, which differ from the
+   * rlib DLL's on Windows and leave r_mem_using_system_default in
+   * a perpetually-FALSE state. */
+  r_mem_get_vtable (&r_wipe_witness_saved_vtable);
+  v.malloc  = r_wipe_witness_malloc;
+  v.calloc  = r_wipe_witness_calloc;
+  v.realloc = r_wipe_witness_realloc;
+  v.free    = r_wipe_witness_free;
+  r_mem_set_vtable (&v);
+}
+
+static void
+r_wipe_witness_uninstall (void)
+{
+  r_mem_set_vtable (&r_wipe_witness_saved_vtable);
+}
+
+static rboolean
+r_wipe_witness_freed_contains (const ruint8 * needle, rsize needle_size)
+{
+  rsize i;
+  if (needle_size == 0 || needle_size > r_wipe_witness_freed_used)
+    return FALSE;
+  for (i = 0; i + needle_size <= r_wipe_witness_freed_used; i++) {
+    if (memcmp (r_wipe_witness_freed + i, needle, needle_size) == 0)
+      return TRUE;
+  }
+  return FALSE;
+}
+
+#endif


### PR DESCRIPTION
## Summary

Four wipe-on-free fixes for crypto modules where secret-bearing buffers were released to the heap allocator intact. Each commit ships with a regression test that uses an allocator-hook helper (`test/wipewitness.h`) to snapshot every freed buffer and assert a sentinel byte sequence the destructor was meant to clear does not survive in the captured pile.

- **raes** (closes #104) — `r_cipher_aes_free` wipes the whole `RAesCipher` (key + erk/drk round-key schedules, all key-equivalent) before `r_free`. CBC-decrypt / CTR / CFB-encrypt / CFB-decrypt also wipe their per-call stack scratch on the way out.
- **rhmac** (closes #105) — `r_hmac_free` wipes `keyblock` (post-hash or zero-padded HMAC key); `r_hmac_reset` wipes the alloca'd ipad/opad expansion before the stack frame is popped.
- **rmsgdigest** (closes #107) — `r_msg_digest_free` wipes the full `md` allocation (`md->mdsize` covers the trailing per-algorithm compression state and partial-block buffer); `r_msg_digest_get_data` also wipes its alloca'd state clone. Wiped unconditionally — the same struct backs `RHmac` and the legacy-PEM `EVP_BytesToKey` KDF, where the mid-stream state is key-dependent.
- **rpem** (closes #108) — `r_pem_block_get_key` now tracks the decrypted DER plaintext and wipes it on every return path. The encrypted branch switches from `r_asn1_bin_decoder_new_with_data` to the const-data variant so the PEM code can wipe + free itself after `r_asn1_bin_decoder_unref` (the `_with_data` ownership path would have freed without wiping). Wrong-passphrase failures also get a wipe.

## Test plan

- [x] `build-debug-test/test/rlibtest` — full suite green (1395 pass, +4 new wipe-witness tests vs base)
- [x] `build-asan/test/rlibtest` — full suite green
- [x] Each new wipe-witness test was manually verified to fail when its corresponding wipe is reverted, then passed once the wipe was restored
- [x] Each commit builds and tests pass in isolation (bisect-safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)