### PR TITLE
Doxygen documentation pass on the string headers

### DIFF
--- a/include/rlib/charset/rascii.h
+++ b/include/rlib/charset/rascii.h
@@ -24,43 +24,129 @@
 
 #include <rlib/rtypes.h>
 
+/**
+ * @file rlib/charset/rascii.h
+ * @brief ASCII character classification and case conversion.
+ *
+ * Locale-independent counterparts to the @c <ctype.h> predicates and
+ * @c <ctype.h>-style case conversion. All classification predicates
+ * are macros that index a shared 256-entry lookup table; they're
+ * branch-free and safe to use on @c rchar / signed @c char (the
+ * macro cast to @c ruint8 keeps negative chars away from out-of-
+ * bounds table access).
+ *
+ * For multibyte / Unicode handling see @c rlib/charset/runicode.h.
+ */
+
 R_BEGIN_DECLS
 
+/**
+ * @brief Bit flags backing the classification predicate macros.
+ *
+ * Each entry of @c r_ascii_table is an @c ruint16 OR-set of these
+ * flags. The predicate macros mask out a single flag and return
+ * non-zero / zero. Not meant to be referenced directly by callers;
+ * use the @c r_ascii_is* macros instead.
+ */
 typedef enum {
-  R_ASCII_ALNUM  = 1 << 0,
-  R_ASCII_ALPHA  = 1 << 1,
-  R_ASCII_CNTRL  = 1 << 2,
-  R_ASCII_DIGIT  = 1 << 3,
-  R_ASCII_GRAPH  = 1 << 4,
-  R_ASCII_LOWER  = 1 << 5,
-  R_ASCII_PRINT  = 1 << 6,
-  R_ASCII_PUNCT  = 1 << 7,
-  R_ASCII_SPACE  = 1 << 8,
-  R_ASCII_UPPER  = 1 << 9,
-  R_ASCII_XDIGIT = 1 << 10
+  R_ASCII_ALNUM  = 1 << 0,    /**< Alphabetic or digit. */
+  R_ASCII_ALPHA  = 1 << 1,    /**< Alphabetic ('a'-'z' or 'A'-'Z'). */
+  R_ASCII_CNTRL  = 1 << 2,    /**< Control character (0x00-0x1f and 0x7f). */
+  R_ASCII_DIGIT  = 1 << 3,    /**< Decimal digit ('0'-'9'). */
+  R_ASCII_GRAPH  = 1 << 4,    /**< Printable, excluding space. */
+  R_ASCII_LOWER  = 1 << 5,    /**< Lowercase letter. */
+  R_ASCII_PRINT  = 1 << 6,    /**< Printable, including space. */
+  R_ASCII_PUNCT  = 1 << 7,    /**< Punctuation. */
+  R_ASCII_SPACE  = 1 << 8,    /**< Whitespace (' ', '\\t', '\\n', '\\v', '\\f', '\\r'). */
+  R_ASCII_UPPER  = 1 << 9,    /**< Uppercase letter. */
+  R_ASCII_XDIGIT = 1 << 10    /**< Hexadecimal digit ('0'-'9', 'a'-'f', 'A'-'F'). */
 } RAsciiType;
 
+/**
+ * @brief 256-entry lookup table indexed by @c ruint8 byte value.
+ *
+ * Each entry holds the OR of @c RAsciiType flags applicable to that
+ * byte. Backing storage for the classification macros below.
+ */
 R_API extern const ruint16 r_ascii_table[256];
 
+/**
+ * @name Character classification
+ * @{
+ */
+/** @brief TRUE iff @p c is alphabetic or a decimal digit. */
 #define r_ascii_isalnum(c) ((r_ascii_table[(ruint8) (c)] & R_ASCII_ALNUM) != 0)
+/** @brief TRUE iff @p c is an alphabetic character. */
 #define r_ascii_isalpha(c) ((r_ascii_table[(ruint8) (c)] & R_ASCII_ALPHA) != 0)
+/** @brief TRUE iff @p c is a control character. */
 #define r_ascii_iscntrl(c) ((r_ascii_table[(ruint8) (c)] & R_ASCII_CNTRL) != 0)
+/** @brief TRUE iff @p c is a decimal digit. */
 #define r_ascii_isdigit(c) ((r_ascii_table[(ruint8) (c)] & R_ASCII_DIGIT) != 0)
+/** @brief TRUE iff @p c is printable and not whitespace. */
 #define r_ascii_isgraph(c) ((r_ascii_table[(ruint8) (c)] & R_ASCII_GRAPH) != 0)
+/** @brief TRUE iff @p c is a lowercase letter. */
 #define r_ascii_islower(c) ((r_ascii_table[(ruint8) (c)] & R_ASCII_LOWER) != 0)
+/** @brief TRUE iff @p c is printable (graph + space). */
 #define r_ascii_isprint(c) ((r_ascii_table[(ruint8) (c)] & R_ASCII_PRINT) != 0)
+/** @brief TRUE iff @p c is a punctuation character. */
 #define r_ascii_ispunct(c) ((r_ascii_table[(ruint8) (c)] & R_ASCII_PUNCT) != 0)
+/** @brief TRUE iff @p c is whitespace. */
 #define r_ascii_isspace(c) ((r_ascii_table[(ruint8) (c)] & R_ASCII_SPACE) != 0)
+/** @brief TRUE iff @p c is an uppercase letter. */
 #define r_ascii_isupper(c) ((r_ascii_table[(ruint8) (c)] & R_ASCII_UPPER) != 0)
+/** @brief TRUE iff @p c is a hexadecimal digit. */
 #define r_ascii_isxdigit(c) ((r_ascii_table[(ruint8) (c)] & R_ASCII_XDIGIT) != 0)
+/** @} */
 
+/**
+ * @name Digit values
+ * @{
+ */
+/**
+ * @brief Return the numeric value of decimal digit @p c (0-9).
+ * @return Value in @c [0,9], or -1 if @p c isn't a decimal digit.
+ */
 R_API rint8 r_ascii_digit_value (rchar c);
+/**
+ * @brief Return the numeric value of hex digit @p c (0-15).
+ * @return Value in @c [0,15], or -1 if @p c isn't a hex digit.
+ */
 R_API rint8 r_ascii_xdigit_value (rchar c);
+/** @} */
 
+/**
+ * @name Case conversion
+ * @{
+ */
+/**
+ * @brief Return @p c upper-cased.
+ *
+ * Non-letter inputs and already-uppercase letters are returned
+ * unchanged.
+ */
 #define r_ascii_upper(c) r_ascii_islower (c) ? ((c) - 0x20) : (c)
+/**
+ * @brief Return @p c lower-cased.
+ *
+ * Non-letter inputs and already-lowercase letters are returned
+ * unchanged.
+ */
 #define r_ascii_lower(c) r_ascii_isupper (c) ? ((c) + 0x20) : (c)
+/**
+ * @brief Upper-case every byte in @p str in place.
+ * @param str Buffer to convert.
+ * @param len Bytes to convert, or -1 to fall back to @c r_strlen.
+ * @return @p str.
+ */
 R_API rchar * r_ascii_make_upper (rchar * str, rssize len);
+/**
+ * @brief Lower-case every byte in @p str in place.
+ * @param str Buffer to convert.
+ * @param len Bytes to convert, or -1 to fall back to @c r_strlen.
+ * @return @p str.
+ */
 R_API rchar * r_ascii_make_lower (rchar * str, rssize len);
+/** @} */
 
 R_END_DECLS
 

--- a/include/rlib/charset/runicode.h
+++ b/include/rlib/charset/runicode.h
@@ -24,32 +24,115 @@
 
 #include <rlib/rtypes.h>
 
+/**
+ * @file rlib/charset/runicode.h
+ * @brief UTF-8 / UTF-16 conversions.
+ *
+ * Two flavours of conversion: an in-buffer pair (caller supplies
+ * the destination) and an allocating pair (returns a fresh buffer
+ * the caller @c r_free's). Both pairs report partial-conversion
+ * state via output pointers - useful for streaming, where a source
+ * span might end mid-codepoint and the next chunk has to resume
+ * from the last @c srcendptr.
+ *
+ * Code units are counted in their respective natural element type:
+ * UTF-8 in @c rchar bytes, UTF-16 in @c runichar2 code units.
+ */
+
 R_BEGIN_DECLS
 
+/** @brief Unicode code point (0..0x10FFFF), one per "character". */
 typedef ruint32   runichar;
+/** @brief 32-bit code unit (UTF-32). Same as @c runichar. */
 typedef ruint32   runichar4;
+/** @brief 16-bit code unit (UTF-16). */
 typedef ruint16   runichar2;
 
+/**
+ * @brief Status returned by the conversion functions.
+ *
+ * @c R_UNICODE_OK is the only success value; the rest signal
+ * different failure modes the caller may want to recover from.
+ */
 typedef enum {
-  R_UNICODE_OK = 0,
-  R_UNICODE_OOM,
-  R_UNICODE_INVAL,
-  R_UNICODE_OVERFLOW,
-  R_UNICODE_INVALID_CODE_POINT,
-  R_UNICODE_INCOMPLETE_CODE_POINT,
+  R_UNICODE_OK = 0,                  /**< Conversion completed. */
+  R_UNICODE_OOM,                     /**< Allocation failed (allocating variants). */
+  R_UNICODE_INVAL,                   /**< Caller passed a bad argument. */
+  R_UNICODE_OVERFLOW,                /**< Destination buffer too small. */
+  R_UNICODE_INVALID_CODE_POINT,      /**< Source bytes don't form a valid codepoint. */
+  R_UNICODE_INCOMPLETE_CODE_POINT,   /**< Source ended mid-codepoint; resume from @c srcendptr. */
 } RUnicodeResult;
 
+/**
+ * @name In-buffer conversion
+ *
+ * Caller supplies the destination buffer. On @c R_UNICODE_OK the
+ * @p dstoutsize out-pointer holds the number of code units written
+ * (UTF-16 units for to_utf16, bytes for to_utf8). @p srcendptr
+ * receives a pointer to the byte / code unit one past the last
+ * consumed source element, which equals @c src + @c srcsize on
+ * complete conversion and a position before the end on
+ * @c R_UNICODE_INCOMPLETE_CODE_POINT.
+ * @{
+ */
+
+/**
+ * @brief Encode UTF-8 @p src into UTF-16 @p dst.
+ *
+ * @param dst        Destination UTF-16 buffer.
+ * @param dstsize    Capacity of @p dst in @c runichar2 code units.
+ * @param src        UTF-8 source bytes.
+ * @param srcsize    Bytes in @p src, or -1 to fall back to @c r_strlen.
+ * @param dstoutsize Receives the number of code units written.
+ * @param srcendptr  Receives a pointer one past the last consumed byte.
+ */
 R_API RUnicodeResult r_utf8_to_utf16 (runichar2 * dst, rsize dstsize,
     const rchar * src, rssize srcsize, rsize * dstoutsize, rchar ** srcendptr);
+/**
+ * @brief Decode UTF-16 @p src into UTF-8 @p dst.
+ *
+ * @param dst        Destination UTF-8 buffer.
+ * @param dstsize    Capacity of @p dst in bytes.
+ * @param src        UTF-16 source code units.
+ * @param srcsize    Code units in @p src.
+ * @param dstoutsize Receives the number of bytes written.
+ * @param srcendptr  Receives a pointer one past the last consumed code unit.
+ */
 R_API RUnicodeResult r_utf16_to_utf8 (rchar * dst, rsize dstsize,
     const runichar2 * src, rsize srcsize, rsize * dstoutsize, runichar2 ** srcendptr);
 
+/** @} */
+
+/**
+ * @name Allocating conversion
+ *
+ * Same conversions but the destination is allocated by the function
+ * and returned. Caller @c r_free's. @p res, when non-NULL, receives
+ * the same status code that the in-buffer variant would have
+ * returned; @p retsize receives the output length in code units;
+ * @p endptr receives the consumed-source pointer.
+ * @{
+ */
+
+/**
+ * @brief Allocate and encode UTF-8 @p src as UTF-16.
+ * @return Freshly allocated UTF-16 buffer, or NULL on failure.
+ */
 R_API runichar2 * r_utf8_to_utf16_dup (const rchar * src, rssize srcsize,
     RUnicodeResult * res, rsize * retsize, rchar ** endptr) R_ATTR_MALLOC;
