### PR TITLE
crypto: Hardware-accelerated AES via AES-NI / ARMv8 AES

### DIFF
--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -20,8 +20,17 @@
 #include <rlib/crypto/raes.h>
 #include <rlib/crypto/raes-data.inc>
 
+#include <rlib/rcpufeatures.h>
 #include <rlib/rmem.h>
 #include <rlib/rstr.h>
+
+#if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
+# include <wmmintrin.h>           /* AES-NI */
+#endif
+
+#if defined(R_ARCH_AARCH64)
+# include <arm_neon.h>            /* ARMv8 AES */
+#endif
 
 #define R_AES_MAX_KEY_BYTES   32
 
@@ -419,6 +428,107 @@ r_cipher_aes_new_from_hex (RCryptoCipherMode mode, const rchar * hexkey)
   return ret;
 }
 
+#if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
+/* AES-NI uses the same {LE u32} round-key layout the SW path
+ * already produces - _mm_loadu_si128 sees the four LE u32s as a
+ * 16-byte block with byte 0 in the low lane, matching the AES
+ * state's column-major layout. Decrypt likewise consumes drk
+ * directly since the SW key schedule pre-applies InvMixColumns
+ * to the middle keys, which is what _mm_aesdec_si128 expects. */
+# if defined(__GNUC__) || defined(__clang__)
+__attribute__((target("aes,sse2")))
+# endif
+static rboolean
+r_cipher_aes_ecb_encrypt_block_aesni (const RAesCipher * aes,
+    ruint8 ciphertxt[R_AES_BLOCK_BYTES],
+    const ruint8 plaintxt[R_AES_BLOCK_BYTES])
+{
+  __m128i block = _mm_loadu_si128 ((const __m128i *)plaintxt);
+  const __m128i * rk = (const __m128i *)aes->erk;
+  ruint8 i;
+
+  block = _mm_xor_si128 (block, _mm_loadu_si128 (rk++));
+  for (i = 1; i < aes->rounds; i++, rk++)
+    block = _mm_aesenc_si128 (block, _mm_loadu_si128 (rk));
+  block = _mm_aesenclast_si128 (block, _mm_loadu_si128 (rk));
+
+  _mm_storeu_si128 ((__m128i *)ciphertxt, block);
+  return TRUE;
+}
+
+# if defined(__GNUC__) || defined(__clang__)
+__attribute__((target("aes,sse2")))
+# endif
+static rboolean
+r_cipher_aes_ecb_decrypt_block_aesni (const RAesCipher * aes,
+    ruint8 plaintxt[R_AES_BLOCK_BYTES],
+    const ruint8 ciphertxt[R_AES_BLOCK_BYTES])
+{
+  __m128i block = _mm_loadu_si128 ((const __m128i *)ciphertxt);
+  const __m128i * rk = (const __m128i *)aes->drk;
+  ruint8 i;
+
+  block = _mm_xor_si128 (block, _mm_loadu_si128 (rk++));
+  for (i = 1; i < aes->rounds; i++, rk++)
+    block = _mm_aesdec_si128 (block, _mm_loadu_si128 (rk));
+  block = _mm_aesdeclast_si128 (block, _mm_loadu_si128 (rk));
+
+  _mm_storeu_si128 ((__m128i *)plaintxt, block);
+  return TRUE;
+}
+#endif
+
+#if defined(R_ARCH_AARCH64) && !defined(_MSC_VER)
+/* ARMv8 AESE/AESD do (AddRoundKey then SubBytes/ShiftRows) in a
+ * single instruction, paired with AESMC/AESIMC for MixColumns.
+ * Decrypt expects the encrypt round keys in reverse order - the
+ * SW drk array (InvMixColumns pre-applied) doesn't match, so the
+ * decrypt path walks erk backward instead. */
+__attribute__((target("+crypto")))
+static rboolean
+r_cipher_aes_ecb_encrypt_block_armv8 (const RAesCipher * aes,
+    ruint8 ciphertxt[R_AES_BLOCK_BYTES],
+    const ruint8 plaintxt[R_AES_BLOCK_BYTES])
+{
+  uint8x16_t block = vld1q_u8 (plaintxt);
+  const ruint8 * rk = (const ruint8 *)aes->erk;
+  ruint8 i;
+
+  for (i = 0; i < aes->rounds - 1; i++, rk += 16) {
+    block = vaeseq_u8 (block, vld1q_u8 (rk));
+    block = vaesmcq_u8 (block);
+  }
+  block = vaeseq_u8 (block, vld1q_u8 (rk));
+  rk += 16;
+  block = veorq_u8 (block, vld1q_u8 (rk));
+
+  vst1q_u8 (ciphertxt, block);
+  return TRUE;
+}
+
+__attribute__((target("+crypto")))
+static rboolean
+r_cipher_aes_ecb_decrypt_block_armv8 (const RAesCipher * aes,
+    ruint8 plaintxt[R_AES_BLOCK_BYTES],
+    const ruint8 ciphertxt[R_AES_BLOCK_BYTES])
+{
+  uint8x16_t block = vld1q_u8 (ciphertxt);
+  const ruint8 * rk = (const ruint8 *)aes->erk + aes->rounds * 16;
+  ruint8 i;
+
+  for (i = 0; i < aes->rounds - 1; i++, rk -= 16) {
+    block = vaesdq_u8 (block, vld1q_u8 (rk));
+    block = vaesimcq_u8 (block);
+  }
+  block = vaesdq_u8 (block, vld1q_u8 (rk));
+  rk -= 16;
+  block = veorq_u8 (block, vld1q_u8 (rk));
+
+  vst1q_u8 (plaintxt, block);
+  return TRUE;
+}
+#endif
+
 rboolean
 r_cipher_aes_ecb_encrypt_block (const RCryptoCipher * cipher,
     ruint8 ciphertxt[R_AES_BLOCK_BYTES], const ruint8 plaintxt[R_AES_BLOCK_BYTES])
