### PR TITLE
Wire up ECDSA sign and verify on prime curves

### DIFF
--- a/rlib/crypto/recc.c
+++ b/rlib/crypto/recc.c
@@ -21,7 +21,9 @@
 
 #include <rlib/crypto/recc.h>
 
+#include <rlib/asn1/rasn1.h>
 #include <rlib/rmem.h>
+#include <rlib/rrand.h>
 
 /* ECC keys keep two parallel representations: the raw SEC 1 octet
  * string the key was constructed from (for ASN.1 round-trips and
@@ -49,7 +51,32 @@ typedef struct {
 
   rsize scalarsize;
   ruint8 * scalar;
+
+  /* Mod-n Montgomery context cached for r_ecdsa_sign: precomputing the
+   * ctx + R^2 + (n-2) Fermat exponent + d in Mont form means each
+   * signature pays one fixed-iteration scalar-mul plus one CT
+   * invmod_mont, with no per-call Mont setup. Populated by
+   * r_ecdsa_priv_key_precompute_cache when the key is constructed as
+   * an ECDSA key on a math-capable curve; has_ecdsa_cache flags that
+   * setup succeeded. Unused for ECDH keys. */
+  RMpintFEMontCtx ctx_n;
+  RMpintFE mont_r_sq_n;
+  RMpintFE n_minus_2_fe;
+  RMpintFE d_M;
+  ruint n_minus_2_bits;
+  ruint n_bits;
+  rboolean has_ecdsa_cache;
 } REccPrivKey;
+
+/* Forward declarations - the algo-info structs in the key-init helpers
+ * below reference these, and the bodies live further down so the
+ * cache-aware sign / verify code sits next to the cache populate. */
+static RCryptoResult r_ecdsa_sign (const RCryptoKey * key, RPrng * prng,
+    RMsgDigestType mdtype, rconstpointer hash, rsize hashsize,
+    rpointer sig, rsize * sigsize);
+static RCryptoResult r_ecdsa_verify (const RCryptoKey * key,
+    RMsgDigestType mdtype, rconstpointer hash, rsize hashsize,
+    rconstpointer sig, rsize sigsize);
 
 static void
 r_ecc_pub_key_free (rpointer data)
