### PR TITLE
crypto: Constant-time RSA private-key modular exponentiation

### DIFF
--- a/rlib/crypto/rrsa.c
+++ b/rlib/crypto/rrsa.c
@@ -650,7 +650,20 @@ r_rsa_raw_encrypt (const RCryptoKey * key, RPrng * prng,
 
 /* The actual c^d mod n step. Caller is responsible for blinding c before
  * the call and unblinding m after — keeping that logic separate keeps the
- * CRT/non-CRT dispatch readable. */
+ * CRT/non-CRT dispatch readable.
+ *
+ * The exponentiations use r_mpint_expmod_ct so the private exponent
+ * (d, or the CRT exponents dP / dQ) doesn't leak via array-indexed
+ * Mont ladder dispatch or variable-time per-iteration reduce. The
+ * exp_bits caps are bit_count of the respective moduli - dP < p,
+ * dQ < q, d < n - so the loops are bounded by public constants.
+ *
+ * Residual leak: the CRT post-processing (m2 reduce, subtract, mul
+ * by qInv, etc.) uses variable-time mpint primitives on values that
+ * depend on the secret intermediates m1 / m2. Closing this needs CT
+ * variants of mpint sub/mul/mod (or a wider FE type for RSA-sized
+ * operands); for now it's flagged as the same dig_used residual the
+ * CT expmod itself has. */
 static rboolean
 r_rsa_modexp_private (const RRsaPrivKey * key, const rmpint * c, rmpint * m)
 {
@@ -672,8 +685,10 @@ r_rsa_modexp_private (const RRsaPrivKey * key, const rmpint * c, rmpint * m)
     r_mpint_init (&m2_p);
     r_mpint_init (&h);
 
-    ok = r_mpint_expmod (&m1, c, &key->dp, &key->p)
-      && r_mpint_expmod (&m2, c, &key->dq, &key->q)
+    ok = r_mpint_expmod_ct (&m1, c, &key->dp, &key->p,
+            r_mpint_bits_used (&key->p))
+      && r_mpint_expmod_ct (&m2, c, &key->dq, &key->q,
+            r_mpint_bits_used (&key->q))
       && r_mpint_mod (&m2_p, &m2, &key->p)
       && r_mpint_sub (&h, &m1, &m2_p);
     if (ok && r_mpint_isneg (&h))
@@ -690,7 +705,8 @@ r_rsa_modexp_private (const RRsaPrivKey * key, const rmpint * c, rmpint * m)
     r_mpint_clear (&h);
     return ok;
   } else {
-    return r_mpint_expmod (m, c, &key->d, &key->pub.n);
+    return r_mpint_expmod_ct (m, c, &key->d, &key->pub.n,
+        r_mpint_bits_used (&key->pub.n));
   }
 }
 


### PR DESCRIPTION
## Summary

\`r_rsa_modexp_private\` is the single chokepoint for every RSA private operation — PKCS#1 v1.5 decrypt and sign both route through it for the \`c^d mod n\` step (or the CRT pair \`c^dp mod p\` / \`c^dq mod q\`). The exponentiations went through \`r_mpint_expmod\`, whose Montgomery ladder uses \`R[bit ^ 1] / R[bit]\` array indexing driven by the private exponent's bits plus a variable-time per-iteration reduce — leaking the private exponent via cache and timing.

Switch all three call sites to \`r_mpint_expmod_ct\` (the CT variant landed for DSA in #134). \`exp_bits\` caps use \`bit_count\` of the respective moduli — \`dP < p\`, \`dQ < q\`, \`d < n\` — so the inner loops iterate a bound determined by public per-key constants. The CRT path passes the half-size bit counts, preserving the existing ~4x speedup the CRT decomposition gives.

The blinding wrapper in \`r_rsa_raw_decrypt_internal\` stays unchanged. Its remit was always wider than just the exponent: the private exponentiation runs on a blinded \`c' = c * r^e mod n\`, so any input-related leakage from the expmod is against a randomised value rather than the real ciphertext. What it doesn't cover is the CRT post-processing (sub / mul / mod on m1, m2) or the unblinding mulmod, both of which run variable-time on values derived from the actual plaintext. Closing those needs CT variants of mpint sub / mul / mod or a wider fixed-width FE type sized for RSA operands — flagged inline as the same \`dig_used\` residual that #129 already classified.

## Test plan

- [x] Default suite on debug, asan, clang, gcc-warn, tsan
- [x] Heavy suite (incl. wycheproof PKCS#1 vectors) on debug + asan
- [x] RSA decrypt + sign + verify roundtrips, including the implicit-rejection PKCS#1 v1.5 paths
- [x] No new compiler warnings on the strict build
- [x] CI green across the matrix

Closes #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)