### PR TITLE
ci: Build only debugoptimized on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,10 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [gcc, clang]
-        buildtype: [debugoptimized, release]
+        # PR runs build only debugoptimized to keep CI fast; master
+        # pushes / scheduled / manual runs build both buildtypes.
+        # Same pattern repeated across the other platform jobs.
+        buildtype: ${{ fromJSON(github.event_name == 'pull_request' && '["debugoptimized"]' || '["debugoptimized","release"]') }}
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies
@@ -51,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [gcc, clang]
-        buildtype: [debugoptimized, release]
+        buildtype: ${{ fromJSON(github.event_name == 'pull_request' && '["debugoptimized"]' || '["debugoptimized","release"]') }}
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies
@@ -79,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        buildtype: [debugoptimized, release]
+        buildtype: ${{ fromJSON(github.event_name == 'pull_request' && '["debugoptimized"]' || '["debugoptimized","release"]') }}
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies
@@ -103,7 +106,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        buildtype: [debugoptimized, release]
+        buildtype: ${{ fromJSON(github.event_name == 'pull_request' && '["debugoptimized"]' || '["debugoptimized","release"]') }}
     steps:
       - uses: actions/checkout@v6
       - uses: ilammy/msvc-dev-cmd@v1
@@ -133,7 +136,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        buildtype: [debugoptimized, release]
+        buildtype: ${{ fromJSON(github.event_name == 'pull_request' && '["debugoptimized"]' || '["debugoptimized","release"]') }}
     steps:
       - uses: actions/checkout@v6
       - uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
## Summary

Drops the release variant from every platform matrix on PR runs; master pushes, scheduled cron, and manual dispatches keep the full debugoptimized + release sweep. Halves the platform-matrix job count on PRs (12 → 6).

| Event | Buildtypes built |
|---|---|
| pull_request | debugoptimized only |
| push to master | debugoptimized + release |
| schedule / workflow_dispatch | debugoptimized + release |

Sanitizers, Docs, and the gated Full-test-sweep jobs are unchanged.

Uses an inline `fromJSON` ternary on each matrix's `buildtype` list so each job's strategy stays self-contained — avoids the alternative of a setup-job that emits the matrix as JSON output + a `needs:` dependency on every parallel job.

## Test plan

- [ ] This PR run: 6 platform-matrix jobs (one buildtype each), not 12.
- [ ] After merge: master push job count returns to 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)