### PR TITLE
rlib: Add runtime CPU feature detection API

### DIFF
--- a/include/rlib/rcpufeatures.h
+++ b/include/rlib/rcpufeatures.h
@@ -1,0 +1,267 @@
+/* RLIB - Convenience library for useful things
+ * Copyright (C) 2026 Haakon Sporsheim <haakon.sporsheim@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ * See the COPYING file at the root of the source repository.
+ */
+#ifndef __R_CPUFEATURES_H__
+#define __R_CPUFEATURES_H__
+
+#if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
+#error "#include <rlib.h> only pelase."
+#endif
+
+#include <rlib/rtypes.h>
+
+/**
+ * @defgroup r_cpufeatures CPU feature detection
+ * @brief Runtime queries for the host CPU's optional instruction-set
+ * extensions.
+ * @{
+ */
+
+/**
+ * @file rlib/rcpufeatures.h
+ * @brief Runtime CPU feature detection.
+ *
+ * Bitmask of optional CPU extensions probed once at first use and
+ * cached for the process lifetime. The set is intentionally broader
+ * than what rlib's own code dispatches on - callers can use it to
+ * pick algorithm variants, gate diagnostic output, or surface the
+ * host's capabilities in @c --version-style banners.
+ *
+ * **Detection sources:**
+ *  - **x86 / x86_64**: @c cpuid leaf 1 (legacy SSE / AES / AVX / etc.)
+ *    and leaf 7 sub-leaf 0 (AVX2 / AVX-512 / BMI / SHA-NI). AVX-family
+ *    flags are gated on the OS having enabled @c OSXSAVE and the
+ *    corresponding @c xcr0 state bits (XMM, YMM, opmask, ZMM_hi256,
+ *    Hi16_ZMM), so a true bit guarantees that issuing those
+ *    instructions won't fault on a context switch.
+ *  - **AArch64 Linux**: @c getauxval (@c AT_HWCAP and @c AT_HWCAP2).
+ *  - **AArch64 Darwin**: @c sysctlbyname ("hw.optional.arm.FEAT_*").
+ *  - **AArch64 Windows**: @c IsProcessorFeaturePresent.
+ *
+ * On architectures with no detection backend the result is always 0
+ * and every @c r_cpu_has call returns @c FALSE; callers that dispatch
+ * on a feature flag transparently fall back to their software path.
+ *
+ * **Bit layout** (32 bits total, x86 in 0-23, AArch64 in 24-47):
+ *  - x86 base SSE family: bits 0-7
+ *  - x86 AVX / AVX-512 family: bits 8-15
+ *  - x86 misc (SHA-NI, BMI, POPCNT, F16C, RDRAND): bits 16-23
+ *  - AArch64 base + crypto: bits 24-39
+ *  - AArch64 misc (atomics, dotprod, SVE): bits 40-47
+ */
+
+/**
+ * @brief Bitmask of CPU extension flags.
+ *
+ * Treat as an opaque bitfield - combine with bitwise-OR, query with
+ * bitwise-AND or @c r_cpu_has. Underlying type is @c ruint64 to leave
+ * headroom for future flags beyond the 32-bit cutoff.
+ */
+typedef ruint64 RCpuFeature;
+
+/** @brief Sentinel: no extensions detected (always 0). */
+#define R_CPU_FEATURE_NONE              ((RCpuFeature)0)
+
+/** @internal Shift helper - keeps the bit width explicit so flags
+ * past bit 31 don't accidentally fall back to int and truncate. */
+#define R_CPU_BIT_(n)                   (((RCpuFeature)1) << (n))
+
+/* x86 / x86_64 base SSE family (bits 0-7) */
+
+/** @brief x86 SSE (Pentium III+); 128-bit XMM single-precision FP. */
+#define R_CPU_FEATURE_SSE               R_CPU_BIT_( 0)
+/** @brief x86 SSE2 (Pentium 4+); 128-bit integer + double-precision FP. */
+#define R_CPU_FEATURE_SSE2              R_CPU_BIT_( 1)
+/** @brief x86 SSE3 (Prescott+); horizontal add, @c LDDQU, @c MWAIT. */
+#define R_CPU_FEATURE_SSE3              R_CPU_BIT_( 2)
+/** @brief x86 SSSE3 (Core 2+); byte shuffle (@c PSHUFB), align right. */
+#define R_CPU_FEATURE_SSSE3             R_CPU_BIT_( 3)
+/** @brief x86 SSE4.1 (Penryn+); blend, dot product, packed compare. */
+#define R_CPU_FEATURE_SSE4_1            R_CPU_BIT_( 4)
+/** @brief x86 SSE4.2 (Nehalem+); @c CRC32 instruction (hardware
+ * Castagnoli CRC32C), string compare, @c PCMPGTQ. */
+#define R_CPU_FEATURE_SSE4_2            R_CPU_BIT_( 5)
+/** @brief x86 AES-NI; single-instruction AES round operations
+ * (@c AESENC / @c AESENCLAST / @c AESDEC / @c AESDECLAST + key
+ * schedule helpers). */
+#define R_CPU_FEATURE_AES_NI            R_CPU_BIT_( 6)
+/** @brief x86 PCLMULQDQ; carry-less multiply used for GHASH (AES-GCM)
+ * and PCLMUL-folding CRC variants. */
+#define R_CPU_FEATURE_PCLMUL            R_CPU_BIT_( 7)
+
+/* x86 / x86_64 AVX / AVX-512 family (bits 8-15) */
+
+/** @brief x86 AVX (Sandy Bridge+); 256-bit YMM vector ops. Only set
+ * when the OS has enabled AVX-state context switching - using AVX
+ * without that would corrupt FP state across a thread switch. */
+#define R_CPU_FEATURE_AVX               R_CPU_BIT_( 8)
+/** @brief x86 AVX2 (Haswell+); 256-bit integer vector ops. Same OS
+ * precondition as @c R_CPU_FEATURE_AVX. */
+#define R_CPU_FEATURE_AVX2              R_CPU_BIT_( 9)
+/** @brief x86 AVX-512 Foundation (Skylake-X+); 512-bit ZMM vector
+ * ops. Only set when the OS has additionally enabled AVX-512 state
+ * (@c xcr0 bits 5-7). */
+#define R_CPU_FEATURE_AVX512F           R_CPU_BIT_(10)
+/** @brief x86 AVX-512BW; byte/word integer ops on ZMM. Implies F. */
+#define R_CPU_FEATURE_AVX512BW          R_CPU_BIT_(11)
+/** @brief x86 AVX-512DQ; double-word/quad-word ops, fast scatter/
+ * gather. Implies F. */
+#define R_CPU_FEATURE_AVX512DQ          R_CPU_BIT_(12)
+/** @brief x86 AVX-512VL; lets 128/256-bit ops use AVX-512 features
+ * (masking, extended register file). Implies F. */
+#define R_CPU_FEATURE_AVX512VL          R_CPU_BIT_(13)
+
+/* x86 / x86_64 misc (bits 16-23) */
+
+/** @brief x86 SHA-NI (Goldmont+, Zen+); hardware SHA-1 and SHA-256
+ * round instructions. */
+#define R_CPU_FEATURE_SHA_NI            R_CPU_BIT_(16)
+/** @brief x86 BMI1 (Haswell+, Piledriver+); @c ANDN, @c BEXTR,
+ * @c BLSI, @c BLSMSK, @c BLSR, @c TZCNT. */
+#define R_CPU_FEATURE_BMI1              R_CPU_BIT_(17)
+/** @brief x86 BMI2 (Haswell+, Zen+); @c BZHI, @c MULX, @c PDEP,
+ * @c PEXT, @c RORX, @c SARX / @c SHLX / @c SHRX. */
+#define R_CPU_FEATURE_BMI2              R_CPU_BIT_(18)
+/** @brief x86 POPCNT (Nehalem+); single-instruction population count. */
+#define R_CPU_FEATURE_POPCNT            R_CPU_BIT_(19)
+/** @brief x86 F16C (Ivy Bridge+, Piledriver+); FP16 ⇄ FP32 conversion
+ * (@c VCVTPH2PS / @c VCVTPS2PH). */
+#define R_CPU_FEATURE_F16C              R_CPU_BIT_(20)
+/** @brief x86 RDRAND (Ivy Bridge+); hardware random number source. */
+#define R_CPU_FEATURE_RDRAND            R_CPU_BIT_(21)
+/** @brief x86 RDSEED (Broadwell+); slower-but-stronger RNG paired with
+ * RDRAND - draws from the raw entropy source rather than the
+ * conditioned stream. */
+#define R_CPU_FEATURE_RDSEED            R_CPU_BIT_(22)
+
+/* AArch64 base + crypto (bits 24-39) */
+
+/** @brief AArch64 NEON / Advanced SIMD; 128-bit integer + FP vector
+ * ops. Architecturally mandatory on AArch64 so this is always set on
+ * the AArch64 backends - exposed for completeness. */
+#define R_CPU_FEATURE_ARM_NEON          R_CPU_BIT_(24)
+/** @brief ARMv8 AES (@c AESE / @c AESD / @c AESMC / @c AESIMC); the
+ * AArch64 analogue of x86 AES-NI. */
+#define R_CPU_FEATURE_ARM_AES           R_CPU_BIT_(25)
+/** @brief ARMv8 polynomial multiply (@c PMULL / @c PMULL2); the
+ * AArch64 analogue of x86 PCLMULQDQ. */
+#define R_CPU_FEATURE_ARM_PMULL         R_CPU_BIT_(26)
+/** @brief ARMv8 SHA-1 instructions. */
+#define R_CPU_FEATURE_ARM_SHA1          R_CPU_BIT_(27)
+/** @brief ARMv8 SHA-256 instructions. */
+#define R_CPU_FEATURE_ARM_SHA2          R_CPU_BIT_(28)
+/** @brief ARMv8.2 SHA-512 instructions. */
+#define R_CPU_FEATURE_ARM_SHA512        R_CPU_BIT_(29)
+/** @brief ARMv8.2 SHA-3 instructions (Keccak round helpers). */
+#define R_CPU_FEATURE_ARM_SHA3          R_CPU_BIT_(30)
+/** @brief ARMv8 CRC32 extension; single-cycle @c CRC32C{B,H,W,X}
+ * instructions for hardware Castagnoli CRC32C. */
+#define R_CPU_FEATURE_ARM_CRC32         R_CPU_BIT_(31)
+
+/* AArch64 misc (bits 32-47) */
+
+/** @brief ARMv8.1 LSE atomics; @c LDADD / @c CAS / @c SWP exclusive-
+ * monitor-free atomics. */
+#define R_CPU_FEATURE_ARM_LSE           R_CPU_BIT_(32)
+/** @brief ARMv8.2 dot product (@c UDOT / @c SDOT); 8-bit signed/
+ * unsigned dot product into 32-bit accumulator. */
+#define R_CPU_FEATURE_ARM_DOTPROD       R_CPU_BIT_(33)
+/** @brief ARMv8.2 half-precision FP arithmetic. */
+#define R_CPU_FEATURE_ARM_FPHP          R_CPU_BIT_(34)
+/** @brief ARMv8.2 half-precision SIMD arithmetic. */
+#define R_CPU_FEATURE_ARM_ASIMDHP       R_CPU_BIT_(35)
+/** @brief ARMv8.6 BFloat16 vector ops (@c BFDOT / @c BFMMLA / etc.). */
+#define R_CPU_FEATURE_ARM_BF16          R_CPU_BIT_(36)
+/** @brief ARMv8.6 8-bit integer matrix multiply (@c USMMLA / @c UMMLA /
+ * @c SMMLA). */
+#define R_CPU_FEATURE_ARM_I8MM          R_CPU_BIT_(37)
+/** @brief ARMv8.2 Scalable Vector Extension (variable-width vectors). */
+#define R_CPU_FEATURE_ARM_SVE           R_CPU_BIT_(38)
+/** @brief ARMv9 SVE2; SVE plus extended integer / crypto operations. */
+#define R_CPU_FEATURE_ARM_SVE2          R_CPU_BIT_(39)
+
+R_BEGIN_DECLS
+
+/**
+ * @brief Return the bitmask of detected CPU features.
+ *
+ * Detection runs once at library load (constructor / DllMain) so
+ * this call is a single cached load - O(1), lock-free, and
+ * trivially thread-safe.
+ *
+ * @return Bitwise-OR of zero or more @c R_CPU_FEATURE_* values.
+ * Returns 0 on architectures with no detection backend (the safe
+ * answer that routes every caller to its software fallback).
+ */
+R_API RCpuFeature r_cpu_features (void);
+
+/**
+ * @brief Test whether the CPU has the given feature.
+ *
+ * Shorthand for @c (r_cpu_features() @c & @c feature) @c != @c 0.
+ * Use for dispatch-site predicates where the branch is on a single
+ * feature; for multi-feature checks (e.g. "AES-NI and PCLMUL"), call
+ * @c r_cpu_features directly and AND the desired mask in one go.
+ *
+ * @param feature  One of the @c R_CPU_FEATURE_* values.
+ * @return @c TRUE if the bit is set in the detected bitmask,
+ * @c FALSE otherwise.
+ */
+R_API rboolean r_cpu_has (RCpuFeature feature);
+
+/**
+ * @brief Return a short canonical name for a single feature flag.
+ *
+ * Names are stable, ASCII-only, suitable for logs / banners / unit
+ * tests (e.g. @c "SSE4.2", @c "AES-NI", @c "ARM_CRC32"). The string
+ * has static storage; callers must not free it.
+ *
+ * @param feature  Exactly one @c R_CPU_FEATURE_* flag - not a bitmask
+ * of multiple. Passing 0 or an OR of flags returns @c "Unknown".
+ * @return Pointer to a static C string. Never @c NULL.
+ */
+R_API const rchar * r_cpu_feature_name (RCpuFeature feature);
+
+/**
+ * @brief Return a static array of every feature this build knows
+ * about.
+ *
+ * The array contains one entry per defined @c R_CPU_FEATURE_* flag
+ * (not the @c NONE sentinel), in declaration order. Combine with
+ * @c r_cpu_has and @c r_cpu_feature_name to enumerate the present
+ * subset, e.g. for a @c --version-style listing:
+ *
+ * @code
+ * rsize n;
+ * const RCpuFeature * all = r_cpu_features_all (&n);
+ * for (rsize i = 0; i < n; i++) {
+ *   if (r_cpu_has (all[i]))
+ *     printf ("  %s\n", r_cpu_feature_name (all[i]));
+ * }
+ * @endcode
+ *
+ * @param[out] count  Number of entries in the returned array.
+ * Must not be @c NULL.
+ * @return Pointer to a static read-only array. Never @c NULL.
+ */
+R_API const RCpuFeature * r_cpu_features_all (rsize * count);
+
+R_END_DECLS
+
+/** @} */ /* r_cpufeatures group */
+
+#endif /* __R_CPUFEATURES_H__ */

