### PR TITLE
Fast-path r_call_once + meson-driven SIMD header dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,35 @@ jobs:
           name: testlog-windows-${{ matrix.buildtype }}
           path: build/meson-logs/
 
+  windows-arm:
+    name: Windows ARM / MSVC / ${{ matrix.buildtype }}
+    # Exercises the AArch64 + Windows IsProcessorFeaturePresent
+    # detection path and the MSVC __crc32c / arm_neon AES intrinsics.
+    runs-on: windows-11-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        buildtype: [debugoptimized, release]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: arm64
+      - name: Install meson + ninja
+        run: pip install meson ninja
+      - name: Configure
+        run: meson setup build --buildtype=${{ matrix.buildtype }}
+      - name: Build
+        run: meson compile -C build
+      - name: Test
+        run: meson test -C build --print-errorlogs --timeout-multiplier 6
+      - name: Upload test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: testlog-windows-arm-${{ matrix.buildtype }}
+          path: build/meson-logs/
+
   sanitizers:
     name: Sanitizers / ${{ matrix.name }}
     runs-on: ubuntu-latest

--- a/config.h.meson
+++ b/config.h.meson
@@ -98,4 +98,10 @@
 #mesondefine HAVE_PTHREAD_SETAFFINITY_NP
 #mesondefine HAVE_PTHREAD_ATTR_SETAFFINITY_NP
 
+#mesondefine HAVE_NMMINTRIN_H
+#mesondefine HAVE_WMMINTRIN_H
+#mesondefine HAVE_ARM_NEON_H
+#mesondefine HAVE_ARM_ACLE_H
+#mesondefine HAVE_INTRIN_H
+
 #endif /* _CONFIG_H_MESON_ */

--- a/include/rlib/rthreads.h
+++ b/include/rlib/rthreads.h
@@ -29,18 +29,49 @@
 
 R_BEGIN_DECLS
 
+/**
+ * @defgroup r_once One-shot initialisation (ROnce)
+ * @brief Run an init function exactly once across all threads, with
+ * a cheap fast path on every subsequent call.
+ * @{
+ */
+
+/**
+ * @brief Lifecycle states of an @c ROnce.
+ *
+ * The states transition INIT -&gt; RUNNING -&gt; DONE exactly
+ * once per @c ROnce instance, driven by the first @c r_call_once
+ * caller. They are an implementation detail of @c r_call_once and
+ * not intended for external use.
+ */
 typedef enum
 {
-  R_ONCE_STATE_INIT,
-  R_ONCE_STATE_RUNNING,
-  R_ONCE_STATE_DONE
+  R_ONCE_STATE_INIT,    /**< Fresh, init function not yet started. */
+  R_ONCE_STATE_RUNNING, /**< Init function executing in some thread. */
+  R_ONCE_STATE_DONE     /**< Init function returned; @c ret is set. */
 } ROnceState;
 
+/**
+ * @brief Static initialiser for an @c ROnce in INIT state.
+ *
+ * Use as @c { static ROnce o = R_ONCE_INIT; } at file or block scope.
+ */
 #define R_ONCE_INIT { R_ONCE_STATE_INIT, NULL }
+/**
+ * @brief One-shot initialisation guard.
+ *
+ * Pass the same @c ROnce instance to every @c r_call_once call; the
+ * supplied init function is invoked at most once across all threads.
+ * Subsequent calls return the cached pointer the init function
+ * returned, on a fast path with no CAS.
+ *
+ * Storage must be either zero-initialised (static / global) or
+ * explicitly seeded with @c R_ONCE_INIT before first use.
+ */
 typedef struct
 {
-  rauint state;
-  rpointer ret;
+  rauint state;     /**< Current @c ROnceState (atomic). */
+  rpointer ret;     /**< Value returned by the init function. */
 } ROnce;
 
 #define R_TSS_INIT(notify) { (RDestroyNotify)(notify), { NULL } }
