### PR TITLE
crypto: Constant-time DSA signing against the nonce k (closes #128)

### DIFF
--- a/include/rlib/data/rmpint.h
+++ b/include/rlib/data/rmpint.h
@@ -187,6 +187,28 @@ R_API rboolean r_mpint_exp (rmpint * dst, const rmpint * b, ruint16 e);
 
 R_API rboolean r_mpint_invmod (rmpint * dst, const rmpint * a, const rmpint * m);
 R_API rboolean r_mpint_expmod (rmpint * dst, const rmpint * b, const rmpint * e, const rmpint * m);
+/* Constant-time variant of r_mpint_expmod. Iterates exactly exp_bits
+ * bits over the exponent and routes the per-bit dispatch through
+ * r_mpint_swap_ct rather than secret-indexed lookups; the per-
+ * iteration Montgomery reduce runs through the CT variant. The base
+ * b is treated as non-secret: the initial lift into Montgomery form
+ * is variable-time.
+ *
+ * exp_bits must upper-bound the bit length of e - silent truncation
+ * otherwise. bit_count(m) is always safe; a tighter bound (such as
+ * bit_count(q) for DSA's k < q) saves work. The bit window is the
+ * one timing channel the caller fully controls; pick the same value
+ * across calls if uniformity matters.
+ *
+ * Residual leak: r_mpint backs the intermediates, so each per-bit
+ * Mont mul iterates the intermediate value's dig_used. That leaks
+ * the bit length of the partial product, not the exponent. Removing
+ * this would require either a fixed-width type sized for the modulus
+ * (cf. RMpintFE for ECC) or non-clamping rmpint variants. For DSA's
+ * mod-p path the leak is on intermediate g^(partial-k) values, not
+ * on k directly. */
+R_API rboolean r_mpint_expmod_ct (rmpint * dst, const rmpint * b,
+    const rmpint * e, const rmpint * m, ruint exp_bits);
 
 R_API rboolean r_mpint_gcd (rmpint * dst, const rmpint * a, const rmpint * b);
 R_API rboolean r_mpint_lcm (rmpint * dst, const rmpint * a, const rmpint * b);

--- a/rlib/crypto/rdsa.c
+++ b/rlib/crypto/rdsa.c
@@ -125,7 +125,12 @@ r_dsa_sign (const RCryptoKey * key, RPrng * prng, RMsgDigestType mdtype,
     rconstpointer hash, rsize hashsize, rpointer sig, rsize * sigsize)
 {
   const RDsaPrivKey * pk = (const RDsaPrivKey *)key;
-  rmpint k, kinv, r, s, z, xr, b;
+  rmpint k, r, s, z, q_minus_2;
+  RMpintFEMontCtx ctx_q;
+  RMpintFE mont_r_sq_q, q_minus_2_fe;
+  RMpintFE k_fe, k_M, kinv_M, z_fe, z_M, x_fe, x_M, r_fe, r_M;
+  RMpintFE xr_M, zr_M, s_M, s_fe;
+  ruint q_minus_2_bits, q_bits;
   ruint8 id = R_ASN1_ID (R_ASN1_ID_UNIVERSAL, R_ASN1_ID_CONSTRUCTED, R_ASN1_ID_SEQUENCE);
   RAsn1BinEncoder * enc = NULL;
   ruint8 * sigbuf = NULL;
@@ -164,16 +169,34 @@ r_dsa_sign (const RCryptoKey * key, RPrng * prng, RMsgDigestType mdtype,
   kbytes = qbytes + 8;
   kbuf = r_alloca (kbytes);
 
-  /* k is the per-signature secret nonce; kinv = k^-1 mod q derives
-   * from it and is equally sensitive. Both want secure-clear so
-   * neither lingers in freed heap after this function returns. */
+  /* k is the per-signature secret nonce; everything derived from it
+   * (kinv_M, s_M, the FE temporaries) is equally sensitive. The
+   * rmpints want secure-clear so they don't linger in freed heap;
+   * the inline-storage FEs get memclear_secure'd at function exit. */
   r_mpint_init_secure (&k);
-  r_mpint_init_secure (&kinv);
   r_mpint_init (&r);
   r_mpint_init (&s);
-  r_mpint_init (&xr);
-  r_mpint_init (&b);
+  r_mpint_init (&q_minus_2);
   r_dsa_hash_to_mpint (&z, &pk->pub.q, hash, hashsize);
+
+  /* Set up mod-q Montgomery context for the CT arithmetic. p_minus_2
+   * here is q_minus_2 - "p" is just the FE convention for "the
+   * modulus", not DSA's p. */
+  if (!r_mpint_fe_mont_ctx_init (&ctx_q, &pk->pub.q))
+    goto cleanup;
+  if (!r_mpint_fe_compute_r_squared (&mont_r_sq_q, &pk->pub.q,
+        ctx_q.n_digits))
+    goto cleanup;
+  if (!r_mpint_sub_i32 (&q_minus_2, &pk->pub.q, 2))
+    goto cleanup;
+  r_mpint_fe_from_mpint (&q_minus_2_fe, &q_minus_2, ctx_q.n_digits);
+  q_minus_2_bits = r_mpint_bits_used (&q_minus_2);
+  q_bits = r_mpint_bits_used (&pk->pub.q);
+
+  /* x is the long-term private key. Lift to FE/Mont once outside the
+   * retry loop. */
+  r_mpint_fe_from_mpint (&x_fe, &pk->x, ctx_q.n_digits);
+  r_mpint_fe_mont_in (&x_M, &x_fe, &mont_r_sq_q, &ctx_q);
 
   for (;;) {
     do {
@@ -184,38 +207,34 @@ r_dsa_sign (const RCryptoKey * key, RPrng * prng, RMsgDigestType mdtype,
         goto cleanup;
     } while (r_mpint_iszero (&k));
 
-    /* r = (g^k mod p) mod q; retry on the (negligible) chance r == 0. */
-    if (!r_mpint_expmod (&r, &pk->pub.g, &k, &pk->pub.p) ||
+    /* r = (g^k mod p) mod q. The CT expmod processes exactly
+     * bit_count(q) bits of k regardless of k's actual value, so the
+     * iteration count doesn't leak k's bit length. */
+    if (!r_mpint_expmod_ct (&r, &pk->pub.g, &k, &pk->pub.p, q_bits) ||
         !r_mpint_mod (&r, &r, &pk->pub.q))
       goto cleanup;
     if (r_mpint_iszero (&r))
       continue;
 
-    /* k^-1 mod q via multiplicative blinding. r_mpint_invmod uses an
-     * extended-Euclidean ladder whose loop and shift counts vary with
-     * the input — and k is the per-signature secret, so its timing
-     * would leak bits of k (the Nguyen/Shparlinski style attack that
-     * lets an attacker recover x from a handful of biased signatures).
-     * Pick a fresh random b in [1, q-1], compute t = k*b mod q, run
-     * invmod on the blinded t, then unblind: k^-1 = t^-1 * b mod q.
-     * invmod still runs in variable time, but on input that no longer
-     * correlates with k. */
-    do {
-      if (!r_prng_fill (prng, kbuf, kbytes))
-        goto cleanup;
-      r_mpint_set_binary (&b, kbuf, kbytes);
-      if (!r_mpint_mod (&b, &b, &pk->pub.q))
-        goto cleanup;
-    } while (r_mpint_iszero (&b));
-
-    /* s = k^-1 * (z + x * r) mod q; retry on s == 0. */
-    if (!r_mpint_mulmod (&kinv, &k, &b, &pk->pub.q) ||
-        !r_mpint_invmod (&kinv, &kinv, &pk->pub.q) ||
-        !r_mpint_mulmod (&kinv, &kinv, &b, &pk->pub.q) ||
-        !r_mpint_mul (&xr, &pk->x, &r) ||
-        !r_mpint_add (&xr, &xr, &z) ||
-        !r_mpint_mul (&s, &kinv, &xr) ||
-        !r_mpint_mod (&s, &s, &pk->pub.q))
+    /* CT s = k^-1 * (z + x*r) mod q. All arithmetic runs through the
+     * fixed-width FE primitives; k^-1 uses Fermat instead of the
+     * extended-Euclidean ladder so the inversion itself no longer
+     * leaks k. The multiplicative blinding the old path used as
+     * defence-in-depth is dropped - the CT inverter is the actual
+     * fix. */
+    r_mpint_fe_from_mpint (&k_fe, &k, ctx_q.n_digits);
+    r_mpint_fe_from_mpint (&z_fe, &z, ctx_q.n_digits);
+    r_mpint_fe_from_mpint (&r_fe, &r, ctx_q.n_digits);
+    r_mpint_fe_mont_in (&k_M, &k_fe, &mont_r_sq_q, &ctx_q);
+    r_mpint_fe_mont_in (&z_M, &z_fe, &mont_r_sq_q, &ctx_q);
+    r_mpint_fe_mont_in (&r_M, &r_fe, &mont_r_sq_q, &ctx_q);
+    r_mpint_fe_invmod_mont (&kinv_M, &k_M, &q_minus_2_fe, q_minus_2_bits,
+        &mont_r_sq_q, &ctx_q);
+    r_mpint_fe_mul_mont (&xr_M, &x_M, &r_M, &ctx_q);
+    r_mpint_fe_add (&zr_M, &z_M, &xr_M, &ctx_q);
+    r_mpint_fe_mul_mont (&s_M, &kinv_M, &zr_M, &ctx_q);
+    r_mpint_fe_mont_out (&s_fe, &s_M, &ctx_q);
+    if (!r_mpint_fe_to_mpint (&s, &s_fe, ctx_q.n_digits))
       goto cleanup;
     if (!r_mpint_iszero (&s))
       break;
@@ -250,12 +269,29 @@ cleanup_with_ret:
   r_free (sigbuf);
   if (enc != NULL) r_asn1_bin_encoder_unref (enc);
   r_mpint_clear (&k);
-  r_mpint_clear (&kinv);
   r_mpint_clear (&r);
   r_mpint_clear (&s);
-  r_mpint_clear (&xr);
-  r_mpint_clear (&b);
   r_mpint_clear (&z);
+  r_mpint_clear (&q_minus_2);
+  /* Inline-storage FE temporaries derived from k / x live on the
+   * stack and would survive the function frame until overwritten;
+   * wipe them explicitly so they don't leak into a later allocation. */
+  r_memclear_secure (&ctx_q, sizeof (ctx_q));
+  r_memclear_secure (&mont_r_sq_q, sizeof (mont_r_sq_q));
+  r_memclear_secure (&q_minus_2_fe, sizeof (q_minus_2_fe));
+  r_memclear_secure (&k_fe, sizeof (k_fe));
+  r_memclear_secure (&k_M, sizeof (k_M));
+  r_memclear_secure (&kinv_M, sizeof (kinv_M));
+  r_memclear_secure (&z_fe, sizeof (z_fe));
+  r_memclear_secure (&z_M, sizeof (z_M));
+  r_memclear_secure (&x_fe, sizeof (x_fe));
+  r_memclear_secure (&x_M, sizeof (x_M));
+  r_memclear_secure (&r_fe, sizeof (r_fe));
+  r_memclear_secure (&r_M, sizeof (r_M));
+  r_memclear_secure (&xr_M, sizeof (xr_M));
+  r_memclear_secure (&zr_M, sizeof (zr_M));
+  r_memclear_secure (&s_M, sizeof (s_M));
+  r_memclear_secure (&s_fe, sizeof (s_fe));
   r_prng_unref (prng);
   (void) own_prng;
   return ret;

--- a/rlib/data/rmpint.c
+++ b/rlib/data/rmpint.c
@@ -1722,6 +1722,90 @@ expmod_failed:
   return FALSE;
 }
 
+rboolean
+r_mpint_expmod_ct (rmpint * dst, const rmpint * b, const rmpint * e,
+    const rmpint * m, ruint exp_bits)
+{
+  /* Constant-time variant of r_mpint_expmod. Iterates a fixed bit
+   * count over the exponent and routes the per-bit dispatch through
+   * r_mpint_swap_ct rather than R[bit^1] / R[bit] array indexing, so
+   * neither the exponent's bit pattern nor its bit length leaks via
+   * memory-access patterns. The per-iteration Montgomery reduce
+   * runs through r_mpint_montgomery_reduce_ct.
+   *
+   * The base b is treated as non-secret: the initial mpint_mod and
+   * mulmod that lift it into Montgomery form are variable-time. For
+   * DSA's r = g^k mod p that's fine (g is public); RSA private-key
+   * use cases want to either pre-lift the base or accept the
+   * setup-time leak.
+   *
+   * exp_bits caps the inner loop: caller knows e is bounded (e.g.
+   * DSA's k < q means exp_bits = bit_count(q)) and passes that. The
+   * function iterates exactly exp_bits bits regardless of e's actual
+   * value, so two callers with different e's run the same loop. The
+   * cap can be larger than e's actual bit length - the extra leading
+   * zeros are no-ops on the ladder. */
+  rmpint R[2];
+  rmpint_digit mp;
+  ruint i;
+  rmpint_digit bit;
+
+  if (R_UNLIKELY (dst == NULL || b == NULL || e == NULL || m == NULL))
+    return FALSE;
+
+  if (!r_mpint_montgomery_setup (&mp, m))
+    return FALSE;
+
+  r_mpint_init_from (&R[0], b, e, m, NULL);
+  r_mpint_init_from (&R[1], b, e, m, NULL);
+
+  /* R[0] = 1 in Montgomery form (= R mod m). */
+  if (!r_mpint_montgomery_normalize (&R[0], m))
+    goto expmod_ct_failed;
+
+  /* R[1] = b in Montgomery form. The base lift is variable-time on b
+   * (documented as non-secret above). */
+  if (r_mpint_ucmp (b, m) > 0) {
+    if (!r_mpint_mod (&R[1], b, m))
+      goto expmod_ct_failed;
+  } else {
+    r_mpint_set (&R[1], b);
+  }
+  if (!r_mpint_mulmod (&R[1], &R[1], &R[0], m))
+    goto expmod_ct_failed;
+
+  /* Iterate exactly exp_bits bits, MSB-down. The swap-wrap pattern
+   * routes both bit=0 and bit=1 through the same operation sequence
+   * (R[1] = R[0]*R[1]; R[0] = R[0]^2), so the per-bit cache and
+   * branch behaviour doesn't depend on the exponent value. */
+  for (i = exp_bits; i > 0; i--) {
+    ruint bp = i - 1;
+    bit = (r_mpint_get_digit (e, (ruint16)(bp / (sizeof (rmpint_digit) * 8))) >>
+           (bp % (sizeof (rmpint_digit) * 8))) & 1u;
+
+    r_mpint_swap_ct (&R[0], &R[1], (ruint32)bit);
+    if (!r_mpint_mul (&R[1], &R[0], &R[1]) ||
+        !r_mpint_montgomery_reduce_ct (&R[1], m, mp) ||
+        !r_mpint_mul (&R[0], &R[0], &R[0]) ||
+        !r_mpint_montgomery_reduce_ct (&R[0], m, mp))
+      goto expmod_ct_failed;
+    r_mpint_swap_ct (&R[0], &R[1], (ruint32)bit);
+  }
+
+  /* Drop R[0] out of Montgomery form. */
+  if (!r_mpint_montgomery_reduce_ct (&R[0], m, mp))
+    goto expmod_ct_failed;
+
+  r_mpint_set (dst, &R[0]);
+  r_mpint_clear (&R[0]);
+  r_mpint_clear (&R[1]);
+  return TRUE;
+expmod_ct_failed:
+  r_mpint_clear (&R[0]);
+  r_mpint_clear (&R[1]);
+  return FALSE;
+}
+
 /* Based on Handbook of Applied Cryptography (HAC) 14.4.3 (p.608) */
 rboolean
 r_mpint_gcd (rmpint * dst, const rmpint * x, const rmpint * y)

--- a/test/rmpint.c
+++ b/test/rmpint.c
@@ -931,6 +931,70 @@ RTEST (rmpint, expmod, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rmpint, expmod_ct, RTEST_FAST)
+{
+  rmpint b, e, m, expected, got;
+  ruint i;
+
+  /* NULL guards. */
+  {
+    rmpint zb = R_MPINT_INIT, ze = R_MPINT_INIT, zm = R_MPINT_INIT;
+    r_assert (!r_mpint_expmod_ct (NULL, &zb, &ze, &zm, 32));
+    r_assert (!r_mpint_expmod_ct (&got, NULL, &ze, &zm, 32));
+    r_assert (!r_mpint_expmod_ct (&got, &zb, NULL, &zm, 32));
+    r_assert (!r_mpint_expmod_ct (&got, &zb, &ze, NULL, 32));
+  }
+
+  r_mpint_init (&b);
+  r_mpint_init (&e);
+  r_mpint_init (&m);
+  r_mpint_init (&expected);
+  r_mpint_init (&got);
+
+  /* Same vector as the r_mpint_expmod test above - 4^13 mod 497 = 445. */
+  r_mpint_set_u32 (&b, 4);
+  r_mpint_set_u32 (&e, 13);
+  r_mpint_set_u32 (&m, 497);
+  r_mpint_set_u32 (&expected, 445);
+  r_assert (r_mpint_expmod_ct (&got, &b, &e, &m, r_mpint_bits_used (&e)));
+  r_assert_cmpint (r_mpint_cmp (&got, &expected), ==, 0);
+
+  /* exp_bits cap larger than e's bit count must still produce the same
+   * result - the extra leading-zero iterations are no-ops. */
+  r_assert (r_mpint_expmod_ct (&got, &b, &e, &m, 64));
+  r_assert_cmpint (r_mpint_cmp (&got, &expected), ==, 0);
+
+  /* Match the variable-time expmod across a handful of cases. */
+  r_mpint_set_u32 (&m, 65537);  /* small Fermat prime, used elsewhere */
+  for (i = 1; i < 16; i++) {
+    r_mpint_set_u32 (&b, 2 + i);
+    r_mpint_set_u32 (&e, 1000 + i * 731);
+    r_assert (r_mpint_expmod (&expected, &b, &e, &m));
+    r_assert (r_mpint_expmod_ct (&got, &b, &e, &m, 32));
+    r_assert_cmpint (r_mpint_cmp (&got, &expected), ==, 0);
+  }
+
+  /* Multi-digit modulus to exercise the rmpint-sized inner mul + reduce.
+   * Clear first - we re-use the mpints with init_str. */
+  r_mpint_clear (&b);
+  r_mpint_clear (&e);
+  r_mpint_clear (&m);
+  r_mpint_clear (&expected);
+  r_mpint_init_str (&b, "4782572232345452435234534", NULL, 10);
+  r_mpint_init_str (&e, "2345243524352435452983475", NULL, 10);
+  r_mpint_init_str (&m, "42359872349587", NULL, 10);
+  r_mpint_init_str (&expected, "8454269506363", NULL, 10);
+  r_assert (r_mpint_expmod_ct (&got, &b, &e, &m, r_mpint_bits_used (&e)));
+  r_assert_cmpint (r_mpint_cmp (&got, &expected), ==, 0);
+
+  r_mpint_clear (&b);
+  r_mpint_clear (&e);
+  r_mpint_clear (&m);
+  r_mpint_clear (&expected);
+  r_mpint_clear (&got);
+}
+RTEST_END;
+
 RTEST (rmpint, ctz, RTEST_FAST)
 {
   rmpint a;


### PR DESCRIPTION
## Summary

Item from #100's follow-up sketch. DSA signing computes \`r = (g^k mod p) mod q\` and \`s = k^-1 * (z + x*r) mod q\` with the nonce \`k\` as the per-signature secret. Both halves of that leaked \`k\` to varying degrees:

- \`r_mpint_expmod\`'s Montgomery ladder uses \`R[bit ^ 1] / R[bit]\` array indexing driven by secret exponent bits, plus a variable-time per-iteration reduce. Cache + timing channel.
- \`r_mpint_invmod\` runs extended Euclidean with control-flow that's directly value-dependent on \`k\`. The previous code worked around this with multiplicative blinding (\`kinv = (k*b)^-1 * b mod q\`) — defence-in-depth, not a real CT fix.
- The \`r_mpint_mulmod\` calls in \`s = kinv * (z + x*r) mod q\` ran through variable-time Montgomery reduction on secret operands.

## What lands

**New** \`r_mpint_expmod_ct\` in the public mpint API. Same shape as \`r_mpint_expmod\` plus an \`exp_bits\` cap. Routes per-bit dispatch through \`r_mpint_swap_ct\` and the reduce through \`r_mpint_montgomery_reduce_ct\`. The cap lets DSA process \`bit_count(q)\` bits regardless of \`p\`'s much larger modulus size — saves a factor of 8 for DSA-2048 vs iterating all \`bit_count(p)\` bits.

The base is documented as non-secret: the initial Montgomery lift is variable-time on \`b\`. Fine for DSA (\`g\` is public); RSA private operations get refined via #129's own CT story.

**Refactored** \`r_dsa_sign\`:

- \`r = (g^k mod p) mod q\` uses \`r_mpint_expmod_ct\` with \`exp_bits = bit_count(q)\`.
- \`k^-1 mod q\` uses the public \`r_mpint_fe_invmod_mont\` (Fermat) — \`q\` fits in \`RMpintFE\`'s 576-bit cap.
- \`s = kinv * (z + x*r) mod q\` runs entirely in fixed-width FE Montgomery arithmetic.
- The blinding chain is dropped now that the inverter is itself CT.
- \`x_M\` (private key in Mont form) is lifted once outside the retry loop.
- FE temporaries get \`r_memclear_secure\`'d at function exit since they live on the stack and would otherwise survive the frame until overwritten.

## Tests

- New \`rmpint/expmod_ct\` test cross-checks against \`r_mpint_expmod\` on a single-digit modulus and a multi-digit modulus, plus the \`exp_bits\` cap behaviour (larger-than-needed cap still produces the right answer via no-op leading iterations).
- DSA's existing sign/verify roundtrip and 365 wycheproof verify vectors cover the refactor end-to-end.

## Test plan

- [x] Default suite on debug, asan, clang, gcc-warn, tsan
- [x] Heavy suite (incl. wycheproof) on debug + asan
- [x] DSA sign/verify roundtrip still works
- [x] No new compiler warnings on the strict build
- [x] CI green across the matrix

## Known residual

\`r_mpint_expmod_ct\` uses \`rmpint\` storage internally, so the per-iteration Mont mul iterates the intermediate value's \`dig_used\`. That leaks the bit length of the partial product (a function of intermediate \`g^(partial-k)\` values), not the exponent itself. Closing this needs either a wider fixed-width type (cf. \`RMpintFE\` for ECC, sized for RSA/DSA-p) or non-clamping rmpint variants — same class as #129's "approach 1" trade-off. Documented inline.

Closes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)