@@ -431,6 +541,15 @@ r_cipher_aes_ecb_encrypt_block (const RCryptoCipher * cipher,
   if (R_UNLIKELY (cipher == NULL)) return FALSE;
 
   aes = (const RAesCipher *)cipher;
+
+#if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
+  if (r_cpu_has (R_CPU_FEATURE_AES_NI))
+    return r_cipher_aes_ecb_encrypt_block_aesni (aes, ciphertxt, plaintxt);
+#elif defined(R_ARCH_AARCH64) && !defined(_MSC_VER)
+  if (r_cpu_has (R_CPU_FEATURE_ARM_AES))
+    return r_cipher_aes_ecb_encrypt_block_armv8 (aes, ciphertxt, plaintxt);
+#endif
+
   rk = aes->erk;
 
   input[0] = r_load_le32 (&plaintxt[0x0]) ^ *rk++;
@@ -486,6 +605,15 @@ r_cipher_aes_ecb_decrypt_block (const RCryptoCipher * cipher,
   if (R_UNLIKELY (cipher == NULL)) return FALSE;
 
   aes = (const RAesCipher *)cipher;
+
+#if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
+  if (r_cpu_has (R_CPU_FEATURE_AES_NI))
+    return r_cipher_aes_ecb_decrypt_block_aesni (aes, plaintxt, ciphertxt);
+#elif defined(R_ARCH_AARCH64) && !defined(_MSC_VER)
+  if (r_cpu_has (R_CPU_FEATURE_ARM_AES))
+    return r_cipher_aes_ecb_decrypt_block_armv8 (aes, plaintxt, ciphertxt);
+#endif
+
   rk = aes->drk;
 
   input[0] = r_load_le32 (&ciphertxt[0x0]) ^ *rk++;

--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -682,14 +682,14 @@ R_AES_AESNI_BLOCKS_X4 (r_cipher_aes_ecb_decrypt_blocks_aesni_256, drk,
       ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES])    \
   {                                                                          \
     uint8x16_t block = vld1q_u8 (src);                                       \
-    const ruint8 * rk = (const ruint8 *)aes->erk + (rounds) * 16;            \
+    const ruint8 * rk = (const ruint8 *)aes->drk;                            \
     ruint8 i;                                                                \
-    for (i = 0; i < (rounds) - 1; i++, rk -= 16) {                           \
+    for (i = 0; i < (rounds) - 1; i++, rk += 16) {                           \
       block = vaesdq_u8 (block, vld1q_u8 (rk));                              \
       block = vaesimcq_u8 (block);                                           \
     }                                                                        \
     block = vaesdq_u8 (block, vld1q_u8 (rk));                                \
-    rk -= 16;                                                                \
+    rk += 16;                                                                \
     block = veorq_u8 (block, vld1q_u8 (rk));                                 \
     vst1q_u8 (dst, block);                                                   \
     return TRUE;                                                             \
@@ -744,17 +744,17 @@ R_AES_ARMV8_DECRYPT (r_cipher_aes_ecb_decrypt_block_armv8_256, 14)
     uint8x16_t b1 = vld1q_u8 (src + 16);                                      \
     uint8x16_t b2 = vld1q_u8 (src + 32);                                      \
     uint8x16_t b3 = vld1q_u8 (src + 48);                                      \
-    const ruint8 * rk = (const ruint8 *)aes->erk + (rounds) * 16;             \
+    const ruint8 * rk = (const ruint8 *)aes->drk;                             \
     uint8x16_t k;                                                             \
     ruint8 i;                                                                 \
-    for (i = 0; i < (rounds) - 1; i++, rk -= 16) {                            \
+    for (i = 0; i < (rounds) - 1; i++, rk += 16) {                            \
       k = vld1q_u8 (rk);                                                      \
       b0 = vaesdq_u8 (b0, k); b0 = vaesimcq_u8 (b0);                          \
       b1 = vaesdq_u8 (b1, k); b1 = vaesimcq_u8 (b1);                          \
       b2 = vaesdq_u8 (b2, k); b2 = vaesimcq_u8 (b2);                          \
       b3 = vaesdq_u8 (b3, k); b3 = vaesimcq_u8 (b3);                          \
     }                                                                         \
-    k = vld1q_u8 (rk); rk -= 16;                                              \
+    k = vld1q_u8 (rk); rk += 16;                                              \
     b0 = vaesdq_u8 (b0, k); b1 = vaesdq_u8 (b1, k);                           \
     b2 = vaesdq_u8 (b2, k); b3 = vaesdq_u8 (b3, k);                           \
     k = vld1q_u8 (rk);                                                        \

--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -62,9 +62,14 @@
       r_aes_rtbl[0][(Y[3]      ) & 0xff] ^ r_aes_rtbl[1][(Y[2] >>  8) & 0xff] ^\
       r_aes_rtbl[2][(Y[1] >> 16) & 0xff] ^ r_aes_rtbl[3][(Y[0] >> 24) & 0xff];
 
+#define R_AES_PARALLEL_BLOCKS  4
+#define R_AES_PARALLEL_BYTES   (R_AES_PARALLEL_BLOCKS * R_AES_BLOCK_BYTES)
+
 typedef struct _RAesCipher RAesCipher;
 typedef rboolean (*RAesBlockFn) (const RAesCipher * aes,
     ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES]);
+typedef void (*RAesBlocksFn) (const RAesCipher * aes,
+    ruint8 * dst, const ruint8 * src);
 
 struct _RAesCipher {
   RCryptoCipher cipher;
@@ -80,31 +85,53 @@ struct _RAesCipher {
    * feature check + extra branch on every block dispatch. */
   RAesBlockFn encrypt_block;
   RAesBlockFn decrypt_block;
+
+  /* 4-way parallel kernels used by the parallelizable mode loops
+   * (ECB, CTR, CBC-decrypt, CFB-decrypt). NULL on the SW path -
+   * mode loops fall back to encrypt_block / decrypt_block in
+   * that case. */
+  RAesBlocksFn encrypt_blocks_x4;
+  RAesBlocksFn decrypt_blocks_x4;
 };
 
 #define R_AES_BLOCK_FN_DECL(name)                                              \
   static rboolean name (const RAesCipher * aes,                                \
       ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES])
+#define R_AES_BLOCKS_FN_DECL(name)                                             \
+  static void name (const RAesCipher * aes,                                    \
+      ruint8 * dst, const ruint8 * src)
 
 R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_encrypt_block_sw);
 R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_decrypt_block_sw);
 
 #if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
-R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_encrypt_block_aesni_128);
-R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_encrypt_block_aesni_192);
-R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_encrypt_block_aesni_256);
-R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_decrypt_block_aesni_128);
-R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_decrypt_block_aesni_192);
-R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_decrypt_block_aesni_256);
+R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_encrypt_block_aesni_128);
+R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_encrypt_block_aesni_192);
+R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_encrypt_block_aesni_256);
+R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_decrypt_block_aesni_128);
+R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_decrypt_block_aesni_192);
+R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_decrypt_block_aesni_256);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_encrypt_blocks_aesni_128);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_encrypt_blocks_aesni_192);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_encrypt_blocks_aesni_256);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks_aesni_128);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks_aesni_192);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks_aesni_256);
 #endif
 
 #if defined(R_ARCH_AARCH64)
-R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_encrypt_block_armv8_128);
-R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_encrypt_block_armv8_192);
-R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_encrypt_block_armv8_256);
-R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_decrypt_block_armv8_128);
-R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_decrypt_block_armv8_192);
-R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_decrypt_block_armv8_256);
+R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_encrypt_block_armv8_128);
+R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_encrypt_block_armv8_192);
+R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_encrypt_block_armv8_256);
+R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_decrypt_block_armv8_128);
+R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_decrypt_block_armv8_192);
+R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_decrypt_block_armv8_256);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_encrypt_blocks_armv8_128);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_encrypt_blocks_armv8_192);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_encrypt_blocks_armv8_256);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks_armv8_128);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks_armv8_192);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks_armv8_256);
 #endif
 
 const RCryptoCipherInfo g__r_crypto_cipher_aes_128_ecb =  { "AES-128-ECB",
@@ -297,16 +324,22 @@ r_cipher_aes_new_with_info (const RCryptoCipherInfo * info, const ruint8 * key)
     if (r_cpu_has (R_CPU_FEATURE_AES_NI)) {
       switch (ret->rounds) {
         case 10:
-          ret->encrypt_block = r_cipher_aes_ecb_encrypt_block_aesni_128;
-          ret->decrypt_block = r_cipher_aes_ecb_decrypt_block_aesni_128;
+          ret->encrypt_block      = r_cipher_aes_ecb_encrypt_block_aesni_128;
+          ret->decrypt_block      = r_cipher_aes_ecb_decrypt_block_aesni_128;
+          ret->encrypt_blocks_x4  = r_cipher_aes_ecb_encrypt_blocks_aesni_128;
+          ret->decrypt_blocks_x4  = r_cipher_aes_ecb_decrypt_blocks_aesni_128;
           break;
         case 12:
-          ret->encrypt_block = r_cipher_aes_ecb_encrypt_block_aesni_192;
-          ret->decrypt_block = r_cipher_aes_ecb_decrypt_block_aesni_192;
+          ret->encrypt_block      = r_cipher_aes_ecb_encrypt_block_aesni_192;
+          ret->decrypt_block      = r_cipher_aes_ecb_decrypt_block_aesni_192;
+          ret->encrypt_blocks_x4  = r_cipher_aes_ecb_encrypt_blocks_aesni_192;
+          ret->decrypt_blocks_x4  = r_cipher_aes_ecb_decrypt_blocks_aesni_192;
           break;
         default: /* 14 = AES-256 */
-          ret->encrypt_block = r_cipher_aes_ecb_encrypt_block_aesni_256;
-          ret->decrypt_block = r_cipher_aes_ecb_decrypt_block_aesni_256;
+          ret->encrypt_block      = r_cipher_aes_ecb_encrypt_block_aesni_256;
+          ret->decrypt_block      = r_cipher_aes_ecb_decrypt_block_aesni_256;
+          ret->encrypt_blocks_x4  = r_cipher_aes_ecb_encrypt_blocks_aesni_256;
+          ret->decrypt_blocks_x4  = r_cipher_aes_ecb_decrypt_blocks_aesni_256;
           break;
       }
     } else
@@ -314,23 +347,31 @@ r_cipher_aes_new_with_info (const RCryptoCipherInfo * info, const ruint8 * key)
     if (r_cpu_has (R_CPU_FEATURE_ARM_AES)) {
       switch (ret->rounds) {
         case 10:
-          ret->encrypt_block = r_cipher_aes_ecb_encrypt_block_armv8_128;
-          ret->decrypt_block = r_cipher_aes_ecb_decrypt_block_armv8_128;
+          ret->encrypt_block      = r_cipher_aes_ecb_encrypt_block_armv8_128;
+          ret->decrypt_block      = r_cipher_aes_ecb_decrypt_block_armv8_128;
+          ret->encrypt_blocks_x4  = r_cipher_aes_ecb_encrypt_blocks_armv8_128;
+          ret->decrypt_blocks_x4  = r_cipher_aes_ecb_decrypt_blocks_armv8_128;
           break;
         case 12:
-          ret->encrypt_block = r_cipher_aes_ecb_encrypt_block_armv8_192;
-          ret->decrypt_block = r_cipher_aes_ecb_decrypt_block_armv8_192;
+          ret->encrypt_block      = r_cipher_aes_ecb_encrypt_block_armv8_192;
+          ret->decrypt_block      = r_cipher_aes_ecb_decrypt_block_armv8_192;
+          ret->encrypt_blocks_x4  = r_cipher_aes_ecb_encrypt_blocks_armv8_192;
+          ret->decrypt_blocks_x4  = r_cipher_aes_ecb_decrypt_blocks_armv8_192;
           break;
         default: /* 14 = AES-256 */
-          ret->encrypt_block = r_cipher_aes_ecb_encrypt_block_armv8_256;
-          ret->decrypt_block = r_cipher_aes_ecb_decrypt_block_armv8_256;
+          ret->encrypt_block      = r_cipher_aes_ecb_encrypt_block_armv8_256;
+          ret->decrypt_block      = r_cipher_aes_ecb_decrypt_block_armv8_256;
+          ret->encrypt_blocks_x4  = r_cipher_aes_ecb_encrypt_blocks_armv8_256;
+          ret->decrypt_blocks_x4  = r_cipher_aes_ecb_decrypt_blocks_armv8_256;
           break;
       }
     } else
 #endif
     {
-      ret->encrypt_block = r_cipher_aes_ecb_encrypt_block_sw;
-      ret->decrypt_block = r_cipher_aes_ecb_decrypt_block_sw;
+      ret->encrypt_block      = r_cipher_aes_ecb_encrypt_block_sw;
+      ret->decrypt_block      = r_cipher_aes_ecb_decrypt_block_sw;
+      ret->encrypt_blocks_x4  = NULL;  /* mode loops fall back to single-block */
+      ret->decrypt_blocks_x4  = NULL;
     }
   }
 
