### PR TITLE
rrsa: Constant-time PKCS#1 v1.5 decrypt via implicit rejection

### DIFF
--- a/include/rlib/crypto/rrsa.h
+++ b/include/rlib/crypto/rrsa.h
@@ -85,8 +85,41 @@ R_API RCryptoResult r_rsa_oaep_decrypt (const RCryptoKey * key,
 
 R_API RCryptoResult r_rsa_pkcs1v1_5_encrypt (const RCryptoKey * key, RPrng * prng,
     rconstpointer data, rsize size, ruint8 * out, rsize * outsize);
+/* Variable-length PKCS#1 v1.5 decrypt that returns distinct error
+ * codes for each padding-validation failure mode and walks the PS
+ * field via an early-out loop. Both of those signals are
+ * attacker-observable - the function is a Bleichenbacher oracle
+ * when exposed to chosen-ciphertext input. SAFE only for
+ * trusted-source ciphertexts (e.g. blob decryption where you
+ * encrypted the data yourself and just need to recover it).
+ *
+ * For network-facing decrypt - TLS-RSA premaster, JWE RSA1_5,
+ * S/MIME, anything else where an attacker can submit ciphertexts
+ * and observe accept / reject - use r_rsa_pkcs1v1_5_decrypt_implicit
+ * below, which collapses every failure mode into a constant-time
+ * synthetic message of caller-supplied length. */
 R_API RCryptoResult r_rsa_pkcs1v1_5_decrypt (const RCryptoKey * key,
     rconstpointer data, rsize size, ruint8 * out, rsize * outsize);
+/* RSAES-PKCS1-v1_5 decrypt with implicit rejection - the standard
+ * Bleichenbacher / ROBOT / Marvin mitigation. Always writes out_size
+ * bytes to `out` and returns R_CRYPTO_OK on any well-formed raw
+ * decrypt: the real plaintext when padding is valid and the
+ * recovered message length matches out_size, or a deterministic
+ * synthetic message derived from the private key + ciphertext
+ * otherwise. The padding check and the length scan are constant-
+ * time across every byte of the recovered block, and success /
+ * failure share the same return code and output length, so a
+ * network attacker can't distinguish them.
+ *
+ * Callers that need to detect "ciphertext doesn't decrypt to what
+ * the protocol expected" must do so at a higher layer (e.g. the
+ * TLS Finished transcript check), never through return-code
+ * inspection on this primitive. out_size must be in (0, k - 11]
+ * where k is the modulus byte length, matching the RSAES-PKCS1-v1_5
+ * maximum-message bound; out_size = 0 or larger out_size returns
+ * R_CRYPTO_WRONG_SIZE. */
+R_API RCryptoResult r_rsa_pkcs1v1_5_decrypt_implicit (const RCryptoKey * key,
+    rconstpointer data, rsize size, ruint8 * out, rsize out_size);
 R_API RCryptoResult r_rsa_pkcs1v1_5_sign_msg (const RCryptoKey * key, RPrng * prng,
     RMsgDigestType mdtype, rconstpointer msg, rsize msgsize,
     rpointer sig, rsize * sigsize);

--- a/rlib/crypto/rrsa.c
+++ b/rlib/crypto/rrsa.c
@@ -21,6 +21,8 @@
 
 #include <rlib/crypto/rrsa.h>
 
+#include <rlib/crypto/rhmac.h>
+
 #include <rlib/asn1/rasn1.h>
 #include <rlib/asn1/roid.h>
 #include <rlib/rmem.h>
@@ -878,6 +880,171 @@ out_wipe:
   if (scratch)
     r_memclear_secure (buffer, size);
   return ret;
+}
+
+/* Branchless u32 equality: 0xFFFFFFFF if a == b, 0 otherwise.
+ *
+ *   x = a ^ b           is zero iff a == b
+ *   y = x | (-x)        top bit set iff x != 0 (one of x or -x is non-zero
+ *                       and has bit 31 set when interpreted as unsigned)
+ *   d = y >> 31         maps to 0 (equal) or 1 (different)
+ *   d - 1               wraps unsigned: 0xFFFFFFFF for equal, 0 for different
+ *
+ * No branches, no data-dependent timing. */
+static inline ruint32
+r_ct_u32_eq (ruint32 a, ruint32 b)
+{
+  ruint32 x = a ^ b;
+  return (((x | ((~x) + 1u)) >> 31) - 1u);
+}
+
+/* Same shape, treating a single byte as a 32-bit value for mask
+ * width. Returns 0xFFFFFFFF if a == b, 0 otherwise. */
+static inline ruint32
+r_ct_byte_eq (ruint8 a, ruint8 b)
+{
+  return r_ct_u32_eq ((ruint32)a, (ruint32)b);
+}
+
+/* Branchless u32 select: mask is the all-ones / all-zeros output of
+ * one of the r_ct_*_eq helpers. */
+static inline ruint32
+r_ct_u32_select (ruint32 mask, ruint32 t, ruint32 f)
+{
+  return (mask & t) | ((~mask) & f);
+}
+
+/* HKDF-Expand-style stretching of HMAC-SHA256 (private exponent,
+ * counter || ciphertext) into out_size bytes of deterministic
+ * synthetic plaintext. Same (key, ciphertext) always produces the
+ * same byte stream, so replaying a chosen ciphertext yields the
+ * same output as before - an attacker can't tell whether the
+ * apparent random data came from a padding failure or from a
+ * different ciphertext that happened to decrypt to it. */
+static rboolean
+r_rsa_pkcs1v1_5_synthetic (const rmpint * d, rconstpointer ciphertext,
+    rsize ct_size, ruint8 * out, rsize out_size)
+{
+  ruint8 * d_bytes;
+  rsize d_size;
+  RHmac * hmac;
+  ruint8 block[32];
+  rsize block_size;
+  ruint8 counter;
+  rsize emitted;
+  rboolean ok = TRUE;
+
+  d_size = r_mpint_bytes_used (d);
+  if (R_UNLIKELY (d_size == 0))
+    return FALSE;
+  d_bytes = r_alloca (d_size);
+  if (R_UNLIKELY (!r_mpint_to_binary_with_size (d, d_bytes, d_size))) {
+    r_memclear_secure (d_bytes, d_size);
+    return FALSE;
+  }
+
+  for (counter = 1, emitted = 0; emitted < out_size && ok; counter++) {
+    block_size = sizeof (block);
+    if ((hmac = r_hmac_new (R_MSG_DIGEST_TYPE_SHA256, d_bytes, d_size)) == NULL) {
+      ok = FALSE;
+      break;
+    }
+    ok = r_hmac_update (hmac, &counter, sizeof (counter)) &&
+         r_hmac_update (hmac, ciphertext, ct_size) &&
+         r_hmac_get_data (hmac, block, sizeof (block), &block_size);
+    r_hmac_free (hmac);
+    if (ok) {
+      rsize take = MIN (block_size, out_size - emitted);
+      r_memcpy (out + emitted, block, take);
+      emitted += take;
+    }
+  }
+
+  r_memclear_secure (d_bytes, d_size);
+  r_memclear_secure (block, sizeof (block));
+  return ok;
+}
+
+RCryptoResult
+r_rsa_pkcs1v1_5_decrypt_implicit (const RCryptoKey * key,
+    rconstpointer data, rsize size, ruint8 * out, rsize out_size)
+{
+  RCryptoResult ret;
+  const RRsaPrivKey * pk;
+  ruint8 * em;
+  ruint8 * synth;
+  rsize k, i;
+  ruint32 valid;
+  ruint32 zero_seen;
+  ruint32 zero_pos;
+
+  if (R_UNLIKELY (key == NULL)) return R_CRYPTO_INVAL;
+  if (R_UNLIKELY (key->algo->algo != R_CRYPTO_ALGO_RSA)) return R_CRYPTO_WRONG_TYPE;
+  if (R_UNLIKELY (key->type != R_CRYPTO_PRIVATE_KEY)) return R_CRYPTO_WRONG_TYPE;
+  if (R_UNLIKELY (data == NULL || out == NULL)) return R_CRYPTO_INVAL;
+
+  pk = (const RRsaPrivKey *)key;
+  k = r_mpint_digits_used (&pk->pub.n) * sizeof (rmpint_digit);
+  if (R_UNLIKELY (size != k)) return R_CRYPTO_WRONG_SIZE;
+  /* PKCS#1 v1.5 requires |PS| >= 8 plus the 0x00 0x02 prefix and the
+   * 0x00 separator, so the message can be at most k - 11 bytes. */
+  if (R_UNLIKELY (out_size == 0 || out_size > k - 11))
+    return R_CRYPTO_WRONG_SIZE;
+
+  em = r_alloca (size);
+  synth = r_alloca (out_size);
+
+  /* Raw decrypt: out-of-range / zero ciphertexts surface as an error
+   * here. Bleichenbacher candidates are always in [0, n), so this
+   * doesn't expose a useful oracle - it's input validation, not a
+   * padding check. */
+  if ((ret = r_rsa_raw_decrypt_internal (pk, NULL, data, em, size)) != R_CRYPTO_OK) {
+    r_memclear_secure (em, size);
+    return ret;
+  }
+
+  if (!r_rsa_pkcs1v1_5_synthetic (&pk->d, data, size, synth, out_size)) {
+    r_memclear_secure (em, size);
+    return R_CRYPTO_ERROR;
+  }
+
+  /* Padding shape:
+   *   em[0] == 0x00
+   *   em[1] == 0x02
+   *   em[2..k-1] = PS || 0x00 || M, |PS| >= 8
+   * To match the requested out_size, the 0x00 separator must be at
+   * position k - out_size - 1. The scan accumulates the position of
+   * the FIRST 0x00 in em[2..k-1] using a once-set "zero_seen" mask;
+   * a too-early zero (PS shorter than 8) trips the position check
+   * against k - out_size - 1, which we enforced to be >= 10 above. */
+  valid = r_ct_byte_eq (em[0], 0x00) & r_ct_byte_eq (em[1], R_RSA_EME_PKCS1);
+
+  zero_seen = 0;
+  zero_pos = 0;
+  for (i = 2; i < size; i++) {
+    ruint32 is_zero = r_ct_byte_eq (em[i], 0x00);
+    ruint32 first_zero = is_zero & ~zero_seen;
+    zero_pos = r_ct_u32_select (first_zero, (ruint32)i, zero_pos);
+    zero_seen |= is_zero;
+  }
+
+  valid &= zero_seen;
+  valid &= r_ct_u32_eq (zero_pos, (ruint32)(k - out_size - 1));
+
+  /* Constant-time select: out[i] = valid ? em[k - out_size + i]
+   *                                      : synth[i]. The load from
+   * em is always at the same offset regardless of where the real
+   * message would actually start, so a malformed em can't tilt the
+   * memory-access pattern. */
+  for (i = 0; i < out_size; i++) {
+    ruint32 real_byte = (ruint32)em[k - out_size + i];
+    ruint32 synth_byte = (ruint32)synth[i];
+    out[i] = (ruint8)r_ct_u32_select (valid, real_byte, synth_byte);
+  }
+
+  r_memclear_secure (em, size);
+  r_memclear_secure (synth, out_size);
+  return R_CRYPTO_OK;
 }
 
 RCryptoResult

