### PR TITLE
test: Fix /rio/open intermittent failure on Windows MSVC

### DIFF
--- a/test/rfileio.c
+++ b/test/rfileio.c
@@ -8,10 +8,10 @@ RTEST (rio, open, RTEST_FAST | RTEST_SYSTEM)
   RIOHandle handle;
 
   r_assert_cmpint (r_io_open_file ("/foo/bar/badger", R_FILE_OPEN_EXISTING,
-        R_FILE_READ, R_FILE_SHARE_EXCLUSIVE, R_FILE_FLAG_NONE, NULL), ==, R_IO_HANDLE_INVALID);
+        R_FILE_READ, R_FILE_SHARE_READ, R_FILE_FLAG_NONE, NULL), ==, R_IO_HANDLE_INVALID);
   rchar * path = r_proc_get_exe_path ();
   r_assert_cmpint ((handle = r_io_open_file (path, R_FILE_OPEN_EXISTING,
-        R_FILE_READ, R_FILE_SHARE_EXCLUSIVE, R_FILE_FLAG_NONE, NULL)), !=, R_IO_HANDLE_INVALID);
+        R_FILE_READ, R_FILE_SHARE_READ, R_FILE_FLAG_NONE, NULL)), !=, R_IO_HANDLE_INVALID);
   r_assert (r_io_close (handle));
 
   r_free (path);


### PR DESCRIPTION
## Summary

\`/rio/open\` re-opens the running EXE to verify \`r_io_open_file\`'s existing-file path. It was passing \`R_FILE_SHARE_EXCLUSIVE\` (Win32 \`dwShareMode = 0\`), which races \`CreateFileW\` against the kernel's image-section handle that holds the EXE with implicit \`FILE_SHARE_READ\`. Result: intermittent failures on \`windows-latest\` MSVC release, surfaced on PR #164.

Switch to \`R_FILE_SHARE_READ\` so the share mode matches the kernel's existing handle. POSIX ignores share mode entirely.

The companion call against the bogus path \`/foo/bar/badger\` is changed to match — share mode is dead code there (the file doesn't exist) but keeping the two assertions visually consistent.

## Test plan

- [x] Linux x86_64 native: all `/rio/*` tests pass.
- [x] CI: Windows MSVC release no longer intermittently fails on `/rio/open`.

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)