### PR TITLE
Crypto microbenchmarks: DSA, ECDH, AES, ECDSA

### DIFF
--- a/bench/meson.build
+++ b/bench/meson.build
@@ -1,5 +1,5 @@
 
-rlibbench = executable('rlibbench', ['revudp.c', 'rrsa.c', 'main.c'],
+rlibbench = executable('rlibbench', ['revudp.c', 'rdsa.c', 'rrsa.c', 'main.c'],
   include_directories : inc,
   link_with : librlib,
   install : false)

--- a/bench/meson.build
+++ b/bench/meson.build
@@ -1,5 +1,5 @@
 
-rlibbench = executable('rlibbench', ['recdh.c', 'revudp.c', 'rdsa.c', 'rrsa.c', 'main.c'],
+rlibbench = executable('rlibbench', ['raes.c', 'recdh.c', 'revudp.c', 'rdsa.c', 'rrsa.c', 'main.c'],
   include_directories : inc,
   link_with : librlib,
   install : false)

--- a/bench/meson.build
+++ b/bench/meson.build
@@ -1,5 +1,5 @@
 
-rlibbench = executable('rlibbench', ['raes.c', 'recdh.c', 'revudp.c', 'rdsa.c', 'rrsa.c', 'main.c'],
+rlibbench = executable('rlibbench', ['raes.c', 'recdh.c', 'recdsa.c', 'revudp.c', 'rdsa.c', 'rrsa.c', 'main.c'],
   include_directories : inc,
   link_with : librlib,
   install : false)

--- a/bench/meson.build
+++ b/bench/meson.build
@@ -1,5 +1,5 @@
 
-rlibbench = executable('rlibbench', ['revudp.c', 'rdsa.c', 'rrsa.c', 'main.c'],
+rlibbench = executable('rlibbench', ['recdh.c', 'revudp.c', 'rdsa.c', 'rrsa.c', 'main.c'],
   include_directories : inc,
   link_with : librlib,
   install : false)

--- a/bench/raes.c
+++ b/bench/raes.c
@@ -1,0 +1,115 @@
+#include <rlib/rlib.h>
+#include <rlib/crypto/raes.h>
+#include <rlib/crypto/rcipher.h>
+
+/* 16 KiB per encrypt call - large enough to amortise the per-call
+ * overhead, small enough to fit comfortably in stack / L1 cache. */
+#define AES_BENCH_BLOCKSIZE  (16 * 1024)
+#define AES_BENCH_ITERS      2000
+
+static void
+print_aes_result (const rchar * label, ruint iters, rsize block_bytes,
+    RClockTime elapsed)
+{
+  rdouble elapsed_s = (rdouble)elapsed / (rdouble)R_SECOND;
+  rdouble total_mib = (rdouble)(iters * block_bytes) / (1024.0 * 1024.0);
+  rdouble mib_per_s = total_mib / elapsed_s;
+
+  r_print ("%"R_TIME_FORMAT"  AES-%s: %.1f MiB/s "
+      "(%u x %"RSIZE_FMT"-byte blocks in %.3f s)\n",
+      R_TIME_ARGS (elapsed), label, mib_per_s,
+      iters, block_bytes, elapsed_s);
+}
+
+/* AES_BENCH_BLOCKSIZE encrypts in a tight loop. The cipher is built
+ * once outside the timed region; the IV is per-call (each block is
+ * an independent encrypt, as the caller-facing API expects). */
+static void
+run_aes_bench (RCryptoCipher * cipher, const rchar * label)
+{
+  ruint8 * input;
+  ruint8 * output;
+  ruint8 iv[16];
+  RClockTime start, end;
+  ruint i;
+
+  r_assert_cmpptr ((input = r_malloc (AES_BENCH_BLOCKSIZE)), !=, NULL);
+  r_assert_cmpptr ((output = r_malloc (AES_BENCH_BLOCKSIZE)), !=, NULL);
+  for (i = 0; i < AES_BENCH_BLOCKSIZE; i++)
+    input[i] = (ruint8)i;
+
+  /* Warm up */
+  for (i = 0; i < 5; i++) {
+    r_memset (iv, 0, sizeof (iv));
+    iv[0] = (ruint8)i;
+    r_assert_cmpint (r_crypto_cipher_encrypt (cipher, output,
+          AES_BENCH_BLOCKSIZE, input, iv, sizeof (iv)),
+        ==, R_CRYPTO_CIPHER_OK);
+  }
+
+  start = r_time_get_ts_monotonic ();
+  for (i = 0; i < AES_BENCH_ITERS; i++) {
+    r_memset (iv, 0, sizeof (iv));
+    iv[0] = (ruint8)(i & 0xff);
+    iv[1] = (ruint8)((i >> 8) & 0xff);
+    r_assert_cmpint (r_crypto_cipher_encrypt (cipher, output,
+          AES_BENCH_BLOCKSIZE, input, iv, sizeof (iv)),
+        ==, R_CRYPTO_CIPHER_OK);
+  }
+  end = r_time_get_ts_monotonic ();
+
+  print_aes_result (label, AES_BENCH_ITERS, AES_BENCH_BLOCKSIZE, end - start);
+
+  r_free (input);
+  r_free (output);
+}
+
+/* Fixed-content key buffers; AES doesn't care about key entropy for
+ * benchmarking purposes (the schedule is the same shape either way).
+ * The 256-bit key uses the upper half of the 32-byte buffer. */
+static const ruint8 aes_bench_key[32] = {
+  0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+  0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+  0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+  0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+};
+
+RTEST_BENCH (raes, cbc_128_encrypt, RTEST_FAST | RTEST_SYSTEM)
+{
+  RCryptoCipher * c;
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  r_assert_cmpptr ((c = r_cipher_aes_128_cbc_new (aes_bench_key)), !=, NULL);
+  run_aes_bench (c, "128 CBC");
+  r_crypto_cipher_unref (c);
+}
+RTEST_END;
+
+RTEST_BENCH (raes, cbc_256_encrypt, RTEST_FAST | RTEST_SYSTEM)
+{
+  RCryptoCipher * c;
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  r_assert_cmpptr ((c = r_cipher_aes_256_cbc_new (aes_bench_key)), !=, NULL);
+  run_aes_bench (c, "256 CBC");
+  r_crypto_cipher_unref (c);
+}
+RTEST_END;
+
+RTEST_BENCH (raes, ctr_128_encrypt, RTEST_FAST | RTEST_SYSTEM)
+{
+  RCryptoCipher * c;
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  r_assert_cmpptr ((c = r_cipher_aes_128_ctr_new (aes_bench_key)), !=, NULL);
+  run_aes_bench (c, "128 CTR");
+  r_crypto_cipher_unref (c);
+}
+RTEST_END;
+
+RTEST_BENCH (raes, ctr_256_encrypt, RTEST_FAST | RTEST_SYSTEM)
+{
+  RCryptoCipher * c;
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  r_assert_cmpptr ((c = r_cipher_aes_256_ctr_new (aes_bench_key)), !=, NULL);
+  run_aes_bench (c, "256 CTR");
+  r_crypto_cipher_unref (c);
+}
+RTEST_END;

--- a/bench/rdsa.c
+++ b/bench/rdsa.c
@@ -1,0 +1,111 @@
+#include <rlib/rlib.h>
+#include <rlib/crypto/rkey.h>
+#include <rlib/crypto/rdsa.h>
+
+#define DSA_BENCH_L         2048
+#define DSA_BENCH_N         256
+#define DSA_BENCH_ITERS     200
+
+static void
+print_dsa_result (const rchar * op, ruint iters, RClockTime elapsed)
+{
+  rdouble elapsed_s = (rdouble)elapsed / (rdouble)R_SECOND;
+  rdouble per_op_ms = elapsed_s * 1000.0 / (rdouble)iters;
+  rdouble ops_per_sec = (rdouble)iters / elapsed_s;
+
+  r_print ("%"R_TIME_FORMAT"  DSA-%u/%u %s: %.3f ms/op, %.1f ops/sec "
+      "(%u iters in %.3f s)\n",
+      R_TIME_ARGS (elapsed), DSA_BENCH_L, DSA_BENCH_N, op,
+      per_op_ms, ops_per_sec, iters, elapsed_s);
+}
+
+RTEST_BENCH (rdsa, sign_2048_256, RTEST_FAST | RTEST_SYSTEM)
+{
+  /* DSA-2048/256 signing loop. Exercises r_dsa_sign end-to-end -
+   * extra-random-bits nonce sampling, the CT k*G expmod and the
+   * Fermat-inverter on k. The key is generated once before the
+   * timed region so the probable-prime search for p/q doesn't
+   * pollute the result. */
+  RCryptoKey * priv;
+  RPrng * prng;
+  ruint8 hash[32];
+  ruint8 sig[256];
+  rsize sig_size;
+  RClockTime start, end;
+  ruint i;
+
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+
+  r_assert_cmpptr ((prng = r_rand_prng_new ()), !=, NULL);
+  r_assert_cmpptr ((priv = r_dsa_priv_key_new_gen (DSA_BENCH_L, DSA_BENCH_N,
+        prng)), !=, NULL);
+
+  for (i = 0; i < sizeof (hash); i++)
+    hash[i] = (ruint8)(i * 7u + 1u);
+
+  for (i = 0; i < 5; i++) {
+    sig_size = sizeof (sig);
+    r_assert_cmpint (r_crypto_key_sign (priv, prng, R_MSG_DIGEST_TYPE_SHA256,
+          hash, sizeof (hash), sig, &sig_size), ==, R_CRYPTO_OK);
+  }
+
+  start = r_time_get_ts_monotonic ();
+  for (i = 0; i < DSA_BENCH_ITERS; i++) {
+    sig_size = sizeof (sig);
+    r_assert_cmpint (r_crypto_key_sign (priv, prng, R_MSG_DIGEST_TYPE_SHA256,
+          hash, sizeof (hash), sig, &sig_size), ==, R_CRYPTO_OK);
+  }
+  end = r_time_get_ts_monotonic ();
+
+  print_dsa_result ("sign", DSA_BENCH_ITERS, end - start);
+
+  r_crypto_key_unref (priv);
+  r_prng_unref (prng);
+}
+RTEST_END;
+
+RTEST_BENCH (rdsa, verify_2048_256, RTEST_FAST | RTEST_SYSTEM)
+{
+  /* DSA-2048/256 verify loop. Sign once outside the timed region
+   * to produce a valid signature, then verify it in a loop. Verify
+   * runs through the variable-time mpint primitives - no Mont
+   * cache, no Fermat-invert - so this number is comparable across
+   * any DSA-perf work landing on the verify side. */
+  RCryptoKey * priv;
+  RPrng * prng;
+  ruint8 hash[32];
+  ruint8 sig[256];
+  rsize sig_size = sizeof (sig);
+  RClockTime start, end;
+  ruint i;
+
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+
+  r_assert_cmpptr ((prng = r_rand_prng_new ()), !=, NULL);
+  r_assert_cmpptr ((priv = r_dsa_priv_key_new_gen (DSA_BENCH_L, DSA_BENCH_N,
+        prng)), !=, NULL);
+
+  for (i = 0; i < sizeof (hash); i++)
+    hash[i] = (ruint8)(i * 7u + 1u);
+
+  r_assert_cmpint (r_crypto_key_sign (priv, prng, R_MSG_DIGEST_TYPE_SHA256,
+        hash, sizeof (hash), sig, &sig_size), ==, R_CRYPTO_OK);
+
+  for (i = 0; i < 5; i++) {
+    r_assert_cmpint (r_crypto_key_verify (priv, R_MSG_DIGEST_TYPE_SHA256,
+          hash, sizeof (hash), sig, sig_size), ==, R_CRYPTO_OK);
+  }
+
+  start = r_time_get_ts_monotonic ();
+  for (i = 0; i < DSA_BENCH_ITERS; i++) {
+    r_assert_cmpint (r_crypto_key_verify (priv, R_MSG_DIGEST_TYPE_SHA256,
+          hash, sizeof (hash), sig, sig_size), ==, R_CRYPTO_OK);
+  }
+  end = r_time_get_ts_monotonic ();
+
+  print_dsa_result ("verify", DSA_BENCH_ITERS, end - start);
+
+  r_crypto_key_unref (priv);
+  r_prng_unref (prng);
+}
+RTEST_END;

--- a/bench/recdh.c
+++ b/bench/recdh.c
@@ -1,0 +1,99 @@
+#include <rlib/rlib.h>
+#include <rlib/crypto/rkey.h>
+#include <rlib/crypto/recc.h>
+#include <rlib/crypto/recurve.h>
+
+#define ECDH_BENCH_ITERS    200
+
+static void
+print_ecdh_result (const rchar * curve_name, ruint iters,
+    RClockTime elapsed)
+{
+  rdouble elapsed_s = (rdouble)elapsed / (rdouble)R_SECOND;
+  rdouble per_op_ms = elapsed_s * 1000.0 / (rdouble)iters;
+  rdouble ops_per_sec = (rdouble)iters / elapsed_s;
+
+  r_print ("%"R_TIME_FORMAT"  ECDH %s compute_shared: %.3f ms/op, "
+      "%.1f ops/sec (%u iters in %.3f s)\n",
+      R_TIME_ARGS (elapsed), curve_name, per_op_ms, ops_per_sec,
+      iters, elapsed_s);
+}
+
+/* One bench body that takes the curve as a parameter so the two
+ * variants only differ in the @c REcurveID they pass in. Each
+ * iteration runs the priv-side compute_shared; the peer keypair is
+ * generated once outside the timed region. */
+static void
+run_ecdh_bench (REcurveID curve_id, const rchar * curve_name)
+{
+  RCryptoKey * priv;
+  RCryptoKey * peer_priv;
+  RCryptoKey * peer_pub;
+  REcurveAffinePoint peer_Q;
+  REcurve curve;
+  RPrng * prng;
+  ruint8 peer_ecp[1 + 2 * 66];   /* coord_bytes <= 66 for secp521r1 */
+  ruint8 shared[128];
+  rsize peer_ecp_size;
+  rsize shared_size;
+  RClockTime start, end;
+  ruint i;
+
+  r_assert_cmpptr ((prng = r_rand_prng_new ()), !=, NULL);
+  r_assert_cmpptr ((priv = r_ecdh_priv_key_new_gen (curve_id, prng)),
+      !=, NULL);
+  r_assert_cmpptr ((peer_priv = r_ecdh_priv_key_new_gen (curve_id, prng)),
+      !=, NULL);
+
+  r_ecurve_point_init (&peer_Q);
+  r_assert (r_ecc_key_get_q (peer_priv, &peer_Q));
+  r_assert (r_ecurve_init (&curve, curve_id));
+  peer_ecp_size = sizeof (peer_ecp);
+  r_assert (r_ecurve_point_to_uncompressed (&peer_Q, &curve,
+        peer_ecp, &peer_ecp_size));
+  r_assert_cmpptr ((peer_pub = r_ecdh_pub_key_new (curve_id, peer_ecp,
+        peer_ecp_size)), !=, NULL);
+
+  for (i = 0; i < 5; i++) {
+    shared_size = sizeof (shared);
+    r_assert_cmpint (r_ecdh_compute_shared (priv, peer_pub,
+          shared, &shared_size), ==, R_CRYPTO_OK);
+  }
+
+  start = r_time_get_ts_monotonic ();
+  for (i = 0; i < ECDH_BENCH_ITERS; i++) {
+    shared_size = sizeof (shared);
+    r_assert_cmpint (r_ecdh_compute_shared (priv, peer_pub,
+          shared, &shared_size), ==, R_CRYPTO_OK);
+  }
+  end = r_time_get_ts_monotonic ();
+
+  print_ecdh_result (curve_name, ECDH_BENCH_ITERS, end - start);
+
+  r_ecurve_point_clear (&peer_Q);
+  r_ecurve_clear (&curve);
+  r_crypto_key_unref (priv);
+  r_crypto_key_unref (peer_priv);
+  r_crypto_key_unref (peer_pub);
+  r_prng_unref (prng);
+}
+
+RTEST_BENCH (recdh, compute_shared_secp256r1, RTEST_FAST | RTEST_SYSTEM)
+{
+  /* ECDH on secp256r1 - the most-used curve in the wild. Exercises
+   * the CT scalar-mul ladder (r_ecurve_point_scalar_mul) end-to-end
+   * with the secret peer-derivation. */
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  run_ecdh_bench (R_ECURVE_ID_SECP256R1, "secp256r1");
+}
+RTEST_END;
+
+RTEST_BENCH (recdh, compute_shared_secp384r1, RTEST_FAST | RTEST_SYSTEM)
+{
+  /* ECDH on secp384r1. Same path as secp256r1, wider digit count -
+   * gives a feel for how the CT scalar-mul scales with curve width
+   * without jumping all the way to secp521r1. */
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  run_ecdh_bench (R_ECURVE_ID_SECP384R1, "secp384r1");
+}
+RTEST_END;

--- a/bench/recdsa.c
+++ b/bench/recdsa.c
@@ -1,0 +1,165 @@
+#include <rlib/rlib.h>
+#include <rlib/crypto/rkey.h>
+#include <rlib/crypto/recc.h>
+#include <rlib/crypto/recurve.h>
+
+#define ECDSA_BENCH_ITERS    200
+
+/* Fixed SHA-256-shaped hash; ECDSA signs the raw hash so any 32
+ * bytes work for benchmarking. */
+static const ruint8 ecdsa_bench_hash[32] = {
+  0x9f, 0x86, 0xd0, 0x81, 0x88, 0x4c, 0x7d, 0x65,
+  0x9a, 0x2f, 0xea, 0xa0, 0xc5, 0x5a, 0xd0, 0x15,
+  0xa3, 0xbf, 0x4f, 0x1b, 0x2b, 0x0b, 0x82, 0x2c,
+  0xd1, 0x5d, 0x6c, 0x15, 0xb0, 0xf0, 0x0a, 0x08,
+};
+
+static void
+print_ecdsa_result (const rchar * curve_name, const rchar * op, ruint iters,
+    RClockTime elapsed)
+{
+  rdouble elapsed_s = (rdouble)elapsed / (rdouble)R_SECOND;
+  rdouble per_op_ms = elapsed_s * 1000.0 / (rdouble)iters;
+  rdouble ops_per_sec = (rdouble)iters / elapsed_s;
+
+  r_print ("%"R_TIME_FORMAT"  ECDSA %s %s: %.3f ms/op, %.1f ops/sec "
+      "(%u iters in %.3f s)\n",
+      R_TIME_ARGS (elapsed), curve_name, op,
+      per_op_ms, ops_per_sec, iters, elapsed_s);
+}
+
+/* Build an ECDSA keypair on the given curve. Generates a random
+ * private scalar via the ECDH key-gen path (the same scalar shape
+ * is valid for both algorithms), extracts the scalar bytes and the
+ * uncompressed public point, then hands both to the ECDSA
+ * constructors. Caller releases both returned keys. */
+static rboolean
+make_ecdsa_keypair (REcurveID curve_id, RPrng * prng,
+    RCryptoKey ** priv_out, RCryptoKey ** pub_out)
+{
+  RCryptoKey * ecdh_priv;
+  REcurve curve;
+  REcurveAffinePoint Q;
+  ruint8 ecp_buf[1 + 2 * 66];
+  rsize ecp_size = sizeof (ecp_buf);
+  const ruint8 * scalar_bytes;
+  rsize scalar_size;
+  rboolean ok = FALSE;
+
+  *priv_out = NULL;
+  *pub_out = NULL;
+
+  if ((ecdh_priv = r_ecdh_priv_key_new_gen (curve_id, prng)) == NULL)
+    return FALSE;
+
+  if (!r_ecurve_init (&curve, curve_id))
+    goto fail_after_priv;
+
+  r_ecurve_point_init (&Q);
+  if (!r_ecc_key_get_q (ecdh_priv, &Q))
+    goto fail_after_curve;
+  if (!r_ecurve_point_to_uncompressed (&Q, &curve, ecp_buf, &ecp_size))
+    goto fail_after_curve;
+  if (!r_ecc_priv_key_get_scalar (ecdh_priv, &scalar_bytes, &scalar_size))
+    goto fail_after_curve;
+
+  *priv_out = r_ecdsa_priv_key_new (curve_id, ecp_buf, ecp_size,
+      scalar_bytes, scalar_size);
+  *pub_out  = r_ecdsa_pub_key_new (curve_id, ecp_buf, ecp_size);
+  ok = (*priv_out != NULL && *pub_out != NULL);
+
+fail_after_curve:
+  r_ecurve_point_clear (&Q);
+  r_ecurve_clear (&curve);
+fail_after_priv:
+  r_crypto_key_unref (ecdh_priv);
+  if (!ok) {
+    if (*priv_out != NULL) { r_crypto_key_unref (*priv_out); *priv_out = NULL; }
+    if (*pub_out  != NULL) { r_crypto_key_unref (*pub_out);  *pub_out  = NULL; }
+  }
+  return ok;
+}
+
+RTEST_BENCH (recdsa, sign_secp256r1, RTEST_FAST | RTEST_SYSTEM)
+{
+  /* ECDSA sign on secp256r1. Exercises r_ecdsa_sign end-to-end -
+   * nonce sampling, CT k*G via r_ecurve_point_scalar_mul, the
+   * Fermat-inverter on k, and the s = k^-1 * (e + d*r) FE arithmetic. */
+  RCryptoKey * priv, * pub;
+  RPrng * prng;
+  ruint8 sig[128];
+  rsize sig_size;
+  RClockTime start, end;
+  ruint i;
+
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+
+  r_assert_cmpptr ((prng = r_rand_prng_new ()), !=, NULL);
+  r_assert (make_ecdsa_keypair (R_ECURVE_ID_SECP256R1, prng, &priv, &pub));
+
+  for (i = 0; i < 5; i++) {
+    sig_size = sizeof (sig);
+    r_assert_cmpint (r_crypto_key_sign (priv, prng, R_MSG_DIGEST_TYPE_SHA256,
+          ecdsa_bench_hash, sizeof (ecdsa_bench_hash), sig, &sig_size),
+        ==, R_CRYPTO_OK);
+  }
+
+  start = r_time_get_ts_monotonic ();
+  for (i = 0; i < ECDSA_BENCH_ITERS; i++) {
+    sig_size = sizeof (sig);
+    r_assert_cmpint (r_crypto_key_sign (priv, prng, R_MSG_DIGEST_TYPE_SHA256,
+          ecdsa_bench_hash, sizeof (ecdsa_bench_hash), sig, &sig_size),
+        ==, R_CRYPTO_OK);
+  }
+  end = r_time_get_ts_monotonic ();
+
+  print_ecdsa_result ("secp256r1", "sign", ECDSA_BENCH_ITERS, end - start);
+
+  r_crypto_key_unref (priv);
+  r_crypto_key_unref (pub);
+  r_prng_unref (prng);
+}
+RTEST_END;
+
+RTEST_BENCH (recdsa, verify_secp256r1, RTEST_FAST | RTEST_SYSTEM)
+{
+  /* ECDSA verify on secp256r1. Verify is variable-time on the
+   * public signature; runs through two scalar-muls (u1*G and u2*Q)
+   * plus a point add and a mod reduction. */
+  RCryptoKey * priv, * pub;
+  RPrng * prng;
+  ruint8 sig[128];
+  rsize sig_size = sizeof (sig);
+  RClockTime start, end;
+  ruint i;
+
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+
+  r_assert_cmpptr ((prng = r_rand_prng_new ()), !=, NULL);
+  r_assert (make_ecdsa_keypair (R_ECURVE_ID_SECP256R1, prng, &priv, &pub));
+
+  r_assert_cmpint (r_crypto_key_sign (priv, prng, R_MSG_DIGEST_TYPE_SHA256,
+        ecdsa_bench_hash, sizeof (ecdsa_bench_hash), sig, &sig_size),
+      ==, R_CRYPTO_OK);
+
+  for (i = 0; i < 5; i++) {
+    r_assert_cmpint (r_crypto_key_verify (pub, R_MSG_DIGEST_TYPE_SHA256,
+          ecdsa_bench_hash, sizeof (ecdsa_bench_hash), sig, sig_size),
+        ==, R_CRYPTO_OK);
+  }
+
+  start = r_time_get_ts_monotonic ();
+  for (i = 0; i < ECDSA_BENCH_ITERS; i++) {
+    r_assert_cmpint (r_crypto_key_verify (pub, R_MSG_DIGEST_TYPE_SHA256,
+          ecdsa_bench_hash, sizeof (ecdsa_bench_hash), sig, sig_size),
+        ==, R_CRYPTO_OK);
+  }
+  end = r_time_get_ts_monotonic ();
+
+  print_ecdsa_result ("secp256r1", "verify", ECDSA_BENCH_ITERS, end - start);
+
+  r_crypto_key_unref (priv);
+  r_crypto_key_unref (pub);
+  r_prng_unref (prng);
+}
+RTEST_END;


### PR DESCRIPTION
## Summary

Four new bench files, one commit each, matching the existing `bench/rrsa.c` pattern. Closes the high-priority items from #142.

| Bench | Scope | Local result (release, this machine) |
|---|---|---|
| `bench/rdsa.c` | DSA-2048/256 sign + verify | sign 2.3 ms/op, verify 5.8 ms/op |
| `bench/recdh.c` | ECDH on secp256r1 + secp384r1 | secp256r1 0.9 ms/op, secp384r1 2.3 ms/op |
| `bench/raes.c` | AES-128/256 × CBC/CTR bulk encrypt (16 KiB blocks) | 302–443 MiB/s depending on key/mode |
| `bench/recdsa.c` | ECDSA sign + verify on secp256r1 | sign 1.0 ms/op, verify 1.8 ms/op |

Each bench follows the rrsa convention: key/state set up once outside the timed region, brief warm-up, then 200 iters (or 2000 × 16 KiB for AES) timed via `r_time_get_ts_monotonic` and printed as `ms/op` + `ops/sec` (or `MiB/s` for AES).

## Notes worth flagging

- **AES is software-only.** ~388 MiB/s on AES-128-CBC. With AES-NI / ARMv8 crypto extensions a modern CPU does 2–5 GiB/s — 10×ish gap visible now in the numbers. Out of scope here but a natural future perf target.
- **DSA verify still runs variable-time mpint primitives.** DSA sign benefited from the Montgomery cache + CT-FE work tracked under #128; verify did not. The 2.5× sign/verify ratio is partly inherent (2 expmods vs 1) but partly fixable.
- **#142's "Out of scope: ECDSA" footnote is stale** since PR #144 wired ECDSA up. The `recdsa` commit body calls this out; worth updating the issue once this merges.

## Test plan

- [x] Each new bench builds clean and runs successfully on its own
- [x] All 12 crypto benches run together via `build-release/bench/rlibbench -f '/r*'` with sensible output
- [ ] CI green on the PR