### PR TITLE
ci: Drop matrix.compiler from full-tests name template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
           path: build/meson-logs/
 
   full-tests:
-    name: Full test sweep / ${{ matrix.compiler }}
+    name: Full test sweep
     runs-on: ubuntu-latest
     # Only on the scheduled cron and on demand. The corpus is sized for
     # ~10 minutes of wall time per run, which is fine for a nightly /


### PR DESCRIPTION
## Summary

Cosmetic CI fix. The \`full-tests\` job has a job-level \`if:\` that gates it to \`schedule\` and \`workflow_dispatch\` only. GitHub Actions evaluates that gate **before** matrix expansion, so on every PR the check shows up as the literal pre-expansion name \`Full test sweep / \${{ matrix.compiler }}\` with status \`skipping\`, which looks like a YAML bug but isn't.

Dropping \`/ \${{ matrix.compiler }}\` from \`name:\` removes the un-interpolated template from PR checks. On the scheduled run, GitHub still disambiguates the expanded matrix children automatically as \`Full test sweep (gcc)\` / \`Full test sweep (clang)\`, so no information is lost.

## Test plan

- [x] On this PR's checks list, the row should no longer show \`\${{ matrix.compiler }}\` — just \`Full test sweep\` with \`skipping\`.
- [ ] Next scheduled cron run (04:00 UTC) should show two expanded matrix children with their parenthesised compiler names — to be observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)