@@ -94,7 +121,7 @@ r_ecdsa_pub_key_init (RCryptoKey * key, ruint bits)
 {
   static const RCryptoAlgoInfo ecdsa_pub_key_info = {
     R_CRYPTO_ALGO_ECDSA, R_ECDSA_STR,
-    NULL, NULL, NULL, NULL, NULL
+    NULL, NULL, NULL, r_ecdsa_verify, NULL
   };
 
   r_ref_init (key, r_ecc_pub_key_free);
@@ -187,6 +214,15 @@ r_ecc_priv_key_free (rpointer data)
   REccPrivKey * key;
 
   if ((key = data) != NULL) {
+    if (key->has_ecdsa_cache) {
+      /* The cached Mont fields hold values derived from the secret d
+       * (and the long-term curve order); wipe before freeing so they
+       * don't linger on the heap after the key is released. */
+      r_memclear_secure (&key->ctx_n, sizeof (key->ctx_n));
+      r_memclear_secure (&key->mont_r_sq_n, sizeof (key->mont_r_sq_n));
+      r_memclear_secure (&key->n_minus_2_fe, sizeof (key->n_minus_2_fe));
+      r_memclear_secure (&key->d_M, sizeof (key->d_M));
+    }
     if (key->has_d) {
       r_mpint_clear (&key->d);
     }
@@ -279,6 +315,323 @@ r_ecc_priv_key_load_scalar (REccPrivKey * priv, REcurveID curve,
   return TRUE;
 }
 
+/* Populate the per-key Mont-mod-n cache used by r_ecdsa_sign. Returns
+ * FALSE if the math layer isn't loaded (unsupported curve, or no ecp
+ * supplied at construction and the curve never got initialised) or
+ * if the order n is even / oversized for the FE storage. The caller
+ * sets pk->has_ecdsa_cache on success - if this returns FALSE the
+ * key is still usable for things that don't need the cache (parsing,
+ * ECDH, etc.), it just can't sign. */
+static rboolean
+r_ecdsa_priv_key_precompute_cache (REccPrivKey * pk)
+{
+  rmpint n_minus_2;
+  RMpintFE d_fe;
+  rboolean ok = FALSE;
+
+  if (!pk->pub.has_math || !pk->has_d)
+    return FALSE;
+
+  if (!r_mpint_fe_mont_ctx_init (&pk->ctx_n, &pk->pub.curve.n))
+    return FALSE;
+  if (!r_mpint_fe_compute_r_squared (&pk->mont_r_sq_n, &pk->pub.curve.n,
+        pk->ctx_n.n_digits))
+    return FALSE;
+
+  r_mpint_init (&n_minus_2);
+  if (r_mpint_sub_i32 (&n_minus_2, &pk->pub.curve.n, 2)) {
+    r_mpint_fe_from_mpint (&pk->n_minus_2_fe, &n_minus_2, pk->ctx_n.n_digits);
+    pk->n_minus_2_bits = r_mpint_bits_used (&n_minus_2);
+    pk->n_bits = r_mpint_bits_used (&pk->pub.curve.n);
+
+    /* d is already range-checked to [1, n-1] by r_ecc_priv_key_load_scalar,
+     * so the FE conversion + Mont lift below is well-defined. */
+    r_mpint_fe_from_mpint (&d_fe, &pk->d, pk->ctx_n.n_digits);
+    r_mpint_fe_mont_in (&pk->d_M, &d_fe, &pk->mont_r_sq_n, &pk->ctx_n);
+    r_memclear_secure (&d_fe, sizeof (d_fe));
+    ok = TRUE;
+  }
+  r_mpint_clear (&n_minus_2);
+  return ok;
+}
+
+/* SEC 1 §4.1.4 step 5 / FIPS 186-4 §6.4: the integer e fed to the
+ * sign / verify equations is formed from the leftmost min(N, hashlen)
+ * bits of the message hash, where N is the bit length of n. Same
+ * truncation rule DSA uses; rdsa.c carries a private copy of this
+ * helper - kept local here so recc.c doesn't reach across the layer
+ * for a one-screen utility that's unlikely to change. */
+static void
+r_ecdsa_hash_to_mpint (rmpint * e, const rmpint * n,
+    const ruint8 * hash, rsize hashsize)
+{
+  ruint nbits = r_mpint_bits_used (n);
+  rsize hashbits = hashsize * 8;
+  rsize use_bits = nbits < hashbits ? nbits : hashbits;
+  rsize use_bytes = (use_bits + 7) / 8;
+
+  r_mpint_init_binary (e, hash, use_bytes);
+  if ((use_bits & 7) != 0)
+    r_mpint_shr (e, e, 8 - (use_bits & 7));
+}
+
+/* Decode Ecdsa-Sig-Value ::= SEQUENCE { r INTEGER, s INTEGER }
+ * (RFC 5480 §2.2 references RFC 3279 §2.2.3 for the exact ASN.1 -
+ * structurally identical to DSA's Dss-Sig-Value). DER-mandated;
+ * minimum-byte INTEGER encoding is enforced to close a malleability
+ * gap an unstrict decoder would open. */
+static rboolean
+r_ecdsa_decode_sig (rconstpointer sig, rsize sigsize, rmpint * r, rmpint * s)
+{
+  RAsn1BinDecoder * dec;
+  RAsn1BinTLV tlv = R_ASN1_BIN_TLV_INIT;
+  rboolean ok = FALSE;
+
+  if ((dec = r_asn1_bin_decoder_new (R_ASN1_DER, sig, sigsize)) == NULL)
+    return FALSE;
+
+#define MINIMAL_POS_INT(tlv) \
+    ((tlv).len >= 1 && \
+     !((tlv).len >= 2 && (tlv).value[0] == 0 && ((tlv).value[1] & 0x80) == 0))
+
+  r_mpint_init (r);
+  r_mpint_init (s);
+  if (r_asn1_bin_decoder_next (dec, &tlv) == R_ASN1_DECODER_OK &&
+      R_ASN1_BIN_TLV_ID_TAG (&tlv) == R_ASN1_ID_SEQUENCE &&
+      tlv.value + tlv.len == (const ruint8 *)sig + sigsize &&
+      r_asn1_bin_decoder_into (dec, &tlv) == R_ASN1_DECODER_OK &&
+      MINIMAL_POS_INT (tlv) &&
+      r_asn1_bin_tlv_parse_integer_mpint (&tlv, r) == R_ASN1_DECODER_OK &&
+      r_asn1_bin_decoder_next (dec, &tlv) == R_ASN1_DECODER_OK &&
+      MINIMAL_POS_INT (tlv) &&
+      r_asn1_bin_tlv_parse_integer_mpint (&tlv, s) == R_ASN1_DECODER_OK &&
+      r_asn1_bin_decoder_next (dec, &tlv) == R_ASN1_DECODER_EOC) {
+    ok = TRUE;
+  }
+#undef MINIMAL_POS_INT
+  r_asn1_bin_decoder_unref (dec);
+  if (!ok) {
+    r_mpint_clear (r);
+    r_mpint_clear (s);
+  }
+  return ok;
+}
+
+static RCryptoResult
+r_ecdsa_sign (const RCryptoKey * key, RPrng * prng, RMsgDigestType mdtype,
+    rconstpointer hash, rsize hashsize, rpointer sig, rsize * sigsize)
+{
+  const REccPrivKey * pk = (const REccPrivKey *)key;
+  REcurveAffinePoint kG;
+  rmpint k, r, s, e;
+  RMpintFE k_fe, k_M, kinv_M, e_fe, e_M, r_fe, r_M;
+  RMpintFE dr_M, er_M, s_M, s_fe;
+  ruint8 id = R_ASN1_ID (R_ASN1_ID_UNIVERSAL, R_ASN1_ID_CONSTRUCTED, R_ASN1_ID_SEQUENCE);
+  RAsn1BinEncoder * enc = NULL;
+  ruint8 * sigbuf = NULL;
+  rsize nbytes, kbytes, sigbufsize;
+  ruint8 * kbuf;
+  rboolean own_prng = FALSE;
+  rboolean ok = FALSE;
+  RCryptoResult ret;
+
+  (void) mdtype;  /* ECDSA signs the raw hash; mdtype is informational. */
+
+  if (R_UNLIKELY (key->type != R_CRYPTO_PRIVATE_KEY))
+    return R_CRYPTO_WRONG_TYPE;
+  if (R_UNLIKELY (hash == NULL || hashsize == 0 || sig == NULL || sigsize == NULL))
+    return R_CRYPTO_INVAL;
+  if (R_UNLIKELY (!pk->has_ecdsa_cache))
+    return R_CRYPTO_NOT_AVAILABLE;
+
+  if (prng == NULL) {
+    if ((prng = r_rand_prng_new ()) == NULL)
+      return R_CRYPTO_ERROR;
+    own_prng = TRUE;
+  } else {
+    r_prng_ref (prng);
+  }
+
+  /* FIPS 186-4 Appendix B.5.1 "Extra Random Bits": sample N+64 uniform
+   * bits and reduce mod n to drive the residual bias on k below 2^-64.
+   * The naive "sample N bits then reduce" path skews the low end of
+   * [1, n-1] and stacks across signatures - same fix DSA uses. */
+  nbytes = (r_mpint_bits_used (&pk->pub.curve.n) + 7) / 8;
+  kbytes = nbytes + 8;
+  kbuf = r_alloca (kbytes);
+
+  r_mpint_init_secure (&k);
+  r_mpint_init (&r);
+  r_mpint_init (&s);
+  r_ecdsa_hash_to_mpint (&e, &pk->pub.curve.n, hash, hashsize);
+  r_ecurve_point_init (&kG);
+
+  /* e is loop-invariant (no dependency on k) so the FE / Mont lift is
+   * a once-off above the retry. */
+  r_mpint_fe_from_mpint (&e_fe, &e, pk->ctx_n.n_digits);
+  r_mpint_fe_mont_in (&e_M, &e_fe, &pk->mont_r_sq_n, &pk->ctx_n);
+
+  for (;;) {
+    do {
+      if (!r_prng_fill (prng, kbuf, kbytes))
+        goto cleanup;
+      r_mpint_set_binary (&k, kbuf, kbytes);
+      if (!r_mpint_mod (&k, &k, &pk->pub.curve.n))
+        goto cleanup;
+    } while (r_mpint_iszero (&k));
+
+    /* r = x-coordinate of k*G mod n. The CT scalar-mul iterates a
+     * fixed bit count (curve order's bit length + 1) regardless of
+     * k's actual value, so the timing doesn't leak k's bit length. */
+    if (!r_ecurve_point_scalar_mul (&kG, &k, &pk->pub.curve.G, &pk->pub.curve))
+      goto cleanup;
+    if (kG.is_infinity)
+      continue;
+    if (!r_mpint_mod (&r, &kG.x, &pk->pub.curve.n))
+      goto cleanup;
+    if (r_mpint_iszero (&r))
+      continue;
+
+    /* CT s = k^-1 * (e + d*r) mod n. Fermat inversion via the FE
+     * primitives so k^-1 doesn't leak; same shape as the DSA s
+     * computation (with d / n / e replacing x / q / z). */
+    r_mpint_fe_from_mpint (&k_fe, &k, pk->ctx_n.n_digits);
+    r_mpint_fe_from_mpint (&r_fe, &r, pk->ctx_n.n_digits);
+    r_mpint_fe_mont_in (&k_M, &k_fe, &pk->mont_r_sq_n, &pk->ctx_n);
+    r_mpint_fe_mont_in (&r_M, &r_fe, &pk->mont_r_sq_n, &pk->ctx_n);
+    r_mpint_fe_invmod_mont (&kinv_M, &k_M, &pk->n_minus_2_fe,
+        pk->n_minus_2_bits, &pk->mont_r_sq_n, &pk->ctx_n);
+    r_mpint_fe_mul_mont (&dr_M, &pk->d_M, &r_M, &pk->ctx_n);
+    r_mpint_fe_add (&er_M, &e_M, &dr_M, &pk->ctx_n);
+    r_mpint_fe_mul_mont (&s_M, &kinv_M, &er_M, &pk->ctx_n);
+    r_mpint_fe_mont_out (&s_fe, &s_M, &pk->ctx_n);
+    if (!r_mpint_fe_to_mpint (&s, &s_fe, pk->ctx_n.n_digits))
+      goto cleanup;
+    if (!r_mpint_iszero (&s))
+      break;
+  }
+
+  /* Ecdsa-Sig-Value ::= SEQUENCE { r INTEGER, s INTEGER } */
+  if ((enc = r_asn1_bin_encoder_new (R_ASN1_DER)) == NULL)
+    goto cleanup;
+  if (r_asn1_bin_encoder_begin_constructed (enc, id, 0) != R_ASN1_ENCODER_OK)
+    goto cleanup;
+  if (r_asn1_bin_encoder_add_integer_mpint (enc, &r) != R_ASN1_ENCODER_OK ||
+      r_asn1_bin_encoder_add_integer_mpint (enc, &s) != R_ASN1_ENCODER_OK) {
+    r_asn1_bin_encoder_end_constructed (enc);
+    goto cleanup;
+  }
+  r_asn1_bin_encoder_end_constructed (enc);
+
+  if ((sigbuf = r_asn1_bin_encoder_get_data (enc, &sigbufsize)) == NULL)
+    goto cleanup;
+  if (*sigsize < sigbufsize) {
+    ret = R_CRYPTO_BUFFER_TOO_SMALL;
+    goto cleanup_with_ret;
+  }
+  r_memcpy (sig, sigbuf, sigbufsize);
+  *sigsize = sigbufsize;
+  ok = TRUE;
+
+cleanup:
+  ret = ok ? R_CRYPTO_OK : R_CRYPTO_SIGN_FAILED;
+cleanup_with_ret:
+  r_free (sigbuf);
+  if (enc != NULL) r_asn1_bin_encoder_unref (enc);
+  r_mpint_clear (&k);
+  r_mpint_clear (&r);
+  r_mpint_clear (&s);
+  r_mpint_clear (&e);
+  r_ecurve_point_clear (&kG);
+  /* Inline-storage FE temporaries derived from k live on the stack
+   * and would survive the function frame until overwritten; wipe
+   * them explicitly. The key-cached fields (ctx_n / mont_r_sq_n /
+   * n_minus_2_fe / d_M) stay with the key and get wiped in
+   * r_ecc_priv_key_free. */
+  r_memclear_secure (&k_fe, sizeof (k_fe));
+  r_memclear_secure (&k_M, sizeof (k_M));
+  r_memclear_secure (&kinv_M, sizeof (kinv_M));
+  r_memclear_secure (&e_fe, sizeof (e_fe));
+  r_memclear_secure (&e_M, sizeof (e_M));
+  r_memclear_secure (&r_fe, sizeof (r_fe));
+  r_memclear_secure (&r_M, sizeof (r_M));
+  r_memclear_secure (&dr_M, sizeof (dr_M));
+  r_memclear_secure (&er_M, sizeof (er_M));
+  r_memclear_secure (&s_M, sizeof (s_M));
+  r_memclear_secure (&s_fe, sizeof (s_fe));
+  r_prng_unref (prng);
+  (void) own_prng;
+  return ret;
+}
+
+static RCryptoResult
+r_ecdsa_verify (const RCryptoKey * key, RMsgDigestType mdtype,
+    rconstpointer hash, rsize hashsize, rconstpointer sig, rsize sigsize)
+{
+  /* The pub key carries the curve / generator / Q. Priv keys also
+   * route through here (RCryptoAlgoInfo::verify is shared on both
+   * info structs), so cast through the pub view either way. */
+  const REccPubKey * pk = (const REccPubKey *)key;
+  rmpint r, s, e, w, u1, u2, x_mod_n;
+  REcurveAffinePoint u1G, u2Q, P;
+  RCryptoResult ret = R_CRYPTO_VERIFY_FAILED;
+
+  (void) mdtype;
+
+  if (R_UNLIKELY (hash == NULL || hashsize == 0 || sig == NULL || sigsize == 0))
+    return R_CRYPTO_INVAL;
+  if (R_UNLIKELY (!pk->has_math))
+    return R_CRYPTO_NOT_AVAILABLE;
+  if (R_UNLIKELY (pk->Q.is_infinity))
+    return R_CRYPTO_VERIFY_FAILED;
+
+  if (!r_ecdsa_decode_sig (sig, sigsize, &r, &s))
+    return R_CRYPTO_VERIFY_FAILED;
+
+  /* Range check: r, s in [1, n-1]. */
+  if (r_mpint_cmp_i32 (&r, 1) < 0 || r_mpint_cmp (&r, &pk->curve.n) >= 0 ||
+      r_mpint_cmp_i32 (&s, 1) < 0 || r_mpint_cmp (&s, &pk->curve.n) >= 0)
+    goto out;
+
+  r_ecdsa_hash_to_mpint (&e, &pk->curve.n, hash, hashsize);
+  r_mpint_init (&w);
+  r_mpint_init (&u1);
+  r_mpint_init (&u2);
+  r_mpint_init (&x_mod_n);
+  r_ecurve_point_init (&u1G);
+  r_ecurve_point_init (&u2Q);
+  r_ecurve_point_init (&P);
+
+  /* P = u1*G + u2*Q where u1 = e*w, u2 = r*w, w = s^-1 mod n. Valid
+   * iff P is finite and P.x mod n == r. Variable-time throughout -
+   * all inputs are public so no CT requirement. */
+  if (r_mpint_invmod (&w, &s, &pk->curve.n) &&
+      r_mpint_mul (&u1, &e, &w) && r_mpint_mod (&u1, &u1, &pk->curve.n) &&
+      r_mpint_mul (&u2, &r, &w) && r_mpint_mod (&u2, &u2, &pk->curve.n) &&
+      r_ecurve_point_scalar_mul (&u1G, &u1, &pk->curve.G, &pk->curve) &&
+      r_ecurve_point_scalar_mul (&u2Q, &u2, &pk->Q, &pk->curve) &&
+      r_ecurve_point_add (&P, &u1G, &u2Q, &pk->curve) &&
+      !P.is_infinity &&
+      r_mpint_mod (&x_mod_n, &P.x, &pk->curve.n) &&
+      r_mpint_cmp (&x_mod_n, &r) == 0) {
+    ret = R_CRYPTO_OK;
+  }
+
+  r_mpint_clear (&e);
+  r_mpint_clear (&w);
+  r_mpint_clear (&u1);
+  r_mpint_clear (&u2);
+  r_mpint_clear (&x_mod_n);
+  r_ecurve_point_clear (&u1G);
+  r_ecurve_point_clear (&u2Q);
+  r_ecurve_point_clear (&P);
+
+out:
+  r_mpint_clear (&r);
+  r_mpint_clear (&s);
+  return ret;
+}
+
 static RCryptoKey *
 r_ecc_priv_key_new_full (REcurveID curve, RCryptoAlgorithm algo,
     rconstpointer ecp, rsize ecpsize,
@@ -286,7 +639,8 @@ r_ecc_priv_key_new_full (REcurveID curve, RCryptoAlgorithm algo,
 {
   REccPrivKey * ret;
   static const RCryptoAlgoInfo ecdsa_priv_key_info = {
-    R_CRYPTO_ALGO_ECDSA, R_ECDSA_STR, NULL, NULL, NULL, NULL, NULL
+    R_CRYPTO_ALGO_ECDSA, R_ECDSA_STR,
+    NULL, NULL, r_ecdsa_sign, r_ecdsa_verify, NULL
   };
   static const RCryptoAlgoInfo ecdh_priv_key_info = {
     R_CRYPTO_ALGO_ECDH, R_ECDH_STR, NULL, NULL, NULL, NULL, NULL
@@ -321,6 +675,16 @@ r_ecc_priv_key_new_full (REcurveID curve, RCryptoAlgorithm algo,
   ret->pub.key.type = R_CRYPTO_PRIVATE_KEY;
   ret->pub.key.algo = is_ecdh ? &ecdh_priv_key_info : &ecdsa_priv_key_info;
   ret->pub.key.bits = (ruint) (scalarsize * 8);
+
+  /* For ECDSA keys with the math layer loaded, populate the mod-n
+   * Mont cache so r_ecdsa_sign skips the per-call setup. Failure
+   * here doesn't fail the construction - keys without the cache are
+   * still useful for parsing / round-tripping / verifying, they just
+   * can't sign. The cache also doesn't apply to ECDH keys at all. */
+  if (!is_ecdh && ret->pub.has_math) {
+    if (r_ecdsa_priv_key_precompute_cache (ret))
+      ret->has_ecdsa_cache = TRUE;
+  }
 
   return (RCryptoKey *) ret;
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -26,6 +26,7 @@ rlibtest_sources = [
   'rdictionary.c',
   'rdsa.c',
   'recdh.c',
+  'recdsa.c',
   'recurve.c',
   'rdirtree.c',
   'relf.c',

--- a/test/recdsa.c
+++ b/test/recdsa.c
@@ -1,0 +1,288 @@
+#include <rlib/rcrypto.h>
+
+#include <rlib/crypto/recc.h>
+#include <rlib/crypto/recurve.h>
+
+/* Per-curve coverage for the sign-then-verify roundtrip. Generating Q
+ * from d at test time keeps the fixtures small and exercises the math
+ * layer's encoding round-trip alongside the ECDSA path. The scalars
+ * below are deliberately not "nice" - just arbitrary in-range values
+ * that produce a valid keypair on each curve. */
+typedef struct {
+  REcurveID curve;
+  const rchar * d_hex;
+} REcdsaTestCurve;
+
+/* A single short scalar works as a valid d on every curve we ship -
+ * the order n is always well above 2^128. Keeping one value across
+ * curves makes the test data trivial and avoids per-curve range
+ * arithmetic. */
+#define ECDSA_TEST_D_HEX  "0x123456789abcdef0123456789abcdef"
+
+static const REcdsaTestCurve test_curves[] = {
+  { R_ECURVE_ID_SECP192R1, ECDSA_TEST_D_HEX },
+  { R_ECURVE_ID_SECP224R1, ECDSA_TEST_D_HEX },
+  { R_ECURVE_ID_SECP256R1, ECDSA_TEST_D_HEX },
+  { R_ECURVE_ID_SECP384R1, ECDSA_TEST_D_HEX },
+  { R_ECURVE_ID_SECP521R1, ECDSA_TEST_D_HEX },
+  { R_ECURVE_ID_SECP256K1, ECDSA_TEST_D_HEX },
+};
+
+/* SHA-256 of "rlib ecdsa test message" - any fixed 32-byte hash works
+ * for ECDSA sign / verify; we just need a deterministic value the
+ * tampered-hash test can mutate without re-running a hashing
+ * primitive. */
+static const ruint8 hash_a[32] = {
+  0x9f, 0x86, 0xd0, 0x81, 0x88, 0x4c, 0x7d, 0x65,
+  0x9a, 0x2f, 0xea, 0xa0, 0xc5, 0x5a, 0xd0, 0x15,
+  0xa3, 0xbf, 0x4f, 0x1b, 0x2b, 0x0b, 0x82, 0x2c,
+  0xd1, 0x5d, 0x6c, 0x15, 0xb0, 0xf0, 0x0a, 0x08,
+};
+static const ruint8 hash_b[32] = {
+  0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14,
+  0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24,
+  0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c,
+  0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
+};
+
+/* Build an ECDSA keypair from a hex scalar: compute Q = d*G on the
+ * curve, SEC 1-encode Q as uncompressed bytes, then hand both halves
+ * to the construction APIs. Returns FALSE on any step that fails
+ * (e.g. unsupported curve, d outside [1, n-1]). */
+static rboolean
+make_ecdsa_keypair_from_d_hex (REcurveID curve_id, const rchar * d_hex,
+    RCryptoKey ** priv_out, RCryptoKey ** pub_out)
+{
+  REcurve curve;
+  rmpint d;
+  REcurveAffinePoint Q;
+  ruint8 ecpbuf[1 + 2 * 66 + 1];  /* coord_bytes <= 66 for secp521r1 */
+  ruint8 dbuf[66];
+  rsize ecpsize = sizeof (ecpbuf);
+  rsize dbytes;
+  rboolean ok = FALSE;
+
+  *priv_out = NULL;
+  *pub_out = NULL;
+
+  if (!r_ecurve_init (&curve, curve_id))
+    return FALSE;
+
+  r_mpint_init_str (&d, d_hex, NULL, 16);
+  r_ecurve_point_init (&Q);
+
+  /* d must be in [1, n-1]. */
+  if (r_mpint_cmp_i32 (&d, 1) < 0 || r_mpint_cmp (&d, &curve.n) >= 0)
+    goto out;
+
+  if (!r_ecurve_point_scalar_mul (&Q, &d, &curve.G, &curve))
+    goto out;
+  if (Q.is_infinity)
+    goto out;
+
+  if (!r_ecurve_point_to_uncompressed (&Q, &curve, ecpbuf, &ecpsize))
+    goto out;
+
+  /* Pack d as fixed-width bytes matching the curve's coord size. */
+  dbytes = curve.coord_bytes;
+  if (dbytes > sizeof (dbuf))
+    goto out;
+  if (!r_mpint_to_binary_with_size (&d, dbuf, dbytes))
+    goto out;
+
+  *pub_out = r_ecdsa_pub_key_new (curve_id, ecpbuf, ecpsize);
+  *priv_out = r_ecdsa_priv_key_new (curve_id, ecpbuf, ecpsize, dbuf, dbytes);
+  ok = (*pub_out != NULL && *priv_out != NULL);
+  if (!ok) {
+    if (*pub_out != NULL) { r_crypto_key_unref (*pub_out); *pub_out = NULL; }
+    if (*priv_out != NULL) { r_crypto_key_unref (*priv_out); *priv_out = NULL; }
+  }
+
+out:
+  r_mpint_clear (&d);
+  r_ecurve_point_clear (&Q);
+  r_ecurve_clear (&curve);
+  return ok;
+}
+
+RTEST_LOOP (recdsa, sign_verify_roundtrip, RTEST_FAST,
+    0, R_N_ELEMENTS (test_curves))
+{
+  /* Sign with the private key, verify with the matching public key,
+   * across every prime curve the math layer supports. */
+  const REcdsaTestCurve * tc = &test_curves[__i];
+  RCryptoKey * priv, * pub;
+  RPrng * prng;
+  ruint8 sig[256];
+  rsize sigsize = sizeof (sig);
+
+  r_assert (make_ecdsa_keypair_from_d_hex (tc->curve, tc->d_hex, &priv, &pub));
+  r_assert_cmpptr ((prng = r_rand_prng_new ()), !=, NULL);
+
+  r_assert_cmpint (r_crypto_key_sign (priv, prng, R_MSG_DIGEST_TYPE_SHA256,
+        hash_a, sizeof (hash_a), sig, &sigsize), ==, R_CRYPTO_OK);
+  r_assert_cmpuint (sigsize, >, 0);
+  r_assert_cmpint (r_crypto_key_verify (pub, R_MSG_DIGEST_TYPE_SHA256,
+        hash_a, sizeof (hash_a), sig, sigsize), ==, R_CRYPTO_OK);
+
+  /* Verify also works through the priv key (verify hook is wired on
+   * both algo-info structs). */
+  r_assert_cmpint (r_crypto_key_verify (priv, R_MSG_DIGEST_TYPE_SHA256,
+        hash_a, sizeof (hash_a), sig, sigsize), ==, R_CRYPTO_OK);
+
+  r_crypto_key_unref (priv);
+  r_crypto_key_unref (pub);
+  r_prng_unref (prng);
+}
+RTEST_END;
+
+RTEST (recdsa, verify_rejects_tampered_hash, RTEST_FAST)
+{
+  /* Signature was generated over hash_a; verifying against hash_b
+   * must fail with VERIFY_FAILED, not OK. */
+  RCryptoKey * priv, * pub;
+  RPrng * prng;
+  ruint8 sig[128];
+  rsize sigsize = sizeof (sig);
+
+  r_assert (make_ecdsa_keypair_from_d_hex (R_ECURVE_ID_SECP256R1,
+        test_curves[2].d_hex, &priv, &pub));
+  r_assert_cmpptr ((prng = r_rand_prng_new ()), !=, NULL);
+
+  r_assert_cmpint (r_crypto_key_sign (priv, prng, R_MSG_DIGEST_TYPE_SHA256,
+        hash_a, sizeof (hash_a), sig, &sigsize), ==, R_CRYPTO_OK);
+  r_assert_cmpint (r_crypto_key_verify (pub, R_MSG_DIGEST_TYPE_SHA256,
+        hash_b, sizeof (hash_b), sig, sigsize), ==, R_CRYPTO_VERIFY_FAILED);
+
+  r_crypto_key_unref (priv);
+  r_crypto_key_unref (pub);
+  r_prng_unref (prng);
+}
+RTEST_END;
+
+RTEST (recdsa, verify_rejects_malformed_signature, RTEST_FAST)
+{
+  /* Garbage bytes that aren't a valid Ecdsa-Sig-Value SEQUENCE must
+   * surface as VERIFY_FAILED rather than crashing the ASN.1 decoder.
+   * A well-formed SEQUENCE with r = 0 must also be rejected by the
+   * range check before any scalar-mul work happens. */
+  RCryptoKey * priv, * pub;
+  static const ruint8 junk[] = { 0xde, 0xad, 0xbe, 0xef };
+  static const ruint8 r_zero[] = { 0x30, 0x06, 0x02, 0x01, 0x00, 0x02, 0x01, 0x01 };
+
+  r_assert (make_ecdsa_keypair_from_d_hex (R_ECURVE_ID_SECP256R1,
+        test_curves[2].d_hex, &priv, &pub));
+
+  r_assert_cmpint (r_crypto_key_verify (pub, R_MSG_DIGEST_TYPE_SHA256,
+        hash_a, sizeof (hash_a), junk, sizeof (junk)),
+      ==, R_CRYPTO_VERIFY_FAILED);
+  r_assert_cmpint (r_crypto_key_verify (pub, R_MSG_DIGEST_TYPE_SHA256,
+        hash_a, sizeof (hash_a), r_zero, sizeof (r_zero)),
+      ==, R_CRYPTO_VERIFY_FAILED);
+
+  r_crypto_key_unref (priv);
+  r_crypto_key_unref (pub);
+}
+RTEST_END;
+
+RTEST (recdsa, sign_fresh_k_each_call, RTEST_FAST)
+{
+  /* Signing the same hash twice must yield different signatures -
+   * matching outputs would mean a constant k, which leaks d. The
+   * sample size is tiny (we just need to see the two signatures
+   * differ at all), so collisions on a healthy PRNG are negligible. */
+  RCryptoKey * priv, * pub;
+  RPrng * prng;
+  ruint8 sig1[128], sig2[128];
+  rsize sigsize1 = sizeof (sig1), sigsize2 = sizeof (sig2);
+
+  r_assert (make_ecdsa_keypair_from_d_hex (R_ECURVE_ID_SECP256R1,
+        test_curves[2].d_hex, &priv, &pub));
+  r_assert_cmpptr ((prng = r_rand_prng_new ()), !=, NULL);
+
+  r_assert_cmpint (r_crypto_key_sign (priv, prng, R_MSG_DIGEST_TYPE_SHA256,
+        hash_a, sizeof (hash_a), sig1, &sigsize1), ==, R_CRYPTO_OK);
+  r_assert_cmpint (r_crypto_key_sign (priv, prng, R_MSG_DIGEST_TYPE_SHA256,
+        hash_a, sizeof (hash_a), sig2, &sigsize2), ==, R_CRYPTO_OK);
+  r_assert (sigsize1 != sigsize2 || r_memcmp (sig1, sig2, sigsize1) != 0);
+
+  r_crypto_key_unref (priv);
+  r_crypto_key_unref (pub);
+  r_prng_unref (prng);
+}
+RTEST_END;
+
+RTEST (recdsa, rfc6979_a2_5_p256_sample_verify, RTEST_FAST)
+{
+  /* RFC 6979 Appendix A.2.5 vector: ECDSA-P-256 + SHA-256, message
+   * "sample", deterministic k. Used here only for verify - our sign
+   * path samples k with extra random bits, so we can't reproduce the
+   * RFC's exact (r, s) - but verifying the canonical signature is a
+   * strong interop check against any reference implementation. */
+  static const ruint8 pubkey[] = {
+    0x04,
+    /* Q_x */
+    0x60, 0xFE, 0xD4, 0xBA, 0x25, 0x5A, 0x9D, 0x31, 0xC9, 0x61, 0xEB, 0x74,
+    0xC6, 0x35, 0x6D, 0x68, 0xC0, 0x49, 0xB8, 0x92, 0x3B, 0x61, 0xFA, 0x6C,
+    0xE6, 0x69, 0x62, 0x2E, 0x60, 0xF2, 0x9F, 0xB6,
+    /* Q_y */
+    0x79, 0x03, 0xFE, 0x10, 0x08, 0xB8, 0xBC, 0x99, 0xA4, 0x1A, 0xE9, 0xE9,
+    0x56, 0x28, 0xBC, 0x64, 0xF2, 0xF1, 0xB2, 0x0C, 0x2D, 0x7E, 0x9F, 0x51,
+    0x77, 0xA3, 0xC2, 0x94, 0xD4, 0x46, 0x22, 0x99,
+  };
+  static const ruint8 hash[] = {
+    /* SHA-256("sample") */
+    0xAF, 0x2B, 0xDB, 0xE1, 0xAA, 0x9B, 0x6E, 0xC1, 0xE2, 0xAD, 0xE1, 0xD6,
+    0x94, 0xF4, 0x1F, 0xC7, 0x1A, 0x83, 0x1D, 0x02, 0x68, 0xE9, 0x89, 0x15,
+    0x62, 0x11, 0x3D, 0x8A, 0x62, 0xAD, 0xD1, 0xBF,
+  };
+  /* DER ASN.1 of Ecdsa-Sig-Value { r, s }: both r and s have the high
+   * bit set in their MSB, so each INTEGER gets a leading 0x00 byte
+   * (33 content bytes each). Outer SEQUENCE length = 2*(2 + 33) = 70. */
+  static const ruint8 sig[] = {
+    0x30, 0x46,
+    0x02, 0x21, 0x00,
+    0xEF, 0xD4, 0x8B, 0x2A, 0xAC, 0xB6, 0xA8, 0xFD, 0x11, 0x40, 0xDD, 0x9C,
+    0xD4, 0x5E, 0x81, 0xD6, 0x9D, 0x2C, 0x87, 0x7B, 0x56, 0xAA, 0xF9, 0x91,
+    0xC3, 0x4D, 0x0E, 0xA8, 0x4E, 0xAF, 0x37, 0x16,
+    0x02, 0x21, 0x00,
+    0xF7, 0xCB, 0x1C, 0x94, 0x2D, 0x65, 0x7C, 0x41, 0xD4, 0x36, 0xC7, 0xA1,
+    0xB6, 0xE2, 0x9F, 0x65, 0xF3, 0xE9, 0x00, 0xDB, 0xB9, 0xAF, 0xF4, 0x06,
+    0x4D, 0xC4, 0xAB, 0x2F, 0x84, 0x3A, 0xCD, 0xA8,
+  };
+  RCryptoKey * pub;
+
+  r_assert_cmpptr ((pub = r_ecdsa_pub_key_new (R_ECURVE_ID_SECP256R1,
+        pubkey, sizeof (pubkey))), !=, NULL);
+  r_assert_cmpint (r_crypto_key_verify (pub, R_MSG_DIGEST_TYPE_SHA256,
+        hash, sizeof (hash), sig, sizeof (sig)), ==, R_CRYPTO_OK);
+
+  r_crypto_key_unref (pub);
+}
+RTEST_END;
+
+RTEST (recdsa, sign_rejects_pub_key, RTEST_FAST)
+{
+  /* r_crypto_key_sign on a public key must surface WRONG_TYPE rather
+   * than crashing. The verify hook is wired on the pub algo-info, but
+   * sign is not. */
+  RCryptoKey * priv, * pub;
+  RPrng * prng;
+  ruint8 sig[128];
+  rsize sigsize = sizeof (sig);
+
+  r_assert (make_ecdsa_keypair_from_d_hex (R_ECURVE_ID_SECP256R1,
+        test_curves[2].d_hex, &priv, &pub));
+  r_assert_cmpptr ((prng = r_rand_prng_new ()), !=, NULL);
+
+  /* r_crypto_key_sign returns NOT_AVAILABLE when the algo info has a
+   * NULL sign hook; that's what pub keys carry. */
+  r_assert_cmpint (r_crypto_key_sign (pub, prng, R_MSG_DIGEST_TYPE_SHA256,
+        hash_a, sizeof (hash_a), sig, &sigsize),
+      ==, R_CRYPTO_NOT_AVAILABLE);
+
+  r_crypto_key_unref (priv);
+  r_crypto_key_unref (pub);
+  r_prng_unref (prng);
+}
+RTEST_END;


### PR DESCRIPTION
## Summary

- `r_ecdsa_sign` — constant-time, mirrors the DSA sign path. FIPS 186-4 §B.5.1 extra-random-bits nonce sampling, `k*G` via the existing CT scalar-mul ladder, `s = k⁻¹·(e + d·r) mod n` through the fixed-width `RMpintFE` primitives with Fermat invmod of `k`.
- `r_ecdsa_verify` — variable-time (all inputs are public). Decode (r, s), range-check, compute `u1·G + u2·Q`, accept iff the result's x-coord reduces to r mod n. Bad ASN.1 / out-of-range r,s / point-at-infinity all surface as `VERIFY_FAILED`.
- Per-key mod-n Montgomery cache on `RECCPrivKey` populated by `r_ecdsa_priv_key_precompute_cache` so each signature pays one scalar-mul + one invmod, no per-call Mont setup. Wiped on key free.
- Both `ecdsa_pub_key_info` and `ecdsa_priv_key_info` algo-infos updated — verify hook on both, sign on priv.

Covers all six prime curves the math layer supports (secp192r1 / 224r1 / 256r1 / 384r1 / 521r1 / 256k1). Test surface includes an RFC 6979 Appendix A.2.5 KAT verify vector for ECDSA-P-256 + SHA-256, plus the standard fail-paths (tampered hash, malformed sig, r=0 sig, fresh-k-each-call, sign-with-pub-key rejection).

Residual that's left for follow-up: `r = (k*G).x mod n` flows through variable-time `r_mpint_mod` on an mpint derived from secret k — same posture as DSA's analogous `(g^k mod p) mod q`. Not a regression.

## Test plan

- [x] Full default + `--heavy` suite passes (3769 tests including the new ECDSA suite)
- [x] ASan/UBSan and TSan green on the new tests
- [x] gcc-warn release build clean; clang and MSVC matrices via CI on push
- [x] RFC 6979 A.2.5 vector verifies as expected against the canonical (r, s)
- [x] Per-curve sign-then-verify roundtrip on all six prime curves