### PR TITLE
Add Doxygen CI build with GitHub Pages publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,62 @@ jobs:
           name: testlog-sanitizers-${{ matrix.name }}
           path: build/meson-logs/
 
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Doxygen
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen
+      - name: Generate documentation
+        run: doxygen docs/Doxyfile
+      - name: Upload PR-review artifact
+        # 14-day retention for reviewers to browse a branch's output
+        # without checking out and building. Kept across all events
+        # (PR, master push, schedule, manual) so the artifact is
+        # always there to download.
+        uses: actions/upload-artifact@v4
+        with:
+          name: rlib-docs
+          path: docs/output/html
+          retention-days: 14
+      - name: Upload GitHub Pages artifact
+        # Pages publishes only from master pushes; PRs / scheduled
+        # runs skip this step. upload-pages-artifact is a separate
+        # action from upload-artifact - the pages-specific format is
+        # what the deploy-pages step downstream consumes.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/output/html
+
+  docs-deploy:
+    name: Deploy docs to GitHub Pages
+    needs: docs
+    # Master pushes only - PRs don't deploy, scheduled cron runs
+    # don't deploy. The site is regenerated entirely each time, so
+    # a missed scheduled run doesn't matter.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write          # publish to the gh-pages target
+      id-token: write       # OIDC for the deploy action's auth
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    # Serialise Pages deploys so two rapid master pushes don't fight
+    # each other; cancel-in-progress = false lets the in-flight deploy
+    # finish before the next one starts (deploys take seconds).
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4
+
   full-tests:
     name: Full test sweep
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /waf*-*-*
 /.waf*
 /_build*
+/docs/output/

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1,0 +1,90 @@
+# Doxygen configuration for rlib. Kept tight on purpose: only values
+# that differ from Doxygen's defaults are set, so upgrading Doxygen
+# inherits new defaults without us having to chase a 3000-line config.
+#
+# Documentation convention: /** ... */ comments opt declarations into
+# the generated docs. Plain /* ... */ comments stay invisible to the
+# generator and are used for "for-the-implementor" prose that doesn't
+# belong on the API surface. Per-domain documentation passes happen
+# on follow-up issues - each one converts that scope's API comments
+# from /* */ to /** */, adds @param / @return tags where useful, and
+# graduates that scope to WARN_AS_ERROR.
+
+PROJECT_NAME            = "rlib"
+PROJECT_BRIEF           = "Convenience library for useful things"
+
+# Source layout: public API headers under include/, implementations
+# under rlib/. README.md at the repo root anchors the main page.
+INPUT                   = include rlib README.md
+RECURSIVE               = YES
+FILE_PATTERNS           = *.h *.c *.md
+USE_MDFILE_AS_MAINPAGE  = README.md
+
+# Output lands under docs/output/html; .gitignore drops the tree.
+OUTPUT_DIRECTORY        = docs/output
+
+# EXTRACT_ALL stays off (the default) so /** */ is the opt-in marker
+# for "show this on the API page". EXTRACT_STATIC picks up static
+# helpers in .c files that explicitly carry /** */, useful for
+# implementation-side prose that still wants doxygen rendering.
+EXTRACT_STATIC          = YES
+
+OPTIMIZE_OUTPUT_FOR_C   = YES
+
+# Don't pull Markdown headings into the navigation tree. Without this,
+# the README's Setext-style H1 / H2 headings get auto-nested under
+# the "Data Structures" navtree node (a known Doxygen quirk when the
+# main page is a markdown file). Setting to 0 keeps the README's
+# in-page TOC working while removing the misplaced nav entries.
+TOC_INCLUDE_HEADINGS    = 0
+
+# Strip rlib's visibility / attribute macros before parsing so the
+# parser sees plain declarations. Adding new R_* attribute macros
+# here as they appear in headers keeps Doxygen's view of the API
+# matching the C parser's.
+ENABLE_PREPROCESSING    = YES
+MACRO_EXPANSION         = YES
+EXPAND_ONLY_PREDEF      = YES
+PREDEFINED              = R_API= \
+                          R_API_HIDDEN= \
+                          R_BEGIN_DECLS= \
+                          R_END_DECLS= \
+                          R_ATTR_MALLOC= \
+                          R_ATTR_NULL_TERMINATED= \
+                          R_ATTR_PRINTF(x,y)= \
+                          R_ATTR_WARN_UNUSED= \
+                          R_UNLIKELY(x)=x \
+                          R_LIKELY(x)=x
+
+# Paths shown in the generated docs are repo-relative ("include/rlib/...")
+# rather than absolute, so the output is reproducible regardless of where
+# CI checks the source out.
+FULL_PATH_NAMES         = YES
+STRIP_FROM_PATH         = .
+STRIP_FROM_INC_PATH     = include
+
+# Output formats: HTML only. LaTeX / man / RTF / XML are all switched
+# off until somebody asks for them.
+GENERATE_HTML           = YES
+GENERATE_LATEX          = NO
+GENERATE_MAN            = NO
+GENERATE_RTF            = NO
+GENERATE_XML            = NO
+
+# Skip graphviz - keeps the CI install footprint small and the run fast.
+# Worth revisiting once we want call / include graphs.
+HAVE_DOT                = NO
+
+# Stdout stays quiet so CI logs don't drown in progress trivia.
+# WARN_IF_UNDOCUMENTED stays off until per-domain documentation lands
+# - flipping it on now would spam every declaration in the repo, none
+# of which carry /** */ yet. WARN_IF_DOC_ERROR catches structural
+# breakage in any /** */ comment that does exist, and is worth keeping
+# on even at this stage. WARN_AS_ERROR follows scopes as they
+# graduate from /* */ to /** */.
+QUIET                   = YES
+WARNINGS                = YES
+WARN_IF_UNDOCUMENTED    = NO
+WARN_IF_DOC_ERROR       = YES
+WARN_NO_PARAMDOC        = NO
+WARN_AS_ERROR           = NO


