### PR TITLE
Crypto microbenchmarks: RSA-3072/4096 + verify, FFDH, SHA-256/512

### DIFF
--- a/bench/meson.build
+++ b/bench/meson.build
@@ -1,5 +1,5 @@
 
-rlibbench = executable('rlibbench', ['raes.c', 'recdh.c', 'recdsa.c', 'revudp.c', 'rdsa.c', 'rrsa.c', 'main.c'],
+rlibbench = executable('rlibbench', ['raes.c', 'recdh.c', 'recdsa.c', 'revudp.c', 'rdh.c', 'rdsa.c', 'rrsa.c', 'main.c'],
   include_directories : inc,
   link_with : librlib,
   install : false)

--- a/bench/meson.build
+++ b/bench/meson.build
@@ -1,5 +1,5 @@
 
-rlibbench = executable('rlibbench', ['raes.c', 'recdh.c', 'recdsa.c', 'revudp.c', 'rdh.c', 'rdsa.c', 'rrsa.c', 'main.c'],
+rlibbench = executable('rlibbench', ['raes.c', 'rdh.c', 'rdsa.c', 'recdh.c', 'recdsa.c', 'revudp.c', 'rmsgdigest.c', 'rrsa.c', 'main.c'],
   include_directories : inc,
   link_with : librlib,
   install : false)

--- a/bench/raes.c
+++ b/bench/raes.c
@@ -1,6 +1,7 @@
 #include <rlib/rlib.h>
 #include <rlib/crypto/raes.h>
 #include <rlib/crypto/rcipher.h>
+#include "util.h"
 
 /* 16 KiB per encrypt call - large enough to amortise the per-call
  * overhead, small enough to fit comfortably in stack / L1 cache. */
@@ -8,17 +9,12 @@
 #define AES_BENCH_ITERS      2000
 
 static void
-print_aes_result (const rchar * label, ruint iters, rsize block_bytes,
+print_aes_result (const rchar * variant, ruint iters, rsize block_bytes,
     RClockTime elapsed)
 {
-  rdouble elapsed_s = (rdouble)elapsed / (rdouble)R_SECOND;
-  rdouble total_mib = (rdouble)(iters * block_bytes) / (1024.0 * 1024.0);
-  rdouble mib_per_s = total_mib / elapsed_s;
-
-  r_print ("%"R_TIME_FORMAT"  AES-%s: %.1f MiB/s "
-      "(%u x %"RSIZE_FMT"-byte blocks in %.3f s)\n",
-      R_TIME_ARGS (elapsed), label, mib_per_s,
-      iters, block_bytes, elapsed_s);
+  rchar * label = r_strprintf ("AES-%s", variant);
+  bench_print_throughput (label, iters, block_bytes, elapsed);
+  r_free (label);
 }
 
 /* AES_BENCH_BLOCKSIZE encrypts in a tight loop. The cipher is built

--- a/bench/rdh.c
+++ b/bench/rdh.c
@@ -1,6 +1,7 @@
 #include <rlib/rlib.h>
 #include <rlib/crypto/rkey.h>
 #include <rlib/crypto/rdh.h>
+#include "util.h"
 
 #define DH_BENCH_ITERS    200
 
@@ -8,14 +9,9 @@ static void
 print_dh_result (const rchar * group_name, ruint iters,
     RClockTime elapsed)
 {
-  rdouble elapsed_s = (rdouble)elapsed / (rdouble)R_SECOND;
-  rdouble per_op_ms = elapsed_s * 1000.0 / (rdouble)iters;
-  rdouble ops_per_sec = (rdouble)iters / elapsed_s;
-
-  r_print ("%"R_TIME_FORMAT"  DH %s compute_shared: %.3f ms/op, "
-      "%.1f ops/sec (%u iters in %.3f s)\n",
-      R_TIME_ARGS (elapsed), group_name, per_op_ms, ops_per_sec,
-      iters, elapsed_s);
+  rchar * label = r_strprintf ("DH %s compute_shared", group_name);
+  bench_print_ops (label, iters, elapsed);
+  r_free (label);
 }
 
 /* One bench body that takes the DH group as a parameter so the two

--- a/bench/rdh.c
+++ b/bench/rdh.c
@@ -1,0 +1,96 @@
+#include <rlib/rlib.h>
+#include <rlib/crypto/rkey.h>
+#include <rlib/crypto/rdh.h>
+
+#define DH_BENCH_ITERS    200
+
+static void
+print_dh_result (const rchar * group_name, ruint iters,
+    RClockTime elapsed)
+{
+  rdouble elapsed_s = (rdouble)elapsed / (rdouble)R_SECOND;
+  rdouble per_op_ms = elapsed_s * 1000.0 / (rdouble)iters;
+  rdouble ops_per_sec = (rdouble)iters / elapsed_s;
+
+  r_print ("%"R_TIME_FORMAT"  DH %s compute_shared: %.3f ms/op, "
+      "%.1f ops/sec (%u iters in %.3f s)\n",
+      R_TIME_ARGS (elapsed), group_name, per_op_ms, ops_per_sec,
+      iters, elapsed_s);
+}
+
+/* One bench body that takes the DH group as a parameter so the two
+ * variants only differ in the @c RDhNamedGroup they pass in. Each
+ * iteration runs the priv-side compute_shared; the peer keypair is
+ * generated once outside the timed region. */
+static void
+run_dh_bench (RDhNamedGroup group, const rchar * group_name)
+{
+  RCryptoKey * priv;
+  RCryptoKey * peer_priv;
+  RCryptoKey * peer_pub;
+  RPrng * prng;
+  rmpint p, g, peer_y;
+  ruint8 shared[256];    /* 2048-bit groups; widen if larger groups land */
+  rsize shared_size;
+  RClockTime start, end;
+  ruint i;
+
+  r_assert_cmpptr ((prng = r_rand_prng_new ()), !=, NULL);
+  r_assert (r_dh_named_group_get_params (group, &p, &g));
+
+  r_assert_cmpptr ((priv = r_dh_priv_key_new_gen_named (group, prng)),
+      !=, NULL);
+  r_assert_cmpptr ((peer_priv = r_dh_priv_key_new_gen_named (group, prng)),
+      !=, NULL);
+
+  /* Build a public-only view of the peer key for r_dh_compute_shared. */
+  r_mpint_init (&peer_y);
+  r_assert (r_dh_pub_key_get_y (peer_priv, &peer_y));
+  r_assert_cmpptr ((peer_pub = r_dh_pub_key_new (&p, &g, &peer_y)),
+      !=, NULL);
+
+  for (i = 0; i < 5; i++) {
+    shared_size = sizeof (shared);
+    r_assert_cmpint (r_dh_compute_shared (priv, peer_pub,
+          shared, &shared_size), ==, R_CRYPTO_OK);
+  }
+
+  start = r_time_get_ts_monotonic ();
+  for (i = 0; i < DH_BENCH_ITERS; i++) {
+    shared_size = sizeof (shared);
+    r_assert_cmpint (r_dh_compute_shared (priv, peer_pub,
+          shared, &shared_size), ==, R_CRYPTO_OK);
+  }
+  end = r_time_get_ts_monotonic ();
+
+  print_dh_result (group_name, DH_BENCH_ITERS, end - start);
+
+  r_mpint_clear (&peer_y);
+  r_mpint_clear (&p);
+  r_mpint_clear (&g);
+  r_crypto_key_unref (priv);
+  r_crypto_key_unref (peer_priv);
+  r_crypto_key_unref (peer_pub);
+  r_prng_unref (prng);
+}
+
+RTEST_BENCH (rdh, compute_shared_modp_2048, RTEST_FAST | RTEST_SYSTEM)
+{
+  /* MODP-2048 (RFC 3526 group 14) - the workhorse for IKE / SSH /
+   * legacy TLS. Exercises the windowed-CT expmod the RSA private
+   * path also uses, here on the public modulus side. */
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  run_dh_bench (R_DH_GROUP_MODP_2048, "MODP-2048");
+}
+RTEST_END;
+
+RTEST_BENCH (rdh, compute_shared_ffdhe_2048, RTEST_FAST | RTEST_SYSTEM)
+{
+  /* FFDHE-2048 (RFC 7919) - the TLS-targeted analogue of MODP-2048.
+   * Same expmod engine, different group parameters - the perf
+   * delta against MODP-2048 surfaces any group-dependent
+   * Montgomery setup overhead. */
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  run_dh_bench (R_DH_GROUP_FFDHE_2048, "FFDHE-2048");
+}
+RTEST_END;

--- a/bench/rdsa.c
+++ b/bench/rdsa.c
@@ -1,6 +1,7 @@
 #include <rlib/rlib.h>
 #include <rlib/crypto/rkey.h>
 #include <rlib/crypto/rdsa.h>
+#include "util.h"
 
 #define DSA_BENCH_L         2048
 #define DSA_BENCH_N         256
@@ -9,14 +10,9 @@
 static void
 print_dsa_result (const rchar * op, ruint iters, RClockTime elapsed)
 {
-  rdouble elapsed_s = (rdouble)elapsed / (rdouble)R_SECOND;
-  rdouble per_op_ms = elapsed_s * 1000.0 / (rdouble)iters;
-  rdouble ops_per_sec = (rdouble)iters / elapsed_s;
-
-  r_print ("%"R_TIME_FORMAT"  DSA-%u/%u %s: %.3f ms/op, %.1f ops/sec "
-      "(%u iters in %.3f s)\n",
-      R_TIME_ARGS (elapsed), DSA_BENCH_L, DSA_BENCH_N, op,
-      per_op_ms, ops_per_sec, iters, elapsed_s);
+  rchar * label = r_strprintf ("DSA-%u/%u %s", DSA_BENCH_L, DSA_BENCH_N, op);
+  bench_print_ops (label, iters, elapsed);
+  r_free (label);
 }
 
 RTEST_BENCH (rdsa, sign_2048_256, RTEST_FAST | RTEST_SYSTEM)

--- a/bench/recdh.c
+++ b/bench/recdh.c
@@ -2,6 +2,7 @@
 #include <rlib/crypto/rkey.h>
 #include <rlib/crypto/recc.h>
 #include <rlib/crypto/recurve.h>
+#include "util.h"
 
 #define ECDH_BENCH_ITERS    200
 
@@ -9,14 +10,9 @@ static void
 print_ecdh_result (const rchar * curve_name, ruint iters,
     RClockTime elapsed)
 {
-  rdouble elapsed_s = (rdouble)elapsed / (rdouble)R_SECOND;
-  rdouble per_op_ms = elapsed_s * 1000.0 / (rdouble)iters;
-  rdouble ops_per_sec = (rdouble)iters / elapsed_s;
-
-  r_print ("%"R_TIME_FORMAT"  ECDH %s compute_shared: %.3f ms/op, "
-      "%.1f ops/sec (%u iters in %.3f s)\n",
-      R_TIME_ARGS (elapsed), curve_name, per_op_ms, ops_per_sec,
-      iters, elapsed_s);
+  rchar * label = r_strprintf ("ECDH %s compute_shared", curve_name);
+  bench_print_ops (label, iters, elapsed);
+  r_free (label);
 }
 
 /* One bench body that takes the curve as a parameter so the two

--- a/bench/recdsa.c
+++ b/bench/recdsa.c
@@ -2,6 +2,7 @@
 #include <rlib/crypto/rkey.h>
 #include <rlib/crypto/recc.h>
 #include <rlib/crypto/recurve.h>
+#include "util.h"
 
 #define ECDSA_BENCH_ITERS    200
 
@@ -18,14 +19,9 @@ static void
 print_ecdsa_result (const rchar * curve_name, const rchar * op, ruint iters,
     RClockTime elapsed)
 {
-  rdouble elapsed_s = (rdouble)elapsed / (rdouble)R_SECOND;
-  rdouble per_op_ms = elapsed_s * 1000.0 / (rdouble)iters;
-  rdouble ops_per_sec = (rdouble)iters / elapsed_s;
-
-  r_print ("%"R_TIME_FORMAT"  ECDSA %s %s: %.3f ms/op, %.1f ops/sec "
-      "(%u iters in %.3f s)\n",
-      R_TIME_ARGS (elapsed), curve_name, op,
-      per_op_ms, ops_per_sec, iters, elapsed_s);
+  rchar * label = r_strprintf ("ECDSA %s %s", curve_name, op);
+  bench_print_ops (label, iters, elapsed);
+  r_free (label);
 }
 
 /* Build an ECDSA keypair on the given curve. Generates a random

--- a/bench/rmsgdigest.c
+++ b/bench/rmsgdigest.c
@@ -1,0 +1,86 @@
+#include <rlib/rlib.h>
+
+/* 16 KiB per hash call - large enough to amortise the per-call
+ * setup cost, small enough to fit comfortably in L1 cache. */
+#define DIGEST_BENCH_BLOCKSIZE  (16 * 1024)
+#define DIGEST_BENCH_ITERS      2000
+
+static void
+print_digest_result (const rchar * label, ruint iters, rsize block_bytes,
+    RClockTime elapsed)
+{
+  rdouble elapsed_s = (rdouble)elapsed / (rdouble)R_SECOND;
+  rdouble total_mib = (rdouble)(iters * block_bytes) / (1024.0 * 1024.0);
+  rdouble mib_per_s = total_mib / elapsed_s;
+
+  r_print ("%"R_TIME_FORMAT"  %s: %.1f MiB/s "
+      "(%u x %"RSIZE_FMT"-byte blocks in %.3f s)\n",
+      R_TIME_ARGS (elapsed), label, mib_per_s,
+      iters, block_bytes, elapsed_s);
+}
+
+/* Hash @c DIGEST_BENCH_BLOCKSIZE bytes per iteration. The digest is
+ * reset between iterations so each loop body exercises one full
+ * compression-function pass over the buffer. The buffer + digest
+ * object are allocated once outside the timed region. */
+static void
+run_digest_bench (RMsgDigestType type, const rchar * label)
+{
+  RMsgDigest * md;
+  ruint8 * input;
+  ruint8 out[64];        /* SHA-512 = 64 bytes; covers anything smaller */
+  rsize out_size;
+  RClockTime start, end;
+  ruint i;
+
+  r_assert_cmpptr ((md = r_msg_digest_new (type)), !=, NULL);
+  r_assert_cmpptr ((input = r_malloc (DIGEST_BENCH_BLOCKSIZE)), !=, NULL);
+  for (i = 0; i < DIGEST_BENCH_BLOCKSIZE; i++)
+    input[i] = (ruint8)i;
+
+  /* Warm up */
+  for (i = 0; i < 5; i++) {
+    r_msg_digest_reset (md);
+    r_assert (r_msg_digest_update (md, input, DIGEST_BENCH_BLOCKSIZE));
+    r_assert (r_msg_digest_finish (md));
+    r_assert (r_msg_digest_get_data (md, out, sizeof (out), &out_size));
+  }
+
+  start = r_time_get_ts_monotonic ();
+  for (i = 0; i < DIGEST_BENCH_ITERS; i++) {
+    r_msg_digest_reset (md);
+    r_assert (r_msg_digest_update (md, input, DIGEST_BENCH_BLOCKSIZE));
+    r_assert (r_msg_digest_finish (md));
+    r_assert (r_msg_digest_get_data (md, out, sizeof (out), &out_size));
+  }
+  end = r_time_get_ts_monotonic ();
+
+  print_digest_result (label, DIGEST_BENCH_ITERS, DIGEST_BENCH_BLOCKSIZE,
+      end - start);
+
+  r_free (input);
+  r_msg_digest_free (md);
+}
+
+RTEST_BENCH (rmsgdigest, sha256, RTEST_FAST | RTEST_SYSTEM)
+{
+  /* SHA-256 bulk throughput. 32-bit-word compression function;
+   * the workhorse digest for nearly every protocol in rlib (TLS,
+   * SSH, sign / verify, HKDF). Establishes a baseline before any
+   * future hash-perf or hardware-accel work. */
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  run_digest_bench (R_MSG_DIGEST_TYPE_SHA256, "SHA-256");
+}
+RTEST_END;
+
+RTEST_BENCH (rmsgdigest, sha512, RTEST_FAST | RTEST_SYSTEM)
+{
+  /* SHA-512 bulk throughput. 64-bit-word compression function;
+   * faster than SHA-256 on 64-bit hosts despite the larger digest
+   * because it processes 128-byte blocks at a time (vs SHA-256's
+   * 64). The MiB/s delta against SHA-256 surfaces whether the
+   * 64-bit advantage actually lands. */
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  run_digest_bench (R_MSG_DIGEST_TYPE_SHA512, "SHA-512");
+}
+RTEST_END;

--- a/bench/rmsgdigest.c
+++ b/bench/rmsgdigest.c
@@ -1,23 +1,10 @@
 #include <rlib/rlib.h>
+#include "util.h"
 
 /* 16 KiB per hash call - large enough to amortise the per-call
  * setup cost, small enough to fit comfortably in L1 cache. */
 #define DIGEST_BENCH_BLOCKSIZE  (16 * 1024)
 #define DIGEST_BENCH_ITERS      2000
-
-static void
-print_digest_result (const rchar * label, ruint iters, rsize block_bytes,
-    RClockTime elapsed)
-{
-  rdouble elapsed_s = (rdouble)elapsed / (rdouble)R_SECOND;
-  rdouble total_mib = (rdouble)(iters * block_bytes) / (1024.0 * 1024.0);
-  rdouble mib_per_s = total_mib / elapsed_s;
-
-  r_print ("%"R_TIME_FORMAT"  %s: %.1f MiB/s "
-      "(%u x %"RSIZE_FMT"-byte blocks in %.3f s)\n",
-      R_TIME_ARGS (elapsed), label, mib_per_s,
-      iters, block_bytes, elapsed_s);
-}
 
 /* Hash @c DIGEST_BENCH_BLOCKSIZE bytes per iteration. The digest is
  * reset between iterations so each loop body exercises one full
@@ -55,7 +42,7 @@ run_digest_bench (RMsgDigestType type, const rchar * label)
   }
   end = r_time_get_ts_monotonic ();
 
-  print_digest_result (label, DIGEST_BENCH_ITERS, DIGEST_BENCH_BLOCKSIZE,
+  bench_print_throughput (label, DIGEST_BENCH_ITERS, DIGEST_BENCH_BLOCKSIZE,
       end - start);
 
   r_free (input);

--- a/bench/rrsa.c
+++ b/bench/rrsa.c
@@ -1,6 +1,7 @@
 #include <rlib/rlib.h>
 #include <rlib/crypto/rkey.h>
 #include <rlib/crypto/rrsa.h>
+#include "util.h"
 
 /* Per-bench iter counts. Private-side (decrypt / sign) is the
  * cubic-in-bits cost driver, so iters are tuned per key size to
@@ -13,21 +14,13 @@
 #define RSA_BENCH_ITERS_4096     50
 #define RSA_BENCH_ITERS_VERIFY 2000
 
-/* Print a single throughput line matching the revudp bench's layout
- * convention - elapsed timestamp + descriptive label + the numbers
- * worth reading at a glance. */
 static void
 print_rsa_result (const rchar * op, ruint bits, ruint iters,
     RClockTime elapsed)
 {
-  rdouble elapsed_s = (rdouble)elapsed / (rdouble)R_SECOND;
-  rdouble per_op_ms = elapsed_s * 1000.0 / (rdouble)iters;
-  rdouble ops_per_sec = (rdouble)iters / elapsed_s;
-
-  r_print ("%"R_TIME_FORMAT"  RSA-%u %s: %.3f ms/op, %.1f ops/sec "
-      "(%u iters in %.3f s)\n",
-      R_TIME_ARGS (elapsed), bits, op, per_op_ms, ops_per_sec,
-      iters, elapsed_s);
+  rchar * label = r_strprintf ("RSA-%u %s", bits, op);
+  bench_print_ops (label, iters, elapsed);
+  r_free (label);
 }
 
 /* PKCS#1v1.5 decrypt loop for the given key size. Exercises

--- a/bench/rrsa.c
+++ b/bench/rrsa.c
@@ -2,8 +2,16 @@
 #include <rlib/crypto/rkey.h>
 #include <rlib/crypto/rrsa.h>
 
-#define RSA_BENCH_BITS    2048
-#define RSA_BENCH_ITERS   200
+/* Per-bench iter counts. Private-side (decrypt / sign) is the
+ * cubic-in-bits cost driver, so iters are tuned per key size to
+ * keep wall-clock per bench in the ~1s range; verify uses a much
+ * larger count because public-key modexp with e=65537 is ~100x
+ * faster, and matching the private-side wall-clock budget keeps
+ * comparable measurement noise across all five benches. */
+#define RSA_BENCH_ITERS_2048    200
+#define RSA_BENCH_ITERS_3072    100
+#define RSA_BENCH_ITERS_4096     50
+#define RSA_BENCH_ITERS_VERIFY 2000
 
 /* Print a single throughput line matching the revudp bench's layout
  * convention - elapsed timestamp + descriptive label + the numbers
@@ -22,76 +30,77 @@ print_rsa_result (const rchar * op, ruint bits, ruint iters,
       iters, elapsed_s);
 }
 
-RTEST_BENCH (rrsa, decrypt_2048, RTEST_FAST | RTEST_SYSTEM)
+/* PKCS#1v1.5 decrypt loop for the given key size. Exercises
+ * r_rsa_modexp_private end-to-end (CRT halves + post-processing). The
+ * key is generated once outside the timed region so its variable-time
+ * prime search doesn't pollute the result. */
+static void
+run_rsa_decrypt_bench (ruint bits, ruint iters)
 {
-  /* RSA-2048 PKCS#1v1.5 decrypt loop. Exercises r_rsa_modexp_private
-   * end-to-end including the CRT halves and the post-processing. The
-   * key is generated once before the timed region so its variable-
-   * time prime search doesn't pollute the result. */
   RCryptoKey * priv;
   RPrng * prng;
   ruint8 plaintext[32];
-  ruint8 ciphertext[RSA_BENCH_BITS / 8];
-  ruint8 decrypted[RSA_BENCH_BITS / 8];
+  ruint8 * ciphertext;
+  ruint8 * decrypted;
   rsize ct_size, pt_size;
+  rsize buf_size = bits / 8;
   RClockTime start, end;
   ruint i;
 
-  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
-
+  r_assert_cmpptr ((ciphertext = r_malloc (buf_size)), !=, NULL);
+  r_assert_cmpptr ((decrypted = r_malloc (buf_size)), !=, NULL);
   r_assert_cmpptr ((prng = r_rand_prng_new ()), !=, NULL);
-  r_assert_cmpptr ((priv = r_rsa_priv_key_new_gen (RSA_BENCH_BITS, 65537, prng)),
+  r_assert_cmpptr ((priv = r_rsa_priv_key_new_gen (bits, 65537, prng)),
       !=, NULL);
   r_assert (r_rsa_priv_key_set_padding (priv, R_RSA_PADDING_PKCS1_V15));
 
   for (i = 0; i < sizeof (plaintext); i++)
     plaintext[i] = (ruint8)i;
-  ct_size = sizeof (ciphertext);
+  ct_size = buf_size;
   r_assert_cmpint (r_crypto_key_encrypt (priv, prng, plaintext,
         sizeof (plaintext), ciphertext, &ct_size), ==, R_CRYPTO_OK);
 
   /* Brief warm-up so cold caches don't bias the first iterations. */
   for (i = 0; i < 5; i++) {
-    pt_size = sizeof (decrypted);
+    pt_size = buf_size;
     r_assert_cmpint (r_crypto_key_decrypt (priv, prng, ciphertext, ct_size,
           decrypted, &pt_size), ==, R_CRYPTO_OK);
   }
 
   start = r_time_get_ts_monotonic ();
-  for (i = 0; i < RSA_BENCH_ITERS; i++) {
-    pt_size = sizeof (decrypted);
+  for (i = 0; i < iters; i++) {
+    pt_size = buf_size;
     r_assert_cmpint (r_crypto_key_decrypt (priv, prng, ciphertext, ct_size,
           decrypted, &pt_size), ==, R_CRYPTO_OK);
   }
   end = r_time_get_ts_monotonic ();
 
-  print_rsa_result ("decrypt", RSA_BENCH_BITS, RSA_BENCH_ITERS, end - start);
+  print_rsa_result ("decrypt", bits, iters, end - start);
 
   r_crypto_key_unref (priv);
   r_prng_unref (prng);
+  r_free (ciphertext);
+  r_free (decrypted);
 }
-RTEST_END;
 
-RTEST_BENCH (rrsa, sign_2048, RTEST_FAST | RTEST_SYSTEM)
+/* PKCS#1v1.5 sign loop for the given key size. Same underlying
+ * private-key modexp as decrypt; exercised through the signing API
+ * surface (DigestInfo wrap + r_crypto_key_sign). */
+static void
+run_rsa_sign_bench (ruint bits, ruint iters)
 {
-  /* RSA-2048 PKCS#1v1.5 signature loop. Same underlying private-key
-   * modexp as the decrypt bench, but exercised through the signing
-   * API surface (DigestInfo wrap + r_crypto_key_sign). The two share
-   * one private-op cost driver; comparing them surfaces any padding-
-   * path overhead that differs between encrypt-direction and sign-
-   * direction PKCS#1v1.5. */
   RCryptoKey * priv;
   RPrng * prng;
-  ruint8 hash[32];  /* SHA-256 digest size */
-  ruint8 sig[RSA_BENCH_BITS / 8];
+  ruint8 hash[32];
+  ruint8 * sig;
   rsize sig_size;
+  rsize buf_size = bits / 8;
   RClockTime start, end;
   ruint i;
 
-  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
-
+  r_assert_cmpptr ((sig = r_malloc (buf_size)), !=, NULL);
   r_assert_cmpptr ((prng = r_rand_prng_new ()), !=, NULL);
-  r_assert_cmpptr ((priv = r_rsa_priv_key_new_gen (RSA_BENCH_BITS, 65537, prng)),
+  r_assert_cmpptr ((priv = r_rsa_priv_key_new_gen (bits, 65537, prng)),
       !=, NULL);
   r_assert (r_rsa_priv_key_set_padding (priv, R_RSA_PADDING_PKCS1_V15));
 
@@ -99,22 +108,121 @@ RTEST_BENCH (rrsa, sign_2048, RTEST_FAST | RTEST_SYSTEM)
     hash[i] = (ruint8)(i * 7u + 1u);
 
   for (i = 0; i < 5; i++) {
-    sig_size = sizeof (sig);
+    sig_size = buf_size;
     r_assert_cmpint (r_crypto_key_sign (priv, prng, R_MSG_DIGEST_TYPE_SHA256,
           hash, sizeof (hash), sig, &sig_size), ==, R_CRYPTO_OK);
   }
 
   start = r_time_get_ts_monotonic ();
-  for (i = 0; i < RSA_BENCH_ITERS; i++) {
-    sig_size = sizeof (sig);
+  for (i = 0; i < iters; i++) {
+    sig_size = buf_size;
     r_assert_cmpint (r_crypto_key_sign (priv, prng, R_MSG_DIGEST_TYPE_SHA256,
           hash, sizeof (hash), sig, &sig_size), ==, R_CRYPTO_OK);
   }
   end = r_time_get_ts_monotonic ();
 
-  print_rsa_result ("sign", RSA_BENCH_BITS, RSA_BENCH_ITERS, end - start);
+  print_rsa_result ("sign", bits, iters, end - start);
 
   r_crypto_key_unref (priv);
   r_prng_unref (prng);
+  r_free (sig);
+}
+
+/* PKCS#1v1.5 verify loop. Signs once outside the timed region to
+ * produce a valid signature, then verifies that signature in a
+ * loop. Each iteration runs r_crypto_key_verify which exercises
+ * the public-key modexp (e=65537, ~17 squarings + 1 multiplication)
+ * plus DigestInfo unwrap. The verify call is dispatched on a
+ * dedicated pub-only key extracted from priv via (n, e); this
+ * mirrors what callers do when they receive a peer's public key
+ * over the wire. */
+static void
+run_rsa_verify_bench (ruint bits, ruint iters)
+{
+  RCryptoKey * priv;
+  RCryptoKey * pub;
+  RPrng * prng;
+  rmpint n, e;
+  ruint8 hash[32];
+  ruint8 * sig;
+  rsize sig_size;
+  rsize buf_size = bits / 8;
+  RClockTime start, end;
+  ruint i;
+
+  r_assert_cmpptr ((sig = r_malloc (buf_size)), !=, NULL);
+  r_assert_cmpptr ((prng = r_rand_prng_new ()), !=, NULL);
+  r_assert_cmpptr ((priv = r_rsa_priv_key_new_gen (bits, 65537, prng)),
+      !=, NULL);
+  r_assert (r_rsa_priv_key_set_padding (priv, R_RSA_PADDING_PKCS1_V15));
+
+  r_mpint_init (&n);
+  r_mpint_init (&e);
+  r_assert (r_rsa_pub_key_get_n (priv, &n));
+  r_assert (r_rsa_pub_key_get_e (priv, &e));
+  r_assert_cmpptr ((pub = r_rsa_pub_key_new (&n, &e)), !=, NULL);
+  r_assert (r_rsa_pub_key_set_padding (pub, R_RSA_PADDING_PKCS1_V15));
+  r_mpint_clear (&n);
+  r_mpint_clear (&e);
+
+  for (i = 0; i < sizeof (hash); i++)
+    hash[i] = (ruint8)(i * 7u + 1u);
+
+  sig_size = buf_size;
+  r_assert_cmpint (r_crypto_key_sign (priv, prng, R_MSG_DIGEST_TYPE_SHA256,
+        hash, sizeof (hash), sig, &sig_size), ==, R_CRYPTO_OK);
+
+  for (i = 0; i < 5; i++) {
+    r_assert_cmpint (r_crypto_key_verify (pub, R_MSG_DIGEST_TYPE_SHA256,
+          hash, sizeof (hash), sig, sig_size), ==, R_CRYPTO_OK);
+  }
+
+  start = r_time_get_ts_monotonic ();
+  for (i = 0; i < iters; i++) {
+    r_assert_cmpint (r_crypto_key_verify (pub, R_MSG_DIGEST_TYPE_SHA256,
+          hash, sizeof (hash), sig, sig_size), ==, R_CRYPTO_OK);
+  }
+  end = r_time_get_ts_monotonic ();
+
+  print_rsa_result ("verify", bits, iters, end - start);
+
+  r_crypto_key_unref (priv);
+  r_crypto_key_unref (pub);
+  r_prng_unref (prng);
+  r_free (sig);
+}
+
+RTEST_BENCH (rrsa, decrypt_2048, RTEST_FAST | RTEST_SYSTEM)
+{
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  run_rsa_decrypt_bench (2048, RSA_BENCH_ITERS_2048);
+}
+RTEST_END;
+
+RTEST_BENCH (rrsa, decrypt_3072, RTEST_FAST | RTEST_SYSTEM)
+{
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  run_rsa_decrypt_bench (3072, RSA_BENCH_ITERS_3072);
+}
+RTEST_END;
+
+RTEST_BENCH (rrsa, decrypt_4096, RTEST_FAST | RTEST_SYSTEM)
+{
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  run_rsa_decrypt_bench (4096, RSA_BENCH_ITERS_4096);
+}
+RTEST_END;
+
+RTEST_BENCH (rrsa, sign_2048, RTEST_FAST | RTEST_SYSTEM)
+{
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  run_rsa_sign_bench (2048, RSA_BENCH_ITERS_2048);
+}
+RTEST_END;
+
+RTEST_BENCH (rrsa, verify_2048, RTEST_FAST | RTEST_SYSTEM)
+{
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  run_rsa_verify_bench (2048, RSA_BENCH_ITERS_VERIFY);
 }
 RTEST_END;

--- a/bench/util.h
+++ b/bench/util.h
@@ -1,0 +1,46 @@
+#ifndef __RLIB_BENCH_UTIL_H__
+#define __RLIB_BENCH_UTIL_H__
+
+#include <rlib/rlib.h>
+
+/* Shared microbench output formatters. All RTEST_BENCH bodies in
+ * the crypto benches end with one of these two calls; centralising
+ * the math + format here keeps every result line identical and
+ * comparable across primitives.
+ *
+ * Callers build a descriptive label (e.g. "RSA-2048 decrypt",
+ * "ECDH secp256r1 compute_shared", "AES-128 CBC") and pass it as
+ * the first argument. */
+
+/* "<label>: X.XXX ms/op, Y.Y ops/sec (iters in s)" — use for
+ * asymmetric ops where per-call cost is the metric. */
+static inline void
+bench_print_ops (const rchar * label, ruint iters, RClockTime elapsed)
+{
+  rdouble elapsed_s = (rdouble)elapsed / (rdouble)R_SECOND;
+  rdouble per_op_ms = elapsed_s * 1000.0 / (rdouble)iters;
+  rdouble ops_per_sec = (rdouble)iters / elapsed_s;
+
+  r_print ("%"R_TIME_FORMAT"  %s: %.3f ms/op, %.1f ops/sec "
+      "(%u iters in %.3f s)\n",
+      R_TIME_ARGS (elapsed), label, per_op_ms, ops_per_sec,
+      iters, elapsed_s);
+}
+
+/* "<label>: X.X MiB/s (iters x block-byte blocks in s)" — use
+ * for symmetric / hash primitives where throughput is the metric. */
+static inline void
+bench_print_throughput (const rchar * label, ruint iters,
+    rsize block_bytes, RClockTime elapsed)
+{
+  rdouble elapsed_s = (rdouble)elapsed / (rdouble)R_SECOND;
+  rdouble total_mib = (rdouble)(iters * block_bytes) / (1024.0 * 1024.0);
+  rdouble mib_per_s = total_mib / elapsed_s;
+
+  r_print ("%"R_TIME_FORMAT"  %s: %.1f MiB/s "
+      "(%u x %"RSIZE_FMT"-byte blocks in %.3f s)\n",
+      R_TIME_ARGS (elapsed), label, mib_per_s,
+      iters, block_bytes, elapsed_s);
+}
+
+#endif /* __RLIB_BENCH_UTIL_H__ */


### PR DESCRIPTION
## Summary

Closes out the medium-priority items in #142. Three commits, mirroring the previous PR pattern.

| Commit | Scope | Local result (release, this machine) |
|---|---|---|
| `bench: Expand rrsa with 3072/4096 decrypt and 2048 verify` | RSA private path widened to 3 key sizes + RSA public-side verify | decrypt 3.847 / 11.027 / 25.426 ms/op (2048 / 3072 / 4096); verify 0.357 ms/op |
| `bench: Add finite-field DH compute_shared microbenchmarks` | `bench/rdh.c` covering MODP-2048 + FFDHE-2048 | 22.452 / 22.479 ms/op |
| `bench: Add SHA-256 and SHA-512 throughput microbenchmarks` | `bench/rmsgdigest.c` covering the two workhorse digests | 419.8 / 647.1 MiB/s |

Each new bench follows the existing convention: key / state set up once outside the timed region, brief warm-up, then either 200 iters (asymmetric ops) or 2000 iters (verify + bulk-throughput) timed via `r_time_get_ts_monotonic`. The RSA inline bodies were lifted into `run_rsa_decrypt_bench` / `run_rsa_sign_bench` / `run_rsa_verify_bench` helpers so each `RTEST_BENCH` wrapper is one line; the same parameterised-helper pattern is used in `bench/rdh.c` and `bench/rmsgdigest.c`.

## Notes worth flagging

- **RSA private-op cost scales cubically.** 2048 → 4096 (2x bits) is ~6.6x on the numbers above; matches the FE_Big windowed expmod expectation.
- **RSA verify is ~10x cheaper than sign on 2048** (0.36 vs 3.90 ms/op) because the public exponent is fixed at 65537 (~17 squarings + 1 mul vs the full private exponent). The verify bench uses `RSA_BENCH_ITERS_PUB = 2000` to keep the wall-clock window comparable.
- **MODP-2048 ≈ FFDHE-2048** to within 0.1%. Confirms the FFDHE-specific code path has no group-dependent setup overhead worth chasing.
- **SHA-512 outpaces SHA-256** (647 vs 420 MiB/s) on this 64-bit host — expected because SHA-512's 64-bit word + 128-byte block plays to native register width, while SHA-256 stays on 32-bit words and 64-byte blocks.

## What this leaves

After this lands, only the four low-priority items in #142 remain (HMAC, AES-ECB/CFB/OFB, legacy digests, CRC throughput). All are smaller and lower-value than what's already covered.

## Test plan

- [x] Each new / changed bench builds clean and runs successfully
- [x] All 19 crypto benches run together via `build-release/bench/rlibbench -f '/r*'` with sensible output
- [ ] CI green on the PR