### PR TITLE
Bump GitHub Actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         compiler: [gcc, clang]
         buildtype: [debugoptimized, release]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -37,7 +37,7 @@ jobs:
         run: meson test -C build --print-errorlogs
       - name: Upload test logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: testlog-linux-${{ matrix.compiler }}-${{ matrix.buildtype }}
           path: build/meson-logs/
@@ -50,7 +50,7 @@ jobs:
       matrix:
         buildtype: [debugoptimized, release]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: brew install meson ninja
       - name: Configure
@@ -61,7 +61,7 @@ jobs:
         run: meson test -C build --print-errorlogs
       - name: Upload test logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: testlog-macos-${{ matrix.buildtype }}
           path: build/meson-logs/
@@ -74,7 +74,7 @@ jobs:
       matrix:
         buildtype: [debugoptimized, release]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ilammy/msvc-dev-cmd@v1
       - name: Install meson + ninja
         run: pip install meson ninja
@@ -89,7 +89,7 @@ jobs:
         run: meson test -C build --print-errorlogs --timeout-multiplier 6
       - name: Upload test logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: testlog-windows-${{ matrix.buildtype }}
           path: build/meson-logs/
@@ -108,7 +108,7 @@ jobs:
             sanitize: thread
             extra_args: ''
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -129,7 +129,7 @@ jobs:
         run: meson test -C build --print-errorlogs --timeout-multiplier 4
       - name: Upload test logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: testlog-sanitizers-${{ matrix.name }}
           path: build/meson-logs/
@@ -138,7 +138,7 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Doxygen
         run: |
           sudo apt-get update
@@ -150,7 +150,7 @@ jobs:
         # without checking out and building. Kept across all events
         # (PR, master push, schedule, manual) so the artifact is
         # always there to download.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rlib-docs
           path: docs/output/html
@@ -161,7 +161,7 @@ jobs:
         # action from upload-artifact - the pages-specific format is
         # what the deploy-pages step downstream consumes.
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/output/html
 
@@ -188,7 +188,7 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   full-tests:
     name: Full test sweep
@@ -202,7 +202,7 @@ jobs:
       matrix:
         compiler: [gcc, clang]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -225,7 +225,7 @@ jobs:
         run: meson test -C build --print-errorlogs --timeout-multiplier 30 --test-args=-H
       - name: Upload test logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: testlog-full-${{ matrix.compiler }}
           path: build/meson-logs/


### PR DESCRIPTION
## Summary

GitHub flagged the workflow's `actions/checkout@v4` and `actions/upload-artifact@v4` as Node.js 20-based ahead of the runner default switching to Node 24 on June 2nd 2026 (Node 20 is removed entirely on September 16th 2026). Bump the four GitHub-official actions to their current major.

| Action | Old | New | Notes |
|---|---|---|---|
| `actions/checkout` | v4 | v6 | Node 24 + separate credentials file |
| `actions/upload-artifact` | v4 | v7 | Node 24 + ESM internals + opt-in `archive: false` we don't use |
| `actions/upload-pages-artifact` | v3 | v5 | Pulls in upload-artifact v7 |
| `actions/deploy-pages` | v4 | v5 | Explicit Node 24 upgrade |

Pinning convention preserved — floating major tag, so patch-level fixes arrive automatically; future major bumps land as their own commits. The third-party `ilammy/msvc-dev-cmd@v1` wasn't flagged and stays on its current pin.

## Test plan

- [x] `actionlint` clean
- [ ] PR CI green across all jobs (linux × 4, macos × 2, windows × 2, sanitizers × 2, docs)
- [ ] Master push fires `docs-deploy` and republishes to https://haaspors.github.io/rlib/