### PR TITLE
rdsa: Gate gen_sign_verify_roundtrip to the heavy sweep

### DIFF
--- a/test/rdsa.c
+++ b/test/rdsa.c
@@ -598,7 +598,7 @@ RTEST (rdsa, sign_msg_rejects_empty, RTEST_FAST)
 }
 RTEST_END;
 
-RTEST (rdsa, gen_sign_verify_roundtrip, RTEST_SLOW)
+HEAVY_RTEST (rdsa, gen_sign_verify_roundtrip, RTEST_SLOW)
 {
   /* Generate a fresh DSA-1024 / N=160 keypair, sign a SHA-1-sized hash
    * with it, verify with the matching public view. Exercises the full


### PR DESCRIPTION
## Summary

DSA-1024/160 keygen does a probable-prime search whose runtime is dominated by random Miller-Rabin trial count. Three consecutive local invocations took 0.12s / 0.74s / 0.36s. Under ASan + slower CI hardware the long tail brushes the 8s \`RTEST_SLOW\` per-test cap and trips an intermittent timeout (observed on master at \`in flight for 0:00:08.001\`).

\`HEAVY_RTEST\` is documented for exactly this case ("slow prime generation, gated to the nightly / on-demand sweep"), so promote the test. The default suite still exercises DSA sign / verify math via \`rdsa/sign_verify_roundtrip\` (precomputed parameters) and the \`wycheproof_2048_256_sha256_verify\` corpus; the unique value of \`gen_sign_verify_roundtrip\` is the end-to-end keygen-then-sign integration, which lives in nightly going forward.

## Test plan

- [x] Default: \`build-debug-test/test/rlibtest -f '/rdsa/gen_sign_verify_roundtrip'\` — 0 ran, heavy-skip count went 2264 → 2265
- [x] Heavy: \`build-debug-test/test/rlibtest --heavy -f '/rdsa/gen_sign_verify_roundtrip'\` — passed in 1.17s
- [x] Full default suite still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)