### PR TITLE
mpint: Fix MR witness with dig_used=0 from all-zero random tmp

### DIFF
--- a/rlib/data/rmpint.c
+++ b/rlib/data/rmpint.c
@@ -476,6 +476,12 @@ r_mpint_prime_miller_rabin_full (const rmpint * n, RPrng * prng)
       if (!r_mpint_shr (&a, &a, abits - bits))
         goto error;
     }
+    /* r_mpint_set_binary clamps trailing zero digits, so an all-zero
+     * tmp leaves dig_used == 0. The OR below sets data[0] but does
+     * not restore dig_used, so without this nudge subsequent
+     * dig_used-driven ops would still treat the witness as zero. */
+    if (a.dig_used == 0)
+      a.dig_used = 1;
     a.data[0] |= 3;
     if (r_mpint_cmp (&a, &n1) >= 0) {
       if (!r_mpint_shr (&a, &a, 1))


### PR DESCRIPTION
## Summary

Fixes the `/rmpint/gen_prime` CI flake (~10% rate on the 3-bit branch). The bug has been latent in `r_mpint_prime_miller_rabin_full` since 797a6ee but became reachable from the gen_prime loop after 31a6f17 (PR #151).

## Root cause

The MR witness construction in `r_mpint_prime_miller_rabin_full`:

```c
r_mpint_set_binary (&a, tmp, size);   // ends with r_mpint_clamp
if ((abits = r_mpint_bits_used (&a)) > bits) { /* shr to fit */ }
a.data[0] |= 3;                       // touches data[0] only
if (a >= n - 1) /* shr by 1 */;
```

When `tmp` is all zero bytes, `set_binary` clamps `dig_used` to 0. The OR writes `data[0] = 3` but leaves `dig_used = 0`, so every `dig_used`-driven op (`r_mpint_cmp`, `r_mpint_expmod`, `r_mpint_mulmod`) treats the witness as zero. `expmod(0, r, n) = 0`, MR sees `a != n-1`, votes `R_MPINT_NON_PRIME`. A genuine prime can be rejected and `gen_prime` falls through to a larger candidate.

For a 3-bit candidate (`size=1`), `P(all-zero) = 1/256` per round × 27 rounds ≈ 10% per MR call. For a 1024-bit candidate (`size=128`), the probability is `1/256^128` — never fires. So this is essentially a tests-only impact, but the underlying defect is real and the fix belongs in MR.

## Fix

Three lines — restore `dig_used` to 1 before the OR if `set_binary` clamped it away:

```c
if (a.dig_used == 0)
  a.dig_used = 1;
a.data[0] |= 3;
```

## Test plan

- [x] Repro'd locally at ~10% rate before the fix
- [x] 500 consecutive `/rmpint/gen_prime` runs clean after the fix
- [x] Full `/rmpint/` suite still green
- [x] CI green on the PR