+/**
+ * @brief Allocate and decode UTF-16 @p src as UTF-8.
+ * @return Freshly allocated UTF-8 buffer, or NULL on failure.
+ */
 R_API rchar * r_utf16_to_utf8_dup (const runichar2 * src, rsize srcsize,
     RUnicodeResult * res, rsize * retsize, runichar2 ** endptr) R_ATTR_MALLOC;
 
+/** @} */
+
 #if 0
+/* TODO: UTF-32 conversions - prototypes sketched but not yet
+ * implemented. Left as a placeholder so the namespace shape stays
+ * visible. */
 R_API runichar * r_utf8_to_uft32 (const rchar * str, rlong len,
     rboolean * error, rlong * inlen, rlong * retlen) R_ATTR_MALLOC;
 R_API rchar * r_utf32_to_uft8 (const runichar *, rlong len,

--- a/include/rlib/data/rstring.h
+++ b/include/rlib/data/rstring.h
@@ -25,45 +25,158 @@
 #include <rlib/rtypes.h>
 #include <stdarg.h>
 
+/**
+ * @file rlib/data/rstring.h
+ * @brief Mutable string-builder type.
+ *
+ * @c RString complements the immutable @c rchar @c * helpers in
+ * @c rlib/rstr.h. Each instance owns a heap buffer that grows as
+ * needed when bytes are appended / inserted / overwritten, so
+ * callers don't have to chase capacity by hand. Construct with
+ * @c r_string_new or @c r_string_new_sized; release with
+ * @c r_string_free or, if you want to keep the inner @c rchar @c *
+ * after, @c r_string_free_keep.
+ *
+ * The mutating functions return the resulting length so callers
+ * can chain or detect failure (0 with no prior length is the only
+ * ambiguous case; otherwise a non-zero result means the operation
+ * was applied).
+ */
+
 R_BEGIN_DECLS
 
+/** @brief Opaque heap-allocated mutable string. */
 typedef struct RString RString;
 
+/**
+ * @name Lifecycle
+ * @{
+ */
+
+/**
+ * @brief Allocate an RString seeded from the NUL-terminated @p cstr.
+ * @param cstr Initial contents; pass NULL for an empty string.
+ * @return The allocated RString, or NULL on allocation failure.
+ *         Caller @c r_string_free's.
+ */
 R_ATTR_WARN_UNUSED_RESULT
 R_API RString * r_string_new (const rchar * cstr) R_ATTR_MALLOC;
+/**
+ * @brief Allocate an empty RString with @p size bytes of buffer
+ * reserved up front.
+ *
+ * Useful when the caller knows roughly how much they're going to
+ * append, to skip a few of the growth-doubling steps.
+ *
+ * @param size Initial buffer capacity in bytes (not including the
+ *             terminating NUL).
+ */
 R_ATTR_WARN_UNUSED_RESULT
 R_API RString * r_string_new_sized (rsize size) R_ATTR_MALLOC;
 
+/** @brief Free the RString and its backing buffer. */
 R_API void r_string_free (RString * str);
+/**
+ * @brief Free the RString struct but return its inner @c rchar @c *.
+ *
+ * Ownership of the returned buffer transfers to the caller, who
+ * is responsible for @c r_free'ing it. Useful when the build-up
+ * phase is over and the string proper is what gets handed
+ * downstream.
+ */
 R_ATTR_WARN_UNUSED_RESULT
 R_API rchar * r_string_free_keep (RString * str);
 
+/** @} */
+
+/**
+ * @name Queries
+ * @{
+ */
+
+/** @brief Current length in bytes (excluding the terminating NUL). */
 R_API rsize r_string_length (RString * str);
+/** @brief Capacity of the underlying buffer in bytes. */
 R_API rsize r_string_alloc_size (RString * str);
 
+/** @brief Byte-compare two @c RString contents. Behaves like @c r_strcmp. */
 R_API int r_string_cmp (RString * str1, RString * str2);
+/** @brief Byte-compare an @c RString against a NUL-terminated C string. */
 R_API int r_string_cmp_cstr (RString * str, const rchar * cstr);
 
+/** @} */
+
+/**
+ * @name Mutations
+ *
+ * All return the resulting length in bytes after the operation.
+ * Family layout: reset → append* → prepend* → insert* → overwrite*
+ * → truncate / erase. The @c _len variants take an explicit byte
+ * count, useful for non-NUL-terminated source spans; the @c _printf
+ * / @c _vprintf variants format their arguments via the C runtime's
+ * printf into the build buffer in one step.
+ * @{
+ */
+
+/**
+ * @brief Discard the current contents and seed @p str from a fresh
+ * NUL-terminated C string.
+ * @param str  Target string.
+ * @param cstr Replacement contents; pass NULL or "" to clear.
+ * @return New length after the reset.
+ */
 R_API rsize r_string_reset (RString * str, const rchar * cstr);
 
+/** @brief Append a single byte to @p str. */
 R_API rsize r_string_append_c (RString * str, rchar c);
+/** @brief Append a NUL-terminated C string to @p str. */
 R_API rsize r_string_append (RString * str, const rchar * cstr);
+/** @brief Append @p len bytes from @p cstr to @p str. */
 R_API rsize r_string_append_len (RString * str, const rchar * cstr, rsize len);
+/**
+ * @brief printf-format and append the result to @p str.
+ * @return New length after the append.
+ */
 R_API rsize r_string_append_printf (RString * str, const rchar * fmt, ...) R_ATTR_PRINTF (2, 3);
+/** @brief va_list flavour of r_string_append_printf. */
 R_API rsize r_string_append_vprintf (RString * str, const rchar * fmt, va_list ap) R_ATTR_PRINTF (2, 0);
 
+/** @brief Prepend a NUL-terminated C string to the front of @p str. */
 R_API rsize r_string_prepend (RString * str, const rchar * cstr);
+/** @brief Prepend @p len bytes from @p cstr to the front of @p str. */
 R_API rsize r_string_prepend_len (RString * str, const rchar * cstr, rsize len);
+/** @brief printf-format and prepend the result to the front of @p str. */
 R_API rsize r_string_prepend_printf (RString * str, const rchar * fmt, ...) R_ATTR_PRINTF (2, 3);
+/** @brief va_list flavour of r_string_prepend_printf. */
 R_API rsize r_string_prepend_vprintf (RString * str, const rchar * fmt, va_list ap) R_ATTR_PRINTF (2, 0);
 
+/**
+ * @brief Insert @p cstr at byte offset @p pos, sliding the existing
+ * tail to the right.
+ * @return New length after the insert.
+ */
 R_API rsize r_string_insert (RString * str, rsize pos, const rchar * cstr);
+/** @brief Length-bounded variant of r_string_insert. */
 R_API rsize r_string_insert_len (RString * str, rsize pos, const rchar * cstr, rsize len);
+/**
+ * @brief Overwrite bytes starting at @p pos with @p cstr.
+ *
+ * Unlike @c insert, no existing bytes shift; the string grows only
+ * if the write extends past the current length.
+ */
 R_API rsize r_string_overwrite (RString * str, rsize pos, const rchar * cstr);
+/** @brief Length-bounded variant of r_string_overwrite. */
 R_API rsize r_string_overwrite_len (RString * str, rsize pos, const rchar * cstr, rsize len);
 
+/** @brief Trim @p str to @p len bytes. No-op if it's already shorter. */
 R_API rsize r_string_truncate (RString * str, rsize len);
+/**
+ * @brief Remove @p len bytes starting at byte offset @p pos.
+ * @return New length after the erase.
+ */
 R_API rsize r_string_erase (RString * str, rsize pos, rsize len);
+
+/** @} */
 
 R_END_DECLS
 

--- a/include/rlib/rbase64.h
+++ b/include/rlib/rbase64.h
@@ -24,16 +24,97 @@
 
 #include <rlib/rtypes.h>
 
+/**
+ * @file rlib/rbase64.h
+ * @brief Base64 encoding and decoding (RFC 4648).
+ *
+ * Two flavours of each direction: an in-buffer form (caller supplies
+ * the destination) and an allocating form (returns a freshly
+ * @c r_malloc'd buffer the caller @c r_free's). Encoding uses the
+ * standard alphabet with @c '=' padding; decoding accepts the same
+ * alphabet and ignores whitespace.
+ */
+
 R_BEGIN_DECLS
 
+/**
+ * @brief TRUE iff @p ch is a valid base64 alphabet character or @c '='.
+ *
+ * Whitespace and other characters return FALSE.
+ */
 R_API rboolean r_base64_is_valid_char (rchar ch);
 
+/**
+ * @name In-buffer encoding / decoding
+ * @{
+ */
+
+/**
+ * @brief Encode @p size bytes from @p src as base64 into @p dst.
+ *
+ * The output is NOT NUL-terminated; the returned length tells the
+ * caller exactly how many bytes were written. Use the @c _dup
+ * variant if you need a NUL-terminated string.
+ *
+ * @param dst   Destination buffer.
+ * @param dsize Capacity of @p dst in bytes.
+ * @param src   Source bytes.
+ * @param size  Bytes to encode from @p src.
+ * @return Number of bytes written to @p dst.
+ */
 R_API rsize r_base64_encode (rchar * dst, rsize dsize, rconstpointer src, rsize size);
+/**
+ * @brief Decode base64 @p src into @p dst.
+ *
+ * Whitespace in @p src is skipped. Decoding stops at the first
+ * invalid character (a NUL counts as invalid).
+ *
+ * @param dst   Destination buffer.
+ * @param dsize Capacity of @p dst in bytes.
+ * @param src   Source base64 characters.
+ * @param size  Bytes in @p src, or -1 to fall back to @c r_strlen.
+ * @return Number of bytes written to @p dst.
+ */
 R_API rsize r_base64_decode (ruint8 * dst, rsize dsize, const rchar * src, rssize size);
 
+/** @} */
+
+/**
+ * @name Allocating encoding / decoding
+ *
+ * Allocate the destination buffer and return it. *@p outsize (when
+ * non-NULL) receives the output length. Caller @c r_free's the
+ * returned buffer.
+ * @{
+ */
+
+/**
+ * @brief Encode @p size bytes from @p data as base64, returning a
+ * NUL-terminated string.
+ * @param data    Source bytes.
+ * @param size    Bytes to encode.
+ * @param outsize Receives the output length (excluding the NUL).
+ * @return Freshly allocated NUL-terminated base64 string, or NULL.
+ */
 R_API rchar * r_base64_encode_dup (rconstpointer data, rsize size, rsize * outsize) R_ATTR_MALLOC;
+/**
+ * @brief Like r_base64_encode_dup but inserts a newline every
+ * @p linesize characters.
+ *
+ * Useful for MIME-style line-wrapped base64. Pass @p linesize @c 0
+ * for no wrapping (equivalent to the un-suffixed variant).
+ */
 R_API rchar * r_base64_encode_dup_full (rconstpointer data, rsize size, rsize linesize, rsize * outsize) R_ATTR_MALLOC;
+/**
+ * @brief Decode a base64 string into a freshly allocated byte buffer.
+ * @param data    Source base64 characters.
+ * @param size    Bytes in @p data, or -1 to fall back to @c r_strlen.
+ * @param outsize Receives the output length.
+ * @return Freshly allocated byte buffer, or NULL on failure.
+ */
 R_API ruint8 * r_base64_decode_dup (const rchar * data, rssize size, rsize * outsize) R_ATTR_MALLOC;
+
+/** @} */
 
 R_END_DECLS
 

--- a/include/rlib/rcrc.h
+++ b/include/rlib/rcrc.h
@@ -24,16 +24,61 @@
 
 #include <rlib/rtypes.h>
 
+/**
+ * @file rlib/rcrc.h
+ * @brief CRC32 checksum variants.
+ *
+ * Three 32-bit CRC flavours over arbitrary byte buffers, each in
+ * one-shot and streaming form:
+ *
+ *  - **CRC32** - IEEE 802.3 / zlib / PNG (polynomial 0x04C11DB7,
+ *    reflected).
+ *  - **CRC32C** - Castagnoli, used by SCTP, iSCSI, Btrfs, etc.
+ *    (polynomial 0x1EDC6F41, reflected).
+ *  - **CRC32 bzip2** - non-reflected variant used by bzip2
+ *    (polynomial 0x04C11DB7).
+ *
+ * The @c _update functions take a running CRC value so callers can
+ * checksum bytes incrementally; seed the first call with
+ * @c R_CRC32_INIT. The macro shorthands (@c r_crc32 / @c r_crc32c /
+ * @c r_crc32bzip2) wrap the one-shot case.
+ */
+
+/** @brief Seed value for an empty / unstarted CRC32 stream. */
 #define R_CRC32_INIT              0
 
 R_BEGIN_DECLS
 
+/** @brief One-shot CRC32 (IEEE) over @p buf / @p size bytes. */
 #define r_crc32(buf, size)        r_crc32_update (R_CRC32_INIT, buf, size)
+/** @brief One-shot CRC32C (Castagnoli) over @p buf / @p size bytes. */
 #define r_crc32c(buf, size)       r_crc32c_update (R_CRC32_INIT, buf, size)
+/** @brief One-shot CRC32 bzip2 over @p buf / @p size bytes. */
 #define r_crc32bzip2(buf, size)   r_crc32bzip2_update (R_CRC32_INIT, buf, size)
 
+/**
+ * @brief Extend a CRC32 (IEEE) running checksum with another chunk
+ * of @p size bytes from @p buffer.
+ *
+ * Seed the running value with @c R_CRC32_INIT on the first call.
+ *
+ * @param crc     Current running CRC (use @c R_CRC32_INIT to start).
+ * @param buffer  Next chunk of bytes to feed.
+ * @param size    Bytes in @p buffer.
+ * @return Updated CRC value.
+ */
 R_API ruint32 r_crc32_update (ruint32 crc, rconstpointer buffer, rsize size);
+/**
+ * @brief Extend a CRC32C (Castagnoli) running checksum.
+ *
+ * Same seeding and arguments as @c r_crc32_update.
+ */
 R_API ruint32 r_crc32c_update (ruint32 crc, rconstpointer buffer, rsize size);
+/**
+ * @brief Extend a CRC32 bzip2 (non-reflected) running checksum.
+ *
+ * Same seeding and arguments as @c r_crc32_update.
+ */
 R_API ruint32 r_crc32bzip2_update (ruint32 crc, rconstpointer buffer, rsize size);
 
 R_END_DECLS

--- a/include/rlib/rstr.h
+++ b/include/rlib/rstr.h
@@ -27,158 +27,514 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+/**
+ * @file rlib/rstr.h
+ * @brief NUL-terminated string utilities.
+ *
+ * Mostly thin wrappers around the C runtime's string functions, plus
+ * rlib-specific helpers for pointer-and-size string views (RStrChunk),
+ * key-value parsing (RStrKV), pattern matching, integer / float
+ * parsing, ASCII string lists (rchar **), and printf / scanf
+ * convenience.
+ *
+ * Functions in this header generally operate on @c rchar @c * strings;
+ * a separate @c rssize size argument indicates that -1 means "scan to
+ * the terminating NUL" while a non-negative value bounds the operation
+ * regardless of NUL bytes within. Functions that take only a pointer
+ * (no size) require a NUL-terminated input.
+ */
+
 R_BEGIN_DECLS
 
+/**
+ * @brief Compile-time string length, excluding the terminating NUL.
+ *
+ * Only meaningful on string literals or fixed-size arrays of @c rchar.
+ * @param str A string literal or character array.
+ * @return Length of @p str in bytes.
+ */
 #define R_STR_SIZEOF(str) (sizeof (str) - 1)
+
+/**
+ * @brief Expand a string literal into a (pointer, length) argument
+ * pair suitable for functions that take a separate size.
+ *
+ * Convenience helper for call sites like
+ * @c r_str_idx_of_str(haystack, -1, R_STR_WITH_SIZE_ARGS("needle"))
+ * that avoids spelling the literal twice.
+ *
+ * @param str A string literal or character array.
+ */
 #define R_STR_WITH_SIZE_ARGS(str) (str), R_STR_SIZEOF (str)
 
+/**
+ * @brief Status code returned by the string-parsing helpers.
+ *
+ * Returned by the @c r_str_to_* numeric parsers, @c r_str_chunk_next_line,
+ * and the @c r_str_kv_parse family.
+ */
 typedef enum {
-  R_STR_PARSE_OK,
-  R_STR_PARSE_RANGE,
-  R_STR_PARSE_INVAL,
+  R_STR_PARSE_OK,        /**< Parse succeeded. */
+  R_STR_PARSE_RANGE,     /**< Value parsed but is outside the target type's range. */
+  R_STR_PARSE_INVAL,     /**< Input was malformed or no digits were consumed. */
 } RStrParse;
 
 
-R_API rsize r_strlen (const rchar * str);
+/**
+ * @name Length and errno descriptions
+ *
+ * Basic utilities used by the rest of this header. @c r_strlen
+ * mirrors @c strlen; @c r_strerror is a thread-safe wrapper around
+ * the C runtime's @c strerror.
+ * @{
+ */
 
-/* Thread-safe wrapper around the C runtime's strerror.  Writes the
- * error description for errnum into buf (size bytes, NUL-terminated)
- * and returns either buf or, on GNU libc, a static pointer with the
- * same contents.  Always returns a usable string. */
+/**
+ * @brief Thread-safe wrapper around the C runtime's strerror.
+ *
+ * Writes the error description for @p errnum into @p buf (@p size
+ * bytes, NUL-terminated) and returns either @p buf or, on GNU libc, a
+ * static pointer with the same contents. Always returns a usable
+ * string even when @p errnum is unknown to the C runtime.
+ *
+ * @param errnum   The errno value to describe.
+ * @param buf      Caller-supplied output buffer.
+ * @param size     Capacity of @p buf in bytes.
+ * @return A pointer to a NUL-terminated description; either @p buf
+ *         or, on platforms whose runtime returns a static string, that
+ *         static pointer.
+ */
 R_API const rchar * r_strerror (int errnum, rchar * buf, rsize size);
 
-/* Compare strings */
-R_API int r_strcmp (const rchar * a, const rchar * b);
-R_API int r_strcasecmp (const rchar * a, const rchar * b);
-R_API int r_strncmp (const rchar * a, const rchar * b, rsize len);
-R_API int r_strncasecmp (const rchar * a, const rchar * b, rsize len);
-R_API int r_strcmp_size (const rchar * a, rssize asize, const rchar * b, rssize bsize);
-R_API int r_strcasecmp_size (const rchar * a, rssize asize, const rchar * b, rssize bsize);
+/**
+ * @brief Return the byte length of the NUL-terminated string @p str.
+ *
+ * Behaves like the standard C @c strlen.
+ *
+ * @param str A NUL-terminated string.
+ * @return Number of bytes preceding the terminating NUL.
+ */
+R_API rsize r_strlen (const rchar * str);
+
+/** @} */
+
+/**
+ * @name Comparison
+ *
+ * Match the standard C strcmp / strncmp semantics: a negative, zero
+ * or positive result indicates @p a < @p b, @p a == @p b or
+ * @p a > @p b respectively. The @c casecmp variants compare
+ * case-insensitively in the ASCII range. The @c _size variants take
+ * explicit lengths instead of requiring NUL termination; pass -1 on
+ * either side to fall back to @c r_strlen.
+ * @{
+ */
+
+/** @brief Convenience macro: TRUE iff @p a and @p b compare equal. */
 #define r_str_equals(a,b) (r_strcmp (a, b) == 0)
+/** @brief Case-insensitive byte-comparison of two NUL-terminated strings. */
+R_API int r_strcasecmp (const rchar * a, const rchar * b);
+/** @brief Case-insensitive byte-comparison with explicit sizes; -1 means NUL-terminated. */
+R_API int r_strcasecmp_size (const rchar * a, rssize asize, const rchar * b, rssize bsize);
+/** @brief Byte-comparison of two NUL-terminated strings. Behaves like @c strcmp. */
+R_API int r_strcmp (const rchar * a, const rchar * b);
+/** @brief Byte-comparison with explicit sizes; -1 means NUL-terminated. */
+R_API int r_strcmp_size (const rchar * a, rssize asize, const rchar * b, rssize bsize);
+/** @brief Case-insensitive byte-comparison of at most @p len bytes. */
+R_API int r_strncasecmp (const rchar * a, const rchar * b, rsize len);
+/** @brief Byte-comparison of at most @p len bytes. Behaves like @c strncmp. */
+R_API int r_strncmp (const rchar * a, const rchar * b, rsize len);
 
+/** @} */
+
+/**
+ * @name Prefix / suffix / substring tests
+ *
+ * Boolean predicates that don't return a position.
+ * @{
+ */
+
+/**
+ * @brief Test whether @p str begins with @p prefix.
+ * @param str    NUL-terminated input string.
+ * @param prefix NUL-terminated prefix to look for.
+ * @return TRUE if @p str starts with @p prefix; FALSE otherwise.
+ */
 R_API rboolean r_str_has_prefix (const rchar * str, const rchar * prefix);
-R_API rboolean r_str_has_suffix (const rchar * str, const rchar * suffix);
+/**
+ * @brief Test whether @p str contains @p sub anywhere.
+ *
+ * Convenience macro equivalent to
+ * @c r_str_idx_of_str(str,-1,sub,-1) @c >= @c 0.
+ */
 #define r_str_has_substring(str, sub) (r_str_idx_of_str (str, -1, sub, -1) >= 0)
+/**
+ * @brief Test whether @p str ends with @p suffix.
+ * @param str    NUL-terminated input string.
+ * @param suffix NUL-terminated suffix to look for.
+ * @return TRUE if @p str ends with @p suffix; FALSE otherwise.
+ */
+R_API rboolean r_str_has_suffix (const rchar * str, const rchar * suffix);
 
-/* Search/scan for characters/strings */
-R_API rsize r_strspn (const rchar * str, const rchar * set);
-R_API rsize r_strcspn (const rchar * str, const rchar * cset);
-R_API rchar * r_strchr (const rchar * str, int c);
-R_API rchar * r_strnchr (const rchar * str, int c, rsize size);
-R_API rchar * r_strrchr (const rchar * str, int c);
-R_API rchar * r_strnrchr (const rchar * str, int c, rsize size);
-R_API rchar * r_strstr (const rchar * str, const rchar * sub);
-R_API rchar * r_strnstr (const rchar * str, const rchar * sub, rsize size);
-R_API rchar * r_strpbrk (const rchar * str, const rchar * set);
-R_API rchar * r_str_ptr_of_c (const rchar * str, rssize strsize, rchar c);
-R_API rchar * r_str_ptr_of_c_any (const rchar * str, rssize strsize,
-    const rchar * c, rssize chars);
-R_API rchar * r_str_ptr_of_str (const rchar * str, rssize strsize,
-    const rchar * sub, rssize subsize);
-R_API rchar * r_str_ptr_of_str_case (const rchar * str, rssize strsize,
-    const rchar * sub, rssize subsize);
+/** @} */
+
+/**
+ * @name Character / substring search
+ *
+ * The @c r_str* names mirror their C-stdlib equivalents
+ * (@c strspn, @c strchr, @c strstr, etc.) and require NUL-terminated
+ * input. The @c r_str_ptr_of_* / @c r_str_idx_of_* variants take an
+ * explicit size (-1 = NUL-terminated) and return either a pointer
+ * into @p str on match (or NULL on miss) or a byte index (or -1).
+ * @{
+ */
+
+/**
+ * @brief Locate the first occurrence of byte @p c in @p str, returning
+ * its index.
+ * @return Byte index of the match, or -1 if not found.
+ */
 R_API rssize r_str_idx_of_c (const rchar * str, rssize strsize, rchar c);
-R_API rssize r_str_idx_of_c_case (const rchar * str, rssize strsize, rchar c);
+/**
+ * @brief Index of the first byte in @p str that occurs in the set
+ * @p c (the first @p chars bytes of which form the set).
+ */
 R_API rssize r_str_idx_of_c_any (const rchar * str, rssize strsize,
     const rchar * c, rssize chars);
+/** @brief Case-insensitive variant of r_str_idx_of_c. */
+R_API rssize r_str_idx_of_c_case (const rchar * str, rssize strsize, rchar c);
+/** @brief Index of the first occurrence of @p sub inside @p str. */
 R_API rssize r_str_idx_of_str (const rchar * str, rssize strsize,
     const rchar * sub, rssize subsize);
+/** @brief Case-insensitive variant of r_str_idx_of_str. */
 R_API rssize r_str_idx_of_str_case (const rchar * str, rssize strsize,
     const rchar * sub, rssize subsize);
+/**
+ * @brief Locate the first occurrence of byte @p c in @p str.
+ * @param str     Input buffer.
+ * @param strsize Size of @p str in bytes, or -1 to fall back to
+ *                @c r_strlen.
+ * @param c       Byte to find.
+ * @return Pointer into @p str at the match, or NULL.
+ */
+R_API rchar * r_str_ptr_of_c (const rchar * str, rssize strsize, rchar c);
+/**
+ * @brief Locate the first occurrence in @p str of any byte from the
+ * set @p c (the first @p chars bytes of which form the lookup set).
+ * @param str     Input buffer.
+ * @param strsize Bytes in @p str, or -1.
+ * @param c       Pointer to the lookup set.
+ * @param chars   Bytes in @p c, or -1.
+ * @return Pointer into @p str at the match, or NULL.
+ */
+R_API rchar * r_str_ptr_of_c_any (const rchar * str, rssize strsize,
+    const rchar * c, rssize chars);
+/**
+ * @brief Locate the first occurrence of @p sub inside @p str.
+ * @param str     Input buffer.
+ * @param strsize Bytes in @p str, or -1.
+ * @param sub     Substring to search for.
+ * @param subsize Bytes in @p sub, or -1.
+ * @return Pointer into @p str at the match, or NULL.
+ */
+R_API rchar * r_str_ptr_of_str (const rchar * str, rssize strsize,
+    const rchar * sub, rssize subsize);
+/**
+ * @brief Case-insensitive variant of r_str_ptr_of_str.
+ *
+ * Comparison is case-insensitive in the ASCII range; non-ASCII bytes
+ * are compared verbatim.
+ */
+R_API rchar * r_str_ptr_of_str_case (const rchar * str, rssize strsize,
+    const rchar * sub, rssize subsize);
+/**
+ * @brief Locate the first occurrence of @p c in @p str. Behaves like
+ * @c strchr.
+ * @return Pointer into @p str at the match, or NULL if not found.
+ */
+R_API rchar * r_strchr (const rchar * str, int c);
+/**
+ * @brief Length of the initial substring of @p str that contains no
+ * bytes from @p cset. Behaves like @c strcspn.
+ */
+R_API rsize r_strcspn (const rchar * str, const rchar * cset);
+/**
+ * @brief Bounded variant of r_strchr; scans at most @p size bytes.
+ * @return Pointer into @p str at the match, or NULL.
+ */
+R_API rchar * r_strnchr (const rchar * str, int c, rsize size);
+/** @brief Bounded variant of r_strrchr; scans at most @p size bytes. */
+R_API rchar * r_strnrchr (const rchar * str, int c, rsize size);
+/** @brief Bounded variant of r_strstr; scans at most @p size bytes. */
+R_API rchar * r_strnstr (const rchar * str, const rchar * sub, rsize size);
+/**
+ * @brief Locate the first byte in @p str that occurs in @p set.
+ * Behaves like @c strpbrk.
+ */
+R_API rchar * r_strpbrk (const rchar * str, const rchar * set);
+/**
+ * @brief Locate the last occurrence of @p c in @p str. Behaves like
+ * @c strrchr.
+ */
+R_API rchar * r_strrchr (const rchar * str, int c);
+/**
+ * @brief Length of the initial substring of @p str that consists
+ * entirely of bytes from @p set. Behaves like @c strspn.
+ */
+R_API rsize r_strspn (const rchar * str, const rchar * set);
+/**
+ * @brief Locate the first occurrence of @p sub inside @p str.
+ * Behaves like @c strstr.
+ */
+R_API rchar * r_strstr (const rchar * str, const rchar * sub);
 
-/* Copy and concatenate */
-R_API rchar * r_strcpy (rchar * dst, const rchar * src);
-R_API rchar * r_strncpy (rchar * dst, const rchar * src, rsize len);
-R_API rchar * r_strcat (rchar * dst, const rchar * src);
-R_API rchar * r_strncat (rchar * dst, const rchar * src, rsize len);
+/** @} */
+
+/**
+ * @name Copy and concatenate
+ *
+ * @c r_strcpy / @c r_strncpy / @c r_strcat / @c r_strncat behave
+ * exactly as their standard C counterparts. @c r_stpcpy / @c r_stpncpy
+ * return a pointer to the terminating NUL of the destination after
+ * the copy, useful for chained appends.
+ * @{
+ */
+
+/** @brief Like r_strcpy but returns the address of the NUL it wrote. */
 R_API rchar * r_stpcpy (rchar * dst, const rchar * src);
+/** @brief Like r_strncpy but returns the address of the NUL it wrote. */
 R_API rchar * r_stpncpy (rchar * dst, const rchar * src, rsize len);
+/** @brief Append @p src to @p dst. Behaves like @c strcat. */
+R_API rchar * r_strcat (rchar * dst, const rchar * src);
+/** @brief Copy @p src into @p dst including the terminating NUL. Behaves like @c strcpy. */
+R_API rchar * r_strcpy (rchar * dst, const rchar * src);
+/** @brief Append at most @p len bytes of @p src to @p dst. Behaves like @c strncat. */
+R_API rchar * r_strncat (rchar * dst, const rchar * src, rsize len);
+/** @brief Copy at most @p len bytes of @p src into @p dst. Behaves like @c strncpy. */
+R_API rchar * r_strncpy (rchar * dst, const rchar * src, rsize len);
 
+/** @} */
+
+/**
+ * @name Duplication
+ *
+ * All return freshly @c r_malloc'd buffers; caller @c r_free's. NULL
+ * is returned on allocation failure (and, for r_strdup, when @p str
+ * itself is NULL).
+ * @{
+ */
+
+/** @brief Duplicate a NUL-terminated string. */
 R_API rchar * r_strdup (const rchar * str);
+/**
+ * @brief Duplicate the first @p size bytes of @p str.
+ * @param str  Input buffer to copy from.
+ * @param size Bytes to copy, or -1 to fall back to r_strlen(str).
+ */
 R_API rchar * r_strdup_size (const rchar * str, rssize size);
-R_API rchar * r_strndup (const rchar * str, rsize n);
-R_API rchar * r_strdup_wstrip (const rchar * str);
+/** @brief Duplicate @p str with leading and trailing @p chars removed. */
 R_API rchar * r_strdup_strip (const rchar * str, const rchar * chars);
+/** @brief Duplicate @p str with leading and trailing whitespace removed. */
+R_API rchar * r_strdup_wstrip (const rchar * str);
+/** @brief Duplicate at most @p n bytes of @p str (always NUL-terminated). */
+R_API rchar * r_strndup (const rchar * str, rsize n);
 
-/* Strip for whitespace or specific characters */
-R_API rchar * r_str_wstrip (rchar * str);
-R_API const rchar * r_str_lwstrip (const rchar * str);
-R_API rchar * r_str_twstrip (rchar * str);
+/** @} */
 
-R_API rchar * r_str_strip (rchar * str, const rchar * chars);
+/**
+ * @name Strip
+ *
+ * In-place strip functions mutate @p str by NUL-truncating from the
+ * trailing side and return a pointer somewhere inside @p str past
+ * any leading match. The @c l*-prefixed variants only strip leading
+ * characters and return a const pointer (the source isn't written).
+ * The @c t*-prefixed variants only strip trailing characters.
+ * @{
+ */
+
+/** @brief Skip leading @p chars; returns a pointer past them. */
 R_API const rchar * r_str_lstrip (const rchar * str, const rchar * chars);
+/** @brief Skip leading whitespace; returns a pointer past it. */
+R_API const rchar * r_str_lwstrip (const rchar * str);
+/** @brief Strip leading and trailing @p chars from @p str in place. */
+R_API rchar * r_str_strip (rchar * str, const rchar * chars);
+/** @brief Strip trailing @p chars from @p str in place. */
 R_API rchar * r_str_tstrip (rchar * str, const rchar * chars);
+/** @brief Strip trailing whitespace from @p str in place. */
+R_API rchar * r_str_twstrip (rchar * str);
+/** @brief Strip leading and trailing whitespace from @p str in place. */
+R_API rchar * r_str_wstrip (rchar * str);
 
-/* String chunk */
-typedef struct {
-  rchar * str;
-  rsize size;
-} RStrChunk;
-#define R_STR_CHUNK_INIT        { NULL, 0 }
-#define r_str_chunk_dup(chunk)  r_strndup ((chunk)->str, (chunk)->size)
-#define r_str_chunk_end(chunk)  ((chunk)->str + (chunk)->size)
-R_API int r_str_chunk_cmp (const RStrChunk * buf, const rchar * str, rssize size);
-R_API int r_str_chunk_casecmp (const RStrChunk * buf, const rchar * str, rssize size);
-R_API rboolean r_str_chunk_has_prefix (const RStrChunk * buf, const rchar * str, rssize size);
-#define r_str_chunk_ptr_of_c(buf, c)                r_str_ptr_of_c ((buf)->str, (buf)->size, c)
-#define r_str_chunk_ptr_of_c_any(buf, c, chars)     r_str_ptr_of_c_any ((buf)->str, (buf)->size, c, chars)
-#define r_str_chunk_ptr_of_c_case(buf, c)           r_str_ptr_of_c_case ((buf)->str, (buf)->size, c)
-#define r_str_chunk_ptr_of_str(buf, sub, subsize)      r_str_ptr_of_str ((buf)->str, (buf)->size, sub, subsize)
-#define r_str_chunk_ptr_of_str_case(buf, sub, subsize) r_str_ptr_of_str_case ((buf)->str, (buf)->size, sub, subsize)
-#define r_str_chunk_idx_of_c(buf, c)                r_str_idx_of_c ((buf)->str, (buf)->size, c)
-#define r_str_chunk_idx_of_c_any(buf, c, chars)     r_str_idx_of_c_any ((buf)->str, (buf)->size, c, chars)
-#define r_str_chunk_idx_of_c_case(buf, c)           r_str_idx_of_c_case ((buf)->str, (buf)->size, c)
-#define r_str_chunk_idx_of_str(buf, sub, subsize)      r_str_idx_of_str ((buf)->str, (buf)->size, sub, subsize)
-#define r_str_chunk_idx_of_str_case(buf, sub, subsize) r_str_idx_of_str_case ((buf)->str, (buf)->size, sub, subsize)
-R_API RStrParse r_str_chunk_next_line (const RStrChunk * buf, RStrChunk * line);
-R_API ruint r_str_chunk_split (RStrChunk * buf, const rchar * delim, ...) R_ATTR_NULL_TERMINATED;
-R_API ruint r_str_chunk_splitv (RStrChunk * buf, const rchar * delim, va_list args);
-R_API void r_str_chunk_lwstrip (RStrChunk * buf);
-R_API void r_str_chunk_wstrip (RStrChunk * buf);
+/** @} */
 
-/* Key-Value string chunks */
-typedef struct {
-  RStrChunk key;
-  RStrChunk val;
-} RStrKV;
-#define R_STR_KV_INIT           { R_STR_CHUNK_INIT, R_STR_CHUNK_INIT }
-#define r_str_kv_dup_key(kv)    r_str_chunk_dup (&(kv)->key)
-#define r_str_kv_dup_value(kv)  r_str_chunk_dup (&(kv)->val)
-R_API RStrParse r_str_kv_parse (RStrKV * kv, const rchar * str, rssize size,
-    const rchar * delim, const rchar ** endptr);
-R_API RStrParse r_str_kv_parse_multiple (RStrKV * kv, const rchar * str, rssize size,
-    const rchar * kvdelim, rssize kvdsize, const rchar * delim, rssize dsize,
-    const rchar ** endptr);
-R_API rboolean r_str_kv_is_key (const RStrKV * kv, const rchar * key, rssize size);
-R_API rboolean r_str_kv_is_value (const RStrKV * kv, const rchar * val, rssize size);
+/**
+ * @name Join and split
+ *
+ * Join and split helpers that allocate fresh buffers. Caller owns
+ * the result and is responsible for @c r_free / @c r_strv_free.
+ * @{
+ */
 
-/* Join and split */
+/**
+ * @brief Concatenate the variadic NUL-terminated strings, separating
+ * them with @p delim, into a freshly allocated buffer.
+ *
+ * The variadic list is NULL-terminated; an empty list yields a
+ * fresh empty string.
+ */
 R_API rchar * r_strjoin (const rchar * delim, ...) R_ATTR_NULL_TERMINATED;
+/** @brief va_list flavour of r_strjoin. */
 R_API rchar * r_strjoinv (const rchar * delim, va_list args);
+/**
+ * @brief Join into a caller-supplied buffer of @p size bytes.
+ * @return @p str on success; output is always NUL-terminated.
+ *         Truncates rather than failing if @p size is too small.
+ */
 R_API rchar * r_strnjoin (rchar * str, rsize size, const rchar * delim, ...) R_ATTR_NULL_TERMINATED;
+/** @brief va_list flavour of r_strnjoin. */
 R_API rchar * r_strnjoinv (rchar * str, rsize size, const rchar * delim, va_list args);
+/**
+ * @brief Split @p str on @p delim into a freshly allocated rchar**
+ * string vector (NULL-terminated).
+ *
+ * @param str   NUL-terminated input string.
+ * @param delim NUL-terminated separator string.
+ * @param max   Upper bound on the number of pieces produced; 0 means
+ *              unlimited. Use @c r_strv_free on the result.
+ */
 R_API rchar ** r_strsplit (const rchar * str, const rchar * delim, rsize max);
 
-/* Parsing from string to numbers (integers and floats) */
+/** @} */
+
+/**
+ * @name printf-style formatting
+ *
+ * Thin wrappers around the C runtime's printf family. The @c r_sprintf
+ * / @c r_vsprintf forms exist mostly to silence MSVC's deprecation
+ * warning on plain @c sprintf; the rest match their standard
+ * counterparts. @c r_asprintf / @c r_vasprintf allocate the output
+ * buffer; @c r_strprintf / @c r_strvprintf return the allocated
+ * buffer directly (caller @c r_free's).
+ * @{
+ */
+
+/**
+ * @brief Format into a freshly @c r_malloc'd buffer and store its
+ * address at *@p str.
+ *
+ * @return Number of bytes written (excluding the terminating NUL),
+ *         or a negative value on failure.
+ */
+R_API int     r_asprintf (rchar ** str, const rchar * fmt, ...) R_ATTR_PRINTF (2, 3);
+/** @brief @c snprintf passthrough. */
+#define r_snprintf      snprintf
+#ifdef _MSC_VER
+/* MSVC deprecates plain sprintf / vsprintf (C4996). Route through
+ * the secure *_s variants using SIZE_MAX as the buffer size, which
+ * skips the runtime bounds check and preserves the unbounded
+ * semantics callers expect (they've already sized the buffer). */
+/**
+ * @brief @c sprintf-compatible wrapper. On MSVC routes through the
+ * secure @c vsprintf_s to avoid the C4996 deprecation warning.
+ */
+static inline int r_sprintf (rchar * buf, const rchar * fmt, ...)
+{
+  va_list ap;
+  int ret;
+  va_start (ap, fmt);
+  ret = vsprintf_s (buf, (size_t)-1, fmt, ap);
+  va_end (ap);
+  return ret;
+}
+/** @brief @c vsprintf-compatible wrapper; see r_sprintf. */
+#define r_vsprintf(buf, fmt, ap)  vsprintf_s ((buf), (size_t)-1, (fmt), (ap))
+#else
+/** @brief @c sprintf passthrough on non-MSVC platforms. */
+#define r_sprintf       sprintf
+/** @brief @c vsprintf passthrough on non-MSVC platforms. */
+#define r_vsprintf      vsprintf
+#endif
+/**
+ * @brief Format into a freshly @c r_malloc'd buffer and return it.
+ * @return The allocated string, or NULL on failure. Caller @c r_free's.
+ */
+R_API rchar * r_strprintf (const rchar * fmt, ...) R_ATTR_PRINTF (1, 2);
+/** @brief va_list flavour of r_strprintf. */
+R_API rchar * r_strvprintf (const rchar * fmt, va_list args) R_ATTR_PRINTF (1, 0);
+/** @brief va_list flavour of r_asprintf. */
+R_API int     r_vasprintf (rchar ** str, const rchar * fmt, va_list args) R_ATTR_PRINTF (2, 0);
+/** @brief @c vsnprintf passthrough. */
+#define r_vsnprintf     vsnprintf
+
+/** @} */
+
+/**
+ * @name scanf-style scanning
+ * @{
+ */
+
+/** @brief @c sscanf passthrough. */
+R_API int     r_strscanf (const rchar * str, const rchar * fmt, ...) R_ATTR_SCANF (2, 3);
+/** @brief va_list flavour of r_strscanf. */
+R_API int     r_strvscanf (const rchar * str, const rchar * fmt, va_list args) R_ATTR_SCANF (2, 0);
+
+/** @} */
+
+/**
+ * @name String-to-number parsing
+ *
+ * Each function parses an integer from @p str using base @p base
+ * (2 through 36; 0 means autodetect via the standard 0 / 0x / 0b
+ * prefixes). On success the parsed value is returned and, if
+ * @p endptr is non-NULL, *@p endptr is set to one past the last
+ * consumed character. On failure the return value is 0 (signed)
+ * or 0 (unsigned), *@p endptr equals @p str, and *@p res (if
+ * non-NULL) carries @c R_STR_PARSE_INVAL or @c R_STR_PARSE_RANGE.
+ *
+ * The fixed-width spellings are the source of truth; @c r_str_to_int
+ * / @c r_str_to_uint and the @c r_strto* shortcut macros below
+ * dispatch to the right width based on the host's @c int / @c long
+ * size.
+ * @{
+ */
+
+/**
+ * @brief Parse a double-precision float from @p str.
+ *
+ * Accepts the same syntax as the C runtime's @c strtod. *@p res
+ * (when non-NULL) is set as for the integer parsers.
+ */
+R_API rdouble r_str_to_double (const rchar * str, const rchar ** endptr, RStrParse * res);
+/** @brief Single-precision counterpart of r_str_to_double. */
+R_API rfloat r_str_to_float (const rchar * str, const rchar ** endptr, RStrParse * res);
+/** @brief Parse an 8-bit signed integer from @p str. */
 R_API rint8   r_str_to_int8   (const rchar * str, const rchar ** endptr,
     ruint base, RStrParse * res);
-R_API ruint8  r_str_to_uint8  (const rchar * str, const rchar ** endptr,
-    ruint base, RStrParse * res);
+/** @brief Parse a 16-bit signed integer from @p str. */
 R_API rint16  r_str_to_int16  (const rchar * str, const rchar ** endptr,
     ruint base, RStrParse * res);
-R_API ruint16 r_str_to_uint16 (const rchar * str, const rchar ** endptr,
-    ruint base, RStrParse * res);
+/** @brief Parse a 32-bit signed integer from @p str. */
 R_API rint32  r_str_to_int32  (const rchar * str, const rchar ** endptr,
     ruint base, RStrParse * res);
-R_API ruint32 r_str_to_uint32 (const rchar * str, const rchar ** endptr,
-    ruint base, RStrParse * res);
+/** @brief Parse a 64-bit signed integer from @p str. */
 R_API rint64  r_str_to_int64  (const rchar * str, const rchar ** endptr,
     ruint base, RStrParse * res);
+/** @brief Parse an 8-bit unsigned integer from @p str. */
+R_API ruint8  r_str_to_uint8  (const rchar * str, const rchar ** endptr,
+    ruint base, RStrParse * res);
+/** @brief Parse a 16-bit unsigned integer from @p str. */
+R_API ruint16 r_str_to_uint16 (const rchar * str, const rchar ** endptr,
+    ruint base, RStrParse * res);
+/** @brief Parse a 32-bit unsigned integer from @p str. */
+R_API ruint32 r_str_to_uint32 (const rchar * str, const rchar ** endptr,
+    ruint base, RStrParse * res);
+/** @brief Parse a 64-bit unsigned integer from @p str. */
 R_API ruint64 r_str_to_uint64 (const rchar * str, const rchar ** endptr,
     ruint base, RStrParse * res);
+
 #if RLIB_SIZEOF_INT == 8
-#define r_str_to_int   r_str_to_int64
-#define r_str_to_uint  r_str_to_uint64
+#define r_str_to_int   r_str_to_int64    /**< Parse an @c int (host-width). */
+#define r_str_to_uint  r_str_to_uint64   /**< Parse an @c unsigned (host-width). */
 #elif RLIB_SIZEOF_INT == 4
 #define r_str_to_int   r_str_to_int32
 #define r_str_to_uint  r_str_to_uint32
@@ -189,9 +545,14 @@ R_API ruint64 r_str_to_uint64 (const rchar * str, const rchar ** endptr,
 #define r_str_to_int   r_str_to_int8
 #define r_str_to_uint  r_str_to_uint8
 #endif
+
+/** @brief @c strtod equivalent; drops the optional res argument. */
+#define r_strtod(str, endptr) r_str_to_double (str, endptr, NULL)
+/** @brief @c strtof equivalent; drops the optional res argument. */
+#define r_strtof(str, endptr) r_str_to_float  (str, endptr, NULL)
 #if RLIB_SIZEOF_LONG == 8
-#define r_strtol(str, endptr, base)   r_str_to_int64 (str, endptr, base, NULL)
-#define r_strtoul(str, endptr, base)  r_str_to_uint64 (str, endptr, base, NULL)
+#define r_strtol(str, endptr, base)   r_str_to_int64 (str, endptr, base, NULL)   /**< @c strtol equivalent. */
+#define r_strtoul(str, endptr, base)  r_str_to_uint64 (str, endptr, base, NULL)  /**< @c strtoul equivalent. */
 #elif RLIB_SIZEOF_LONG == 4
 #define r_strtol(str, endptr, base)   r_str_to_int32 (str, endptr, base, NULL)
 #define r_strtoul(str, endptr, base)  r_str_to_uint32 (str, endptr, base, NULL)
@@ -202,108 +563,382 @@ R_API ruint64 r_str_to_uint64 (const rchar * str, const rchar ** endptr,
 #define r_strtol(str, endptr, base)   r_str_to_int8 (str, endptr, base, NULL)
 #define r_strtoul(str, endptr, base)  r_str_to_uint8 (str, endptr, base, NULL)
 #endif
+/** @brief @c strtoll equivalent (always 64-bit). */
 #define r_strtoll(str, endptr, base)  r_str_to_int64 (str, endptr, base, NULL)
+/** @brief @c strtoull equivalent (always 64-bit). */
 #define r_strtoull(str, endptr, base) r_str_to_uint64 (str, endptr, base, NULL)
 
-R_API rfloat r_str_to_float (const rchar * str, const rchar ** endptr, RStrParse * res);
-R_API rdouble r_str_to_double (const rchar * str, const rchar ** endptr, RStrParse * res);
-#define r_strtof(str, endptr) r_str_to_float  (str, endptr, NULL)
-#define r_strtod(str, endptr) r_str_to_double (str, endptr, NULL)
+/** @} */
 
-/* Match pattern - very much the same as r_mem_scan* */
+/**
+ * @name String chunk (pointer-and-size view)
+ *
+ * @c RStrChunk borrows its bytes from elsewhere - the chunk does not
+ * own the storage and freeing it is up to the caller. Used by the
+ * parsers and tokenisers in this header so they can return spans
+ * without allocating, and by @c r_str_kv_* for key / value pairs.
+ *
+ * The macro shorthand for search and indexing methods (e.g.
+ * @c r_str_chunk_idx_of_c) delegates to the non-chunk equivalents
+ * in the "Character / substring search" group above.
+ * @{
+ */
+
+/**
+ * @brief Pointer-and-size view of a string region.
+ */
+typedef struct {
+  rchar * str;     /**< First byte of the chunk; not NUL-terminated. */
+  rsize size;      /**< Length of the chunk in bytes. */
+} RStrChunk;
+/** @brief Zero-initialiser for stack RStrChunk values. */
+#define R_STR_CHUNK_INIT        { NULL, 0 }
+/** @brief Duplicate the chunk's bytes into a fresh NUL-terminated string. */
+#define r_str_chunk_dup(chunk)  r_strndup ((chunk)->str, (chunk)->size)
+/** @brief Pointer one past the last byte of the chunk. */
+#define r_str_chunk_end(chunk)  ((chunk)->str + (chunk)->size)
+
+/** @brief Case-insensitive variant of r_str_chunk_cmp. */
+R_API int r_str_chunk_casecmp (const RStrChunk * buf, const rchar * str, rssize size);
+/**
+ * @brief Compare a chunk against a (str, size) pair byte-for-byte.
+ * @param buf  Chunk under test.
+ * @param str  String to compare against.
+ * @param size Bytes in @p str, or -1 to fall back to r_strlen.
+ * @return Negative, zero, or positive as in @c r_strcmp.
+ */
+R_API int r_str_chunk_cmp (const RStrChunk * buf, const rchar * str, rssize size);
+/**
+ * @brief Test whether the chunk starts with the given prefix.
+ * @param buf  Chunk under test.
+ * @param str  Prefix to look for.
+ * @param size Bytes in @p str, or -1 to fall back to r_strlen.
+ */
+R_API rboolean r_str_chunk_has_prefix (const RStrChunk * buf, const rchar * str, rssize size);
+/** @brief Convenience: r_str_idx_of_c on the chunk's bytes. */
+#define r_str_chunk_idx_of_c(buf, c)                r_str_idx_of_c ((buf)->str, (buf)->size, c)
+/** @brief Convenience: r_str_idx_of_c_any on the chunk's bytes. */
+#define r_str_chunk_idx_of_c_any(buf, c, chars)     r_str_idx_of_c_any ((buf)->str, (buf)->size, c, chars)
+/** @brief Convenience: r_str_idx_of_c_case on the chunk's bytes. */
+#define r_str_chunk_idx_of_c_case(buf, c)           r_str_idx_of_c_case ((buf)->str, (buf)->size, c)
+/** @brief Convenience: r_str_idx_of_str on the chunk's bytes. */
+#define r_str_chunk_idx_of_str(buf, sub, subsize)      r_str_idx_of_str ((buf)->str, (buf)->size, sub, subsize)
+/** @brief Convenience: r_str_idx_of_str_case on the chunk's bytes. */
+#define r_str_chunk_idx_of_str_case(buf, sub, subsize) r_str_idx_of_str_case ((buf)->str, (buf)->size, sub, subsize)
+/** @brief Strip leading whitespace from the chunk in place. */
+R_API void r_str_chunk_lwstrip (RStrChunk * buf);
+/**
+ * @brief Consume one line from @p buf into @p line.
+ *
+ * Updates @p buf->str / @p buf->size in place so successive calls
+ * iterate the lines of the original chunk. Line terminators are not
+ * included in @p line. Returns @c R_STR_PARSE_OK on success or
+ * @c R_STR_PARSE_INVAL when @p buf is empty.
+ */
+R_API RStrParse r_str_chunk_next_line (const RStrChunk * buf, RStrChunk * line);
+/** @brief Convenience: r_str_ptr_of_c on the chunk's bytes. */
+#define r_str_chunk_ptr_of_c(buf, c)                r_str_ptr_of_c ((buf)->str, (buf)->size, c)
+/** @brief Convenience: r_str_ptr_of_c_any on the chunk's bytes. */
+#define r_str_chunk_ptr_of_c_any(buf, c, chars)     r_str_ptr_of_c_any ((buf)->str, (buf)->size, c, chars)
+/** @brief Convenience: r_str_ptr_of_c_case on the chunk's bytes. */
+#define r_str_chunk_ptr_of_c_case(buf, c)           r_str_ptr_of_c_case ((buf)->str, (buf)->size, c)
+/** @brief Convenience: r_str_ptr_of_str on the chunk's bytes. */
+#define r_str_chunk_ptr_of_str(buf, sub, subsize)      r_str_ptr_of_str ((buf)->str, (buf)->size, sub, subsize)
+/** @brief Convenience: r_str_ptr_of_str_case on the chunk's bytes. */
+#define r_str_chunk_ptr_of_str_case(buf, sub, subsize) r_str_ptr_of_str_case ((buf)->str, (buf)->size, sub, subsize)
+/**
+ * @brief Split @p buf into chunks using the NUL-terminated string
+ * @p delim as the separator.
+ *
+ * The variadic arguments must be (RStrChunk *) pointers terminated
+ * by a single NULL; each is filled with one piece of @p buf in order.
+ *
+ * @return Number of output chunks that were filled.
+ */
+R_API ruint r_str_chunk_split (RStrChunk * buf, const rchar * delim, ...) R_ATTR_NULL_TERMINATED;
+/** @brief va_list flavour of r_str_chunk_split. */
+R_API ruint r_str_chunk_splitv (RStrChunk * buf, const rchar * delim, va_list args);
+/** @brief Strip leading and trailing whitespace from the chunk in place. */
+R_API void r_str_chunk_wstrip (RStrChunk * buf);
+
+/** @} */
+
+/**
+ * @name Key-value parsing
+ *
+ * @c RStrKV is a pair of chunks built from one @c key<delim>value
+ * binding inside a larger string. Like @c RStrChunk, neither member
+ * owns the underlying storage; freeing is up to whoever owns the
+ * input buffer.
+ * @{
+ */
+
+/**
+ * @brief A pair of borrowed chunks representing one key / value
+ * binding inside a larger string.
+ *
+ * Filled by the @c r_str_kv_parse family.
+ */
+typedef struct {
+  RStrChunk key;     /**< Key chunk (left of the delimiter). */
+  RStrChunk val;     /**< Value chunk (right of the delimiter). */
+} RStrKV;
+/** @brief Zero-initialiser for stack RStrKV values. */
+#define R_STR_KV_INIT           { R_STR_CHUNK_INIT, R_STR_CHUNK_INIT }
+/** @brief Duplicate the key chunk into a fresh NUL-terminated string. */
+#define r_str_kv_dup_key(kv)    r_str_chunk_dup (&(kv)->key)
+/** @brief Duplicate the value chunk into a fresh NUL-terminated string. */
+#define r_str_kv_dup_value(kv)  r_str_chunk_dup (&(kv)->val)
+
+/**
+ * @brief Parse one @c key<delim>value pair starting at @p str.
+ *
+ * On success, @p kv->key and @p kv->val are filled with views into
+ * @p str (no copies) and *@p endptr (when non-NULL) is set to one
+ * past the consumed bytes. @p delim is a NUL-terminated string of
+ * separator characters; the first occurrence of any of them ends
+ * the key.
+ *
+ * @param kv     Receives the parsed key / value chunks.
+ * @param str    Input buffer.
+ * @param size   Bytes in @p str, or -1 to fall back to r_strlen.
+ * @param delim  NUL-terminated set of separator characters.
+ * @param endptr Optional out-pointer set to one past the consumed bytes.
+ */
+R_API RStrParse r_str_kv_parse (RStrKV * kv, const rchar * str, rssize size,
+    const rchar * delim, const rchar ** endptr);
+/**
+ * @brief Parse a sequence of key / value pairs.
+ *
+ * @p kv must point to enough storage for the caller's expected
+ * number of pairs. @p kvdelim separates keys from values within
+ * each pair; @p delim separates pairs from each other. Sizes may be
+ * -1 to fall back to r_strlen on each delimiter string.
+ *
+ * @return @c R_STR_PARSE_OK on success.
+ */
+R_API RStrParse r_str_kv_parse_multiple (RStrKV * kv, const rchar * str, rssize size,
+    const rchar * kvdelim, rssize kvdsize, const rchar * delim, rssize dsize,
+    const rchar ** endptr);
+
+/**
+ * @brief Test whether the KV's key matches @p key (first @p size
+ * bytes; -1 = NUL-terminated).
+ */
+R_API rboolean r_str_kv_is_key (const RStrKV * kv, const rchar * key, rssize size);
+/** @brief Test whether the KV's value matches @p val. */
+R_API rboolean r_str_kv_is_value (const RStrKV * kv, const rchar * val, rssize size);
+
+/** @} */
+
+/**
+ * @name Pattern matching
+ *
+ * Simple shell-style pattern matching (@c '?' single-byte wildcard,
+ * @c '*' any-length wildcard). The detailed variant
+ * (@c r_str_match_pattern) populates an @c RStrMatchResult with the
+ * exact span each pattern token consumed; the simple variant just
+ * returns TRUE / FALSE.
+ * @{
+ */
+
+/**
+ * @brief Token type produced by the pattern matcher.
+ *
+ * The same vocabulary as @c r_mem_scan_*: a pattern is a sequence of
+ * literal-byte runs interleaved with single-byte and sized
+ * wildcards.
+ */
 typedef enum {
-  R_STR_TOKEN_NONE = -1,
-  R_STR_TOKEN_CHARS,
-  R_STR_TOKEN_WILDCARD,
-  R_STR_TOKEN_WILDCARD_SIZED,
-  R_STR_TOKEN_COUNT
+  R_STR_TOKEN_NONE = -1,        /**< Sentinel for "unset" token type. */
+  R_STR_TOKEN_CHARS,            /**< Literal byte run. */
+  R_STR_TOKEN_WILDCARD,         /**< Single-byte wildcard ("?"). */
+  R_STR_TOKEN_WILDCARD_SIZED,   /**< Multi-byte wildcard with an explicit length. */
+  R_STR_TOKEN_COUNT             /**< Number of token types; not a value. */
 } RStrTokenType;
 
+/**
+ * @brief Status code from r_str_match_pattern.
+ *
+ * Negative values are errors; @c R_STR_MATCH_RESULT_OK and
+ * @c R_STR_MATCH_RESULT_NO_MATCH are the two regular outcomes.
+ */
 typedef enum {
-  R_STR_MATCH_RESULT_INVAL             = -4,
-  R_STR_MATCH_RESULT_OOM               = -3,
-  R_STR_MATCH_RESULT_INVALID_PATTERN   = -2,
-  R_STR_MATCH_RESULT_PATTERN_NOT_IMPL  = -1,
-  R_STR_MATCH_RESULT_OK                =  0,
-  R_STR_MATCH_RESULT_NO_MATCH
+  R_STR_MATCH_RESULT_INVAL             = -4,   /**< Caller passed a bad argument. */
+  R_STR_MATCH_RESULT_OOM               = -3,   /**< Allocation for the result failed. */
+  R_STR_MATCH_RESULT_INVALID_PATTERN   = -2,   /**< @p pattern didn't parse. */
+  R_STR_MATCH_RESULT_PATTERN_NOT_IMPL  = -1,   /**< Recognised pattern token isn't yet supported. */
+  R_STR_MATCH_RESULT_OK                =  0,   /**< Match found; result populated. */
+  R_STR_MATCH_RESULT_NO_MATCH                  /**< Pattern parsed but didn't match. */
 } RStrMatchResultType;
 
+/**
+ * @brief One token of a parsed pattern, paired with the matched span.
+ */
 typedef struct _RStrMatchToken {
-  RStrTokenType type;
-  const rchar * pattern;
-  RStrChunk chunk;
+  RStrTokenType type;     /**< Kind of token this entry came from. */
+  const rchar * pattern;  /**< Pointer into the original pattern at this token's start. */
+  RStrChunk chunk;        /**< Span of the input that this token matched. */
 } RStrMatchToken;
 
+/**
+ * @brief Result of r_str_match_pattern.
+ *
+ * Variable-length: the @c token array is a flexible member sized to
+ * @c tokens entries. Allocated by the matcher; caller @c r_free's.
+ */
 typedef struct _RStrMatchResult {
-  rchar * ptr;
-  rchar * end;
-  rsize tokens;
-  RStrMatchToken token[0];
+  rchar * ptr;            /**< Pointer into the input where the match starts. */
+  rchar * end;            /**< Pointer one past the last matched byte. */
+  rsize tokens;           /**< Number of entries in @c token. */
+  RStrMatchToken token[0];/**< Per-token match spans. */
 } RStrMatchResult;
 
+/**
+ * @brief Test whether @p str matches a simple shell-style pattern.
+ *
+ * Accepts @c '?' (single-byte wildcard) and @c '*' (any-length
+ * wildcard) in @p pattern. Returns TRUE on match. Cheaper than
+ * r_str_match_pattern when the caller only needs the boolean
+ * answer.
+ *
+ * @param str     Input buffer.
+ * @param size    Bytes in @p str, or -1 to fall back to r_strlen.
+ * @param pattern NUL-terminated pattern with '?' / '*' wildcards.
+ */
 R_API rboolean r_str_match_simple_pattern (const rchar * str, rssize size,
     const rchar * pattern);
+/**
+ * @brief Match @p str against @p pattern and, on success, allocate a
+ * detailed match-result record into *@p result.
+ *
+ * The record carries one @c RStrMatchToken per pattern token, giving
+ * the exact input span each token matched. Caller @c r_free's
+ * *@p result on success.
+ *
+ * @return One of @c R_STR_MATCH_RESULT_OK / @c _NO_MATCH; negative
+ *         on error.
+ */
 R_API RStrMatchResultType r_str_match_pattern (const rchar * str, rssize size,
     const rchar * pattern, RStrMatchResult ** result);
 
-/* Formatting strings */
-#ifdef _MSC_VER
-/* MSVC deprecates plain sprintf / vsprintf (C4996). Route through
- * the secure *_s variants using SIZE_MAX as the buffer size, which
- * skips the runtime bounds check and preserves the unbounded
- * semantics callers expect (they've already sized the buffer). */
-static inline int r_sprintf (rchar * buf, const rchar * fmt, ...)
-{
-  va_list ap;
-  int ret;
-  va_start (ap, fmt);
-  ret = vsprintf_s (buf, (size_t)-1, fmt, ap);
-  va_end (ap);
-  return ret;
-}
-#define r_vsprintf(buf, fmt, ap)  vsprintf_s ((buf), (size_t)-1, (fmt), (ap))
-#else
-#define r_sprintf       sprintf
-#define r_vsprintf      vsprintf
-#endif
-#define r_snprintf      snprintf
-#define r_vsnprintf     vsnprintf
-R_API int     r_asprintf (rchar ** str, const rchar * fmt, ...) R_ATTR_PRINTF (2, 3);
-R_API int     r_vasprintf (rchar ** str, const rchar * fmt, va_list args) R_ATTR_PRINTF (2, 0);
-R_API rchar * r_strprintf (const rchar * fmt, ...) R_ATTR_PRINTF (1, 2);
-R_API rchar * r_strvprintf (const rchar * fmt, va_list args) R_ATTR_PRINTF (1, 0);
+/** @} */
 
-/* Dump/format memory to string */
-R_API void r_str_dump (rchar * dst, const rchar * src, rsize size);
+/**
+ * @name Memory dump and hex
+ *
+ * Helpers that render a byte buffer as printable text - either a
+ * hex+ASCII dump suitable for logging, or a plain hex string for
+ * serialisation. @c r_str_hex_to_binary / @c r_str_hex_mem invert the
+ * hex variants.
+ * @{
+ */
+
+/**
+ * @brief Required bytes in the destination buffer to dump @p align
+ * source bytes per line via @c r_str_mem_dump.
+ */
 #define R_STR_MEM_DUMP_SIZE(align) \
   ((align * 4) + (align / 4) + (RLIB_SIZEOF_VOID_P * 2) + 8)
+/**
+ * @brief Render @p src (@p size bytes) into the caller-supplied @p dst
+ * as a hex+ASCII dump line.
+ *
+ * @p dst must be at least @c R_STR_MEM_DUMP_SIZE(align) bytes for
+ * each line of @p align input bytes the caller wants emitted.
+ */
+R_API void r_str_dump (rchar * dst, const rchar * src, rsize size);
+/**
+ * @brief Decode hex digits from @p hex into a freshly allocated byte
+ * buffer; stores the resulting size in *@p outsize.
+ * @return The buffer, or NULL on failure. Caller @c r_free's.
+ */
+R_API ruint8 * r_str_hex_mem (const rchar * hex, rsize * outsize) R_ATTR_MALLOC;
+/**
+ * @brief Decode hex digits from @p hex into @p bin (capacity @p size
+ * bytes).
+ * @return Number of bytes written to @p bin.
+ */
+R_API rsize r_str_hex_to_binary (const rchar * hex, ruint8 * bin, rsize size);
+/**
+ * @brief Render @p size bytes from @p ptr into @p str as a multi-line
+ * hex+ASCII dump.
+ * @param str   Destination buffer.
+ * @param ptr   Source bytes to render.
+ * @param size  Number of bytes to consume from @p ptr.
+ * @param align Number of source bytes per line; see R_STR_MEM_DUMP_SIZE
+ *              for the destination capacity formula.
+ * @return TRUE on success.
+ */
 R_API rboolean r_str_mem_dump (rchar * str, const ruint8 * ptr,
     rsize size, rsize align);
+/**
+ * @brief Like r_str_mem_dump but allocates the destination buffer.
+ * @return Freshly allocated NUL-terminated dump; caller @c r_free's.
+ */
 R_API rchar * r_str_mem_dump_dup (const ruint8 * ptr,
     rsize size, rsize align);
+/**
+ * @brief Encode @p size bytes from @p ptr as a contiguous lowercase
+ * hex string.
+ * @return Freshly allocated NUL-terminated hex string.
+ */
 R_API rchar * r_str_mem_hex (const ruint8 * ptr, rsize size);
+/**
+ * @brief Encode @p ptr as hex with an arbitrary divider inserted
+ * every @p interval bytes (e.g. ":" for "DE:AD:BE:EF").
+ */
 R_API rchar * r_str_mem_hex_full (const ruint8 * ptr, rsize size,
     const rchar * divider, rsize interval);
 
-R_API rsize r_str_hex_to_binary (const rchar * hex, ruint8 * bin, rsize size);
-R_API ruint8 * r_str_hex_mem (const rchar * hex, rsize * outsize) R_ATTR_MALLOC;
+/** @} */
 
-/* Scanning */
-R_API int     r_strscanf (const rchar * str, const rchar * fmt, ...) R_ATTR_SCANF (2, 3);
-R_API int     r_strvscanf (const rchar * str, const rchar * fmt, va_list args) R_ATTR_SCANF (2, 0);
+/**
+ * @name String list / string vector
+ *
+ * Two flavours of list-of-strings. The @c r_str_list_* form returns
+ * an @c RSList (singly linked list of @c rchar @c *). The @c r_strv_*
+ * form returns a NULL-terminated @c rchar @c ** array. Both copy
+ * the input strings; ownership of the result transfers to the
+ * caller.
+ * @{
+ */
 
-/* String list */
+/**
+ * @brief Build an RSList from a NULL-terminated variadic argument
+ * list of NUL-terminated strings.
+ */
 R_API RSList * r_str_list_new (const rchar * str0, ...);
+/** @brief va_list flavour of r_str_list_new. */
 R_API RSList * r_str_list_newv (const rchar * str0, va_list args);
-
+/**
+ * @brief Build a NULL-terminated @c rchar** vector from a variadic
+ * argument list of NUL-terminated strings.
+ *
+ * Use @c r_strv_free on the result.
+ */
 R_API rchar ** r_strv_new (const rchar * str0, ...);
+/** @brief va_list flavour of r_strv_new. */
 R_API rchar ** r_strv_newv (const rchar * str0, va_list args);
+/** @brief Duplicate a string vector (each element and the vector itself). */
 R_API rchar ** r_strv_copy (rchar * const * strv);
-R_API void r_strv_free (rchar ** strv);
-R_API rsize r_strv_len (rchar * const * strv);
-R_API void r_strv_foreach (rchar ** strv, RFunc func, rpointer user);
+
+/** @brief TRUE iff @p strv contains a string equal to @p str. */
 R_API rboolean r_strv_contains (rchar * const * strv, const rchar * str);
+/** @brief Invoke @p func(s, @p user) for each string @c s in @p strv. */
+R_API void r_strv_foreach (rchar ** strv, RFunc func, rpointer user);
+/**
+ * @brief Join the strings in @p strv with @p delim into a freshly
+ * allocated buffer; caller @c r_free's.
+ */
 R_API rchar * r_strv_join (rchar * const * strv, const rchar * delim);
+/** @brief Number of strings in @p strv (the trailing NULL excluded). */
+R_API rsize r_strv_len (rchar * const * strv);
+
+/** @brief Free a string vector built by r_strv_new and friends. */
+R_API void r_strv_free (rchar ** strv);
+
+/** @} */
 
 R_END_DECLS
 

--- a/include/rlib/rtypes.h
+++ b/include/rlib/rtypes.h
@@ -29,109 +29,261 @@
 #include <limits.h>
 #include <float.h>
 
+/**
+ * @file rlib/rtypes.h
+ * @brief Foundational type aliases used by every rlib header.
+ *
+ * rlib spells its primitive types with an @c r prefix
+ * (@c rint32, @c rsize, @c rchar, @c rpointer, ...) so callers can
+ * grep for the project's surface and so the size-suffixed names
+ * map predictably to the bit widths their compilers would otherwise
+ * negotiate via @c stdint.h. The fixed-width @c rXX / @c ruXX
+ * typedefs live in the build-generated @c rlib/rconfig.h; the
+ * native-width ones (@c rchar, @c rshort, ...) live here.
+ */
+
 R_BEGIN_DECLS
 
+/**
+ * @name Boolean type
+ * @{
+ */
+/** @brief Boolean type (typedef'd to @c int). */
 typedef int                     rboolean;
+/** @} */
+
+/**
+ * @name Floating-point types and constants
+ * @{
+ */
+/** @brief Single-precision floating point. */
 typedef float                   rfloat;
+/** @brief Double-precision floating point. */
 typedef double                  rdouble;
 
+/** @brief Smallest positive normalised @c rfloat. */
 #define RFLOAT_MIN              FLT_MIN
+/** @brief Largest finite @c rfloat. */
 #define RFLOAT_MAX              FLT_MAX
+/** @brief Smallest positive normalised @c rdouble. */
 #define RDOUBLE_MIN             DBL_MIN
+/** @brief Largest finite @c rdouble. */
 #define RDOUBLE_MAX             DBL_MAX
+/* The platform-specific spellings of infinity / NaN below are
+ * documented identically on every branch; Doxygen picks whichever
+ * branch is active under its preprocessor config, so the comments
+ * have to live on all three so the symbols show up no matter which
+ * branch survives. */
 #if defined(_MSC_VER)
+/** @brief +infinity as @c rfloat. */
 #define RFLOAT_INFINITY         ((rfloat)(1e+300 * 1e+300))
+/** @brief Quiet NaN as @c rfloat. */
 #define RFLOAT_NAN              (RFLOAT_INFINITY * 0.0f)
+/** @brief +infinity as @c rdouble. */
 #define RDOUBLE_INFINITY        ((rdouble)(1e+300 * 1e+300))
+/** @brief Quiet NaN as @c rdouble. */
 #define RDOUBLE_NAN             (RDOUBLE_INFINITY * 0.0)
 #elif defined(__GNUC__)
+/** @brief +infinity as @c rfloat. */
 #define RFLOAT_INFINITY         (__builtin_huge_valf())
+/** @brief Quiet NaN as @c rfloat. */
 #define RFLOAT_NAN              (__builtin_nanf("0x7fc00000"))
+/** @brief +infinity as @c rdouble. */
 #define RDOUBLE_INFINITY        (__builtin_huge_val())
+/** @brief Quiet NaN as @c rdouble. */
 #define RDOUBLE_NAN             ((rdouble)RFLOAT_NAN)
 #else
+/** @brief +infinity as @c rfloat. */
 #define RFLOAT_INFINITY         ((rfloat)1e500)
+/** @brief Quiet NaN as @c rfloat. */
 #define RFLOAT_NAN              (__nan())
+/** @brief +infinity as @c rdouble. */
 #define RDOUBLE_INFINITY        ((rdouble)1e500)
+/** @brief Quiet NaN as @c rdouble. */
 #define RDOUBLE_NAN             ((rdouble)RFLOAT_NAN)
 #endif
 
+/** @brief Euler's number, e. */
 #define R_E                 2.718281828459045235360287471352662497757247093700
+/** @brief Natural log of 2. */
 #define R_LN2               0.693147180559945309417232121458176568075500134360
+/** @brief Natural log of 10. */
 #define R_LN10              2.302585092994045684017991454684364207601101488629
+/** @brief log_10 of 2. */
 #define R_LOG_2_BASE10      0.301029995663981195213738894724493026768189881462
+/** @brief pi. */
 #define R_PI                3.141592653589793238462643383279502884197169399375
+/** @brief Square root of 2. */
 #define R_SQRT2             1.414213562373095048801688724209698078569671875377
+/** @} */
 
+/**
+ * @name Native-width integer types
+ *
+ * Aliases for the C native types whose width depends on the host
+ * (@c char, @c short, @c int, @c long). Use the fixed-width
+ * @c rXX / @c ruXX names from @c rlib/rconfig.h when the size
+ * needs to be predictable.
+ * @{
+ */
+/** @brief Default character type (@c char). */
 typedef char                    rchar;
+/** @brief Default short type (@c short). */
 typedef short                   rshort;
+/** @brief Default long type (@c long). */
 typedef long                    rlong;
+/** @brief Explicit-signed char (same as @c rchar on rlib's targets). */
 typedef char                    rschar;
+/** @brief Explicit-signed short. */
 typedef short                   rsshort;
+/** @brief Explicit-signed long. */
 typedef long                    rslong;
+/** @brief Explicit-signed int. */
 typedef int                     rsint;
+/** @brief Unsigned char. */
 typedef unsigned char           ruchar;
+/** @brief Unsigned short. */
 typedef unsigned short          rushort;
+/** @brief Unsigned long. */
 typedef unsigned long           rulong;
+/** @brief Unsigned int. */
 typedef unsigned int            ruint;
 
-#define RCHAR_MIN               CHAR_MIN
-#define RCHAR_MAX               CHAR_MAX
-#define RSHORT_MIN              SHRT_MIN
-#define RSHORT_MAX              SHRT_MAX
-#define RUSHORT_MAX             USHRT_MAX
-#define RINT_MIN                INT_MIN
-#define RINT_MAX                INT_MAX
-#define RUINT_MAX               UINT_MAX
-#define RLONG_MIN               LONG_MIN
-#define RLONG_MAX               LONG_MAX
-#define RULONG_MAX              ULONG_MAX
+#define RCHAR_MIN               CHAR_MIN     /**< Minimum value of @c rchar. */
+#define RCHAR_MAX               CHAR_MAX     /**< Maximum value of @c rchar. */
+#define RSHORT_MIN              SHRT_MIN     /**< Minimum value of @c rshort. */
+#define RSHORT_MAX              SHRT_MAX     /**< Maximum value of @c rshort. */
+#define RUSHORT_MAX             USHRT_MAX    /**< Maximum value of @c rushort. */
+#define RINT_MIN                INT_MIN      /**< Minimum value of @c rsint. */
+#define RINT_MAX                INT_MAX      /**< Maximum value of @c rsint. */
+#define RUINT_MAX               UINT_MAX     /**< Maximum value of @c ruint. */
+#define RLONG_MIN               LONG_MIN     /**< Minimum value of @c rlong. */
+#define RLONG_MAX               LONG_MAX     /**< Maximum value of @c rlong. */
+#define RULONG_MAX              ULONG_MAX    /**< Maximum value of @c rulong. */
+/** @} */
 
-/* All r[u]intN typedefs in rconfig.h */
+/**
+ * @name Fixed-width integer limits
+ *
+ * The actual @c rint8 / @c ruint8 / ... typedefs live in
+ * @c rlib/rconfig.h (chosen per host so the sizes are guaranteed);
+ * the @c MIN / @c MAX constants live here so a single include of
+ * @c rlib/rtypes.h covers both.
+ * @{
+ */
+/** @brief Minimum value of @c rint8. */
 #define RINT8_MIN               ((rint8)   0x80)
+/** @brief Maximum value of @c rint8. */
 #define RINT8_MAX               ((rint8)   0x7f)
+/** @brief Maximum value of @c ruint8. */
 #define RUINT8_MAX              ((ruint8)  0xff)
+/** @brief Minimum value of @c rint16. */
 #define RINT16_MIN              ((rint16)  0x8000)
+/** @brief Maximum value of @c rint16. */
 #define RINT16_MAX              ((rint16)  0x7fff)
+/** @brief Maximum value of @c ruint16. */
 #define RUINT16_MAX             ((ruint16) 0xffff)
+/** @brief Minimum value of @c rint32. */
 #define RINT32_MIN              ((rint32)  0x80000000)
+/** @brief Maximum value of @c rint32. */
 #define RINT32_MAX              ((rint32)  0x7fffffff)
+/** @brief Maximum value of @c ruint32. */
 #define RUINT32_MAX             ((ruint32) 0xffffffff)
+/** @brief Minimum value of @c rint64. */
 #define RINT64_MIN              ((rint64) RINT64_CONSTANT(0x8000000000000000))
+/** @brief Maximum value of @c rint64. */
 #define RINT64_MAX              RINT64_CONSTANT(0x7fffffffffffffff)
+/** @brief Maximum value of @c ruint64. */
 #define RUINT64_MAX             RUINT64_CONSTANT(0xffffffffffffffff)
+/** @} */
 
-/* r[s]size typedefs in rconfig.h */
+/**
+ * @name Size and file-offset types
+ *
+ * @c rsize / @c rssize (unsigned and signed pointer-sized) are
+ * typedef'd in @c rlib/rconfig.h. @c roffset is a 64-bit signed
+ * offset used for file / stream positions, large enough to address
+ * past the 32-bit boundary on platforms that need it.
+ * @{
+ */
+/** @brief 64-bit signed file / stream offset. */
 typedef rint64                  roffset;
+/** @brief Minimum value of @c roffset. */
 #define ROFFSET_MIN             RINT64_MIN
+/** @brief Maximum value of @c roffset. */
 #define ROFFSET_MAX             RINT64_MAX
 
+/** @brief printf length modifier for @c roffset. */
 #define ROFFSET_MODIFIER        RINT64_MODIFIER
+/** @brief printf format specifier for @c roffset. */
 #define ROFFSET_FMT             RINT64_FMT
+/** @brief Suffix a literal as an @c roffset value. */
 #define ROFFSET_CONSTANT(val)   RINT64_CONSTANT(val)
+/** @} */
 
-/* r[u]intptr typedefs in rconfig.h */
+/**
+ * @name Pointer types
+ *
+ * @c rpointer / @c rconstpointer alias @c void @c * / @c const
+ * @c void @c *. The conversion macros cast through @c rintptr /
+ * @c ruintptr / @c rsize to silence pedantic warnings about
+ * pointer / integer conversions on platforms where the widths
+ * happen to mismatch.
+ * @{
+ */
+/** @brief Generic pointer (alias for @c void @c *). */
 typedef void*                   rpointer;
+/** @brief Generic const pointer (alias for @c const @c void @c *). */
 typedef const void*             rconstpointer;
+/** @brief Reinterpret a pointer as an @c rsint. */
 #define RPOINTER_TO_INT(p)      ((rsint) (rintptr) (p))
+/** @brief Reinterpret a pointer as a @c ruint. */
 #define RPOINTER_TO_UINT(p)     ((ruint) (ruintptr) (p))
+/** @brief Reinterpret a pointer as an @c rsize. */
 #define RPOINTER_TO_SIZE(p)     ((rsize) (p))
+/** @brief Reinterpret an @c rsint as a pointer. */
 #define RINT_TO_POINTER(i)      ((rpointer) (rintptr) (i))
+/** @brief Reinterpret a @c ruint as a pointer. */
 #define RUINT_TO_POINTER(u)     ((rpointer) (ruintptr) (u))
+/** @brief Reinterpret an @c rsize as a pointer. */
 #define RSIZE_TO_POINTER(s)     ((rpointer) (rsize) (s))
+/** @} */
 
-/* Clock and time related */
+/**
+ * @name Clock time
+ *
+ * Monotonic timestamps and durations expressed as @c ruint64
+ * nanoseconds. The sentinel @c R_CLOCK_TIME_NONE doubles as an
+ * "infinite" wait value.
+ * @{
+ */
+/** @brief Unsigned 64-bit timestamp / duration, in nanoseconds. */
 typedef ruint64                 RClockTime;
+/** @brief Signed clock-time difference. */
 typedef rint64                  RClockTimeDiff;
+/** @brief Sentinel value for "no time" / "invalid time". */
 #define R_CLOCK_TIME_NONE       ((RClockTime) -1)
+/** @brief Alias for @c R_CLOCK_TIME_NONE used as a "wait forever" sentinel. */
 #define R_CLOCK_TIME_INFINITE   R_CLOCK_TIME_NONE
+/** @} */
 
-/* IO Handle */
+/**
+ * @name I/O handle
+ *
+ * Cross-platform OS I/O handle: a Windows @c HANDLE pointer on
+ * Win32, a POSIX @c int file descriptor everywhere else.
+ * @{
+ */
 #if defined (R_OS_WIN32)
+/** @brief OS I/O handle (Win32 @c HANDLE on Windows; @c int fd elsewhere). */
 typedef rpointer RIOHandle;
+/** @brief printf format specifier for an @c RIOHandle. */
 #define R_IO_HANDLE_FMT           "p"
+/** @brief Sentinel for "no handle". */
 #define R_IO_HANDLE_INVALID       INVALID_HANDLE_VALUE
+/** @brief Convert an @c rpointer to an @c RIOHandle. */
 #define RPOINTER_TO_IO_HANDLE(p)  (p)
+/** @brief Convert an @c RIOHandle to an @c rpointer. */
 #define RIO_HANDLE_TO_POINTER(h)  (h)
 #else
 typedef int RIOHandle;
@@ -140,20 +292,49 @@ typedef int RIOHandle;
 #define RPOINTER_TO_IO_HANDLE(p)  RPOINTER_TO_INT (p)
 #define RIO_HANDLE_TO_POINTER(h)  RINT_TO_POINTER (h)
 #endif
+/** @} */
 
 
-/* Function prototypes */
+/**
+ * @name Function-pointer prototypes
+ *
+ * Common callback shapes used across rlib's container / iterator
+ * APIs. Library users typically don't write these typedefs out -
+ * they pass function pointers that match the shape into the call
+ * sites that ask for them.
+ * @{
+ */
+/** @brief Destructor callback: free / release the value at @p ptr. */
 typedef void (*RDestroyNotify) (rpointer ptr);
+/** @brief Generic iteration callback over (data, user) pairs. */
 typedef void (*RFunc) (rpointer data, rpointer user);
+/** @brief Comparison callback returning <0 / 0 / >0 for @p a vs @p b. */
 typedef int (*RCmpFunc) (rconstpointer a, rconstpointer b);
+/** @brief Equality predicate. */
 typedef rboolean (*REqualFunc) (rconstpointer a, rconstpointer b);
+/** @brief Hash function over an opaque key. */
 typedef rsize (*RHashFunc) (rconstpointer key);
+/** @brief Iteration callback over (key, value, user) triples. */
 typedef void (*RKeyValueFunc) (rpointer key, rpointer value, rpointer user);
+/** @brief Iteration callback over (const char *key, value, user). */
 typedef void (*RStrKeyValueFunc) (const rchar * key, rpointer value, rpointer user);
+/**
+ * @brief Iteration callback that can short-circuit by returning FALSE.
+ */
 typedef rboolean (*RFuncReturn) (rpointer data, rpointer user);
+/** @brief Key-value iteration callback that can short-circuit. */
 typedef rboolean (*RKeyValueFuncReturn) (rpointer key, rpointer value, rpointer user);
+/**
+ * @brief Type-erased function pointer used as a "any callable"
+ * placeholder before downcasting to the actual signature.
+ *
+ * Casting between this and a real function-pointer type is
+ * well-defined; casting through @c void @c * would not be.
+ */
 typedef void (*RFuncUniversal) ();
+/** @brief Type-erased function pointer that returns an @c rpointer. */
 typedef rpointer (*RFuncUniversalReturn) ();
+/** @} */
 
 
 R_END_DECLS


### PR DESCRIPTION
## Summary

First domain-by-domain documentation pass under the `docs/Doxyfile` toolchain. Seven public headers in and around the string surface now carry full Doxygen comments (`/** */` with `@brief` / `@param` / `@return` annotations, named groups, file-level overviews):

| Header | What it is |
|---|---|
| `include/rlib/rstr.h` | NUL-terminated string utilities (the headline pass; conventions established here) |
| `include/rlib/data/rstring.h` | The mutable `RString` builder, heap-owning complement to `rstr.h` |
| `include/rlib/charset/rascii.h` | ASCII character classification + case conversion |
| `include/rlib/charset/runicode.h` | UTF-8 / UTF-16 conversion |
| `include/rlib/rbase64.h` | RFC 4648 base64 encoder / decoder |
| `include/rlib/rcrc.h` | CRC32 in three flavours (IEEE / Castagnoli / bzip2) |
| `include/rlib/rtypes.h` | Foundational type aliases every other rlib header leans on |

One commit per file so each lands as its own reviewable unit.

## Conventions established here (intent: reuse them as the rest of the codebase gets documented)

- One `@brief` per declaration. C-stdlib wrappers get a one-line brief that names the underlying function; rlib-specific helpers get full prose plus `@param` / `@return`.
- Macros and constants carry `/** */` comments too.
- `@name` groups in most-useful-first order; within each group, ctor-like first, ops alphabetical, dtor-like last.
- Types declared at the top of the group that owns them, with forward dependencies respected (e.g. `RStrChunk` declared before the Pattern matching group that embeds it).

## Test plan

- [x] Zero Doxygen warnings against the project's `docs/Doxyfile` (`EXTRACT_ALL = NO` + `WARN_IF_DOC_ERROR = YES`)
- [x] No source-code changes (comments-only); debug, gcc-warn, ASan, TSan, clang all build clean
- [x] All 1516 default tests pass
- [x] CI green on the PR
- [ ] Generated `Docs` artifact shows the new pages with proper grouping and the README-anchored main page