@@ -550,6 +591,53 @@ R_AES_AESNI_BLOCK (r_cipher_aes_ecb_decrypt_block_aesni_192, drk,
     _mm_aesdec_si128, _mm_aesdeclast_si128, 12)
 R_AES_AESNI_BLOCK (r_cipher_aes_ecb_decrypt_block_aesni_256, drk,
     _mm_aesdec_si128, _mm_aesdeclast_si128, 14)
+
+/* 4-way parallel kernel: four independent blocks fed through the
+ * round-key chain at every step. AESENC has 1-cycle throughput +
+ * 4-cycle latency on Zen3 / Skylake+, so the 4-way interleave
+ * lets the CPU schedule a new AESENC every cycle instead of
+ * waiting for the prior round to retire - lifts ECB-128 above
+ * 15 GiB/s vs the ~9 GiB/s single-block ceiling. */
+# define R_AES_AESNI_BLOCKS_X4(name, key_arr, op_round, op_last, rounds)     \
+  R_AES_X86_TARGET                                                           \
+  static void                                                                \
+  name (const RAesCipher * aes, ruint8 * dst, const ruint8 * src)            \
+  {                                                                          \
+    __m128i b0 = _mm_loadu_si128 ((const __m128i *)(src     ));              \
+    __m128i b1 = _mm_loadu_si128 ((const __m128i *)(src + 16));              \
+    __m128i b2 = _mm_loadu_si128 ((const __m128i *)(src + 32));              \
+    __m128i b3 = _mm_loadu_si128 ((const __m128i *)(src + 48));              \
+    const __m128i * rk = (const __m128i *)aes->key_arr;                      \
+    __m128i k = _mm_loadu_si128 (rk++);                                      \
+    ruint8 i;                                                                \
+    b0 = _mm_xor_si128 (b0, k); b1 = _mm_xor_si128 (b1, k);                  \
+    b2 = _mm_xor_si128 (b2, k); b3 = _mm_xor_si128 (b3, k);                  \
+    for (i = 1; i < (rounds); i++, rk++) {                                   \
+      k = _mm_loadu_si128 (rk);                                              \
+      b0 = op_round (b0, k); b1 = op_round (b1, k);                          \
+      b2 = op_round (b2, k); b3 = op_round (b3, k);                          \
+    }                                                                        \
+    k = _mm_loadu_si128 (rk);                                                \
+    b0 = op_last (b0, k); b1 = op_last (b1, k);                              \
+    b2 = op_last (b2, k); b3 = op_last (b3, k);                              \
+    _mm_storeu_si128 ((__m128i *)(dst     ), b0);                            \
+    _mm_storeu_si128 ((__m128i *)(dst + 16), b1);                            \
+    _mm_storeu_si128 ((__m128i *)(dst + 32), b2);                            \
+    _mm_storeu_si128 ((__m128i *)(dst + 48), b3);                            \
+  }
+
+R_AES_AESNI_BLOCKS_X4 (r_cipher_aes_ecb_encrypt_blocks_aesni_128, erk,
+    _mm_aesenc_si128, _mm_aesenclast_si128, 10)
+R_AES_AESNI_BLOCKS_X4 (r_cipher_aes_ecb_encrypt_blocks_aesni_192, erk,
+    _mm_aesenc_si128, _mm_aesenclast_si128, 12)
+R_AES_AESNI_BLOCKS_X4 (r_cipher_aes_ecb_encrypt_blocks_aesni_256, erk,
+    _mm_aesenc_si128, _mm_aesenclast_si128, 14)
+R_AES_AESNI_BLOCKS_X4 (r_cipher_aes_ecb_decrypt_blocks_aesni_128, drk,
+    _mm_aesdec_si128, _mm_aesdeclast_si128, 10)
+R_AES_AESNI_BLOCKS_X4 (r_cipher_aes_ecb_decrypt_blocks_aesni_192, drk,
+    _mm_aesdec_si128, _mm_aesdeclast_si128, 12)
+R_AES_AESNI_BLOCKS_X4 (r_cipher_aes_ecb_decrypt_blocks_aesni_256, drk,
+    _mm_aesdec_si128, _mm_aesdeclast_si128, 14)
 #endif
 
 #if defined(R_ARCH_AARCH64)
@@ -613,6 +701,75 @@ R_AES_ARMV8_ENCRYPT (r_cipher_aes_ecb_encrypt_block_armv8_256, 14)
 R_AES_ARMV8_DECRYPT (r_cipher_aes_ecb_decrypt_block_armv8_128, 10)
 R_AES_ARMV8_DECRYPT (r_cipher_aes_ecb_decrypt_block_armv8_192, 12)
 R_AES_ARMV8_DECRYPT (r_cipher_aes_ecb_decrypt_block_armv8_256, 14)
+
+/* 4-way parallel kernels - same rationale as the AES-NI multi-
+ * block path: ARMv8 AESE / AESD have 3-cycle latency / 1-cycle
+ * throughput on Cortex / Apple Silicon, so interleaving 4
+ * independent blocks keeps the pipeline full. */
+# define R_AES_ARMV8_BLOCKS_X4_ENCRYPT(name, rounds)                          \
+  R_AES_ARM_TARGET                                                            \
+  static void                                                                 \
+  name (const RAesCipher * aes, ruint8 * dst, const ruint8 * src)             \
+  {                                                                           \
+    uint8x16_t b0 = vld1q_u8 (src);                                           \
+    uint8x16_t b1 = vld1q_u8 (src + 16);                                      \
+    uint8x16_t b2 = vld1q_u8 (src + 32);                                      \
+    uint8x16_t b3 = vld1q_u8 (src + 48);                                      \
+    const ruint8 * rk = (const ruint8 *)aes->erk;                             \
+    uint8x16_t k;                                                             \
+    ruint8 i;                                                                 \
+    for (i = 0; i < (rounds) - 1; i++, rk += 16) {                            \
+      k = vld1q_u8 (rk);                                                      \
+      b0 = vaeseq_u8 (b0, k); b0 = vaesmcq_u8 (b0);                           \
+      b1 = vaeseq_u8 (b1, k); b1 = vaesmcq_u8 (b1);                           \
+      b2 = vaeseq_u8 (b2, k); b2 = vaesmcq_u8 (b2);                           \
+      b3 = vaeseq_u8 (b3, k); b3 = vaesmcq_u8 (b3);                           \
+    }                                                                         \
+    k = vld1q_u8 (rk); rk += 16;                                              \
+    b0 = vaeseq_u8 (b0, k); b1 = vaeseq_u8 (b1, k);                           \
+    b2 = vaeseq_u8 (b2, k); b3 = vaeseq_u8 (b3, k);                           \
+    k = vld1q_u8 (rk);                                                        \
+    b0 = veorq_u8 (b0, k); b1 = veorq_u8 (b1, k);                             \
+    b2 = veorq_u8 (b2, k); b3 = veorq_u8 (b3, k);                             \
+    vst1q_u8 (dst     , b0); vst1q_u8 (dst + 16, b1);                         \
+    vst1q_u8 (dst + 32, b2); vst1q_u8 (dst + 48, b3);                         \
+  }
+
+# define R_AES_ARMV8_BLOCKS_X4_DECRYPT(name, rounds)                          \
+  R_AES_ARM_TARGET                                                            \
+  static void                                                                 \
+  name (const RAesCipher * aes, ruint8 * dst, const ruint8 * src)             \
+  {                                                                           \
+    uint8x16_t b0 = vld1q_u8 (src);                                           \
+    uint8x16_t b1 = vld1q_u8 (src + 16);                                      \
+    uint8x16_t b2 = vld1q_u8 (src + 32);                                      \
+    uint8x16_t b3 = vld1q_u8 (src + 48);                                      \
+    const ruint8 * rk = (const ruint8 *)aes->erk + (rounds) * 16;             \
+    uint8x16_t k;                                                             \
+    ruint8 i;                                                                 \
+    for (i = 0; i < (rounds) - 1; i++, rk -= 16) {                            \
+      k = vld1q_u8 (rk);                                                      \
+      b0 = vaesdq_u8 (b0, k); b0 = vaesimcq_u8 (b0);                          \
+      b1 = vaesdq_u8 (b1, k); b1 = vaesimcq_u8 (b1);                          \
+      b2 = vaesdq_u8 (b2, k); b2 = vaesimcq_u8 (b2);                          \
+      b3 = vaesdq_u8 (b3, k); b3 = vaesimcq_u8 (b3);                          \
+    }                                                                         \
+    k = vld1q_u8 (rk); rk -= 16;                                              \
+    b0 = vaesdq_u8 (b0, k); b1 = vaesdq_u8 (b1, k);                           \
+    b2 = vaesdq_u8 (b2, k); b3 = vaesdq_u8 (b3, k);                           \
+    k = vld1q_u8 (rk);                                                        \
+    b0 = veorq_u8 (b0, k); b1 = veorq_u8 (b1, k);                             \
+    b2 = veorq_u8 (b2, k); b3 = veorq_u8 (b3, k);                             \
+    vst1q_u8 (dst     , b0); vst1q_u8 (dst + 16, b1);                         \
+    vst1q_u8 (dst + 32, b2); vst1q_u8 (dst + 48, b3);                         \
+  }
+
+R_AES_ARMV8_BLOCKS_X4_ENCRYPT (r_cipher_aes_ecb_encrypt_blocks_armv8_128, 10)
+R_AES_ARMV8_BLOCKS_X4_ENCRYPT (r_cipher_aes_ecb_encrypt_blocks_armv8_192, 12)
+R_AES_ARMV8_BLOCKS_X4_ENCRYPT (r_cipher_aes_ecb_encrypt_blocks_armv8_256, 14)
+R_AES_ARMV8_BLOCKS_X4_DECRYPT (r_cipher_aes_ecb_decrypt_blocks_armv8_128, 10)
+R_AES_ARMV8_BLOCKS_X4_DECRYPT (r_cipher_aes_ecb_decrypt_blocks_armv8_192, 12)
+R_AES_ARMV8_BLOCKS_X4_DECRYPT (r_cipher_aes_ecb_decrypt_blocks_armv8_256, 14)
 
 #endif
 
