### PR TITLE
ASN.1 export for ECDSA and ECDH keys

### DIFF
--- a/include/rlib/crypto/recurve.h
+++ b/include/rlib/crypto/recurve.h
@@ -122,6 +122,13 @@ R_API void r_ecurve_clear (REcurve * curve);
  * enum value. Returns FALSE for OIDs we don't recognise. */
 R_API rboolean r_ecurve_id_from_oid (REcurveID * curve,
     rconstpointer oid, rsize oidsize);
+/* Inverse of r_ecurve_id_from_oid: returns a pointer to the pre-
+ * encoded OID bytes for the given curve, with the length written to
+ * *size. Length is exposed because several curve OIDs contain an
+ * embedded NUL, so a NUL-terminated convention (strlen on the
+ * macro) would truncate them. NULL + *size = 0 for unknown curves;
+ * size may be NULL if the caller already knows the length. */
+R_API const ruint8 * r_ecurve_oid_from_id (REcurveID curve, rsize * size);
 
 R_API rboolean r_ecurve_point_neg (REcurveAffinePoint * out,
     const REcurveAffinePoint * a, const REcurve * curve);

--- a/rlib/crypto/recc.c
+++ b/rlib/crypto/recc.c
@@ -22,6 +22,7 @@
 #include <rlib/crypto/recc.h>
 
 #include <rlib/asn1/rasn1.h>
+#include <rlib/asn1/roid.h>
 #include <rlib/rmem.h>
 #include <rlib/rrand.h>
 
@@ -70,13 +71,35 @@ typedef struct {
 
 /* Forward declarations - the algo-info structs in the key-init helpers
  * below reference these, and the bodies live further down so the
- * cache-aware sign / verify code sits next to the cache populate. */
+ * cache-aware sign / verify code sits next to the cache populate. The
+ * ASN.1 export wrappers are similarly forward-declared so all the
+ * algo-info structs in the same compilation unit can name them. */
 static RCryptoResult r_ecdsa_sign (const RCryptoKey * key, RPrng * prng,
     RMsgDigestType mdtype, rconstpointer hash, rsize hashsize,
     rpointer sig, rsize * sigsize);
 static RCryptoResult r_ecdsa_verify (const RCryptoKey * key,
     RMsgDigestType mdtype, rconstpointer hash, rsize hashsize,
     rconstpointer sig, rsize sigsize);
+static RCryptoResult r_ecdsa_pub_key_export (const RCryptoKey * key,
+    RAsn1BinEncoder * enc);
+static RCryptoResult r_ecdsa_priv_key_export (const RCryptoKey * key,
+    RAsn1BinEncoder * enc);
+static RCryptoResult r_ecdh_pub_key_export (const RCryptoKey * key,
+    RAsn1BinEncoder * enc);
+static RCryptoResult r_ecdh_priv_key_export (const RCryptoKey * key,
+    RAsn1BinEncoder * enc);
+
+/* Priv-key algo-info tables. Hoisted to file scope so the two
+ * construction paths (r_ecc_priv_key_new_full and r_ecdh_priv_key_new_gen)
+ * pick up the same table without duplicating the definition. */
+static const RCryptoAlgoInfo g_ecdsa_priv_key_info = {
+  R_CRYPTO_ALGO_ECDSA, R_ECDSA_STR,
+  NULL, NULL, r_ecdsa_sign, r_ecdsa_verify, r_ecdsa_priv_key_export
+};
+static const RCryptoAlgoInfo g_ecdh_priv_key_info = {
+  R_CRYPTO_ALGO_ECDH, R_ECDH_STR,
+  NULL, NULL, NULL, NULL, r_ecdh_priv_key_export
+};
 
 static void
 r_ecc_pub_key_free (rpointer data)
@@ -121,7 +144,7 @@ r_ecdsa_pub_key_init (RCryptoKey * key, ruint bits)
 {
   static const RCryptoAlgoInfo ecdsa_pub_key_info = {
     R_CRYPTO_ALGO_ECDSA, R_ECDSA_STR,
-    NULL, NULL, NULL, r_ecdsa_verify, NULL
+    NULL, NULL, NULL, r_ecdsa_verify, r_ecdsa_pub_key_export
   };
 
   r_ref_init (key, r_ecc_pub_key_free);
@@ -160,7 +183,7 @@ r_ecdh_pub_key_init (RCryptoKey * key, ruint bits)
 {
   static const RCryptoAlgoInfo ecdh_pub_key_info = {
     R_CRYPTO_ALGO_ECDH, R_ECDH_STR,
-    NULL, NULL, NULL, NULL, NULL
+    NULL, NULL, NULL, NULL, r_ecdh_pub_key_export
   };
 
   r_ref_init (key, r_ecc_pub_key_free);
@@ -240,12 +263,17 @@ r_ecc_priv_key_free (rpointer data)
   }
 }
 
-/* Load the scalar bytes into priv->d and, if no explicit public point
- * was supplied but the curve is known and the caller wants it,
- * derive Q = d * G so ECDH private keys minted from "just the scalar"
- * still expose a usable public point. Range-checks d to [1, n-1] in
- * both branches; returns FALSE on a scalar that isn't a valid private
- * key for the curve. */
+/* Load the scalar bytes into priv->d. When no explicit public point
+ * is supplied, attempt r_ecurve_init on the named curve; if it
+ * succeeds, derive Q = d * G so subsequent sign / verify / shared-
+ * secret paths can use the parsed key without an out-of-line ecp
+ * dance. derive_q_if_needed only controls the failure semantics
+ * when the math layer can't load the curve: TRUE for ECDH (which
+ * needs Q to do anything useful, so we refuse the construction),
+ * FALSE for ECDSA (which keeps the lenient raw-bytes-only fallback
+ * so ASN.1 / cert fixtures on unsupported curves still parse).
+ * Range-checks d to [1, n-1] whenever math is available; returns
+ * FALSE on a scalar that isn't a valid private key for the curve. */
 static rboolean
 r_ecc_priv_key_load_scalar (REccPrivKey * priv, REcurveID curve,
     const ruint8 * scalar, rsize scalarsize, rboolean derive_q_if_needed)
@@ -282,34 +310,36 @@ r_ecc_priv_key_load_scalar (REccPrivKey * priv, REcurveID curve,
         return FALSE;
       }
     }
