### PR TITLE
ecurve: Constant-time cswap in the Montgomery ladder

### DIFF
--- a/include/rlib/data/rmpint.h
+++ b/include/rlib/data/rmpint.h
@@ -128,6 +128,14 @@ R_API void r_mpint_set_i32 (rmpint * mpi, rint32 value);
 R_API void r_mpint_set_u32 (rmpint * mpi, ruint32 value);
 R_API void r_mpint_set_i64 (rmpint * mpi, rint64 value);
 R_API void r_mpint_set_u64 (rmpint * mpi, ruint64 value);
+/* Constant-time conditional swap: if `bit` is non-zero, exchange
+ * the metadata and data pointer of `a` and `b`; if zero, leave
+ * both untouched. Same execution time and memory access pattern
+ * regardless of the bit, so a Montgomery ladder driven by it
+ * doesn't leak the scalar's bit pattern through the per-step
+ * branch shape. The contents of `data` are NOT swapped - only
+ * the pointer - so this is O(1) regardless of the operand size. */
+R_API void r_mpint_swap_ct (rmpint * a, rmpint * b, ruint32 bit);
 /* Treat reads past dig_used as zero. mpint operations promise that
  * `data[0..dig_used)` carries the value, but several producers (e.g.
  * the final shr in r_mpint_div, and any path that shortens dig_used

--- a/rlib/crypto/recurve.c
+++ b/rlib/crypto/recurve.c
@@ -333,17 +333,47 @@ r_ecurve_point_is_on_curve (const REcurveAffinePoint * point,
   return ok;
 }
 
+/* Constant-time swap of two affine points: exchanges x / y mpint
+ * metadata + data pointer and the is_infinity flag iff bit is set,
+ * with no data-dependent branches or copies. */
+static void
+r_ecurve_point_swap_ct (REcurveAffinePoint * a, REcurveAffinePoint * b,
+    ruint32 bit)
+{
+  ruint32 mask = 0u - (ruint32)(bit & 1u);
+  ruint32 d;
+
+  r_mpint_swap_ct (&a->x, &b->x, bit);
+  r_mpint_swap_ct (&a->y, &b->y, bit);
+  d = ((ruint32)a->is_infinity ^ (ruint32)b->is_infinity) & mask;
+  a->is_infinity = (rboolean)((ruint32)a->is_infinity ^ d);
+  b->is_infinity = (rboolean)((ruint32)b->is_infinity ^ d);
+}
+
 rboolean
 r_ecurve_point_scalar_mul (REcurveAffinePoint * out, const rmpint * scalar,
     const REcurveAffinePoint * point, const REcurve * curve)
 {
   /* Left-to-right Montgomery ladder. Maintain (R0, R1) such that
-   * R1 - R0 == point at every step; one add + one dbl per scalar bit
-   * keeps the high-level branch shape uniform regardless of the
-   * scalar's bit pattern. The underlying mpint ops aren't constant-
-   * time, so this isn't full side-channel hardening — that's a
-   * separate concern. */
-  REcurveAffinePoint R0, R1, tmp;
+   * R1 - R0 == point at every step; one add + one dbl per scalar
+   * bit keeps the high-level branch shape uniform regardless of
+   * the scalar's bit pattern.
+   *
+   * Constant-time wrapping: instead of the textbook
+   *   if (bit) { R0 = R0 + R1; R1 = 2*R1; }
+   *   else     { R1 = R0 + R1; R0 = 2*R0; }
+   * (two different sequences of pointer operations that leak the
+   * bit through the per-step code path) we swap_ct(R0, R1, bit),
+   * always run R1 = R0 + R1 and R0 = 2*R0, then swap_ct back.
+   * Both bit values exercise the exact same operations in the
+   * same order on the same struct fields - the only difference
+   * is whether the swaps are no-ops.
+   *
+   * The underlying r_ecurve_point_add / _dbl and the mpint ops
+   * they call are still variable-time, so this is partial
+   * hardening - removing the per-bit branch shape oracle is what
+   * item 1 of #100 fixes; the rest is in items 2-4. */
+  REcurveAffinePoint R0, R1;
   ruint16 d, b;
   rmpint_digit bit;
   rboolean ok = FALSE;
@@ -355,7 +385,6 @@ r_ecurve_point_scalar_mul (REcurveAffinePoint * out, const rmpint * scalar,
 
   r_ecurve_point_init (&R0);
   r_ecurve_point_init (&R1);
-  r_ecurve_point_init (&tmp);
   r_ecurve_point_set_infinity (&R0);
   r_ecurve_point_copy (&R1, point);
 
@@ -364,17 +393,11 @@ r_ecurve_point_scalar_mul (REcurveAffinePoint * out, const rmpint * scalar,
     for (b = 0; b < sizeof (rmpint_digit) * 8; b++) {
       bit = (dig >> (sizeof (rmpint_digit) * 8 - 1)) & 1;
       dig <<= 1;
-      if (bit) {
-        if (!r_ecurve_point_add (&tmp, &R0, &R1, curve)) goto cleanup;
-        r_ecurve_point_copy (&R0, &tmp);
-        if (!r_ecurve_point_dbl (&tmp, &R1, curve)) goto cleanup;
-        r_ecurve_point_copy (&R1, &tmp);
-      } else {
-        if (!r_ecurve_point_add (&tmp, &R0, &R1, curve)) goto cleanup;
-        r_ecurve_point_copy (&R1, &tmp);
-        if (!r_ecurve_point_dbl (&tmp, &R0, curve)) goto cleanup;
-        r_ecurve_point_copy (&R0, &tmp);
-      }
+
+      r_ecurve_point_swap_ct (&R0, &R1, (ruint32)bit);
+      if (!r_ecurve_point_add (&R1, &R0, &R1, curve)) goto cleanup;
+      if (!r_ecurve_point_dbl (&R0, &R0, curve)) goto cleanup;
+      r_ecurve_point_swap_ct (&R0, &R1, (ruint32)bit);
     }
   }
 
@@ -384,7 +407,6 @@ r_ecurve_point_scalar_mul (REcurveAffinePoint * out, const rmpint * scalar,
 cleanup:
   r_ecurve_point_clear (&R0);
   r_ecurve_point_clear (&R1);
-  r_ecurve_point_clear (&tmp);
   return ok;
 }
 

--- a/rlib/data/rmpint.c
+++ b/rlib/data/rmpint.c
@@ -745,6 +745,63 @@ r_mpint_set_u64 (rmpint * mpi, ruint64 value)
   r_mpint_clamp (mpi);
 }
 
+void
+r_mpint_swap_ct (rmpint * a, rmpint * b, ruint32 bit)
+{
+  /* Branchless conditional XOR-swap.
+   *
+   *   mask     = -bit       -> 0x00... when bit==0, 0xFF... when bit==1
+   *   diff     = (a ^ b) & mask  -> 0 when no swap, (a^b) when swap
+   *   a ^= diff;  b ^= diff;
+   *
+   * Apply to each field in turn, plus the data pointer (cast to
+   * ruintptr so the XOR is well-defined on the integer
+   * representation rather than the pointer value). The data buffer
+   * itself stays in place - only the (a, b) -> buffer mapping
+   * swaps - so cost is O(1) regardless of operand size, and an
+   * attacker observing cache behaviour can't tell whether a swap
+   * happened from where future loads come from.
+   *
+   * Unsigned negation gets the mask to the target width without an
+   * intermediate type-promotion step that would zero-extend a
+   * 32-bit "all-ones" into a ruintptr larger than 32 bits and
+   * leave its upper half clear. */
+  ruint32 mask32;
+  ruintptr maskp;
+  ruint32 d;
+  ruintptr dp, pa, pb;
+
+  if (R_UNLIKELY (a == NULL || b == NULL))
+    return;
+
+  mask32 = 0u - (ruint32)(bit & 1u);
+  maskp  = (ruintptr)0 - (ruintptr)(bit & 1u);
+
+  /* dig_alloc + dig_used pack into a ruint32 (each is ruint16, the
+   * struct lays them adjacently). Swap them as a single word. */
+  d = (((ruint32)a->dig_alloc << 16) | a->dig_used) ^
+      (((ruint32)b->dig_alloc << 16) | b->dig_used);
+  d &= mask32;
+  a->dig_alloc ^= (ruint16)(d >> 16);
+  a->dig_used  ^= (ruint16)(d);
+  b->dig_alloc ^= (ruint16)(d >> 16);
+  b->dig_used  ^= (ruint16)(d);
+
+  d = (a->sign ^ b->sign) & mask32;
+  a->sign ^= d;
+  b->sign ^= d;
+
+  d = (a->flags ^ b->flags) & mask32;
+  a->flags ^= d;
+  b->flags ^= d;
+
+  pa = (ruintptr)a->data;
+  pb = (ruintptr)b->data;
+  dp = (pa ^ pb) & maskp;
+  a->data = (rmpint_digit *)(pa ^ dp);
+  b->data = (rmpint_digit *)(pb ^ dp);
+}
+
 ruint32
 r_mpint_ctz (const rmpint * mpi)
 {

--- a/test/rmpint.c
+++ b/test/rmpint.c
@@ -1225,3 +1225,101 @@ RTEST (rmpint, add_with_stale_high_digits, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rmpint, swap_ct_noop_when_bit_zero, RTEST_FAST)
+{
+  /* bit == 0 must leave both operands bit-identical to their
+   * pre-call state - every field is XOR-and'd with a zero mask. */
+  rmpint a, b;
+  rmpint_digit * a_data_before;
+  rmpint_digit * b_data_before;
+  ruint16 a_alloc_before, a_used_before;
+  ruint16 b_alloc_before, b_used_before;
+
+  r_mpint_init_str (&a, "0xdeadbeef", NULL, 16);
+  r_mpint_init_str (&b, "0x1234567890abcdef", NULL, 16);
+  a_data_before = a.data;
+  b_data_before = b.data;
+  a_alloc_before = a.dig_alloc;
+  a_used_before  = a.dig_used;
+  b_alloc_before = b.dig_alloc;
+  b_used_before  = b.dig_used;
+
+  r_mpint_swap_ct (&a, &b, 0);
+
+  r_assert_cmpptr (a.data, ==, a_data_before);
+  r_assert_cmpptr (b.data, ==, b_data_before);
+  r_assert_cmpuint (a.dig_alloc, ==, a_alloc_before);
+  r_assert_cmpuint (a.dig_used,  ==, a_used_before);
+  r_assert_cmpuint (b.dig_alloc, ==, b_alloc_before);
+  r_assert_cmpuint (b.dig_used,  ==, b_used_before);
+
+  r_mpint_clear (&a);
+  r_mpint_clear (&b);
+}
+RTEST_END;
+
+RTEST (rmpint, swap_ct_swaps_when_bit_set, RTEST_FAST)
+{
+  /* bit == 1 must exchange a and b in every observable way: the
+   * value seen by readers, the secure-clear flag, and the
+   * underlying data pointer (no copy, just a swap). Different
+   * alloc sizes confirm metadata travels with the pointer. */
+  rmpint a, b, expected_a, expected_b;
+  rmpint_digit * a_data_before;
+  rmpint_digit * b_data_before;
+
+  r_mpint_init_str (&a, "0xdeadbeef", NULL, 16);
+  r_mpint_init_str (&b, "0x1234567890abcdef", NULL, 16);
+  r_mpint_init_str (&expected_a, "0xdeadbeef", NULL, 16);
+  r_mpint_init_str (&expected_b, "0x1234567890abcdef", NULL, 16);
+  r_mpint_set_secure_clear (&b);
+
+  a_data_before = a.data;
+  b_data_before = b.data;
+
+  r_mpint_swap_ct (&a, &b, 1);
+
+  /* a now holds what b had, with b's secure-clear flag and data
+   * pointer, and vice versa. */
+  r_assert_cmpint (r_mpint_cmp (&a, &expected_b), ==, 0);
+  r_assert_cmpint (r_mpint_cmp (&b, &expected_a), ==, 0);
+  r_assert_cmpuint (a.flags & R_MPINT_FLAG_SECURE_CLEAR, !=, 0);
+  r_assert_cmpuint (b.flags & R_MPINT_FLAG_SECURE_CLEAR, ==, 0);
+  r_assert_cmpptr (a.data, ==, b_data_before);
+  r_assert_cmpptr (b.data, ==, a_data_before);
+
+  r_mpint_clear (&a);
+  r_mpint_clear (&b);
+  r_mpint_clear (&expected_a);
+  r_mpint_clear (&expected_b);
+}
+RTEST_END;
+
+RTEST (rmpint, swap_ct_double_swap_is_identity, RTEST_FAST)
+{
+  /* Swap-then-swap must return to the starting state regardless
+   * of bit value - the Montgomery-ladder pattern relies on this
+   * to wrap a single arithmetic step. */
+  rmpint a, b, orig_a, orig_b;
+
+  r_mpint_init_str (&a, "0xfeedface", NULL, 16);
+  r_mpint_init_str (&b, "0xcafebabe", NULL, 16);
+  r_mpint_init_str (&orig_a, "0xfeedface", NULL, 16);
+  r_mpint_init_str (&orig_b, "0xcafebabe", NULL, 16);
+
+  r_mpint_swap_ct (&a, &b, 1);
+  r_mpint_swap_ct (&a, &b, 1);
+  r_assert_cmpint (r_mpint_cmp (&a, &orig_a), ==, 0);
+  r_assert_cmpint (r_mpint_cmp (&b, &orig_b), ==, 0);
+
+  r_mpint_swap_ct (&a, &b, 0);
+  r_mpint_swap_ct (&a, &b, 0);
+  r_assert_cmpint (r_mpint_cmp (&a, &orig_a), ==, 0);
+  r_assert_cmpint (r_mpint_cmp (&b, &orig_b), ==, 0);
+
+  r_mpint_clear (&a);
+  r_mpint_clear (&b);
+  r_mpint_clear (&orig_a);
+  r_mpint_clear (&orig_b);
+}
+RTEST_END;


### PR DESCRIPTION
## Summary

First chunk of #100 (constant-time crypto primitives). The Montgomery ladder in \`r_ecurve_point_scalar_mul\` kept the high-level operation count uniform (one add + one dbl per scalar bit) but dispatched on the bit with a real C \`if / else\` that ran two distinct sequences of pointer operations. The per-step code path itself leaked the scalar - the long-term ECDSA / ECDH / DSA private key - through whichever side-channel cared to watch branch direction or pointer-shape.

### Changes

- Add **\`r_mpint_cswap (a, b, bit)\`** — branchless XOR-swap of two mpints conditioned on a bit. Swaps metadata (\`dig_alloc\` / \`dig_used\` / \`sign\` / \`flags\`) plus the \`data\` pointer in O(1) without touching the heap buffer itself. Pointer XOR via \`ruintptr\` cast keeps it portable. Both bit==0 and bit==1 codepaths execute the same XOR-and-store sequence; the only difference is whether the XOR mask is zero or all-ones.
- Add internal **\`r_ecurve_point_cswap\`** in \`recurve.c\` — wraps \`r_mpint_cswap\` for x / y plus a same-shape XOR-swap of the \`is_infinity\` flag.
- Refactor the ladder to the cswap-wrapped form:
  \`\`\`
  cswap (R0, R1, bit);
  R1 = R0 + R1;
  R0 = 2 * R0;
  cswap (R0, R1, bit);
  \`\`\`
  Same arithmetic shape regardless of bit, no if/else, identical struct accesses in both cases.

### Scope

This is **item 1** of the four scope items in #100. The underlying \`r_ecurve_point_add\` / \`_dbl\` are still variable-time and the per-call mpint ops underneath them are too - item 1 only removes the per-bit code-path-shape oracle. Items 2 (constant-time \`mulmod\` / \`squaremod\`), 3 (constant-time \`invmod\`), and 4 (memory-access audit) cover the rest, each landing as its own PR.

## Test plan

- [x] \`build-debug-test/test/rlibtest\` — full default suite green (1473 pass, +3 new cswap tests vs base)
- [x] \`build-asan/test/rlibtest\` — full default suite green
- [x] \`build-debug-test/test/rlibtest --heavy\` — all 3738 heavy tests pass including the Wycheproof ECDH corpus (every secp192r1 / secp224r1 / secp256r1 / secp384r1 / secp521r1 / secp256k1 vector exercises the modified ladder)
- [x] New unit tests cover: cswap as no-op when bit=0, full swap when bit=1 (including data-pointer + secure-clear flag), double-swap returns to identity for both bit values
- [x] Existing \`scalar_mul_identity\` and \`scalar_mul_known_answer\` loops would catch any arithmetic regression in the refactored ladder

🤖 Generated with [Claude Code](https://claude.com/claude-code)