@@ -738,7 +895,9 @@ RCryptoCipherResult
 r_cipher_aes_ecb_encrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize)
 {
+  const RAesCipher * aes;
   const ruint8 * ptr;
+  const ruint8 * end;
 
   (void) iv;
   (void) ivsize;
@@ -748,8 +907,21 @@ r_cipher_aes_ecb_encrypt (const RCryptoCipher * cipher,
   if (R_UNLIKELY (dst == NULL)) return R_CRYPTO_CIPHER_INVAL;
   if (R_UNLIKELY ((size % R_AES_BLOCK_BYTES) > 0)) return R_CRYPTO_CIPHER_WRONG_BLOCK_SIZE;
 
-  for (ptr = data; ptr < ((ruint8 *)data) + size; ptr += R_AES_BLOCK_BYTES, dst += R_AES_BLOCK_BYTES)
-    r_cipher_aes_ecb_encrypt_block (cipher, dst, ptr);
+  aes = (const RAesCipher *)cipher;
+  ptr = data;
+  end = ptr + size;
+  if (aes->encrypt_blocks_x4 != NULL) {
+    while (ptr + R_AES_PARALLEL_BYTES <= end) {
+      aes->encrypt_blocks_x4 (aes, dst, ptr);
+      ptr += R_AES_PARALLEL_BYTES;
+      dst += R_AES_PARALLEL_BYTES;
+    }
+  }
+  while (ptr < end) {
+    aes->encrypt_block (aes, dst, ptr);
+    ptr += R_AES_BLOCK_BYTES;
+    dst += R_AES_BLOCK_BYTES;
+  }
 
   return R_CRYPTO_CIPHER_OK;
 }
@@ -758,7 +930,9 @@ RCryptoCipherResult
 r_cipher_aes_ecb_decrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize)
 {
+  const RAesCipher * aes;
   const ruint8 * ptr;
+  const ruint8 * end;
 
   (void) iv;
   (void) ivsize;
@@ -768,8 +942,21 @@ r_cipher_aes_ecb_decrypt (const RCryptoCipher * cipher,
   if (R_UNLIKELY (dst == NULL)) return R_CRYPTO_CIPHER_INVAL;
   if (R_UNLIKELY ((size % R_AES_BLOCK_BYTES) > 0)) return R_CRYPTO_CIPHER_WRONG_BLOCK_SIZE;
 
-  for (ptr = data; ptr < ((ruint8 *)data) + size; ptr += R_AES_BLOCK_BYTES, dst += R_AES_BLOCK_BYTES)
-    r_cipher_aes_ecb_decrypt_block (cipher, dst, ptr);
+  aes = (const RAesCipher *)cipher;
+  ptr = data;
+  end = ptr + size;
+  if (aes->decrypt_blocks_x4 != NULL) {
+    while (ptr + R_AES_PARALLEL_BYTES <= end) {
+      aes->decrypt_blocks_x4 (aes, dst, ptr);
+      ptr += R_AES_PARALLEL_BYTES;
+      dst += R_AES_PARALLEL_BYTES;
+    }
+  }
+  while (ptr < end) {
+    aes->decrypt_block (aes, dst, ptr);
+    ptr += R_AES_BLOCK_BYTES;
+    dst += R_AES_BLOCK_BYTES;
+  }
 
   return R_CRYPTO_CIPHER_OK;
 }
@@ -801,8 +988,10 @@ RCryptoCipherResult
 r_cipher_aes_cbc_decrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize)
 {
+  const RAesCipher * aes;
   const ruint8 * ptr;
-  ruint8 scratch[R_AES_BLOCK_BYTES];
+  const ruint8 * end;
+  ruint8 scratch[R_AES_PARALLEL_BYTES];
   int i;
 
   if (R_UNLIKELY (cipher == NULL)) return R_CRYPTO_CIPHER_INVAL;
@@ -811,27 +1000,69 @@ r_cipher_aes_cbc_decrypt (const RCryptoCipher * cipher,
   if (R_UNLIKELY (ivsize != R_AES_BLOCK_BYTES)) return R_CRYPTO_CIPHER_INVAL;
   if (R_UNLIKELY ((size % R_AES_BLOCK_BYTES) > 0)) return R_CRYPTO_CIPHER_WRONG_BLOCK_SIZE;
 
-  for (ptr = data; ptr < ((ruint8 *)data) + size; ptr += R_AES_BLOCK_BYTES, dst += R_AES_BLOCK_BYTES) {
-    /* Use scratch memory because decryption can be done inplace */
+  aes = (const RAesCipher *)cipher;
+  ptr = data;
+  end = ptr + size;
+
+  /* 4-way path: snapshot the 4-block ciphertext window (decryption
+   * can be in-place so the original ct must be saved before the
+   * dst write), decrypt all 4 in parallel, then XOR each plaintext
+   * with its chain predecessor (iv for the first, ct[i-1] for the
+   * rest). iv is updated to the last ciphertext of the window. */
+  if (aes->decrypt_blocks_x4 != NULL) {
+    while (ptr + R_AES_PARALLEL_BYTES <= end) {
+      r_memcpy (scratch, ptr, R_AES_PARALLEL_BYTES);
+      aes->decrypt_blocks_x4 (aes, dst, ptr);
+      for (i = 0; i < R_AES_BLOCK_BYTES; i++) dst[i               ] ^= iv[i];
+      for (i = 0; i < R_AES_BLOCK_BYTES; i++) dst[i + R_AES_BLOCK_BYTES    ] ^= scratch[i                          ];
+      for (i = 0; i < R_AES_BLOCK_BYTES; i++) dst[i + R_AES_BLOCK_BYTES * 2] ^= scratch[i + R_AES_BLOCK_BYTES      ];
+      for (i = 0; i < R_AES_BLOCK_BYTES; i++) dst[i + R_AES_BLOCK_BYTES * 3] ^= scratch[i + R_AES_BLOCK_BYTES * 2  ];
+      r_memcpy (iv, scratch + R_AES_BLOCK_BYTES * 3, R_AES_BLOCK_BYTES);
+      ptr += R_AES_PARALLEL_BYTES;
+      dst += R_AES_PARALLEL_BYTES;
+    }
+  }
+
+  while (ptr < end) {
     r_memcpy (scratch, ptr, R_AES_BLOCK_BYTES);
-    r_cipher_aes_ecb_decrypt_block (cipher, dst, ptr);
+    aes->decrypt_block (aes, dst, ptr);
     for (i = 0; i < R_AES_BLOCK_BYTES; i++)
         dst[i] ^= iv[i];
     r_memcpy (iv, scratch, R_AES_BLOCK_BYTES);
+    ptr += R_AES_BLOCK_BYTES;
+    dst += R_AES_BLOCK_BYTES;
   }
 
   r_memclear_secure (scratch, sizeof (scratch));
   return R_CRYPTO_CIPHER_OK;
 }
 
+/* Big-endian counter add-by-n on a 16-byte AES counter block.
+ * n is small (1..R_AES_PARALLEL_BLOCKS) in our callers, so the
+ * carry stops within a few bytes; the early-exit on no-carry
+ * keeps the cost equivalent to the existing byte-by-byte ++iv. */
+static void
+r_aes_ctr_add (ruint8 iv[R_AES_BLOCK_BYTES], ruint32 n)
+{
+  int i;
+  ruint32 carry = n;
+  for (i = R_AES_BLOCK_BYTES; i > 0 && carry != 0; i--) {
+    ruint32 sum = (ruint32) iv[i - 1] + (carry & 0xff);
+    iv[i - 1] = (ruint8) sum;
+    carry = (carry >> 8) + (sum >> 8);
+  }
+}
+
 RCryptoCipherResult
 r_cipher_aes_ctr_encrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize)
 {
+  const RAesCipher * aes;
   const ruint8 * ptr;
+  const ruint8 * end;
   int i;
   rsize bsize = size;
-  ruint8 scratch[R_AES_BLOCK_BYTES];
+  ruint8 scratch[R_AES_PARALLEL_BYTES];
 
   if (R_UNLIKELY (cipher == NULL)) return R_CRYPTO_CIPHER_INVAL;
   if (R_UNLIKELY (data == NULL)) return R_CRYPTO_CIPHER_INVAL;
@@ -841,24 +1072,45 @@ r_cipher_aes_ctr_encrypt (const RCryptoCipher * cipher,
   size %= R_AES_BLOCK_BYTES;
   bsize -= size;
 
-  for (ptr = data; ptr < ((ruint8 *)data) + bsize; ptr += R_AES_BLOCK_BYTES, dst += R_AES_BLOCK_BYTES) {
-    r_cipher_aes_ecb_encrypt_block (cipher, scratch, iv);
-    for (i = 0; i < R_AES_BLOCK_BYTES; i++)
-      dst[i] = scratch[i] ^ ptr[i];
-    for (i = R_AES_BLOCK_BYTES; i > 0; i--) {
-      if (++iv[i - 1] != 0)
-        break;
+  aes = (const RAesCipher *)cipher;
+  ptr = data;
+  end = ptr + bsize;
+
+  /* 4-way path: build 4 consecutive counter blocks (iv, iv+1,
+   * iv+2, iv+3) in scratch, encrypt all 4 in parallel, XOR with
+   * the plaintext window, and advance iv by 4. */
+  if (aes->encrypt_blocks_x4 != NULL) {
+    while (ptr + R_AES_PARALLEL_BYTES <= end) {
+      r_memcpy (scratch + R_AES_BLOCK_BYTES * 0, iv, R_AES_BLOCK_BYTES);
+      r_memcpy (scratch + R_AES_BLOCK_BYTES * 1, iv, R_AES_BLOCK_BYTES);
+      r_memcpy (scratch + R_AES_BLOCK_BYTES * 2, iv, R_AES_BLOCK_BYTES);
+      r_memcpy (scratch + R_AES_BLOCK_BYTES * 3, iv, R_AES_BLOCK_BYTES);
+      r_aes_ctr_add (scratch + R_AES_BLOCK_BYTES * 1, 1);
+      r_aes_ctr_add (scratch + R_AES_BLOCK_BYTES * 2, 2);
+      r_aes_ctr_add (scratch + R_AES_BLOCK_BYTES * 3, 3);
+      aes->encrypt_blocks_x4 (aes, scratch, scratch);
+      for (i = 0; i < R_AES_PARALLEL_BYTES; i++)
+        dst[i] = scratch[i] ^ ptr[i];
+      r_aes_ctr_add (iv, R_AES_PARALLEL_BLOCKS);
+      ptr += R_AES_PARALLEL_BYTES;
+      dst += R_AES_PARALLEL_BYTES;
     }
   }
 
+  while (ptr < end) {
+    aes->encrypt_block (aes, scratch, iv);
+    for (i = 0; i < R_AES_BLOCK_BYTES; i++)
+      dst[i] = scratch[i] ^ ptr[i];
+    r_aes_ctr_add (iv, 1);
+    ptr += R_AES_BLOCK_BYTES;
+    dst += R_AES_BLOCK_BYTES;
+  }
+
   if (size > 0) {
-    r_cipher_aes_ecb_encrypt_block (cipher, scratch, iv);
+    aes->encrypt_block (aes, scratch, iv);
     for (i = 0; i < (int)size; i++)
       dst[i] = scratch[i] ^ ptr[i];
-    for (i = R_AES_BLOCK_BYTES; i > 0; i--) {
-      if (++iv[i - 1] != 0)
-        break;
-    }
+    r_aes_ctr_add (iv, 1);
   }
 
   r_memclear_secure (scratch, sizeof (scratch));
@@ -905,11 +1157,13 @@ RCryptoCipherResult
 r_cipher_aes_cfb_decrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize)
 {
+  const RAesCipher * aes;
   const ruint8 * ptr;
+  const ruint8 * end;
   int i;
   rsize bsize = size;
-  ruint8 scratch[R_AES_BLOCK_BYTES];
-  ruint8 ctsave[R_AES_BLOCK_BYTES];
+  ruint8 scratch[R_AES_PARALLEL_BYTES];
+  ruint8 ctsave[R_AES_PARALLEL_BYTES];
 
   if (R_UNLIKELY (cipher == NULL)) return R_CRYPTO_CIPHER_INVAL;
   if (R_UNLIKELY (data == NULL)) return R_CRYPTO_CIPHER_INVAL;
@@ -919,18 +1173,41 @@ r_cipher_aes_cfb_decrypt (const RCryptoCipher * cipher,
   size %= R_AES_BLOCK_BYTES;
   bsize -= size;
 
-  for (ptr = data; ptr < ((ruint8 *)data) + bsize; ptr += R_AES_BLOCK_BYTES, dst += R_AES_BLOCK_BYTES) {
-    /* Save the consumed ciphertext before XOR in case dst == ptr (in-place). */
+  aes = (const RAesCipher *)cipher;
+  ptr = data;
+  end = ptr + bsize;
+
+  /* 4-way path: encrypt the 4 chain inputs (iv, ct[0], ct[1], ct[2])
+   * in parallel into a keystream, then XOR with the ciphertext window.
+   * iv is updated to ct[3] for the next iteration. */
+  if (aes->encrypt_blocks_x4 != NULL) {
+    while (ptr + R_AES_PARALLEL_BYTES <= end) {
+      r_memcpy (ctsave, ptr, R_AES_PARALLEL_BYTES);
+      r_memcpy (scratch + R_AES_BLOCK_BYTES * 0, iv, R_AES_BLOCK_BYTES);
+      r_memcpy (scratch + R_AES_BLOCK_BYTES * 1, ctsave + R_AES_BLOCK_BYTES * 0, R_AES_BLOCK_BYTES);
+      r_memcpy (scratch + R_AES_BLOCK_BYTES * 2, ctsave + R_AES_BLOCK_BYTES * 1, R_AES_BLOCK_BYTES);
+      r_memcpy (scratch + R_AES_BLOCK_BYTES * 3, ctsave + R_AES_BLOCK_BYTES * 2, R_AES_BLOCK_BYTES);
+      aes->encrypt_blocks_x4 (aes, scratch, scratch);
+      for (i = 0; i < R_AES_PARALLEL_BYTES; i++)
+        dst[i] = scratch[i] ^ ctsave[i];
+      r_memcpy (iv, ctsave + R_AES_BLOCK_BYTES * 3, R_AES_BLOCK_BYTES);
+      ptr += R_AES_PARALLEL_BYTES;
+      dst += R_AES_PARALLEL_BYTES;
+    }
+  }
+
+  while (ptr < end) {
     r_memcpy (ctsave, ptr, R_AES_BLOCK_BYTES);
-    r_cipher_aes_ecb_encrypt_block (cipher, scratch, iv);
+    aes->encrypt_block (aes, scratch, iv);
     for (i = 0; i < R_AES_BLOCK_BYTES; i++)
       dst[i] = scratch[i] ^ ptr[i];
-    /* CFB-decrypt feedback uses the consumed ciphertext. */
     r_memcpy (iv, ctsave, R_AES_BLOCK_BYTES);
+    ptr += R_AES_BLOCK_BYTES;
+    dst += R_AES_BLOCK_BYTES;
   }
 
   if (size > 0) {
-    r_cipher_aes_ecb_encrypt_block (cipher, scratch, iv);
+    aes->encrypt_block (aes, scratch, iv);
     for (i = 0; i < (int)size; i++)
       dst[i] = scratch[i] ^ ptr[i];
   }

--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -62,7 +62,11 @@
       r_aes_rtbl[0][(Y[3]      ) & 0xff] ^ r_aes_rtbl[1][(Y[2] >>  8) & 0xff] ^\
       r_aes_rtbl[2][(Y[1] >> 16) & 0xff] ^ r_aes_rtbl[3][(Y[0] >> 24) & 0xff];
 
-typedef struct {
+typedef struct _RAesCipher RAesCipher;
+typedef rboolean (*RAesBlockFn) (const RAesCipher * aes,
+    ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES]);
+
+struct _RAesCipher {
   RCryptoCipher cipher;
 
   ruint8 key[R_AES_MAX_KEY_BYTES];
@@ -70,7 +74,32 @@ typedef struct {
   ruint32 erk[R_AES_BLOCK_BYTES * sizeof (ruint32)];
   ruint32 drk[R_AES_BLOCK_BYTES * sizeof (ruint32)];
   ruint8 rounds;
-} RAesCipher;
+
+  /* Per-block fast path picked once at construction in
+   * r_cipher_aes_new_with_info based on r_cpu_has; saves the
+   * feature check + extra branch on every block dispatch. */
+  RAesBlockFn encrypt_block;
+  RAesBlockFn decrypt_block;
+};
+
+static rboolean r_cipher_aes_ecb_encrypt_block_sw (const RAesCipher * aes,
+    ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES]);
+static rboolean r_cipher_aes_ecb_decrypt_block_sw (const RAesCipher * aes,
+    ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES]);
+
+#if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
+static rboolean r_cipher_aes_ecb_encrypt_block_aesni (const RAesCipher * aes,
+    ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES]);
+static rboolean r_cipher_aes_ecb_decrypt_block_aesni (const RAesCipher * aes,
+    ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES]);
+#endif
+
+#if defined(R_ARCH_AARCH64)
+static rboolean r_cipher_aes_ecb_encrypt_block_armv8 (const RAesCipher * aes,
+    ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES]);
+static rboolean r_cipher_aes_ecb_decrypt_block_armv8 (const RAesCipher * aes,
+    ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES]);
+#endif
 
 const RCryptoCipherInfo g__r_crypto_cipher_aes_128_ecb =  { "AES-128-ECB",
   R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_ECB, 128, 16, 16,
@@ -257,6 +286,22 @@ r_cipher_aes_new_with_info (const RCryptoCipherInfo * info, const ruint8 * key)
     *rk++ = *src++;
     *rk++ = *src++;
     *rk++ = *src++;
+
+#if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
+    if (r_cpu_has (R_CPU_FEATURE_AES_NI)) {
+      ret->encrypt_block = r_cipher_aes_ecb_encrypt_block_aesni;
+      ret->decrypt_block = r_cipher_aes_ecb_decrypt_block_aesni;
+    } else
+#elif defined(R_ARCH_AARCH64)
+    if (r_cpu_has (R_CPU_FEATURE_ARM_AES)) {
+      ret->encrypt_block = r_cipher_aes_ecb_encrypt_block_armv8;
+      ret->decrypt_block = r_cipher_aes_ecb_decrypt_block_armv8;
+    } else
+#endif
+    {
+      ret->encrypt_block = r_cipher_aes_ecb_encrypt_block_sw;
+      ret->decrypt_block = r_cipher_aes_ecb_decrypt_block_sw;
+    }
   }
 
   return (RCryptoCipher *)ret;
@@ -478,13 +523,18 @@ r_cipher_aes_ecb_decrypt_block_aesni (const RAesCipher * aes,
 }
 #endif
 
-#if defined(R_ARCH_AARCH64) && !defined(_MSC_VER)
+#if defined(R_ARCH_AARCH64)
+# if defined(__GNUC__) || defined(__clang__)
+#  define R_AES_ARM_TARGET R_AES_ARM_TARGET
+# else
+#  define R_AES_ARM_TARGET
+# endif
 /* ARMv8 AESE/AESD do (AddRoundKey then SubBytes/ShiftRows) in a
  * single instruction, paired with AESMC/AESIMC for MixColumns.
  * Decrypt expects the encrypt round keys in reverse order - the
  * SW drk array (InvMixColumns pre-applied) doesn't match, so the
  * decrypt path walks erk backward instead. */
-__attribute__((target("+crypto")))
+R_AES_ARM_TARGET
 static rboolean
 r_cipher_aes_ecb_encrypt_block_armv8 (const RAesCipher * aes,
     ruint8 ciphertxt[R_AES_BLOCK_BYTES],
@@ -506,7 +556,7 @@ r_cipher_aes_ecb_encrypt_block_armv8 (const RAesCipher * aes,
   return TRUE;
 }
 
-__attribute__((target("+crypto")))
+R_AES_ARM_TARGET
 static rboolean
 r_cipher_aes_ecb_decrypt_block_armv8 (const RAesCipher * aes,
     ruint8 plaintxt[R_AES_BLOCK_BYTES],
@@ -529,28 +579,13 @@ r_cipher_aes_ecb_decrypt_block_armv8 (const RAesCipher * aes,
 }
 #endif
 
-rboolean
-r_cipher_aes_ecb_encrypt_block (const RCryptoCipher * cipher,
+static rboolean
+r_cipher_aes_ecb_encrypt_block_sw (const RAesCipher * aes,
     ruint8 ciphertxt[R_AES_BLOCK_BYTES], const ruint8 plaintxt[R_AES_BLOCK_BYTES])
 {
   ruint32 input[4], tmp[4]; /* 4 * 4 = 16 bytes */
-  const ruint32 * rk;
-  const RAesCipher * aes;
+  const ruint32 * rk = aes->erk;
   ruint8 i;
-
-  if (R_UNLIKELY (cipher == NULL)) return FALSE;
-
-  aes = (const RAesCipher *)cipher;
-
-#if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
-  if (r_cpu_has (R_CPU_FEATURE_AES_NI))
-    return r_cipher_aes_ecb_encrypt_block_aesni (aes, ciphertxt, plaintxt);
-#elif defined(R_ARCH_AARCH64) && !defined(_MSC_VER)
-  if (r_cpu_has (R_CPU_FEATURE_ARM_AES))
-    return r_cipher_aes_ecb_encrypt_block_armv8 (aes, ciphertxt, plaintxt);
-#endif
-
-  rk = aes->erk;
 
   input[0] = r_load_le32 (&plaintxt[0x0]) ^ *rk++;
   input[1] = r_load_le32 (&plaintxt[0x4]) ^ *rk++;
@@ -594,27 +629,22 @@ r_cipher_aes_ecb_encrypt_block (const RCryptoCipher * cipher,
 }
 
 rboolean
-r_cipher_aes_ecb_decrypt_block (const RCryptoCipher * cipher,
+r_cipher_aes_ecb_encrypt_block (const RCryptoCipher * cipher,
+    ruint8 ciphertxt[R_AES_BLOCK_BYTES], const ruint8 plaintxt[R_AES_BLOCK_BYTES])
+{
+  const RAesCipher * aes;
+  if (R_UNLIKELY (cipher == NULL)) return FALSE;
+  aes = (const RAesCipher *)cipher;
+  return aes->encrypt_block (aes, ciphertxt, plaintxt);
+}
+
+static rboolean
+r_cipher_aes_ecb_decrypt_block_sw (const RAesCipher * aes,
     ruint8 plaintxt[R_AES_BLOCK_BYTES], const ruint8 ciphertxt[R_AES_BLOCK_BYTES])
 {
   ruint32 input[4], tmp[4]; /* 4 * 4 = 16 bytes */
-  const ruint32 * rk;
-  const RAesCipher * aes;
+  const ruint32 * rk = aes->drk;
   ruint8 i;
-
-  if (R_UNLIKELY (cipher == NULL)) return FALSE;
-
-  aes = (const RAesCipher *)cipher;
-
-#if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
-  if (r_cpu_has (R_CPU_FEATURE_AES_NI))
-    return r_cipher_aes_ecb_decrypt_block_aesni (aes, plaintxt, ciphertxt);
-#elif defined(R_ARCH_AARCH64) && !defined(_MSC_VER)
-  if (r_cpu_has (R_CPU_FEATURE_ARM_AES))
-    return r_cipher_aes_ecb_decrypt_block_armv8 (aes, plaintxt, ciphertxt);
-#endif
-
-  rk = aes->drk;
 
   input[0] = r_load_le32 (&ciphertxt[0x0]) ^ *rk++;
   input[1] = r_load_le32 (&ciphertxt[0x4]) ^ *rk++;
@@ -655,6 +685,16 @@ r_cipher_aes_ecb_decrypt_block (const RCryptoCipher * cipher,
   r_store_le32 (&plaintxt[0xc], input[3]);
 
   return TRUE;
+}
+
+rboolean
+r_cipher_aes_ecb_decrypt_block (const RCryptoCipher * cipher,
+    ruint8 plaintxt[R_AES_BLOCK_BYTES], const ruint8 ciphertxt[R_AES_BLOCK_BYTES])
+{
+  const RAesCipher * aes;
+  if (R_UNLIKELY (cipher == NULL)) return FALSE;
+  aes = (const RAesCipher *)cipher;
+  return aes->decrypt_block (aes, plaintxt, ciphertxt);
 }
 
 RCryptoCipherResult

--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -82,23 +82,29 @@ struct _RAesCipher {
   RAesBlockFn decrypt_block;
 };
 
-static rboolean r_cipher_aes_ecb_encrypt_block_sw (const RAesCipher * aes,
-    ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES]);
-static rboolean r_cipher_aes_ecb_decrypt_block_sw (const RAesCipher * aes,
-    ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES]);
+#define R_AES_BLOCK_FN_DECL(name)                                              \
+  static rboolean name (const RAesCipher * aes,                                \
+      ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES])
+
+R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_encrypt_block_sw);
+R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_decrypt_block_sw);
 
 #if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
-static rboolean r_cipher_aes_ecb_encrypt_block_aesni (const RAesCipher * aes,
-    ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES]);
-static rboolean r_cipher_aes_ecb_decrypt_block_aesni (const RAesCipher * aes,
-    ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES]);
+R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_encrypt_block_aesni_128);
+R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_encrypt_block_aesni_192);
+R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_encrypt_block_aesni_256);
+R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_decrypt_block_aesni_128);
+R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_decrypt_block_aesni_192);
+R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_decrypt_block_aesni_256);
 #endif
 
 #if defined(R_ARCH_AARCH64)