--- a/test/rrsa.c
+++ b/test/rrsa.c
@@ -108,6 +108,186 @@ RTEST (rrsa, decrypt_pkcs, RTEST_FAST)
 }
 RTEST_END;
 
+/* The encrypted plaintext for `rsa_encrypted` above is "foobar\n",
+ * 7 bytes. The implicit-rejection variant takes a fixed out_size
+ * and returns either the real plaintext (when padding valid AND
+ * length matches out_size) or a deterministic synthetic of the
+ * same shape. */
+#define _DECRYPT_IMPLICIT_INIT(_key)                                              \
+  rmpint __n, __e, __d;                                                           \
+  r_mpint_init_str (&__n,                                                         \
+      "0x00aa18aba43b50deef38598faf87d2ab634e4571c130a9bca7b878267414faab8b47"    \
+      "1bd8965f5c9fc3818485eaf529c26246f3055064a8de19c8c338be5496cbaeb059dc0b"    \
+      "358143b44a35449eb264113121a455bd7fde3fac919e94b56fb9bb4f651cdb23ead439"    \
+      "d6cd523eb08191e75b35fd13a7419b3090f24787bd4f4e1967", NULL, 16);            \
+  r_mpint_init_str (&__d,                                                         \
+      "0x1628e4a39ebea86c8df0cd11572691017cfefb14ea1c12e1dedc7856032dad0f9612"    \
+      "00a38684f0a36dca30102e2464989d19a805933794c7d329ebc890089d3c4c6f602766"    \
+      "e5d62add74e82e490bbf92f6a482153853031be2844a700557b97673e727cd1316d3e6"    \
+      "fa7fc991d4227366ec552cbe90d367ef2e2e79fe66d26311", NULL, 16);              \
+  r_mpint_init_str (&__e, "65537", NULL, 10);                                     \
+  r_assert_cmpptr (((_key) = r_rsa_priv_key_new (&__n, &__e, &__d)), !=, NULL)
+
+#define _DECRYPT_IMPLICIT_FINI(_key)                                              \
+  r_mpint_clear (&__n);                                                           \
+  r_mpint_clear (&__d);                                                           \
+  r_mpint_clear (&__e);                                                           \
+  r_crypto_key_unref ((_key))
+
+RTEST (rrsa, decrypt_pkcs_implicit_valid, RTEST_FAST)
+{
+  /* The "foobar\n" plaintext is 7 bytes; ask the implicit-rejection
+   * API for exactly that, and the real plaintext must come back. */
+  static const rchar expected[] = "foobar\n";
+  ruint8 out[7];
+  RCryptoKey * key;
+
+  _DECRYPT_IMPLICIT_INIT (key);
+  r_assert_cmpuint (r_rsa_pkcs1v1_5_decrypt_implicit (key,
+        rsa_encrypted, sizeof (rsa_encrypted), out, sizeof (out)),
+      ==, R_CRYPTO_OK);
+  r_assert_cmpmem (out, ==, expected, sizeof (out));
+  _DECRYPT_IMPLICIT_FINI (key);
+}
+RTEST_END;
+
+RTEST (rrsa, decrypt_pkcs_implicit_wrong_length_synthetic, RTEST_FAST)
+{
+  /* Same valid ciphertext but the caller asks for a different
+   * length than the real plaintext (7 bytes). The function must
+   * still return R_CRYPTO_OK with the requested-length synthetic
+   * - no error-code divergence, no length divergence, no oracle. */
+  static const rchar real_pt[] = "foobar\n";
+  ruint8 out_short[3];
+  ruint8 out_long[16];
+  RCryptoKey * key;
+
+  _DECRYPT_IMPLICIT_INIT (key);
+  r_assert_cmpuint (r_rsa_pkcs1v1_5_decrypt_implicit (key,
+        rsa_encrypted, sizeof (rsa_encrypted), out_short, sizeof (out_short)),
+      ==, R_CRYPTO_OK);
+  /* The synthetic must not coincide with a prefix of the real
+   * plaintext - the chance of collision on 3 random bytes drawn
+   * from HMAC-SHA256 is 2^-24, fine for a single test. */
+  r_assert_cmpmem (out_short, !=, real_pt, sizeof (out_short));
+
+  r_assert_cmpuint (r_rsa_pkcs1v1_5_decrypt_implicit (key,
+        rsa_encrypted, sizeof (rsa_encrypted), out_long, sizeof (out_long)),
+      ==, R_CRYPTO_OK);
+  _DECRYPT_IMPLICIT_FINI (key);
+}
+RTEST_END;
+
+RTEST (rrsa, decrypt_pkcs_implicit_bad_padding_synthetic, RTEST_FAST)
+{
+  /* Flip the first ciphertext byte: with overwhelming probability
+   * the recovered em no longer starts with 0x00 0x02, so the
+   * padding check fails. The function must still return R_CRYPTO_OK
+   * with a synthetic of the requested length, and the synthetic
+   * must NOT match the real plaintext. */
+  static const rchar real_pt[] = "foobar\n";
+  ruint8 corrupt_ct[sizeof (rsa_encrypted)];
+  ruint8 out[7];
+  RCryptoKey * key;
+
+  r_memcpy (corrupt_ct, rsa_encrypted, sizeof (rsa_encrypted));
+  corrupt_ct[0] ^= 0x55;
+
+  _DECRYPT_IMPLICIT_INIT (key);
+  r_assert_cmpuint (r_rsa_pkcs1v1_5_decrypt_implicit (key,
+        corrupt_ct, sizeof (corrupt_ct), out, sizeof (out)),
+      ==, R_CRYPTO_OK);
+  r_assert_cmpmem (out, !=, real_pt, sizeof (out));
+  _DECRYPT_IMPLICIT_FINI (key);
+}
+RTEST_END;
+
+RTEST (rrsa, decrypt_pkcs_implicit_synthetic_deterministic, RTEST_FAST)
+{
+  /* Same (key, ciphertext, out_size) must produce the same
+   * synthetic across calls - replay protection. An attacker
+   * submitting the same crafted ciphertext repeatedly gets the
+   * same bytes back as if it were a deterministic decrypt. */
+  ruint8 corrupt_ct[sizeof (rsa_encrypted)];
+  ruint8 out_a[32], out_b[32];
+  RCryptoKey * key;
+
+  r_memcpy (corrupt_ct, rsa_encrypted, sizeof (rsa_encrypted));
+  corrupt_ct[0] ^= 0xA5;
+
+  _DECRYPT_IMPLICIT_INIT (key);
+  r_assert_cmpuint (r_rsa_pkcs1v1_5_decrypt_implicit (key,
+        corrupt_ct, sizeof (corrupt_ct), out_a, sizeof (out_a)),
+      ==, R_CRYPTO_OK);
+  r_assert_cmpuint (r_rsa_pkcs1v1_5_decrypt_implicit (key,
+        corrupt_ct, sizeof (corrupt_ct), out_b, sizeof (out_b)),
+      ==, R_CRYPTO_OK);
+  r_assert_cmpmem (out_a, ==, out_b, sizeof (out_a));
+  _DECRYPT_IMPLICIT_FINI (key);
+}
+RTEST_END;
+
+RTEST (rrsa, decrypt_pkcs_implicit_synthetic_varies_by_ct, RTEST_FAST)
+{
+  /* Different ciphertexts (both failing padding) must produce
+   * different synthetics - otherwise the synthetic itself becomes
+   * an oracle (an attacker who finds two CTs with matching output
+   * learns something about the key). */
+  ruint8 ct_a[sizeof (rsa_encrypted)];
+  ruint8 ct_b[sizeof (rsa_encrypted)];
+  ruint8 out_a[32], out_b[32];
+  RCryptoKey * key;
+
+  r_memcpy (ct_a, rsa_encrypted, sizeof (rsa_encrypted));
+  r_memcpy (ct_b, rsa_encrypted, sizeof (rsa_encrypted));
+  ct_a[0] ^= 0x11;
+  ct_b[0] ^= 0x22;
+
+  _DECRYPT_IMPLICIT_INIT (key);
+  r_assert_cmpuint (r_rsa_pkcs1v1_5_decrypt_implicit (key,
+        ct_a, sizeof (ct_a), out_a, sizeof (out_a)), ==, R_CRYPTO_OK);
+  r_assert_cmpuint (r_rsa_pkcs1v1_5_decrypt_implicit (key,
+        ct_b, sizeof (ct_b), out_b, sizeof (out_b)), ==, R_CRYPTO_OK);
+  r_assert_cmpmem (out_a, !=, out_b, sizeof (out_a));
+  _DECRYPT_IMPLICIT_FINI (key);
+}
+RTEST_END;
+
+RTEST (rrsa, decrypt_pkcs_implicit_arg_validation, RTEST_FAST)
+{
+  /* NULL / wrong-type / wrong-size / over-long out_size all
+   * surface as input errors. These checks happen before the raw
+   * decrypt so they don't interact with the constant-time path. */
+  ruint8 out[7];
+  RCryptoKey * key;
+
+  _DECRYPT_IMPLICIT_INIT (key);
+  r_assert_cmpuint (r_rsa_pkcs1v1_5_decrypt_implicit (NULL,
+        rsa_encrypted, sizeof (rsa_encrypted), out, sizeof (out)),
+      ==, R_CRYPTO_INVAL);
+  r_assert_cmpuint (r_rsa_pkcs1v1_5_decrypt_implicit (key,
+        NULL, sizeof (rsa_encrypted), out, sizeof (out)),
+      ==, R_CRYPTO_INVAL);
+  r_assert_cmpuint (r_rsa_pkcs1v1_5_decrypt_implicit (key,
+        rsa_encrypted, sizeof (rsa_encrypted), NULL, sizeof (out)),
+      ==, R_CRYPTO_INVAL);
+  r_assert_cmpuint (r_rsa_pkcs1v1_5_decrypt_implicit (key,
+        rsa_encrypted, sizeof (rsa_encrypted) - 1, out, sizeof (out)),
+      ==, R_CRYPTO_WRONG_SIZE);
+  /* out_size == 0 is rejected. */
+  r_assert_cmpuint (r_rsa_pkcs1v1_5_decrypt_implicit (key,
+        rsa_encrypted, sizeof (rsa_encrypted), out, 0),
+      ==, R_CRYPTO_WRONG_SIZE);
+  /* out_size > k - 11 (where k = 128 for this 1024-bit modulus) is
+   * rejected: a message that big can't fit any valid PKCS#1 padding. */
+  r_assert_cmpuint (r_rsa_pkcs1v1_5_decrypt_implicit (key,
+        rsa_encrypted, sizeof (rsa_encrypted), out, 128 - 10),
+      ==, R_CRYPTO_WRONG_SIZE);
+  _DECRYPT_IMPLICIT_FINI (key);
+}
+RTEST_END;
+
+
 RTEST (rrsa, pkcs1v1_5_decrypt_buffer_too_small, RTEST_FAST)
 {
   rmpint n, e, d;
@@ -606,6 +786,66 @@ RTEST_LOOP (rrsa, wycheproof_pkcs1_decrypt, RTEST_SLOW,
   } else {
     r_assert_cmpint (res, !=, R_CRYPTO_OK);
   }
+
+  r_crypto_key_unref (key);
+}
+RTEST_END;
+
+/* Parallel Wycheproof sweep against the implicit-rejection API:
+ * valid vectors must yield the real plaintext when out_size matches
+ * msg_len; invalid vectors must produce R_CRYPTO_OK (raw decrypt
+ * succeeded) with a synthetic that doesn't coincide with the
+ * expected message. Vectors whose ciphertext is mathematically
+ * out-of-range (c == 0 or c >= n) surface as a non-OK error
+ * because the raw decrypt step rejects them before any padding
+ * inspection - those aren't Bleichenbacher candidates. */
+RTEST_LOOP (rrsa, wycheproof_pkcs1_decrypt_implicit, RTEST_SLOW,
+    0, R_N_ELEMENTS (wp_rsa_pkcs1_tests))
+{
+  const WycheproofRsaPkcs1Test * t = &wp_rsa_pkcs1_tests[__i];
+  const WycheproofRsaKey * k = &wp_rsa_keys[t->key_idx];
+  RCryptoKey * key;
+  ruint8 pt[512];
+  rsize out_size;
+  RCryptoResult res;
+
+  r_assert_cmpptr ((key = r_rsa_priv_key_new_binary (k->n, k->n_len,
+          k->e, k->e_len, k->d, k->d_len)), !=, NULL);
+
+  /* Wycheproof has valid vectors with msg_len == 0 (empty plaintext
+   * with a full PS field), but the implicit API requires out_size
+   * >= 1 - empty output buffers don't fit any well-formed PKCS#1
+   * padding. Skip those vectors; the regular pkcs1_decrypt loop
+   * still exercises them via the variable-length API. */
+  if (t->valid && t->msg_len == 0) {
+    r_crypto_key_unref (key);
+    return;
+  }
+
+  /* For valid vectors ask for exactly msg_len; for invalid vectors
+   * pick an arbitrary modest length the synthetic generator can
+   * always satisfy. */
+  out_size = t->valid ? t->msg_len : 32;
+  if (out_size > k->n_len - 11) {
+    r_crypto_key_unref (key);
+    return;
+  }
+
+  res = r_rsa_pkcs1v1_5_decrypt_implicit (key, t->ct, t->ct_len, pt, out_size);
+
+  if (t->valid) {
+    r_assert_cmpint (res, ==, R_CRYPTO_OK);
+    r_assert_cmpmem (pt, ==, t->msg, out_size);
+  } else if (res == R_CRYPTO_OK) {
+    /* Synthetic returned: a few invalid vectors carry an msg_len
+     * (the "what the attacker hoped to recover" plaintext) - the
+     * synthetic must NOT coincide with that. */
+    if (t->msg_len == out_size && t->msg_len > 0 && t->msg != NULL)
+      r_assert_cmpmem (pt, !=, t->msg, out_size);
+  }
+  /* res != R_CRYPTO_OK is acceptable for invalid vectors with
+   * malformed ciphertexts (c out of range, etc.) - not an oracle
+   * because the same error fires for any same-shape malformed input. */
 
   r_crypto_key_unref (key);
 }