-  } else if (derive_q_if_needed) {
-    /* ECDH path with no public point on hand: we need real math.
-     * Refuse outright if the curve isn't supported by the math layer
-     * (returning a parsable-but-useless key would just defer the
-     * failure to compute_shared). */
-    if (!r_ecurve_init (&priv->pub.curve, curve)) {
+  } else {
+    /* No ecp was parsed. Try to load the math layer regardless of
+     * algorithm; if the curve is supported, derive Q from d so the
+     * subsequent sign / verify / compute_shared paths can use it.
+     * For ECDH math is mandatory (a usable key requires Q); we
+     * refuse the construction if init fails. For ECDSA we keep the
+     * lenient fallback - some ASN.1 / cert tests carry keys on
+     * curves the math layer can't yet decode, and those should
+     * still parse as raw-d-only. */
+    if (r_ecurve_init (&priv->pub.curve, curve)) {
+      if (r_mpint_cmp_i32 (&priv->d, 1) < 0 ||
+          r_mpint_cmp (&priv->d, &priv->pub.curve.n) >= 0) {
+        r_ecurve_clear (&priv->pub.curve);
+        r_mpint_clear (&priv->d);
+        return FALSE;
+      }
+      r_ecurve_point_init (&priv->pub.Q);
+      if (!r_ecurve_point_scalar_mul (&priv->pub.Q, &priv->d,
+            &priv->pub.curve.G, &priv->pub.curve)) {
+        r_ecurve_point_clear (&priv->pub.Q);
+        r_ecurve_clear (&priv->pub.curve);
+        r_mpint_clear (&priv->d);
+        return FALSE;
+      }
+      priv->pub.has_math = TRUE;
+    } else if (derive_q_if_needed) {
       r_mpint_clear (&priv->d);
       return FALSE;
     }
-    if (r_mpint_cmp_i32 (&priv->d, 1) < 0 ||
-        r_mpint_cmp (&priv->d, &priv->pub.curve.n) >= 0) {
-      r_ecurve_clear (&priv->pub.curve);
-      r_mpint_clear (&priv->d);
-      return FALSE;
-    }
-    r_ecurve_point_init (&priv->pub.Q);
-    if (!r_ecurve_point_scalar_mul (&priv->pub.Q, &priv->d,
-          &priv->pub.curve.G, &priv->pub.curve)) {
-      r_ecurve_point_clear (&priv->pub.Q);
-      r_ecurve_clear (&priv->pub.curve);
-      r_mpint_clear (&priv->d);
-      return FALSE;
-    }
-    priv->pub.has_math = TRUE;
   }
-  /* else: ECDSA path with no public point - keep d as raw bytes only
-   * so existing ASN.1 / cert tests using encodings the math layer
-   * can't yet decode keep loading. */
 
   priv->has_d = TRUE;
   return TRUE;
@@ -632,19 +662,202 @@ out:
   return ret;
 }
 