--- a/include/rlib/rlib.h
+++ b/include/rlib/rlib.h
@@ -31,6 +31,7 @@
 #include <rlib/rbuffer.h>
 #include <rlib/rclock.h>
 #include <rlib/rclr.h>
+#include <rlib/rcpufeatures.h>
 #include <rlib/rcrc.h>
 #include <rlib/renv.h>
 #include <rlib/rio.h>

--- a/rlib/meson.build
+++ b/rlib/meson.build
@@ -6,6 +6,7 @@ rlib_sources = [
   'rbase64.c',
   'rbuffer.c',
   'rclock.c',
+  'rcpufeatures.c',
   'rcrc.c',
   'renv.c',
   'rio.c',

--- a/rlib/rcpufeatures.c
+++ b/rlib/rcpufeatures.c
@@ -1,0 +1,416 @@
+/* RLIB - Convenience library for useful things
+ * Copyright (C) 2026 Haakon Sporsheim <haakon.sporsheim@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ * See the COPYING file at the root of the source repository.
+ */
+
+#include "config.h"
+#include <rlib/rcpufeatures.h>
+#include <rlib/rthreads.h>            /* ROnce */
+
+#if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
+# if defined(_MSC_VER)
+#  include <intrin.h>
+#  include <immintrin.h>           /* _xgetbv */
+# else
+#  include <cpuid.h>
+# endif
+#endif
+
+#if defined(R_ARCH_AARCH64)
+# if defined(R_OS_LINUX)
+#  include <sys/auxv.h>
+#  if defined(__has_include) && __has_include(<asm/hwcap.h>)
+#   include <asm/hwcap.h>
+#  endif
+# elif defined(R_OS_DARWIN)
+#  include <sys/sysctl.h>
+# elif defined(R_OS_WIN32)
+#  include <windows.h>
+# endif
+#endif
+
+/* Single source of truth for {flag, name} pairs - the known-feature
+ * list and the name lookup both expand from this so they can't drift. */
+#define R_CPU_FOREACH_FEATURE(F)                          \
+  F(SSE,         "SSE")                                   \
+  F(SSE2,        "SSE2")                                  \
+  F(SSE3,        "SSE3")                                  \
+  F(SSSE3,       "SSSE3")                                 \
+  F(SSE4_1,      "SSE4.1")                                \
+  F(SSE4_2,      "SSE4.2")                                \
+  F(AES_NI,      "AES-NI")                                \
+  F(PCLMUL,      "PCLMUL")                                \
+  F(AVX,         "AVX")                                   \
+  F(AVX2,        "AVX2")                                  \
+  F(AVX512F,     "AVX-512F")                              \
+  F(AVX512BW,    "AVX-512BW")                             \
+  F(AVX512DQ,    "AVX-512DQ")                             \
+  F(AVX512VL,    "AVX-512VL")                             \
+  F(SHA_NI,      "SHA-NI")                                \
+  F(BMI1,        "BMI1")                                  \
+  F(BMI2,        "BMI2")                                  \
+  F(POPCNT,      "POPCNT")                                \
+  F(F16C,        "F16C")                                  \
+  F(RDRAND,      "RDRAND")                                \
+  F(RDSEED,      "RDSEED")                                \
+  F(ARM_NEON,    "ARM_NEON")                              \
+  F(ARM_AES,     "ARM_AES")                               \
+  F(ARM_PMULL,   "ARM_PMULL")                             \
+  F(ARM_SHA1,    "ARM_SHA1")                              \
+  F(ARM_SHA2,    "ARM_SHA2")                              \
+  F(ARM_SHA512,  "ARM_SHA512")                            \
+  F(ARM_SHA3,    "ARM_SHA3")                              \
+  F(ARM_CRC32,   "ARM_CRC32")                             \
+  F(ARM_LSE,     "ARM_LSE")                               \
+  F(ARM_DOTPROD, "ARM_DOTPROD")                           \
+  F(ARM_FPHP,    "ARM_FPHP")                              \
+  F(ARM_ASIMDHP, "ARM_ASIMDHP")                           \
+  F(ARM_BF16,    "ARM_BF16")                              \
+  F(ARM_I8MM,    "ARM_I8MM")                              \
+  F(ARM_SVE,     "ARM_SVE")                               \
+  F(ARM_SVE2,    "ARM_SVE2")
+
+static const RCpuFeature g__r_cpu_features_known[] = {
+#define R_CPU_FEATURE_ENUM_ENTRY(name, str)  R_CPU_FEATURE_##name,
+  R_CPU_FOREACH_FEATURE (R_CPU_FEATURE_ENUM_ENTRY)
+#undef R_CPU_FEATURE_ENUM_ENTRY
+};
+
+static ROnce       g__r_cpu_features_once = R_ONCE_INIT;
+static RCpuFeature g__r_cpu_features = 0;
+
+#if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
+
+static rboolean
+r_cpu_x86_cpuid (ruint32 leaf, ruint32 * eax, ruint32 * ebx,
+    ruint32 * ecx, ruint32 * edx)
+{
+# if defined(_MSC_VER)
+  int regs[4] = { 0, 0, 0, 0 };
+  __cpuid (regs, (int)leaf);
+  *eax = (ruint32)regs[0]; *ebx = (ruint32)regs[1];
+  *ecx = (ruint32)regs[2]; *edx = (ruint32)regs[3];
+  return TRUE;
+# else
+  return __get_cpuid (leaf, eax, ebx, ecx, edx) != 0;
+# endif
+}
+
+static rboolean
+r_cpu_x86_cpuid_count (ruint32 leaf, ruint32 sub,
+    ruint32 * eax, ruint32 * ebx, ruint32 * ecx, ruint32 * edx)
+{
+# if defined(_MSC_VER)
+  int regs[4] = { 0, 0, 0, 0 };
+  __cpuidex (regs, (int)leaf, (int)sub);
+  *eax = (ruint32)regs[0]; *ebx = (ruint32)regs[1];
+  *ecx = (ruint32)regs[2]; *edx = (ruint32)regs[3];
+  return TRUE;
+# else
+  return __get_cpuid_count (leaf, sub, eax, ebx, ecx, edx) != 0;
+# endif
+}
+
+static ruint64
+r_cpu_x86_xgetbv (void)
+{
+# if defined(_MSC_VER)
+  return (ruint64)_xgetbv (0);
+# else
+  ruint32 eax_lo, edx_hi;
+  __asm__ volatile ("xgetbv"
+      : "=a" (eax_lo), "=d" (edx_hi)
+      : "c" (0));
+  return ((ruint64)edx_hi << 32) | (ruint64)eax_lo;
+# endif
+}
+
+static RCpuFeature
+r_cpu_detect (void)
+{
+  RCpuFeature ret = 0;
+  ruint32 eax = 0, ebx = 0, ecx = 0, edx = 0;
+  ruint32 max_leaf;
+
+  /* Leaf 0 EAX is the max-supported-leaf marker; gates the leaf-7
+   * probe below so older CPUs don't return garbage there. */
+  if (!r_cpu_x86_cpuid (0, &max_leaf, &ebx, &ecx, &edx))
+    return 0;
+
+  if (!r_cpu_x86_cpuid (1, &eax, &ebx, &ecx, &edx))
+    return 0;
+
+  if (edx & (1u << 25)) ret |= R_CPU_FEATURE_SSE;
+  if (edx & (1u << 26)) ret |= R_CPU_FEATURE_SSE2;
+
+  if (ecx & (1u <<  0)) ret |= R_CPU_FEATURE_SSE3;
+  if (ecx & (1u <<  9)) ret |= R_CPU_FEATURE_SSSE3;
+  if (ecx & (1u << 19)) ret |= R_CPU_FEATURE_SSE4_1;
+  if (ecx & (1u << 20)) ret |= R_CPU_FEATURE_SSE4_2;
+  if (ecx & (1u << 25)) ret |= R_CPU_FEATURE_AES_NI;
+  if (ecx & (1u <<  1)) ret |= R_CPU_FEATURE_PCLMUL;
+  if (ecx & (1u << 23)) ret |= R_CPU_FEATURE_POPCNT;
+  if (ecx & (1u << 30)) ret |= R_CPU_FEATURE_RDRAND;
+
+  /* AVX-family flags require the OS to have enabled the wider
+   * XSAVE state - issuing AVX instructions without that corrupts FP
+   * state across a context switch. cpuid alone is not enough;
+   * OSXSAVE plus the relevant xcr0 bits gate the report. */
+  rboolean osxsave = (ecx & (1u << 27)) != 0;
+  rboolean cpuid_avx = (ecx & (1u << 28)) != 0;
+  ruint64 xcr0 = 0;
+  rboolean os_avx = FALSE, os_avx512 = FALSE;
+
+  if (osxsave) {
+    xcr0 = r_cpu_x86_xgetbv ();
+    os_avx    = (xcr0 & 0x6) == 0x6;
+    os_avx512 = (xcr0 & 0xE6) == 0xE6;
+  }
+
+  if (cpuid_avx && os_avx)
+    ret |= R_CPU_FEATURE_AVX;
+  /* F16C piggybacks on VEX/YMM, so it inherits the AVX OS gate. */
+  if ((ecx & (1u << 29)) && os_avx)
+    ret |= R_CPU_FEATURE_F16C;
+
+  /* Leaf 7 sub-leaf 0: AVX2, AVX-512 family, BMI1/2, SHA-NI, RDSEED. */
+  if (max_leaf >= 7 &&
+      r_cpu_x86_cpuid_count (7, 0, &eax, &ebx, &ecx, &edx)) {
+    if (ebx & (1u <<  3))             ret |= R_CPU_FEATURE_BMI1;
+    if (ebx & (1u <<  8))             ret |= R_CPU_FEATURE_BMI2;
+    if (ebx & (1u << 18))             ret |= R_CPU_FEATURE_RDSEED;
+    if ((ebx & (1u << 29)))           ret |= R_CPU_FEATURE_SHA_NI;
+    if ((ebx & (1u <<  5)) && os_avx) ret |= R_CPU_FEATURE_AVX2;
+    if (os_avx512) {
+      if (ebx & (1u << 16)) ret |= R_CPU_FEATURE_AVX512F;
+      if (ebx & (1u << 17)) ret |= R_CPU_FEATURE_AVX512DQ;
+      if (ebx & (1u << 30)) ret |= R_CPU_FEATURE_AVX512BW;
+      if (ebx & (1u << 31)) ret |= R_CPU_FEATURE_AVX512VL;
+    }
+  }
+
+  (void)edx;
+  return ret;
+}
+
+#elif defined(R_ARCH_AARCH64)
+
+# if defined(R_OS_LINUX)
+
+/* The kernel never reuses HWCAP bits, but a newer extension may not
+ * be in our build's <asm/hwcap.h>. Local fallbacks match the canonical
+ * Linux UAPI bit positions. */
+#  ifndef HWCAP_ASIMD
+#   define HWCAP_ASIMD      (1u <<  1)
+#  endif
+#  ifndef HWCAP_AES
+#   define HWCAP_AES        (1u <<  3)
+#  endif
+#  ifndef HWCAP_PMULL
+#   define HWCAP_PMULL      (1u <<  4)
+#  endif
+#  ifndef HWCAP_SHA1
+#   define HWCAP_SHA1       (1u <<  5)
+#  endif
+#  ifndef HWCAP_SHA2
+#   define HWCAP_SHA2       (1u <<  6)
+#  endif
+#  ifndef HWCAP_CRC32
+#   define HWCAP_CRC32      (1u <<  7)
+#  endif
+#  ifndef HWCAP_ATOMICS
+#   define HWCAP_ATOMICS    (1u <<  8)
+#  endif
+#  ifndef HWCAP_FPHP
+#   define HWCAP_FPHP       (1u <<  9)
+#  endif
+#  ifndef HWCAP_ASIMDHP
+#   define HWCAP_ASIMDHP    (1u << 10)
+#  endif
+#  ifndef HWCAP_SHA3
+#   define HWCAP_SHA3       (1u << 17)
+#  endif
+#  ifndef HWCAP_ASIMDDP
+#   define HWCAP_ASIMDDP    (1u << 20)
+#  endif
+#  ifndef HWCAP_SHA512
+#   define HWCAP_SHA512     (1u << 21)
+#  endif
+#  ifndef HWCAP_SVE
+#   define HWCAP_SVE        (1u << 22)
+#  endif
+#  ifndef HWCAP2_SVE2
+#   define HWCAP2_SVE2      (1u <<  1)
+#  endif
+#  ifndef HWCAP2_I8MM
+#   define HWCAP2_I8MM      (1u << 13)
+#  endif
+#  ifndef HWCAP2_BF16
+#   define HWCAP2_BF16      (1u << 14)
+#  endif
+#  ifndef AT_HWCAP2
+#   define AT_HWCAP2  26
+#  endif
+
+static RCpuFeature
+r_cpu_detect (void)
+{
+  RCpuFeature ret = 0;
+  unsigned long hwcap = getauxval (AT_HWCAP);
+  unsigned long hwcap2 = getauxval (AT_HWCAP2);
+
+  if (hwcap & HWCAP_ASIMD)    ret |= R_CPU_FEATURE_ARM_NEON;
+  if (hwcap & HWCAP_AES)      ret |= R_CPU_FEATURE_ARM_AES;
+  if (hwcap & HWCAP_PMULL)    ret |= R_CPU_FEATURE_ARM_PMULL;
+  if (hwcap & HWCAP_SHA1)     ret |= R_CPU_FEATURE_ARM_SHA1;
+  if (hwcap & HWCAP_SHA2)     ret |= R_CPU_FEATURE_ARM_SHA2;
+  if (hwcap & HWCAP_SHA512)   ret |= R_CPU_FEATURE_ARM_SHA512;
+  if (hwcap & HWCAP_SHA3)     ret |= R_CPU_FEATURE_ARM_SHA3;
+  if (hwcap & HWCAP_CRC32)    ret |= R_CPU_FEATURE_ARM_CRC32;
+  if (hwcap & HWCAP_ATOMICS)  ret |= R_CPU_FEATURE_ARM_LSE;
+  if (hwcap & HWCAP_ASIMDDP)  ret |= R_CPU_FEATURE_ARM_DOTPROD;
+  if (hwcap & HWCAP_FPHP)     ret |= R_CPU_FEATURE_ARM_FPHP;
+  if (hwcap & HWCAP_ASIMDHP)  ret |= R_CPU_FEATURE_ARM_ASIMDHP;
+  if (hwcap & HWCAP_SVE)      ret |= R_CPU_FEATURE_ARM_SVE;
+  if (hwcap2 & HWCAP2_BF16)   ret |= R_CPU_FEATURE_ARM_BF16;
+  if (hwcap2 & HWCAP2_I8MM)   ret |= R_CPU_FEATURE_ARM_I8MM;
+  if (hwcap2 & HWCAP2_SVE2)   ret |= R_CPU_FEATURE_ARM_SVE2;
+  return ret;
+}
+
+# elif defined(R_OS_DARWIN)
+
+static rboolean
+r_cpu_sysctl_present (const char * name)
+{
+  int val = 0;
+  size_t size = sizeof (val);
+  return (sysctlbyname (name, &val, &size, NULL, 0) == 0 && val != 0);
+}
+
+static RCpuFeature
+r_cpu_detect (void)
+{
+  /* NEON is mandatory on AArch64. */
+  RCpuFeature ret = R_CPU_FEATURE_ARM_NEON;
+
+  if (r_cpu_sysctl_present ("hw.optional.arm.FEAT_AES"))
+    ret |= R_CPU_FEATURE_ARM_AES;
+  if (r_cpu_sysctl_present ("hw.optional.arm.FEAT_PMULL"))
+    ret |= R_CPU_FEATURE_ARM_PMULL;
+  if (r_cpu_sysctl_present ("hw.optional.arm.FEAT_SHA1"))
+    ret |= R_CPU_FEATURE_ARM_SHA1;
+  if (r_cpu_sysctl_present ("hw.optional.arm.FEAT_SHA256"))
+    ret |= R_CPU_FEATURE_ARM_SHA2;
+  if (r_cpu_sysctl_present ("hw.optional.arm.FEAT_SHA512"))
+    ret |= R_CPU_FEATURE_ARM_SHA512;
+  if (r_cpu_sysctl_present ("hw.optional.arm.FEAT_SHA3"))
+    ret |= R_CPU_FEATURE_ARM_SHA3;
+  /* Apple's legacy "armv8_crc32" key predates "arm.FEAT_CRC32"; honour
+   * both so older OS versions report correctly. */
+  if (r_cpu_sysctl_present ("hw.optional.arm.FEAT_CRC32") ||
+      r_cpu_sysctl_present ("hw.optional.armv8_crc32"))
+    ret |= R_CPU_FEATURE_ARM_CRC32;
+  if (r_cpu_sysctl_present ("hw.optional.arm.FEAT_LSE"))
+    ret |= R_CPU_FEATURE_ARM_LSE;
+  if (r_cpu_sysctl_present ("hw.optional.arm.FEAT_DotProd"))
+    ret |= R_CPU_FEATURE_ARM_DOTPROD;
+  if (r_cpu_sysctl_present ("hw.optional.arm.FEAT_FP16"))
+    ret |= R_CPU_FEATURE_ARM_FPHP | R_CPU_FEATURE_ARM_ASIMDHP;
+  if (r_cpu_sysctl_present ("hw.optional.arm.FEAT_BF16"))
+    ret |= R_CPU_FEATURE_ARM_BF16;
+  if (r_cpu_sysctl_present ("hw.optional.arm.FEAT_I8MM"))
+    ret |= R_CPU_FEATURE_ARM_I8MM;
+  return ret;
+}
+
+# elif defined(R_OS_WIN32)
+
+#  ifndef PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE
+#   define PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE   34
+#  endif
+#  ifndef PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE
+#   define PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE  30
+#  endif
+
+static RCpuFeature
+r_cpu_detect (void)
+{
+  /* NEON is mandatory on AArch64. */
+  RCpuFeature ret = R_CPU_FEATURE_ARM_NEON;
+  if (IsProcessorFeaturePresent (PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE))
+    ret |= R_CPU_FEATURE_ARM_CRC32;
+  /* Windows bundles AES + PMULL + SHA1/2 under a single "crypto
+   * extensions" predicate; treat them as a quartet. */
+  if (IsProcessorFeaturePresent (PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE))
+    ret |= R_CPU_FEATURE_ARM_AES | R_CPU_FEATURE_ARM_PMULL |
+           R_CPU_FEATURE_ARM_SHA1 | R_CPU_FEATURE_ARM_SHA2;
+  return ret;
+}
+
+# else
+
+static RCpuFeature r_cpu_detect (void) { return 0; }
+
+# endif
+
+#else
+
+static RCpuFeature r_cpu_detect (void) { return 0; }
+
+#endif
+
+static rpointer
+r_cpu_features_detect_once (rpointer user)
+{
+  (void)user;
+  g__r_cpu_features = r_cpu_detect ();
+  return NULL;
+}
+
+RCpuFeature
+r_cpu_features (void)
+{
+  r_call_once (&g__r_cpu_features_once, r_cpu_features_detect_once, NULL);
+  return g__r_cpu_features;
+}
+
+rboolean
+r_cpu_has (RCpuFeature feature)
+{
+  return (r_cpu_features () & feature) != 0;
+}
+
+const rchar *
+r_cpu_feature_name (RCpuFeature feature)
+{
+  if (feature == R_CPU_FEATURE_NONE)
+    return "None";
+  switch (feature) {
+#define R_CPU_FEATURE_NAME_CASE(name, str) \
+    case R_CPU_FEATURE_##name: return str;
+    R_CPU_FOREACH_FEATURE (R_CPU_FEATURE_NAME_CASE)
+#undef R_CPU_FEATURE_NAME_CASE
+    default: return "Unknown";
+  }
+}
+
+const RCpuFeature *
+r_cpu_features_all (rsize * count)
+{
+  *count = R_N_ELEMENTS (g__r_cpu_features_known);
+  return g__r_cpu_features_known;
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -14,6 +14,7 @@ rlibtest_sources = [
   'rcbqueue.c',
   'rcbrlist.c',
   'rclock.c',
+  'rcpufeatures.c',
   'rcrc.c',
   'rcryptocert.c',
   'rcryptocipher.c',

--- a/test/rcpufeatures.c
+++ b/test/rcpufeatures.c
@@ -1,0 +1,102 @@
+#include <rlib/rlib.h>
+
+RTEST (rcpufeatures, features_is_cached, RTEST_FAST)
+{
+  r_assert_cmpuint (r_cpu_features (), ==, r_cpu_features ());
+  r_assert (!r_cpu_has (R_CPU_FEATURE_NONE));
+}
+RTEST_END;
+
+RTEST (rcpufeatures, has_matches_features_bitmask, RTEST_FAST)
+{
+  RCpuFeature features = r_cpu_features ();
+  rsize i, n;
+  const RCpuFeature * all = r_cpu_features_all (&n);
+
+  r_assert_cmpuint (n, >, 0);
+  for (i = 0; i < n; i++) {
+    rboolean masked = (features & all[i]) != 0;
+    r_assert_cmpint (r_cpu_has (all[i]), ==, masked);
+  }
+}
+RTEST_END;
+
+RTEST (rcpufeatures, all_flags_are_single_bits, RTEST_FAST)
+{
+  rsize i, n;
+  const RCpuFeature * all = r_cpu_features_all (&n);
+
+  for (i = 0; i < n; i++) {
+    RCpuFeature f = all[i];
+    r_assert_cmpuint (f, !=, 0);
+    /* x & (x - 1) == 0 iff x is a power of two. */
+    r_assert_cmpuint (f & (f - 1), ==, 0);
+  }
+}
+RTEST_END;
+
+RTEST (rcpufeatures, all_flags_are_unique, RTEST_FAST)
+{
+  rsize i, n;
+  const RCpuFeature * all = r_cpu_features_all (&n);
+  RCpuFeature combined = 0;
+
+  for (i = 0; i < n; i++) {
+    r_assert_cmpuint (combined & all[i], ==, 0);
+    combined |= all[i];
+  }
+}
+RTEST_END;
+
+RTEST (rcpufeatures, feature_name_round_trips, RTEST_FAST)
+{
+  rsize i, n;
+  const RCpuFeature * all = r_cpu_features_all (&n);
+
+  for (i = 0; i < n; i++) {
+    const rchar * name = r_cpu_feature_name (all[i]);
+    r_assert_cmpptr (name, !=, NULL);
+    r_assert_cmpstr (name, !=, "Unknown");
+    r_assert_cmpstr (name, !=, "");
+  }
+}
+RTEST_END;
+
+RTEST (rcpufeatures, feature_name_invalid_input, RTEST_FAST)
+{
+  r_assert_cmpstr (r_cpu_feature_name (R_CPU_FEATURE_NONE), ==, "None");
+  r_assert_cmpstr (r_cpu_feature_name (R_CPU_FEATURE_SSE | R_CPU_FEATURE_SSE2),
+      ==, "Unknown");
+  r_assert_cmpstr (r_cpu_feature_name ((RCpuFeature)1 << 62), ==, "Unknown");
+}
+RTEST_END;
+
+RTEST (rcpufeatures, arch_groups_disjoint, RTEST_FAST)
+{
+  /* No real CPU has x86 and AArch64 extensions reported at the same
+   * time - the detection backends are mutually exclusive per arch. */
+  RCpuFeature x86_mask = R_CPU_FEATURE_SSE        | R_CPU_FEATURE_SSE2     |
+                         R_CPU_FEATURE_SSE3       | R_CPU_FEATURE_SSSE3    |
+                         R_CPU_FEATURE_SSE4_1     | R_CPU_FEATURE_SSE4_2   |
+                         R_CPU_FEATURE_AES_NI     | R_CPU_FEATURE_PCLMUL   |
+                         R_CPU_FEATURE_AVX        | R_CPU_FEATURE_AVX2     |
+                         R_CPU_FEATURE_AVX512F    | R_CPU_FEATURE_AVX512BW |
+                         R_CPU_FEATURE_AVX512DQ   | R_CPU_FEATURE_AVX512VL |
+                         R_CPU_FEATURE_SHA_NI     | R_CPU_FEATURE_BMI1     |
+                         R_CPU_FEATURE_BMI2       | R_CPU_FEATURE_POPCNT   |
+                         R_CPU_FEATURE_F16C       | R_CPU_FEATURE_RDRAND   |
+                         R_CPU_FEATURE_RDSEED;
+  RCpuFeature arm_mask = R_CPU_FEATURE_ARM_NEON   | R_CPU_FEATURE_ARM_AES  |
+                         R_CPU_FEATURE_ARM_PMULL  | R_CPU_FEATURE_ARM_SHA1 |
+                         R_CPU_FEATURE_ARM_SHA2   |
+                         R_CPU_FEATURE_ARM_SHA512 | R_CPU_FEATURE_ARM_SHA3 |
+                         R_CPU_FEATURE_ARM_CRC32  | R_CPU_FEATURE_ARM_LSE  |
+                         R_CPU_FEATURE_ARM_DOTPROD| R_CPU_FEATURE_ARM_FPHP |
+                         R_CPU_FEATURE_ARM_ASIMDHP| R_CPU_FEATURE_ARM_BF16 |
+                         R_CPU_FEATURE_ARM_I8MM   | R_CPU_FEATURE_ARM_SVE  |
+                         R_CPU_FEATURE_ARM_SVE2;
+  RCpuFeature features = r_cpu_features ();
+
+  r_assert (!((features & x86_mask) && (features & arm_mask)));
+}
+RTEST_END;


### PR DESCRIPTION
## Summary

New public module @c rlib/rcpufeatures that probes the host CPU's optional instruction-set extensions at runtime and exposes them through a small, library-shaped API. Foundation for the upcoming hardware-accelerated dispatch paths (CRC32C SSE4.2 / ARMv8 CRC32 in the followup #156 PR; AES-NI / ARMv8 AES in the eventual #30 work) and useful on its own for diagnostics, banners, build sanity checks.

## API

```c
RCpuFeature r_cpu_features (void);
rboolean r_cpu_has (RCpuFeature feature);
const rchar * r_cpu_feature_name (RCpuFeature feature);
const RCpuFeature * r_cpu_features_all (rsize * count);
```

Idiomatic listing:

```c
rsize n;
const RCpuFeature *all = r_cpu_features_all (&n);
for (rsize i = 0; i < n; i++)
  if (r_cpu_has (all[i]))
    printf ("  %s\n", r_cpu_feature_name (all[i]));
```

## Feature coverage

| Family | Flags |
|---|---|
| x86 base SSE | `SSE` `SSE2` `SSE3` `SSSE3` `SSE4_1` `SSE4_2` `AES_NI` `PCLMUL` |
| x86 AVX | `AVX` `AVX2` `AVX512F` `AVX512BW` `AVX512DQ` `AVX512VL` |
| x86 misc | `SHA_NI` `BMI1` `BMI2` `POPCNT` `F16C` `RDRAND` `RDSEED` |
| AArch64 base + crypto | `ARM_NEON` `ARM_AES` `ARM_PMULL` `ARM_SHA1` `ARM_SHA2` `ARM_SHA512` `ARM_SHA3` `ARM_CRC32` |
| AArch64 misc | `ARM_LSE` `ARM_DOTPROD` `ARM_FPHP` `ARM_ASIMDHP` `ARM_BF16` `ARM_I8MM` `ARM_SVE` `ARM_SVE2` |

40 flags total. The list lives behind an X-macro so the known-feature table and the name lookup can't drift apart.

## Correctness notes

- **AVX OS gate.** AVX / AVX2 / AVX-512 / F16C are only reported when both cpuid says yes *and* the OS has enabled the wider XSAVE state (`OSXSAVE` + the relevant `xcr0` bits via `xgetbv`). Issuing an AVX instruction without OS state corrupts FP across context switches; the bench-side fallback can't recover from that, so we never lie.
- **`r_call_once` init.** Detection runs once on first query, then the cache is a plain load. The `r_call_once` CAS uses SEQ_CST, so subsequent readers happen-after the cache write — no torn reads.
- **NEON on AArch64.** Mandatory architecturally, so the AArch64 backends always set the bit even when the kernel/sysctl doesn't expose it explicitly.

## Sample listing (x86_64 Linux, Zen3-class)

```
CPU features (bitmask 0x00000000007f03ff):
  + SSE  + SSE2  + SSE3  + SSSE3  + SSE4.1  + SSE4.2
  + AES-NI  + PCLMUL  + AVX  + AVX2  + SHA-NI
  + BMI1  + BMI2  + POPCNT  + F16C  + RDRAND  + RDSEED
```

## Test plan

- [x] 7 new `/rcpufeatures/` tests: cache idempotence, has-vs-features agreement, single-bit per flag, no duplicates, name round-trip, name on invalid input (`NONE` → `"None"`, OR / unallocated → `"Unknown"`), arch-group disjointness.
- [x] Full 1523-test suite still green.
- [x] Doxygen builds without warnings on the new header.
- [x] Cached detection output verified on x86_64 Linux (17 features reported, all named cleanly).
- [x] CI green on the PR.