-static rboolean r_cipher_aes_ecb_encrypt_block_armv8 (const RAesCipher * aes,
-    ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES]);
-static rboolean r_cipher_aes_ecb_decrypt_block_armv8 (const RAesCipher * aes,
-    ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES]);
+R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_encrypt_block_armv8_128);
+R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_encrypt_block_armv8_192);
+R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_encrypt_block_armv8_256);
+R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_decrypt_block_armv8_128);
+R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_decrypt_block_armv8_192);
+R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_decrypt_block_armv8_256);
 #endif
 
 const RCryptoCipherInfo g__r_crypto_cipher_aes_128_ecb =  { "AES-128-ECB",
@@ -289,13 +295,37 @@ r_cipher_aes_new_with_info (const RCryptoCipherInfo * info, const ruint8 * key)
 
 #if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
     if (r_cpu_has (R_CPU_FEATURE_AES_NI)) {
-      ret->encrypt_block = r_cipher_aes_ecb_encrypt_block_aesni;
-      ret->decrypt_block = r_cipher_aes_ecb_decrypt_block_aesni;
+      switch (ret->rounds) {
+        case 10:
+          ret->encrypt_block = r_cipher_aes_ecb_encrypt_block_aesni_128;
+          ret->decrypt_block = r_cipher_aes_ecb_decrypt_block_aesni_128;
+          break;
+        case 12:
+          ret->encrypt_block = r_cipher_aes_ecb_encrypt_block_aesni_192;
+          ret->decrypt_block = r_cipher_aes_ecb_decrypt_block_aesni_192;
+          break;
+        default: /* 14 = AES-256 */
+          ret->encrypt_block = r_cipher_aes_ecb_encrypt_block_aesni_256;
+          ret->decrypt_block = r_cipher_aes_ecb_decrypt_block_aesni_256;
+          break;
+      }
     } else
 #elif defined(R_ARCH_AARCH64)
     if (r_cpu_has (R_CPU_FEATURE_ARM_AES)) {
-      ret->encrypt_block = r_cipher_aes_ecb_encrypt_block_armv8;
-      ret->decrypt_block = r_cipher_aes_ecb_decrypt_block_armv8;
+      switch (ret->rounds) {
+        case 10:
+          ret->encrypt_block = r_cipher_aes_ecb_encrypt_block_armv8_128;
+          ret->decrypt_block = r_cipher_aes_ecb_decrypt_block_armv8_128;
+          break;
+        case 12:
+          ret->encrypt_block = r_cipher_aes_ecb_encrypt_block_armv8_192;
+          ret->decrypt_block = r_cipher_aes_ecb_decrypt_block_armv8_192;
+          break;
+        default: /* 14 = AES-256 */
+          ret->encrypt_block = r_cipher_aes_ecb_encrypt_block_armv8_256;
+          ret->decrypt_block = r_cipher_aes_ecb_decrypt_block_armv8_256;
+          break;
+      }
     } else
 #endif
     {
@@ -474,109 +504,116 @@ r_cipher_aes_new_from_hex (RCryptoCipherMode mode, const rchar * hexkey)
 }
 
 #if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
+# if defined(__GNUC__) || defined(__clang__)
+#  define R_AES_X86_TARGET __attribute__((target("aes,sse2")))
+# else
+#  define R_AES_X86_TARGET
+# endif
+
 /* AES-NI uses the same {LE u32} round-key layout the SW path
  * already produces - _mm_loadu_si128 sees the four LE u32s as a
  * 16-byte block with byte 0 in the low lane, matching the AES
  * state's column-major layout. Decrypt likewise consumes drk
  * directly since the SW key schedule pre-applies InvMixColumns
- * to the middle keys, which is what _mm_aesdec_si128 expects. */
-# if defined(__GNUC__) || defined(__clang__)
-__attribute__((target("aes,sse2")))
-# endif
-static rboolean
-r_cipher_aes_ecb_encrypt_block_aesni (const RAesCipher * aes,
-    ruint8 ciphertxt[R_AES_BLOCK_BYTES],
-    const ruint8 plaintxt[R_AES_BLOCK_BYTES])
-{
-  __m128i block = _mm_loadu_si128 ((const __m128i *)plaintxt);
-  const __m128i * rk = (const __m128i *)aes->erk;
-  ruint8 i;
+ * to the middle keys, which is what _mm_aesdec_si128 expects.
+ *
+ * The per-bits specialisation pins the round count as a compile-
+ * time literal so the compiler fully unrolls the AESENC / AESDEC
+ * sequence - on Zen3+ that lifts ECB-128 to ~5+ GiB/s vs ~2 GiB/s
+ * for the generic loop where rounds is read from struct state. */
+# define R_AES_AESNI_BLOCK(name, key_arr, op_round, op_last, rounds)         \
+  R_AES_X86_TARGET                                                           \
+  static rboolean                                                            \
+  name (const RAesCipher * aes,                                              \
+      ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES])    \
+  {                                                                          \
+    __m128i block = _mm_loadu_si128 ((const __m128i *)src);                  \
+    const __m128i * rk = (const __m128i *)aes->key_arr;                      \
+    ruint8 i;                                                                \
+    block = _mm_xor_si128 (block, _mm_loadu_si128 (rk++));                   \
+    for (i = 1; i < (rounds); i++, rk++)                                     \
+      block = op_round (block, _mm_loadu_si128 (rk));                        \
+    block = op_last (block, _mm_loadu_si128 (rk));                           \
+    _mm_storeu_si128 ((__m128i *)dst, block);                                \
+    return TRUE;                                                             \
+  }
 
-  block = _mm_xor_si128 (block, _mm_loadu_si128 (rk++));
-  for (i = 1; i < aes->rounds; i++, rk++)
-    block = _mm_aesenc_si128 (block, _mm_loadu_si128 (rk));
-  block = _mm_aesenclast_si128 (block, _mm_loadu_si128 (rk));
-
-  _mm_storeu_si128 ((__m128i *)ciphertxt, block);
-  return TRUE;
-}
-
-# if defined(__GNUC__) || defined(__clang__)
-__attribute__((target("aes,sse2")))
-# endif
-static rboolean
-r_cipher_aes_ecb_decrypt_block_aesni (const RAesCipher * aes,
-    ruint8 plaintxt[R_AES_BLOCK_BYTES],
-    const ruint8 ciphertxt[R_AES_BLOCK_BYTES])
-{
-  __m128i block = _mm_loadu_si128 ((const __m128i *)ciphertxt);
-  const __m128i * rk = (const __m128i *)aes->drk;
-  ruint8 i;
-
-  block = _mm_xor_si128 (block, _mm_loadu_si128 (rk++));
-  for (i = 1; i < aes->rounds; i++, rk++)
-    block = _mm_aesdec_si128 (block, _mm_loadu_si128 (rk));
-  block = _mm_aesdeclast_si128 (block, _mm_loadu_si128 (rk));
-
-  _mm_storeu_si128 ((__m128i *)plaintxt, block);
-  return TRUE;
-}
+R_AES_AESNI_BLOCK (r_cipher_aes_ecb_encrypt_block_aesni_128, erk,
+    _mm_aesenc_si128, _mm_aesenclast_si128, 10)
+R_AES_AESNI_BLOCK (r_cipher_aes_ecb_encrypt_block_aesni_192, erk,
+    _mm_aesenc_si128, _mm_aesenclast_si128, 12)
+R_AES_AESNI_BLOCK (r_cipher_aes_ecb_encrypt_block_aesni_256, erk,
+    _mm_aesenc_si128, _mm_aesenclast_si128, 14)
+R_AES_AESNI_BLOCK (r_cipher_aes_ecb_decrypt_block_aesni_128, drk,
+    _mm_aesdec_si128, _mm_aesdeclast_si128, 10)
+R_AES_AESNI_BLOCK (r_cipher_aes_ecb_decrypt_block_aesni_192, drk,
+    _mm_aesdec_si128, _mm_aesdeclast_si128, 12)
+R_AES_AESNI_BLOCK (r_cipher_aes_ecb_decrypt_block_aesni_256, drk,
+    _mm_aesdec_si128, _mm_aesdeclast_si128, 14)
 #endif
 
 #if defined(R_ARCH_AARCH64)
 # if defined(__GNUC__) || defined(__clang__)