@@ -68,8 +99,28 @@ typedef rpointer (*RThreadFunc) (rpointer data);
 typedef struct _RThread RThread;
 
 
-/* Run once */
+/**
+ * @brief Run @p f exactly once across all threads, return its result.
+ *
+ * The first caller to win the state transition runs @p f with @p a
+ * and stores the returned pointer in @p once. All later callers,
+ * across all threads, get the cached pointer back without re-running
+ * @p f. Concurrent first-callers block until the running thread
+ * finishes.
+ *
+ * The hot path (after init has settled) is a single atomic load and
+ * a branch, so it is cheap enough to call on every entry to a
+ * frequently-invoked function.
+ *
+ * @param once  Persistent @c ROnce instance, seeded with
+ *              @c R_ONCE_INIT or zero-initialised.
+ * @param f     Init function; called at most once per @p once.
+ * @param a     Opaque argument forwarded to @p f.
+ * @return The pointer @p f returned (cached after the first call).
+ */
 R_API rpointer  r_call_once         (ROnce * once, RThreadFunc f, rpointer a);
+
+/** @} */ /* r_once group */
 
 /* Thread spesific storage */
 R_API rpointer r_tss_get            (RTss * tss);

--- a/meson.build
+++ b/meson.build
@@ -273,6 +273,30 @@ elif host_machine.system() == 'darwin'
   ]
 endif
 
+# SIMD / hardware-acceleration intrinsic headers. Used by rcrc.c and
+# raes.c to decide which HW-dispatch path to compile in. has_header
+# is cheap and decoupled from compiler / arch macros, which keeps
+# the per-arch ifdef shape out of the C source.
+if host_machine.cpu_family() in [ 'x86', 'x86_64' ]
+  check_headers += [
+    'nmmintrin.h',  # SSE4.2 (CRC32C)
+    'wmmintrin.h',  # AES-NI
+  ]
+elif host_machine.cpu_family() == 'aarch64'
+  check_headers += [
+    'arm_neon.h',   # NEON + ARMv8 AES
+    'arm_acle.h',   # ACLE (CRC32, etc.) - GCC / clang
+  ]
+  # intrin.h is an MSVC header. GCC / clang ship a same-named shim
+  # that satisfies cc.has_header (the file exists) but errors out
+  # on actual #include via #include_next once the platform-level
+  # header is missing. Restrict the probe to MSVC so HAVE_INTRIN_H
+  # truthfully means "real MSVC intrin.h, includable".
+  if cc.get_id() == 'msvc'
+    check_headers += [ 'intrin.h' ]
+  endif
+endif
+
 check_funcs = [
   # unistd
   [ 'alarm', 'unistd.h' ],

--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -24,11 +24,11 @@
 #include <rlib/rmem.h>
 #include <rlib/rstr.h>
 
-#if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
+#ifdef HAVE_WMMINTRIN_H
 # include <wmmintrin.h>           /* AES-NI */
 #endif
 
-#if defined(R_ARCH_AARCH64)
+#ifdef HAVE_ARM_NEON_H
 # include <arm_neon.h>            /* ARMv8 AES */
 #endif
 
@@ -104,7 +104,7 @@ struct _RAesCipher {
 R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_encrypt_block_sw);
 R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_decrypt_block_sw);
 
-#if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
+#ifdef HAVE_WMMINTRIN_H
 R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_encrypt_block_aesni_128);
 R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_encrypt_block_aesni_192);
 R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_encrypt_block_aesni_256);
@@ -119,7 +119,7 @@ R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks_aesni_192);
 R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks_aesni_256);
 #endif
 
-#if defined(R_ARCH_AARCH64)
+#ifdef HAVE_ARM_NEON_H
 R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_encrypt_block_armv8_128);
 R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_encrypt_block_armv8_192);
 R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_encrypt_block_armv8_256);