+/* ---- ASN.1 export (RFC 5480 SubjectPublicKeyInfo for pub keys,
+ * RFC 5958 OneAsymmetricKey + RFC 5915 ECPrivateKey for priv keys).
+ * ECDSA and ECDH differ only in the AlgorithmIdentifier OID; share
+ * one helper per side, dispatch on the OID. ---- */
+
+/* Emit an OID TLV with an explicit byte length. The library's
+ * r_asn1_bin_encoder_add_oid_rawsz uses strlen, which truncates
+ * mid-OID for any OID containing an embedded NUL (which several of
+ * the ECC curve OIDs do: SECP224R1 / 384R1 / 521R1 / 192K1 / 224K1
+ * / 256K1 all have \x00 in their encoding). */
+static RAsn1EncoderStatus
+r_ecc_encoder_add_oid (RAsn1BinEncoder * enc, const ruint8 * oid, rsize size)
+{
+  ruint8 id_oid = R_ASN1_ID (R_ASN1_ID_UNIVERSAL,
+      R_ASN1_ID_PRIMITIVE, R_ASN1_ID_OBJECT_IDENTIFIER);
+  return r_asn1_bin_encoder_add_raw (enc, id_oid, oid, size);
+}
+
+static RCryptoResult
+r_ecc_pub_key_export_with_algo_oid (const RCryptoKey * key,
+    RAsn1BinEncoder * enc, const ruint8 * algo_oid, rsize algo_oid_size)
+{
+  const REccPubKey * pk = (const REccPubKey *)key;
+  ruint8 id_seq = R_ASN1_ID (R_ASN1_ID_UNIVERSAL,
+      R_ASN1_ID_CONSTRUCTED, R_ASN1_ID_SEQUENCE);
+  const ruint8 * curve_oid;
+  rsize curve_oid_size;
+  RCryptoResult ret = R_CRYPTO_ERROR;
+
+  if (R_UNLIKELY (pk->ecp == NULL || pk->ecpsize == 0))
+    return R_CRYPTO_NOT_AVAILABLE;
+  if ((curve_oid = r_ecurve_oid_from_id (pk->namedcurve, &curve_oid_size)) == NULL)
+    return R_CRYPTO_NOT_AVAILABLE;
+
+  /* SubjectPublicKeyInfo ::= SEQUENCE {
+   *   algorithm AlgorithmIdentifier { algo_oid, named-curve OID },
+   *   subjectPublicKey BIT STRING (SEC 1 uncompressed point bytes) } */
+  if (r_asn1_bin_encoder_begin_constructed (enc, id_seq, 0) != R_ASN1_ENCODER_OK)
+    return R_CRYPTO_ERROR;
+  if (r_asn1_bin_encoder_begin_constructed (enc, id_seq, 0) == R_ASN1_ENCODER_OK) {
+    if (r_ecc_encoder_add_oid (enc, algo_oid, algo_oid_size) == R_ASN1_ENCODER_OK &&
+        r_ecc_encoder_add_oid (enc, curve_oid, curve_oid_size) == R_ASN1_ENCODER_OK) {
+      r_asn1_bin_encoder_end_constructed (enc);
+      if (r_asn1_bin_encoder_add_bit_string_raw (enc, pk->ecp, pk->ecpsize)
+          == R_ASN1_ENCODER_OK)
+        ret = R_CRYPTO_OK;
+    } else {
+      r_asn1_bin_encoder_end_constructed (enc);
+    }
+  }
+  r_asn1_bin_encoder_end_constructed (enc);
+  return ret;
+}
+
+#define R_ECC_OID_LITERAL(macro)  ((const ruint8 *)(macro)), (sizeof (macro) - 1)
+
+static RCryptoResult
+r_ecdsa_pub_key_export (const RCryptoKey * key, RAsn1BinEncoder * enc)
+{
+  return r_ecc_pub_key_export_with_algo_oid (key, enc,
+      R_ECC_OID_LITERAL (R_X9_62_OID_EC_PUB_KEY));
+}
+
+static RCryptoResult
+r_ecdh_pub_key_export (const RCryptoKey * key, RAsn1BinEncoder * enc)
+{
+  return r_ecc_pub_key_export_with_algo_oid (key, enc,
+      R_ECC_OID_LITERAL (R_CERTICOM_OID_ECDH_PUB_KEY));
+}
+
+/* Build the inner ECPrivateKey SEQUENCE (RFC 5915) for the given
+ * private key into a fresh DER buffer. Caller r_free's *buf on
+ * success. The optional [0] curve OID is omitted (the outer
+ * PKCS#8 AlgorithmIdentifier already carries it, which is what the
+ * matching decoder reads); the optional [1] BIT STRING pubkey is
+ * included when the key's ecp bytes are available, so external
+ * libraries that need it round-trip the full payload. */
+static rboolean
+r_ecc_build_ec_private_key_der (const REccPrivKey * pk,
+    ruint8 ** buf, rsize * size)
+{
+  RAsn1BinEncoder * inner;
+  ruint8 id_seq = R_ASN1_ID (R_ASN1_ID_UNIVERSAL,
+      R_ASN1_ID_CONSTRUCTED, R_ASN1_ID_SEQUENCE);
+  ruint8 id_octet = R_ASN1_ID (R_ASN1_ID_UNIVERSAL,
+      R_ASN1_ID_PRIMITIVE, R_ASN1_ID_OCTET_STRING);
+  ruint8 id_ctx1_constructed = R_ASN1_ID (R_ASN1_ID_CONTEXT,
+      R_ASN1_ID_CONSTRUCTED, 1);
+  rboolean ok = FALSE;
+
+  *buf = NULL;
+  *size = 0;
+  if ((inner = r_asn1_bin_encoder_new (R_ASN1_DER)) == NULL)
+    return FALSE;
+
+  if (r_asn1_bin_encoder_begin_constructed (inner, id_seq, 0)
+      == R_ASN1_ENCODER_OK) {
+    if (r_asn1_bin_encoder_add_integer_i32 (inner, 1) == R_ASN1_ENCODER_OK &&
+        r_asn1_bin_encoder_add_raw (inner, id_octet,
+            pk->scalar, pk->scalarsize) == R_ASN1_ENCODER_OK) {
+      ok = TRUE;
+      if (pk->pub.ecp != NULL && pk->pub.ecpsize > 0) {
+        if (r_asn1_bin_encoder_begin_constructed (inner,
+                id_ctx1_constructed, 0) == R_ASN1_ENCODER_OK) {
+          if (r_asn1_bin_encoder_add_bit_string_raw (inner,
+                  pk->pub.ecp, pk->pub.ecpsize) != R_ASN1_ENCODER_OK)
+            ok = FALSE;
+          r_asn1_bin_encoder_end_constructed (inner);
+        } else {
+          ok = FALSE;
+        }
+      }
+    }
+    r_asn1_bin_encoder_end_constructed (inner);
+  }
+
+  if (ok) {
+    *buf = r_asn1_bin_encoder_get_data (inner, size);
+    if (*buf == NULL) ok = FALSE;
+  }
+  r_asn1_bin_encoder_unref (inner);
+  return ok;
+}
+
+static RCryptoResult
+r_ecc_priv_key_export_with_algo_oid (const RCryptoKey * key,
+    RAsn1BinEncoder * enc, const ruint8 * algo_oid, rsize algo_oid_size)
+{
+  const REccPrivKey * pk = (const REccPrivKey *)key;
+  ruint8 id_seq = R_ASN1_ID (R_ASN1_ID_UNIVERSAL,
+      R_ASN1_ID_CONSTRUCTED, R_ASN1_ID_SEQUENCE);
+  ruint8 id_octet = R_ASN1_ID (R_ASN1_ID_UNIVERSAL,
+      R_ASN1_ID_PRIMITIVE, R_ASN1_ID_OCTET_STRING);
+  const ruint8 * curve_oid;
+  rsize curve_oid_size;
+  ruint8 * ecprivkey_der = NULL;
+  rsize ecprivkey_der_size = 0;
+  RCryptoResult ret = R_CRYPTO_ERROR;
+
+  if (R_UNLIKELY (pk->scalar == NULL || pk->scalarsize == 0))
+    return R_CRYPTO_NOT_AVAILABLE;
+  if ((curve_oid = r_ecurve_oid_from_id (pk->pub.namedcurve,
+          &curve_oid_size)) == NULL)
+    return R_CRYPTO_NOT_AVAILABLE;
+  if (!r_ecc_build_ec_private_key_der (pk, &ecprivkey_der, &ecprivkey_der_size))
+    return R_CRYPTO_ERROR;
+
+  /* OneAsymmetricKey ::= SEQUENCE {
+   *   version INTEGER (0),
+   *   privateKeyAlgorithm AlgorithmIdentifier { algo_oid, named-curve OID },
+   *   privateKey OCTET STRING (DER-encoded ECPrivateKey) } */
+  if (r_asn1_bin_encoder_begin_constructed (enc, id_seq, 0)
+      == R_ASN1_ENCODER_OK) {
+    if (r_asn1_bin_encoder_add_integer_i32 (enc, 0) == R_ASN1_ENCODER_OK) {
+      if (r_asn1_bin_encoder_begin_constructed (enc, id_seq, 0)
+          == R_ASN1_ENCODER_OK) {
+        if (r_ecc_encoder_add_oid (enc, algo_oid, algo_oid_size)
+                == R_ASN1_ENCODER_OK &&
+            r_ecc_encoder_add_oid (enc, curve_oid, curve_oid_size)
+                == R_ASN1_ENCODER_OK) {
+          r_asn1_bin_encoder_end_constructed (enc);
+          if (r_asn1_bin_encoder_add_raw (enc, id_octet,
+                  ecprivkey_der, ecprivkey_der_size) == R_ASN1_ENCODER_OK)
+            ret = R_CRYPTO_OK;
+        } else {
+          r_asn1_bin_encoder_end_constructed (enc);
+        }
+      }
+    }
+    r_asn1_bin_encoder_end_constructed (enc);
+  }
+
+  r_free (ecprivkey_der);
+  return ret;
+}
+
+static RCryptoResult
+r_ecdsa_priv_key_export (const RCryptoKey * key, RAsn1BinEncoder * enc)
+{
+  return r_ecc_priv_key_export_with_algo_oid (key, enc,
+      R_ECC_OID_LITERAL (R_X9_62_OID_EC_PUB_KEY));
+}
+
+static RCryptoResult
+r_ecdh_priv_key_export (const RCryptoKey * key, RAsn1BinEncoder * enc)
+{
+  return r_ecc_priv_key_export_with_algo_oid (key, enc,
+      R_ECC_OID_LITERAL (R_CERTICOM_OID_ECDH_PUB_KEY));
+}
+
 static RCryptoKey *
 r_ecc_priv_key_new_full (REcurveID curve, RCryptoAlgorithm algo,
     rconstpointer ecp, rsize ecpsize,
     rconstpointer scalar, rsize scalarsize)
 {
   REccPrivKey * ret;
-  static const RCryptoAlgoInfo ecdsa_priv_key_info = {
-    R_CRYPTO_ALGO_ECDSA, R_ECDSA_STR,
-    NULL, NULL, r_ecdsa_sign, r_ecdsa_verify, NULL
-  };
-  static const RCryptoAlgoInfo ecdh_priv_key_info = {
-    R_CRYPTO_ALGO_ECDH, R_ECDH_STR, NULL, NULL, NULL, NULL, NULL
-  };
   const rboolean is_ecdh = (algo == R_CRYPTO_ALGO_ECDH);
 
   if (scalar == NULL || scalarsize == 0) return NULL;
@@ -673,7 +886,7 @@ r_ecc_priv_key_new_full (REcurveID curve, RCryptoAlgorithm algo,
 
   r_ref_init (&ret->pub.key, r_ecc_priv_key_free);
   ret->pub.key.type = R_CRYPTO_PRIVATE_KEY;
-  ret->pub.key.algo = is_ecdh ? &ecdh_priv_key_info : &ecdsa_priv_key_info;
+  ret->pub.key.algo = is_ecdh ? &g_ecdh_priv_key_info : &g_ecdsa_priv_key_info;
   ret->pub.key.bits = (ruint) (scalarsize * 8);
 
   /* For ECDSA keys with the math layer loaded, populate the mod-n
@@ -761,9 +974,6 @@ r_ecdh_priv_key_new_gen (REcurveID curve, RPrng * prng)
   ruint8 * ecpcopy = NULL;
   ruint8 * scalarbuf = NULL;
   rsize dbytes, ecpsize;
-  static const RCryptoAlgoInfo ecdh_priv_key_info = {
-    R_CRYPTO_ALGO_ECDH, R_ECDH_STR, NULL, NULL, NULL, NULL, NULL
-  };
 
   if (!r_ecurve_init (&params, curve))
     return NULL;
@@ -835,7 +1045,7 @@ r_ecdh_priv_key_new_gen (REcurveID curve, RPrng * prng)
 
   r_ref_init (&ret->pub.key, r_ecc_priv_key_free);
   ret->pub.key.type = R_CRYPTO_PRIVATE_KEY;
-  ret->pub.key.algo = &ecdh_priv_key_info;
+  ret->pub.key.algo = &g_ecdh_priv_key_info;
   ret->pub.key.bits = (ruint) (dbytes * 8);
 
   r_memclear_secure (dbuf, dbytes);

--- a/rlib/crypto/recurve.c
+++ b/rlib/crypto/recurve.c
@@ -850,6 +850,38 @@ r_ecurve_point_from_uncompressed (const ruint8 * in, rsize insize,
   return TRUE;
 }
 
+const ruint8 *
+r_ecurve_oid_from_id (REcurveID curve, rsize * size)
+{
+  /* Inverse of r_ecurve_id_from_oid - returns a pointer to the
+   * pre-encoded OID bytes plus their length. Length is needed
+   * separately because several curve OIDs (SECP224R1 / 384R1 / 521R1
+   * / 192K1 / 224K1 / 256K1) contain an embedded \x00, so strlen on
+   * the macro truncates them mid-OID and r_asn1_bin_encoder_add_oid_rawsz
+   * is unusable. NULL for any curve we don't have an OID mapping for;
+   * *size is then set to 0. */
+#define R_ECURVE_RETURN_OID(macro) \
+    do { \
+      if (size != NULL) *size = sizeof (macro) - 1; \
+      return (const ruint8 *)(macro); \
+    } while (0)
+
+  switch (curve) {
+    case R_ECURVE_ID_SECP192R1: R_ECURVE_RETURN_OID (R_EC_GRP_OID_SECP192R1);
+    case R_ECURVE_ID_SECP224R1: R_ECURVE_RETURN_OID (R_EC_GRP_OID_SECP224R1);
+    case R_ECURVE_ID_SECP256R1: R_ECURVE_RETURN_OID (R_EC_GRP_OID_SECP256R1);
+    case R_ECURVE_ID_SECP384R1: R_ECURVE_RETURN_OID (R_EC_GRP_OID_SECP384R1);
+    case R_ECURVE_ID_SECP521R1: R_ECURVE_RETURN_OID (R_EC_GRP_OID_SECP521R1);
+    case R_ECURVE_ID_SECP192K1: R_ECURVE_RETURN_OID (R_EC_GRP_OID_SECP192K1);
+    case R_ECURVE_ID_SECP224K1: R_ECURVE_RETURN_OID (R_EC_GRP_OID_SECP224K1);
+    case R_ECURVE_ID_SECP256K1: R_ECURVE_RETURN_OID (R_EC_GRP_OID_SECP256K1);
+    default:
+      if (size != NULL) *size = 0;
+      return NULL;
+  }
+#undef R_ECURVE_RETURN_OID
+}
+
 rboolean
 r_ecurve_id_from_oid (REcurveID * curve,
     rconstpointer oid, rsize oidsize)

--- a/rlib/crypto/rkey.c
+++ b/rlib/crypto/rkey.c
@@ -117,6 +117,7 @@ r_crypto_key_to_asn1 (const RCryptoKey * key, RAsn1BinEncoder * enc)
 {
   if (R_UNLIKELY (key == NULL)) return R_CRYPTO_INVAL;
   if (R_UNLIKELY (enc == NULL)) return R_CRYPTO_INVAL;
+  if (R_UNLIKELY (key->algo->export == NULL)) return R_CRYPTO_NOT_AVAILABLE;
 
   return key->algo->export (key, enc);
 }

--- a/test/recdh.c
+++ b/test/recdh.c
@@ -41,6 +41,150 @@ recdh_priv_key_from_hex (REcurveID curve, const rchar * d_hex)
   return key;
 }
 