-#  define R_AES_ARM_TARGET R_AES_ARM_TARGET
+#  define R_AES_ARM_TARGET __attribute__((target("+crypto")))
 # else
 #  define R_AES_ARM_TARGET
 # endif
+
 /* ARMv8 AESE/AESD do (AddRoundKey then SubBytes/ShiftRows) in a
  * single instruction, paired with AESMC/AESIMC for MixColumns.
  * Decrypt expects the encrypt round keys in reverse order - the
  * SW drk array (InvMixColumns pre-applied) doesn't match, so the
- * decrypt path walks erk backward instead. */
-R_AES_ARM_TARGET
-static rboolean
-r_cipher_aes_ecb_encrypt_block_armv8 (const RAesCipher * aes,
-    ruint8 ciphertxt[R_AES_BLOCK_BYTES],
-    const ruint8 plaintxt[R_AES_BLOCK_BYTES])
-{
-  uint8x16_t block = vld1q_u8 (plaintxt);
-  const ruint8 * rk = (const ruint8 *)aes->erk;
-  ruint8 i;
-
-  for (i = 0; i < aes->rounds - 1; i++, rk += 16) {
-    block = vaeseq_u8 (block, vld1q_u8 (rk));
-    block = vaesmcq_u8 (block);
+ * decrypt path walks erk backward instead.
+ *
+ * Per-bits specialisation matches the AES-NI rationale: literal
+ * round count lets the compiler unroll the AESE/AESMC pairs. */
+# define R_AES_ARMV8_ENCRYPT(name, rounds)                                   \
+  R_AES_ARM_TARGET                                                           \
+  static rboolean                                                            \
+  name (const RAesCipher * aes,                                              \
+      ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES])    \
+  {                                                                          \
+    uint8x16_t block = vld1q_u8 (src);                                       \
+    const ruint8 * rk = (const ruint8 *)aes->erk;                            \
+    ruint8 i;                                                                \
+    for (i = 0; i < (rounds) - 1; i++, rk += 16) {                           \
+      block = vaeseq_u8 (block, vld1q_u8 (rk));                              \
+      block = vaesmcq_u8 (block);                                            \
+    }                                                                        \
+    block = vaeseq_u8 (block, vld1q_u8 (rk));                                \
+    rk += 16;                                                                \
+    block = veorq_u8 (block, vld1q_u8 (rk));                                 \
+    vst1q_u8 (dst, block);                                                   \
+    return TRUE;                                                             \
   }
-  block = vaeseq_u8 (block, vld1q_u8 (rk));
-  rk += 16;
-  block = veorq_u8 (block, vld1q_u8 (rk));
 
-  vst1q_u8 (ciphertxt, block);
-  return TRUE;
-}
-
-R_AES_ARM_TARGET
-static rboolean
-r_cipher_aes_ecb_decrypt_block_armv8 (const RAesCipher * aes,
-    ruint8 plaintxt[R_AES_BLOCK_BYTES],
-    const ruint8 ciphertxt[R_AES_BLOCK_BYTES])
-{
-  uint8x16_t block = vld1q_u8 (ciphertxt);
-  const ruint8 * rk = (const ruint8 *)aes->erk + aes->rounds * 16;
-  ruint8 i;
-
-  for (i = 0; i < aes->rounds - 1; i++, rk -= 16) {
-    block = vaesdq_u8 (block, vld1q_u8 (rk));
-    block = vaesimcq_u8 (block);
+# define R_AES_ARMV8_DECRYPT(name, rounds)                                   \
+  R_AES_ARM_TARGET                                                           \
+  static rboolean                                                            \
+  name (const RAesCipher * aes,                                              \
+      ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES])    \
+  {                                                                          \
+    uint8x16_t block = vld1q_u8 (src);                                       \
+    const ruint8 * rk = (const ruint8 *)aes->erk + (rounds) * 16;            \
+    ruint8 i;                                                                \
+    for (i = 0; i < (rounds) - 1; i++, rk -= 16) {                           \
+      block = vaesdq_u8 (block, vld1q_u8 (rk));                              \
+      block = vaesimcq_u8 (block);                                           \
+    }                                                                        \
+    block = vaesdq_u8 (block, vld1q_u8 (rk));                                \
+    rk -= 16;                                                                \
+    block = veorq_u8 (block, vld1q_u8 (rk));                                 \
+    vst1q_u8 (dst, block);                                                   \
+    return TRUE;                                                             \
   }
-  block = vaesdq_u8 (block, vld1q_u8 (rk));
-  rk -= 16;
-  block = veorq_u8 (block, vld1q_u8 (rk));
 
-  vst1q_u8 (plaintxt, block);
-  return TRUE;
-}
+R_AES_ARMV8_ENCRYPT (r_cipher_aes_ecb_encrypt_block_armv8_128, 10)
+R_AES_ARMV8_ENCRYPT (r_cipher_aes_ecb_encrypt_block_armv8_192, 12)
+R_AES_ARMV8_ENCRYPT (r_cipher_aes_ecb_encrypt_block_armv8_256, 14)
+R_AES_ARMV8_DECRYPT (r_cipher_aes_ecb_decrypt_block_armv8_128, 10)
+R_AES_ARMV8_DECRYPT (r_cipher_aes_ecb_decrypt_block_armv8_192, 12)
+R_AES_ARMV8_DECRYPT (r_cipher_aes_ecb_decrypt_block_armv8_256, 14)
+
 #endif
 
 static rboolean