@@ -320,7 +320,7 @@ r_cipher_aes_new_with_info (const RCryptoCipherInfo * info, const ruint8 * key)
     *rk++ = *src++;
     *rk++ = *src++;
 
-#if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
+#ifdef HAVE_WMMINTRIN_H
     if (r_cpu_has (R_CPU_FEATURE_AES_NI)) {
       switch (ret->rounds) {
         case 10:
@@ -343,7 +343,7 @@ r_cipher_aes_new_with_info (const RCryptoCipherInfo * info, const ruint8 * key)
           break;
       }
     } else
-#elif defined(R_ARCH_AARCH64)
+#elif defined(HAVE_ARM_NEON_H)
     if (r_cpu_has (R_CPU_FEATURE_ARM_AES)) {
       switch (ret->rounds) {
         case 10:
@@ -544,7 +544,7 @@ r_cipher_aes_new_from_hex (RCryptoCipherMode mode, const rchar * hexkey)
   return ret;
 }
 
-#if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
+#ifdef HAVE_WMMINTRIN_H
 # if defined(__GNUC__) || defined(__clang__)
 #  define R_AES_X86_TARGET __attribute__((target("aes,sse2")))
 # else
@@ -640,7 +640,7 @@ R_AES_AESNI_BLOCKS_X4 (r_cipher_aes_ecb_decrypt_blocks_aesni_256, drk,
     _mm_aesdec_si128, _mm_aesdeclast_si128, 14)
 #endif
 
-#if defined(R_ARCH_AARCH64)
+#ifdef HAVE_ARM_NEON_H
 # if defined(__GNUC__) || defined(__clang__)
 #  define R_AES_ARM_TARGET __attribute__((target("+crypto")))
 # else
@@ -649,9 +649,9 @@ R_AES_AESNI_BLOCKS_X4 (r_cipher_aes_ecb_decrypt_blocks_aesni_256, drk,
 
 /* ARMv8 AESE/AESD do (AddRoundKey then SubBytes/ShiftRows) in a
  * single instruction, paired with AESMC/AESIMC for MixColumns.
- * Decrypt expects the encrypt round keys in reverse order - the
- * SW drk array (InvMixColumns pre-applied) doesn't match, so the
- * decrypt path walks erk backward instead.
+ * Both directions consume the same {LE u32} round-key layout the
+ * SW path uses - encrypt walks erk forward, decrypt walks the
+ * IMC-pre-applied drk forward (same shape as the AES-NI side).
  *
  * Per-bits specialisation matches the AES-NI rationale: literal
  * round count lets the compiler unroll the AESE/AESMC pairs. */

--- a/rlib/rcrc.c
+++ b/rlib/rcrc.c
@@ -21,12 +21,14 @@
 #include <rlib/rcpufeatures.h>
 #include <rlib/rmem.h>
 
-#if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
+#ifdef HAVE_NMMINTRIN_H
 # include <nmmintrin.h>
 #endif
 
-#if defined(R_ARCH_AARCH64) && !defined(_MSC_VER)
+#ifdef HAVE_ARM_ACLE_H
 # include <arm_acle.h>
+#elif defined(HAVE_INTRIN_H)
+# include <intrin.h>
 #endif
 
 static const ruint32 g__r_crc32_tbl[] = {
@@ -155,7 +157,7 @@ r_crc32c_update_sw (ruint32 crc, rconstpointer buffer, rsize size)
   return ~crc;
 }
 
-#if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
+#ifdef HAVE_NMMINTRIN_H
 /* The per-function target attribute lets us call _mm_crc32_* without
  * -msse4.2 at file scope; r_crc32c_update gates entry on
  * R_CPU_FEATURE_SSE4_2 so the SSE4.2 instructions only ever run
@@ -192,10 +194,13 @@ r_crc32c_update_sse42 (ruint32 crc, rconstpointer buffer, rsize size)
 }
 #endif
 
-#if defined(R_ARCH_AARCH64) && !defined(_MSC_VER)
+#if defined(HAVE_ARM_ACLE_H) || defined(HAVE_INTRIN_H)
 /* Same target-attribute pattern as the SSE4.2 path; entry gated on
- * R_CPU_FEATURE_ARM_CRC32 by r_crc32c_update. */
+ * R_CPU_FEATURE_ARM_CRC32 by r_crc32c_update. MSVC ARM intrinsics
+ * compile in without a per-function target attribute. */
+# if defined(__GNUC__) || defined(__clang__)
 __attribute__((target("+crc")))
+# endif
 static ruint32
 r_crc32c_update_armv8 (ruint32 crc, rconstpointer buffer, rsize size)
 {
@@ -224,10 +229,10 @@ r_crc32c_update_armv8 (ruint32 crc, rconstpointer buffer, rsize size)
 ruint32
 r_crc32c_update (ruint32 crc, rconstpointer buffer, rsize size)
 {
-#if defined(R_ARCH_X86_64) || defined(R_ARCH_X86)
+#ifdef HAVE_NMMINTRIN_H
   if (r_cpu_has (R_CPU_FEATURE_SSE4_2))
     return r_crc32c_update_sse42 (crc, buffer, size);
-#elif defined(R_ARCH_AARCH64) && !defined(_MSC_VER)
+#elif defined(HAVE_ARM_ACLE_H) || defined(HAVE_INTRIN_H)
   if (r_cpu_has (R_CPU_FEATURE_ARM_CRC32))
     return r_crc32c_update_armv8 (crc, buffer, size);
 #endif

--- a/rlib/rthreads.c
+++ b/rlib/rthreads.c
@@ -171,8 +171,17 @@ r_thread_win32_dll_thread_detach (void)
 rpointer
 r_call_once (ROnce * once, RThreadFunc f, rpointer a)
 {
-  ruint old = R_ONCE_STATE_INIT;
+  ruint old;
 
+  /* Double-checked locking: an atomic load up front lets every
+   * post-init call return immediately, skipping the CAS the slow
+   * path needs. The atomic store of DONE in the writer
+   * synchronises-with this load, so the plain write to once->ret
+   * before the store is visible after. */
+  if (R_LIKELY (r_atomic_uint_load (&once->state) == R_ONCE_STATE_DONE))
+    return once->ret;
+
+  old = R_ONCE_STATE_INIT;
   if (r_atomic_uint_cmp_xchg_strong (&once->state, &old, R_ONCE_STATE_RUNNING)) {
     once->ret = f (a);
     r_atomic_uint_store (&once->state, R_ONCE_STATE_DONE);

--- a/test/rthread.c
+++ b/test/rthread.c
@@ -288,6 +288,64 @@ RTEST_STRESS (rthread, rwmutex_stress, RTEST_FAST)
 }
 RTEST_END;
 
+typedef struct {
+  ROnce once;
+  rauint invocations;
+} RThreadsTestOnce;
+
+#define RTHREAD_TEST_ONCE_SENTINEL  RUINT_TO_POINTER (0xcafef00d)
+
+static rpointer
+rthread_test_once_init (rpointer data)
+{
+  RThreadsTestOnce * ctx = data;
+  r_atomic_uint_fetch_add (&ctx->invocations, 1);
+  return RTHREAD_TEST_ONCE_SENTINEL;
+}
+
+RTEST (rthread, call_once_basic, RTEST_FAST)
+{
+  RThreadsTestOnce ctx = { R_ONCE_INIT, 0 };
+  rsize i;
+
+  for (i = 0; i < 16; i++) {
+    r_assert_cmpptr (r_call_once (&ctx.once, rthread_test_once_init, &ctx),
+        ==, RTHREAD_TEST_ONCE_SENTINEL);
+  }
+  r_assert_cmpuint (r_atomic_uint_load (&ctx.invocations), ==, 1);
+}
+RTEST_END;
+
+static rpointer
+rthread_test_once_caller (rpointer data)
+{
+  RThreadsTestOnce * ctx = data;
+  /* Drive enough calls to exercise the slow path on first entry
+   * and the fast path on every later entry. */
+  rsize i;
+  for (i = 0; i < 256; i++)
+    r_assert_cmpptr (r_call_once (&ctx->once, rthread_test_once_init, ctx),
+        ==, RTHREAD_TEST_ONCE_SENTINEL);
+  return NULL;
+}
+
+RTEST_STRESS (rthread, call_once_concurrent, RTEST_FAST)
+{
+  RThreadsTestOnce ctx = { R_ONCE_INIT, 0 };
+  RThread * thr[32];
+  rsize i;
+
+  for (i = 0; i < R_N_ELEMENTS (thr); i++)
+    thr[i] = r_thread_new ("once_caller", rthread_test_once_caller, &ctx);
+  for (i = 0; i < R_N_ELEMENTS (thr); i++) {
+    r_thread_join (thr[i]);
+    r_thread_unref (thr[i]);
+  }
+
+  r_assert_cmpuint (r_atomic_uint_load (&ctx.invocations), ==, 1);
+}
+RTEST_END;
+
 #else
 RTEST (rthread, dummy, RTEST_FAST)
 {


### PR DESCRIPTION
## Summary

- **`r_call_once` fast path**: an atomic load + branch on the steady-state DONE branch lets every post-init call return immediately, skipping the strong CAS the slow path needs. All existing callers (`r_cpu_features`, `r_fs_find_tmp_dir`, `r_sys_cpu_linux_max_cpus`, two in `rtest`) automatically benefit. Public Doxygen added for `ROnce`, `R_ONCE_INIT`, `r_call_once`, with a new `r_once` group.
- **Meson-driven intrinsic header detection**: `nmmintrin.h`, `wmmintrin.h`, `arm_neon.h`, `arm_acle.h`, `intrin.h` probed via `cc.has_header`; expose as `HAVE_*_H` in `config.h`. CRC32C and AES dispatch switch from `R_ARCH_*` / `!defined(_MSC_VER)` gymnastics to header-availability checks.
- **MSVC AArch64 CRC32C**: dropping the `!defined(_MSC_VER)` carve-out + including `<intrin.h>` instead of `<arm_acle.h>` opens the HW CRC32C path for Windows-on-ARM builds. Closes #162.
- **CI**: new `windows-11-arm` job exercises the MSVC AArch64 backend on every PR.
- **Test coverage**: two new `r_call_once` tests (basic single-thread + 32-thread concurrent) lock in the contract the rest of the library now depends on.

## Test plan

- [x] x86_64 native: full suite + new tests (1525/1525 passed, debugoptimized).
- [x] aarch64 cross via qemu-user: full suite + new tests (1525/1525 passed).
- [x] TSan: new `/rthread/call_once_*` tests green under thread sanitizer.
- [ ] CI: Linux x86_64 (gcc, clang), Linux ARM (gcc, clang), macOS, Windows MSVC, **Windows ARM MSVC (new)**, sanitizers (ASan+UBSan, TSan), docs.

## Notes

- The dedicated CRC32C dispatch cache I prototyped earlier in the session is dropped: with the `r_call_once` fast path, `r_cpu_has`-per-call is cheap enough that the cache would be over-engineering. The AES per-cipher cache stays — it's per-instance struct state, not global ROnce, and enables compile-time literal-rounds specialisation.
- New CI job uses the GA `windows-11-arm` runner image (free for public repos since Aug 2025). First run on this PR will tell us if `ilammy/msvc-dev-cmd@v1 arch: arm64` + meson + ninja + `__crc32c{b,w,d}` from `<intrin.h>` cleanly compose on Windows-on-ARM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)