### PR TITLE
rhzrptr: Link new records into the global list on push

### DIFF
--- a/rlib/data/rhzrptr.c
+++ b/rlib/data/rhzrptr.c
@@ -134,7 +134,9 @@ r_hzr_ptr_rec_new (void)
   r_atomic_bool_set (&rec->active);
 
   old = r_atomic_ptr_load (&g__r_hzrptr);
-  while (!r_atomic_ptr_cmp_xchg_weak (&g__r_hzrptr, &old, rec));
+  do {
+    rec->next = old;
+  } while (!r_atomic_ptr_cmp_xchg_weak (&g__r_hzrptr, &old, rec));
 
 done:
   return rec;

--- a/test/rhzrptr.c
+++ b/test/rhzrptr.c
@@ -8,6 +8,32 @@ RTEST (rhzrptr, rec, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rhzrptr, rec_reuse, RTEST_FAST)
+{
+  RHzrPtrRec * recs[16];
+  rsize i, j;
+
+  for (i = 0; i < R_N_ELEMENTS (recs); i++) {
+    recs[i] = r_hzr_ptr_rec_new ();
+    r_assert_cmpptr (recs[i], !=, NULL);
+  }
+  for (i = 0; i < R_N_ELEMENTS (recs); i++)
+    r_hzr_ptr_rec_free (recs[i]);
+
+  for (i = 0; i < R_N_ELEMENTS (recs); i++) {
+    RHzrPtrRec * rec = r_hzr_ptr_rec_new ();
+    rboolean found = FALSE;
+    for (j = 0; j < R_N_ELEMENTS (recs); j++) {
+      if (rec == recs[j]) {
+        found = TRUE;
+        break;
+      }
+    }
+    r_assert (found);
+  }
+}
+RTEST_END;
+
 RTEST (rhzrptr, read, RTEST_FAST)
 {
   rhzrptr hp = R_HZR_PTR_INIT (NULL);


### PR DESCRIPTION
## Summary

\`r_hzr_ptr_rec_new\` was appending a fresh \`RHzrPtrRec\` to the global \`g__r_hzrptr\` list head via \`cmp_xchg\` without ever setting \`rec->next\`. Every previously-published record got detached the moment a new one was pushed - so the list was effectively a one-element stub, record reuse never kicked in (every allocation hit \`r_mem_new0\`), and \`r_hzr_ptr_rec_scan\` couldn't see retired pointers on orphaned records (leak).

Fix is the standard Treiber-stack push:

\`\`\`c
old = r_atomic_ptr_load (&g__r_hzrptr);
do {
  rec->next = old;
} while (!r_atomic_ptr_cmp_xchg_weak (&g__r_hzrptr, &old, rec));
\`\`\`

\`cmp_xchg_weak\` writes the actual current value back into \`old\` on failure, so the loop converges naturally.

## Test plan

- [x] New regression test \`/rhzrptr/rec_reuse\`: alloc N records, free all, alloc N more, assert each new allocation is one of the originals. Fails at iteration 2 without the fix, passes after.
- [x] Existing \`/rhzrptr/*\` tests still pass (5/5).
- [x] Full suite green on x86_64 (1526/1526) and aarch64 via qemu (1526/1526).
- [x] TSan clean on \`/rhzrptr/*\`.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)