### PR DESCRIPTION
## Summary

Wires `r_cipher_aes_ecb_encrypt_block` / `_decrypt_block` to dispatch to hardware implementations on x86 (AES-NI) and AArch64 (ARMv8 AES) when the CPU supports them, falling back to the existing table-driven path everywhere else. Closes #30.

Builds on the runtime CPU detection from #159.

## Commits

1. **`crypto: Dispatch AES block cipher to hardware where available`** — wires AES-NI and ARMv8 AES per-block kernels behind a runtime `r_cpu_has` check. Sets the table for every mode (ECB, CBC, CTR, CFB, OFB) to inherit the speedup since all of them route through the two per-block functions.

2. **`crypto: Cache AES per-block dispatch on RAesCipher`** — moves the dispatch decision from per-call to per-cipher-construction. Stores the chosen path as function pointers on the cipher struct. **Eliminates a per-block CAS inside `r_call_once`** — that single change ~doubled ECB throughput on its own.

3. **`crypto: Specialise AES HW block kernels per key size`** — splits the generic HW kernels into 128 / 192 / 256-bit variants where the round count is a compile-time literal so the compiler fully unrolls. Lifts AES-128 ECB to ~9 GiB/s (single-block AES-NI ceiling).

4. **`crypto: Add 4-way parallel AES kernels for ECB, CTR, CBC-dec, CFB-dec`** — interleaves 4 independent blocks per kernel call to keep the AESENC pipeline full. Lifts AES-128 ECB to ~13 GiB/s and CTR to ~3 GiB/s. Sequential modes (CBC enc, CFB enc, OFB) stay on single-block since their state chain is inherently serial.