+/* Round-trip helper: encode `orig` via r_crypto_key_to_asn1 into a
+ * fresh DER buffer, then decode via the matching ASN.1 entry point
+ * (pub vs priv). Caller frees *out_buf. */
+static RCryptoKey *
+recdh_asn1_roundtrip (const RCryptoKey * orig, ruint8 ** out_buf,
+    rsize * out_size, rboolean is_priv)
+{
+  RAsn1BinEncoder * enc;
+  RAsn1BinDecoder * dec;
+  RAsn1BinTLV tlv = R_ASN1_BIN_TLV_INIT;
+  RCryptoKey * back = NULL;
+
+  *out_buf = NULL;
+  *out_size = 0;
+
+  r_assert_cmpptr ((enc = r_asn1_bin_encoder_new (R_ASN1_DER)), !=, NULL);
+  r_assert_cmpint (r_crypto_key_to_asn1 (orig, enc), ==, R_CRYPTO_OK);
+  r_assert_cmpptr ((*out_buf = r_asn1_bin_encoder_get_data (enc, out_size)),
+      !=, NULL);
+  r_asn1_bin_encoder_unref (enc);
+
+  r_assert_cmpptr ((dec = r_asn1_bin_decoder_new (R_ASN1_DER, *out_buf, *out_size)),
+      !=, NULL);
+  r_assert_cmpint (r_asn1_bin_decoder_next (dec, &tlv), ==, R_ASN1_DECODER_OK);
+  back = is_priv
+      ? r_crypto_key_from_asn1_private_key (dec, &tlv)
+      : r_crypto_key_from_asn1_public_key (dec, &tlv);
+  r_asn1_bin_decoder_unref (dec);
+  return back;
+}
+
+RTEST (recdh, asn1_priv_roundtrip, RTEST_FAST)
+{
+  /* Generate a fresh ECDH priv key, export it via OneAsymmetricKey,
+   * decode back, and confirm the resulting key still computes the
+   * same shared secret as the original against a fixed peer pub key.
+   * That's a stronger functional check than scalar-byte equality:
+   * a mis-decoded scalar or curve would produce a different shared
+   * value. */
+  RCryptoKey * orig, * back, * peer_priv, * peer_pub;
+  ruint8 * buf;
+  rsize bufsize;
+  ruint8 shared_orig[128], shared_back[128];
+  rsize shared_orig_size = sizeof (shared_orig);
+  rsize shared_back_size = sizeof (shared_back);
+  REcurveAffinePoint peer_Q;
+  ruint8 peer_ecp[1 + 2 * 32];
+  rsize peer_ecp_size;
+  REcurve curve;
+
+  r_assert_cmpptr ((orig = r_ecdh_priv_key_new_gen (R_ECURVE_ID_SECP256R1, NULL)),
+      !=, NULL);
+  r_assert_cmpptr ((peer_priv = r_ecdh_priv_key_new_gen (R_ECURVE_ID_SECP256R1, NULL)),
+      !=, NULL);
+
+  /* Build a pub key from the peer for both ECDH calls. */
+  r_ecurve_point_init (&peer_Q);
+  r_assert (r_ecc_key_get_q (peer_priv, &peer_Q));
+  r_assert (r_ecurve_init (&curve, R_ECURVE_ID_SECP256R1));
+  peer_ecp_size = sizeof (peer_ecp);
+  r_assert (r_ecurve_point_to_uncompressed (&peer_Q, &curve,
+        peer_ecp, &peer_ecp_size));
+  r_assert_cmpptr ((peer_pub = r_ecdh_pub_key_new (R_ECURVE_ID_SECP256R1,
+        peer_ecp, peer_ecp_size)), !=, NULL);
+
+  r_assert_cmpptr ((back = recdh_asn1_roundtrip (orig, &buf, &bufsize, TRUE)),
+      !=, NULL);
+  r_assert_cmpuint (r_crypto_key_get_algo (back), ==, R_CRYPTO_ALGO_ECDH);
+  r_assert_cmpuint (r_crypto_key_get_type (back), ==, R_CRYPTO_PRIVATE_KEY);
+  r_assert_cmphex (r_ecc_key_get_curve (back), ==, R_ECURVE_ID_SECP256R1);
+
+  r_assert_cmpint (r_ecdh_compute_shared (orig, peer_pub,
+        shared_orig, &shared_orig_size), ==, R_CRYPTO_OK);
+  r_assert_cmpint (r_ecdh_compute_shared (back, peer_pub,
+        shared_back, &shared_back_size), ==, R_CRYPTO_OK);
+  r_assert_cmpuint (shared_orig_size, ==, shared_back_size);
+  r_assert (r_memcmp (shared_orig, shared_back, shared_orig_size) == 0);
+
+  r_ecurve_point_clear (&peer_Q);
+  r_ecurve_clear (&curve);
+  r_crypto_key_unref (orig);
+  r_crypto_key_unref (back);
+  r_crypto_key_unref (peer_priv);
+  r_crypto_key_unref (peer_pub);
+  r_free (buf);
+}
+RTEST_END;
+
+RTEST (recdh, asn1_pub_roundtrip, RTEST_FAST)
+{
+  /* Round-trip an ECDH pub key via SubjectPublicKeyInfo; the rebuilt
+   * key must still compute the same shared secret against a fixed
+   * peer's priv key. */
+  RCryptoKey * orig_priv, * orig_pub, * back_pub, * peer_priv;
+  ruint8 * buf;
+  rsize bufsize;
+  REcurveAffinePoint Q;
+  ruint8 ecp[1 + 2 * 32];
+  rsize ecp_size;
+  REcurve curve;
+  ruint8 shared_orig[128], shared_back[128];
+  rsize shared_orig_size = sizeof (shared_orig);
+  rsize shared_back_size = sizeof (shared_back);
+
+  r_assert_cmpptr ((orig_priv = r_ecdh_priv_key_new_gen (R_ECURVE_ID_SECP256R1, NULL)),
+      !=, NULL);
+
+  /* Wrap orig_priv's public half as a standalone pub key so we have
+   * something to round-trip; r_ecdh_priv_key_new_gen doesn't expose
+   * the matching pub key separately. */
+  r_ecurve_point_init (&Q);
+  r_assert (r_ecc_key_get_q (orig_priv, &Q));
+  r_assert (r_ecurve_init (&curve, R_ECURVE_ID_SECP256R1));
+  ecp_size = sizeof (ecp);
+  r_assert (r_ecurve_point_to_uncompressed (&Q, &curve, ecp, &ecp_size));
+  r_assert_cmpptr ((orig_pub = r_ecdh_pub_key_new (R_ECURVE_ID_SECP256R1,
+        ecp, ecp_size)), !=, NULL);
+
+  r_assert_cmpptr ((back_pub = recdh_asn1_roundtrip (orig_pub, &buf, &bufsize,
+        FALSE)), !=, NULL);
+  r_assert_cmpuint (r_crypto_key_get_algo (back_pub), ==, R_CRYPTO_ALGO_ECDH);
+  r_assert_cmpuint (r_crypto_key_get_type (back_pub), ==, R_CRYPTO_PUBLIC_KEY);
+  r_assert_cmphex (r_ecc_key_get_curve (back_pub), ==, R_ECURVE_ID_SECP256R1);
+
+  r_assert_cmpptr ((peer_priv = r_ecdh_priv_key_new_gen (R_ECURVE_ID_SECP256R1, NULL)),
+      !=, NULL);
+
+  r_assert_cmpint (r_ecdh_compute_shared (peer_priv, orig_pub,
+        shared_orig, &shared_orig_size), ==, R_CRYPTO_OK);
+  r_assert_cmpint (r_ecdh_compute_shared (peer_priv, back_pub,
+        shared_back, &shared_back_size), ==, R_CRYPTO_OK);
+  r_assert_cmpuint (shared_orig_size, ==, shared_back_size);
+  r_assert (r_memcmp (shared_orig, shared_back, shared_orig_size) == 0);
+
+  r_ecurve_point_clear (&Q);
+  r_ecurve_clear (&curve);
+  r_crypto_key_unref (orig_priv);
+  r_crypto_key_unref (orig_pub);
+  r_crypto_key_unref (back_pub);
+  r_crypto_key_unref (peer_priv);
+  r_free (buf);
+}
+RTEST_END;
+
 RTEST (recdh, gen_key_has_q_and_curve, RTEST_FAST)
 {
   RCryptoKey * key;

--- a/test/recdsa.c
+++ b/test/recdsa.c
@@ -261,6 +261,101 @@ RTEST (recdsa, rfc6979_a2_5_p256_sample_verify, RTEST_FAST)
 }
 RTEST_END;
 
