### PR TITLE
ci: Pass -H to rlibtest via --test-args in the nightly sweep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,8 +163,10 @@ jobs:
         # would fail by definition) or SKIP_RTEST_* (which are
         # environment-dependent, e.g. live DNS). The 30x timeout
         # multiplier gives meson's per-test cap room for the
-        # secp521r1 sweep.
-        run: meson test -C build --print-errorlogs --timeout-multiplier 30 -- -H
+        # secp521r1 sweep. Pass -H via --test-args so the flag
+        # reaches the rlibtest binary; meson otherwise treats any
+        # trailing positional argument as a test-name pattern.
+        run: meson test -C build --print-errorlogs --timeout-multiplier 30 --test-args=-H
       - name: Upload test logs on failure
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

The nightly Full test sweep failed on 2026-05-23 04:00 UTC for both \`Full test sweep (gcc)\` and \`Full test sweep (clang)\`. The job invoked:

\`\`\`
meson test -C build --print-errorlogs --timeout-multiplier 30 -- -H
\`\`\`

intending \`-H\` to reach the \`rlibtest\` binary as the opt-in flag for \`HEAVY_RTEST_*\` tests. meson treats trailing positional arguments as test-name patterns rather than test-binary args, so it tried to match the test named \`-H\`, found none, and errored out before running anything:

\`\`\`
ERROR: *:-H test name does not match any test
\`\`\`

Switch to \`--test-args=-H\`, which is the documented meson knob for forwarding flags to the test binary.

## Test plan

- [x] Locally: \`meson test -C build-debug-test --test-args=-H --no-rebuild\` now invokes the binary with \`-H\` (it actually starts running tests instead of bailing on the test-name match). The local cap-timeout fires because we don't pass \`--timeout-multiplier\` locally — CI's \`--timeout-multiplier 30\` gives the necessary 5-minute headroom for the Wycheproof secp521r1 sweep.
- [ ] Verify on the next scheduled run or via \`gh workflow run ci.yml\` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)