## Measured impact

Zen3-class x86_64, `bench/raes.c` (16 KiB blocks × 2000 iters), single-thread:

| Variant | Master (SW) | This PR | Δ |
|---|---|---|---|
| **AES-128 ECB** | 510 | **13206** | **25.9×** |
| **AES-256 ECB** | 359 | **9293** | **25.9×** |
| **AES-128 CTR** | 425 | **2989** | **7.0×** |
| **AES-256 CTR** | 302 | **2604** | **8.6×** |
| AES-128 CBC | 364 | 890 | 2.4× |
| AES-256 CBC | 282 | 796 | 2.8× |
| AES-128 CFB | 375 | 911 | 2.4× |
| AES-128 OFB | 445 | 1731 | 3.9× |

ECB and CTR hit the AES-NI single-thread ceiling for this CPU. Chained / sequential modes still see ~2-3× from the underlying cipher engine speedup but can't parallelize across blocks by definition.

## Correctness

- All 134 `/raes/` tests pass on this AES-NI host (HW path active per CPU detection).
- All 1523 tests in the full suite still pass.
- HW and SW paths share the same round-key state — AES-NI reads `erk` / `drk` directly (the LE u32 layout matches what `_mm_loadu_si128` expects); ARMv8 walks `erk` backward for decrypt (matches OpenSSL's AESD pattern, no separate decrypt schedule).
- CBC-decrypt and CFB-decrypt aren't currently in `bench/raes.c`, so their multi-block speedups are predicted but not measured here. Correctness for those modes is covered by the test suite.

## What this PR is not

- Not a multi-block extension to CBC-enc / CFB-enc / OFB — those are serial by construction.
- Not a separate CTR kernel that builds counters in XMM registers and XORs in-kernel (would push CTR closer to ECB; ~3 GB/s vs ~13 GB/s gap is the keystream-build + 64-byte XOR overhead in C). Possible follow-up.

## Test plan

- [x] `/raes/` debug tests pass with HW path active
- [x] Full 1523-test suite still green
- [x] `bench/raes.c` reflects the speedup ladder above
- [ ] CI green on the PR (will validate ARMv8 path via macOS Apple Silicon + Linux ARM jobs)