### PR DESCRIPTION
## Summary

Stand up a documentation-generation toolchain. The output is intentionally sparse today — only ~70 declarations across the tree use `/** */`, and that's the convention we're committing to:

- `/** ... */` opts a declaration into the generated docs.
- `/* ... */` stays invisible to the generator; used for prose aimed at implementers rather than callers.

`EXTRACT_ALL` stays at Doxygen's default (off) so the marker actually distinguishes the two. Per-domain documentation passes happen on follow-up issues that convert each scope's API comments, add `@param` / `@return` where useful, and graduate that scope to `WARN_AS_ERROR`.

## What the CI does

- **All events:** build the docs, upload as a 14-day artifact (`rlib-docs`) so reviewers can browse a branch's output without building locally.
- **Master pushes only:** additionally upload the Pages artifact and deploy via `actions/deploy-pages`. Site lives at `https://haaspors.github.io/rlib/`.

The deploy job carries the `pages: write` + `id-token: write` permissions in a dedicated scope (PR builds don't need them), uses a `pages` concurrency group so back-to-back master pushes serialise cleanly, and runs inside the `github-pages` environment so the deployment URL shows up on the PR / commit timeline.

## Doxyfile design

Kept tight — only values that differ from Doxygen's defaults are set, so upgrading Doxygen inherits new defaults without chasing a 3000-line config. Notable settings:

- `PREDEFINED` strips rlib's visibility / attribute macros (`R_API`, `R_API_HIDDEN`, `R_BEGIN_DECLS`, `R_ATTR_*`, `R_LIKELY` / `R_UNLIKELY`) before the parser sees them.
- `TOC_INCLUDE_HEADINGS = 0` to avoid the README's Setext H2 headings auto-nesting under the Data Structures navtree node (a known Doxygen quirk on Markdown main-pages).
- `HAVE_DOT = NO` — no graphviz, no call/include graphs. Keeps install footprint and wall-clock small. Revisit when graphs would actually pay for themselves.

`docs/output/` is gitignored so a local `doxygen docs/Doxyfile` run doesn't pollute the working tree.

## Test plan

- [x] Local `doxygen docs/Doxyfile` run produces a clean tree (no warnings, ~487 files / 6.8 MB).
- [x] YAML lints cleanly.
- [ ] CI build job succeeds on the PR.
- [ ] Master deploy step (`docs-deploy`) succeeds on merge and publishes to https://haaspors.github.io/rlib/.

Repo setup needed (one-time, already done): Settings → Pages → Source: GitHub Actions.