### PR DESCRIPTION
## Summary

Closes #109. Adds the standard Bleichenbacher / ROBOT / Marvin mitigation as a new public primitive, and flags the existing variable-length decrypt API as unsafe for adversarial input.

The existing \`r_rsa_pkcs1v1_5_decrypt\` returns distinct error codes for each padding-validation failure mode (\`INVALID_PADDING\` for "no 0x00 0x02 prefix" vs "PS too short" vs "no separator", \`BUFFER_TOO_SMALL\` for "output too small") and walks PS via an early-out while-loop that terminates at the first 0x00 byte. Both are attacker-observable - the function is a textbook Bleichenbacher oracle when exposed to chosen-ciphertext input (TLS-RSA premaster, JWE RSA1_5, S/MIME).

The new \`r_rsa_pkcs1v1_5_decrypt_implicit\`:
- Takes a fixed \`out_size\` (TLS premaster = 48, etc.) - always writes that many bytes to \`out\`.
- Constant-time padding check: ORs equality / inequality masks across every byte of the recovered block, no early-out.
- Constant-time message-length scan: tracks the first-zero position via a once-set \`zero_seen\` mask, then asserts the position equals \`k - out_size - 1\`.
- On any failure mode (wrong prefix, PS too short, separator missing, length mismatch) returns \`R_CRYPTO_OK\` with a **deterministic synthetic** - HMAC-SHA256 (private exponent, counter || ciphertext) expanded HKDF-style to \`out_size\` bytes. Same (key, ciphertext) → same synthetic so replays don't leak.
- The select between real and synthetic uses a branchless mask; the real-byte load happens from a fixed offset regardless of where the real message would actually start, so a malformed block can't tilt the memory-access pattern.
- Out-of-range ciphertexts (c == 0 or c >= n) surface as a specific raw-decrypt error. Those aren't Bleichenbacher candidates - they're input validation, not a padding-check oracle.

The existing \`r_rsa_pkcs1v1_5_decrypt\` is kept unchanged for back-compat (trusted-source decrypt where the threat model doesn't include an adaptive ciphertext attacker), with a header comment flagging the hazard.

Related: the underlying \`r_mpint_expmod\` is still variable-time per #100 - the timing of the modular exponentiation itself leaks bits of \`d\`. That's an mpint-level concern and out of scope for this PR.

## Test plan

- [x] \`build-debug-test/test/rlibtest\` — full suite green (1470 pass, +6 new unit tests + 1 new Wycheproof loop = 67 iterations)
- [x] \`build-asan/test/rlibtest\` — full suite green
- [x] Both commits build and tests pass in isolation (bisect-safe)
- [x] New unit tests cover: valid match, length-mismatch synthetic, bad-padding synthetic, replay determinism (same input → same output), synthetic varies by ciphertext, argument validation
- [x] Wycheproof corpus (67 iterations from \`rsa_pkcs1_2048.json\`) runs against the new API: valid vectors decrypt correctly, invalid vectors either return \`R_CRYPTO_OK\` with a non-matching synthetic or surface as raw-decrypt errors for out-of-range inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)