+/* Round-trip helper: encode the supplied key via r_crypto_key_to_asn1
+ * into a fresh DER buffer, then decode via the matching ASN.1 entry
+ * point (pub vs priv). Returns the rebuilt key, or NULL on any step
+ * failure. *out_buf is set to the DER bytes for asserting size > 0;
+ * caller frees it. */
+static RCryptoKey *
+recdsa_asn1_roundtrip (const RCryptoKey * orig, ruint8 ** out_buf,
+    rsize * out_size, rboolean is_priv)
+{
+  RAsn1BinEncoder * enc;
+  RAsn1BinDecoder * dec;
+  RAsn1BinTLV tlv = R_ASN1_BIN_TLV_INIT;
+  RCryptoKey * back = NULL;
+
+  *out_buf = NULL;
+  *out_size = 0;
+
+  r_assert_cmpptr ((enc = r_asn1_bin_encoder_new (R_ASN1_DER)), !=, NULL);
+  r_assert_cmpint (r_crypto_key_to_asn1 (orig, enc), ==, R_CRYPTO_OK);
+  r_assert_cmpptr ((*out_buf = r_asn1_bin_encoder_get_data (enc, out_size)),
+      !=, NULL);
+  r_asn1_bin_encoder_unref (enc);
+
+  r_assert_cmpptr ((dec = r_asn1_bin_decoder_new (R_ASN1_DER, *out_buf, *out_size)),
+      !=, NULL);
+  r_assert_cmpint (r_asn1_bin_decoder_next (dec, &tlv), ==, R_ASN1_DECODER_OK);
+  back = is_priv
+      ? r_crypto_key_from_asn1_private_key (dec, &tlv)
+      : r_crypto_key_from_asn1_public_key (dec, &tlv);
+  r_asn1_bin_decoder_unref (dec);
+  return back;
+}
+
+RTEST_LOOP (recdsa, asn1_pub_roundtrip, RTEST_FAST,
+    0, R_N_ELEMENTS (test_curves))
+{
+  /* Export the ECDSA pub key as SubjectPublicKeyInfo, decode back,
+   * confirm the algo / curve / Q survive intact. Run across every
+   * supported curve so a per-curve OID lookup gap shows up here. */
+  const REcdsaTestCurve * tc = &test_curves[__i];
+  RCryptoKey * priv, * pub, * back;
+  ruint8 * buf;
+  rsize bufsize;
+
+  r_assert (make_ecdsa_keypair_from_d_hex (tc->curve, tc->d_hex, &priv, &pub));
+  r_assert_cmpptr ((back = recdsa_asn1_roundtrip (pub, &buf, &bufsize, FALSE)),
+      !=, NULL);
+  r_assert_cmpuint (bufsize, >, 0);
+  r_assert_cmpuint (r_crypto_key_get_algo (back), ==, R_CRYPTO_ALGO_ECDSA);
+  r_assert_cmpuint (r_crypto_key_get_type (back), ==, R_CRYPTO_PUBLIC_KEY);
+  r_assert_cmpuint (r_ecc_key_get_curve (back), ==, tc->curve);
+
+  r_crypto_key_unref (priv);
+  r_crypto_key_unref (pub);
+  r_crypto_key_unref (back);
+  r_free (buf);
+}
+RTEST_END;
+
+RTEST_LOOP (recdsa, asn1_priv_roundtrip, RTEST_FAST,
+    0, R_N_ELEMENTS (test_curves))
+{
+  /* Export the ECDSA priv key as OneAsymmetricKey, decode back, and
+   * confirm sign / verify keeps working on the rebuilt key - the
+   * strongest functional check that the round-trip didn't drop the
+   * scalar or mis-map the curve. */
+  const REcdsaTestCurve * tc = &test_curves[__i];
+  RCryptoKey * priv, * pub, * back;
+  RPrng * prng;
+  ruint8 * buf;
+  rsize bufsize;
+  ruint8 sig[256];
+  rsize sigsize = sizeof (sig);
+
+  r_assert (make_ecdsa_keypair_from_d_hex (tc->curve, tc->d_hex, &priv, &pub));
+  r_assert_cmpptr ((back = recdsa_asn1_roundtrip (priv, &buf, &bufsize, TRUE)),
+      !=, NULL);
+  r_assert_cmpuint (r_crypto_key_get_algo (back), ==, R_CRYPTO_ALGO_ECDSA);
+  r_assert_cmpuint (r_crypto_key_get_type (back), ==, R_CRYPTO_PRIVATE_KEY);
+  r_assert_cmpuint (r_ecc_key_get_curve (back), ==, tc->curve);
+
+  r_assert_cmpptr ((prng = r_rand_prng_new ()), !=, NULL);
+  r_assert_cmpint (r_crypto_key_sign (back, prng, R_MSG_DIGEST_TYPE_SHA256,
+        hash_a, sizeof (hash_a), sig, &sigsize), ==, R_CRYPTO_OK);
+  r_assert_cmpint (r_crypto_key_verify (pub, R_MSG_DIGEST_TYPE_SHA256,
+        hash_a, sizeof (hash_a), sig, sigsize), ==, R_CRYPTO_OK);
+
+  r_crypto_key_unref (priv);
+  r_crypto_key_unref (pub);
+  r_crypto_key_unref (back);
+  r_prng_unref (prng);
+  r_free (buf);
+}
+RTEST_END;
+
 RTEST (recdsa, sign_rejects_pub_key, RTEST_FAST)
 {
   /* r_crypto_key_sign on a public key must surface WRONG_TYPE rather


### PR DESCRIPTION
## Summary

Fills the last gaps in the EC algo-info hooks. Before this branch, `r_crypto_key_to_asn1` on an ECDSA or ECDH key would have segfaulted — the dispatcher in `rkey.c` called `algo->export` unconditionally and both EC algorithm families shipped with NULL hooks.

- `r_crypto_key_to_asn1` now returns `R_CRYPTO_NOT_AVAILABLE` instead of dereferencing a NULL hook.
- New `r_ecurve_oid_from_id` helper returns both bytes + length; length-exposed because six curve OIDs (SECP224R1 / 384R1 / 521R1 / 192K1 / 224K1 / 256K1) contain an embedded `\x00` that `r_asn1_bin_encoder_add_oid_rawsz`'s `strlen` would truncate.
- ECDSA + ECDH pub key export emits RFC 5480 `SubjectPublicKeyInfo` (AlgorithmIdentifier { algo OID, named-curve OID } + BIT STRING of the SEC 1 uncompressed point).
- ECDSA + ECDH priv key export emits RFC 5958 `OneAsymmetricKey` wrapping an RFC 5915 `ECPrivateKey` OCTET STRING (version + scalar + optional `[1]` BIT STRING pubkey when available).
- The two `ecdh_priv_key_info` / `ecdsa_priv_key_info` tables previously defined as `static const` inside two separate functions are hoisted to file scope — one source eliminates drift.
- `r_ecc_priv_key_load_scalar` now attempts `r_ecurve_init` for ECDSA keys constructed without ecp on supported curves, deriving Q from d. This makes round-tripped ECDSA priv keys functionally complete (sign / verify) instead of "parsed but cache-less". Lenient byte-only fallback survives for ECDSA on curves the math layer can't yet decode.

## Test plan

- [x] Per-curve pub + priv round-trip across every supported curve for ECDSA (secp192r1 / 224r1 / 256r1 / 384r1 / 521r1 / 256k1); sign-after-roundtrip verifies under the original pub key
- [x] Pub + priv round-trip on secp256r1 for ECDH; shared-secret equality under a fixed peer key as the functional check
- [x] Full default + `--heavy` suite passes (3781 tests including all wycheproof RSA / DSA / ECDH vectors)
- [x] ASan/UBSan and TSan heavy runs clean
- [x] gcc-warn release build clean; clang and MSVC matrices via CI on push