### PR TITLE
rtest: Fix -p duplication, surface filtered counts, repeatable -f

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -31,6 +31,13 @@ EXTRACT_STATIC          = YES
 
 OPTIMIZE_OUTPUT_FOR_C   = YES
 
+# Hide rlib's opaque-handle internals: the public API exposes
+# `typedef struct _Foo Foo;` but only Foo is meant to appear in
+# generated docs. Excluding _*-prefixed symbols drops the
+# implementation-side struct definitions from the navtree and
+# class lists without affecting the public typedefs.
+EXCLUDE_SYMBOLS         = _*
+
 # Don't pull Markdown headings into the navigation tree. Without this,
 # the README's Setext-style H1 / H2 headings get auto-nested under
 # the "Data Structures" navtree node (a known Doxygen quirk when the

--- a/include/rlib/rargparse.h
+++ b/include/rlib/rargparse.h
@@ -37,6 +37,7 @@ typedef enum {
   R_ARG_OPTION_TYPE_DOUBLE,
   R_ARG_OPTION_TYPE_STRING,
   R_ARG_OPTION_TYPE_FILENAME,
+  R_ARG_OPTION_TYPE_STRING_ARRAY,
   R_ARG_OPTION_TYPE_COUNT,
   R_ARG_OPTION_TYPE_ERROR = R_ARG_OPTION_TYPE_COUNT
 } RArgOptionType;
@@ -166,6 +167,7 @@ R_API rint64 r_arg_parse_ctx_get_option_int64 (RArgParseCtx * ctx, const rchar *
 R_API rdouble r_arg_parse_ctx_get_option_double (RArgParseCtx * ctx, const rchar * longarg);
 R_API rchar * r_arg_parse_ctx_get_option_string (RArgParseCtx * ctx, const rchar * longarg) R_ATTR_MALLOC;
 R_API rchar * r_arg_parse_ctx_get_option_filename (RArgParseCtx * ctx, const rchar * longarg) R_ATTR_MALLOC;
+R_API rchar ** r_arg_parse_ctx_get_option_string_array (RArgParseCtx * ctx, const rchar * longarg) R_ATTR_MALLOC;
 
 R_API const rchar * r_arg_parse_ctx_get_command (const RArgParseCtx * ctx);
 R_API RArgParseCtx * r_arg_parse_ctx_get_command_ctx (RArgParseCtx * ctx);

--- a/include/rlib/rargparse.h
+++ b/include/rlib/rargparse.h
@@ -25,153 +25,383 @@
 #include <rlib/rtypes.h>
 #include <rlib/rref.h>
 
+/**
+ * @defgroup r_argparse Command-line argument parsing
+ * @brief Declarative CLI option parser with grouped options, sub-
+ * commands, positionals, defaults, and accumulated multi-value
+ * options.
+ * @{
+ */
+
+/**
+ * @file rlib/rargparse.h
+ * @brief Command-line argument parsing.
+ *
+ * Declare options as an array of @c RArgOptionEntry structs, hand
+ * them to an @c RArgParser, then run @c r_arg_parser_parse against
+ * @c argc / @c argv. The parse yields an @c RArgParseCtx from which
+ * per-option values are retrieved via the type-specific getters.
+ *
+ * **Typical flow:**
+ *  1. Build a parser with @c r_arg_parser_new.
+ *  2. Register options via @c r_arg_parser_add_option_entries
+ *     (long name, short name, type, flags, description, ...).
+ *  3. Optionally add sub-commands (@c r_arg_parser_add_command)
+ *     and grouped option blocks (@c r_arg_option_group_new).
+ *  4. Parse with @c r_arg_parser_parse; an @c RArgParseCtx is
+ *     returned (or @c NULL with a result code).
+ *  5. Read values via @c r_arg_parse_ctx_get_option_bool /
+ *     _int / _string / _string_array / etc.
+ *  6. Release with @c r_arg_parse_ctx_unref.
+ *
+ * Supports automatic @c --help / @c --version handling, default
+ * values, required options, positional arguments, and an inverse
+ * (no-foo) flag form. @c -h, @c --help, and @c --version are
+ * registered for free unless suppressed by
+ * @c R_ARG_PARSE_FLAG_DISALE_HELP.
+ */
+
 R_BEGIN_DECLS
 
+/** @brief Opaque parser handle. */
 typedef struct _RArgParser RArgParser;
+/** @brief Opaque option-group handle (named subset of options). */
+typedef struct _RArgOptionGroup RArgOptionGroup;
+/** @brief Opaque parse-result context returned by @c r_arg_parser_parse. */
+typedef struct _RArgParseCtx RArgParseCtx;
 
+/**
+ * @brief Value type carried by an @c RArgOptionEntry.
+ *
+ * Picks the parsing and storage strategy for an option:
+ *  - @c NONE / @c BOOL: presence-only flag.
+ *  - @c INT / @c INT64 / @c DOUBLE: numeric value parsed via the
+ *    corresponding @c r_str_to_* family.
+ *  - @c STRING / @c FILENAME: a single string; later occurrences
+ *    overwrite earlier ones.
+ *  - @c STRING_ARRAY: a string that accumulates across multiple
+ *    occurrences; read with @c r_arg_parse_ctx_get_option_string_array.
+ */
 typedef enum {
-  R_ARG_OPTION_TYPE_NONE,
-  R_ARG_OPTION_TYPE_BOOL = R_ARG_OPTION_TYPE_NONE,
-  R_ARG_OPTION_TYPE_INT,
-  R_ARG_OPTION_TYPE_INT64,
-  R_ARG_OPTION_TYPE_DOUBLE,
-  R_ARG_OPTION_TYPE_STRING,
-  R_ARG_OPTION_TYPE_FILENAME,
-  R_ARG_OPTION_TYPE_STRING_ARRAY,
-  R_ARG_OPTION_TYPE_COUNT,
-  R_ARG_OPTION_TYPE_ERROR = R_ARG_OPTION_TYPE_COUNT
+  R_ARG_OPTION_TYPE_NONE,                       /**< Presence-only flag (alias for @c BOOL). */
+  R_ARG_OPTION_TYPE_BOOL = R_ARG_OPTION_TYPE_NONE, /**< Boolean flag. */
+  R_ARG_OPTION_TYPE_INT,                        /**< Signed @c int value. */
+  R_ARG_OPTION_TYPE_INT64,                      /**< Signed @c rint64 value. */
+  R_ARG_OPTION_TYPE_DOUBLE,                     /**< @c rdouble value. */
+  R_ARG_OPTION_TYPE_STRING,                     /**< Single string; last occurrence wins. */
+  R_ARG_OPTION_TYPE_FILENAME,                   /**< Single filename string. */
+  R_ARG_OPTION_TYPE_STRING_ARRAY,               /**< Repeatable string; values accumulate in argv order. */
+  R_ARG_OPTION_TYPE_COUNT,                      /**< Sentinel: number of value types (also @c ERROR). */
+  R_ARG_OPTION_TYPE_ERROR = R_ARG_OPTION_TYPE_COUNT /**< Returned by getters on unknown / wrong-typed option. */
 } RArgOptionType;
 
+/** @brief Per-option behaviour flags. */
 typedef enum {
   R_ARG_OPTION_FLAG_NONE            = 0,
-  R_ARG_OPTION_FLAG_HIDDEN          = 1 << 0,
-  R_ARG_OPTION_FLAG_INVERSE         = 1 << 1,
-  R_ARG_OPTION_FLAG_REQUIRED        = 1 << 2,
-  /* Positional argument: bound by position in argv, not by --name.
-   * 'longarg' is the name used as the storage key and in help text;
-   * 'eqname' (or longarg uppercased) becomes the name in the Usage
-   * line. shortarg is ignored. Cannot be combined with TYPE_NONE
-   * since positionals always carry a value. REQUIRED is implied
-   * when defval is NULL. */
+  R_ARG_OPTION_FLAG_HIDDEN          = 1 << 0, /**< Omit from the @c --help output. */
+  R_ARG_OPTION_FLAG_INVERSE         = 1 << 1, /**< Boolean inverse: @c --no-foo sets foo=FALSE. */
+  R_ARG_OPTION_FLAG_REQUIRED        = 1 << 2, /**< Parser fails if the option is absent. */
+  /**
+   * Positional argument: bound by position in argv, not by @c --name.
+   * @c longarg is the name used as the storage key and in help text;
+   * @c eqname (or @c longarg uppercased) becomes the name in the
+   * Usage line. @c shortarg is ignored. Cannot be combined with
+   * @c TYPE_NONE since positionals always carry a value.
+   * @c REQUIRED is implied when @c defval is @c NULL.
+   */
   R_ARG_OPTION_FLAG_POSITIONAL      = 1 << 3,
 } RArgOptionFlags;
 
+/**
+ * @brief Declarative description of one CLI option.
+ *
+ * Used by @c r_arg_parser_add_option_entries and friends. Typically
+ * declared as a @c static array at file scope, where each row is one
+ * option.
+ */
 typedef struct {
-  const rchar *   longarg;
-  rchar           shortarg;
-  RArgOptionType  type;
-  RArgOptionFlags flags;
-  const rchar *   desc;
-  const rchar *   eqname;
-  /* Default value returned by the getters when the option is absent
+  const rchar *   longarg;    /**< Long-form name (no leading @c --). */
+  rchar           shortarg;   /**< Short-form name (no @c -); @c 0 to disable. */
+  RArgOptionType  type;       /**< Value type. */
+  RArgOptionFlags flags;      /**< Behaviour flags. */
+  const rchar *   desc;       /**< Help-text description. */
+  const rchar *   eqname;     /**< Placeholder name in @c --foo=NAME help; @c NULL picks a default. */
+  /**
+   * Default value returned by the getters when the option is absent
    * from the command line. The string is parsed by the same per-type
-   * parser used for the on-cmdline value; NULL means "no default" and
-   * the getter returns the zero/empty value for the type, as before.
-   * Not meaningful for BOOL (presence is the value); ignored with a
-   * warning if combined with REQUIRED. */
+   * parser used for the on-cmdline value; @c NULL means "no default"
+   * and the getter returns the zero/empty value for the type.
+   * Not meaningful for @c BOOL (presence is the value); ignored with
+   * a warning if combined with @c REQUIRED.
+   */
   const rchar *   defval;
 } RArgOptionEntry;
 
+/** @brief Flags controlling @c r_arg_parser_parse behaviour. */
 typedef enum {
   R_ARG_PARSE_FLAG_NONE               = 0,
-  R_ARG_PARSE_FLAG_DONT_EXIT          = 1 << 0,
-  R_ARG_PARSE_FLAG_DONT_PRINT_STDOUT  = 1 << 1,
-  R_ARG_PARSE_FLAG_DISALE_HELP        = 1 << 2,
-  R_ARG_PARSE_FLAG_ALLOW_UNKNOWN      = 1 << 3,
+  R_ARG_PARSE_FLAG_DONT_EXIT          = 1 << 0, /**< Return errors instead of calling @c exit. */
+  R_ARG_PARSE_FLAG_DONT_PRINT_STDOUT  = 1 << 1, /**< Suppress automatic help / version output. */
+  R_ARG_PARSE_FLAG_DISALE_HELP        = 1 << 2, /**< Don't auto-register @c --help / @c -h. */
+  R_ARG_PARSE_FLAG_ALLOW_UNKNOWN      = 1 << 3, /**< Pass unknown options through instead of failing. */
 } RArgParseFlags;
 
+/** @brief Result code from @c r_arg_parser_parse. */
 typedef enum {
-  R_ARG_PARSE_VERSION = -2,
-  R_ARG_PARSE_HELP = -1,
-  R_ARG_PARSE_OK = 0,
-  R_ARG_PARSE_ARG_ERROR,
-  R_ARG_PARSE_UNKNOWN_OPTION,
-  R_ARG_PARSE_MISSING_OPTION,
-  R_ARG_PARSE_VALUE_ERROR,
-  R_ARG_PARSE_MISSING_COMMAND,
-  R_ARG_PARSE_OOM,
-  R_ARG_PARSE_ERROR,
+  R_ARG_PARSE_VERSION = -2,                     /**< @c --version was requested; ctx is @c NULL. */
+  R_ARG_PARSE_HELP = -1,                        /**< @c --help was requested; ctx is @c NULL. */
+  R_ARG_PARSE_OK = 0,                           /**< Parse succeeded. */
+  R_ARG_PARSE_ARG_ERROR,                        /**< Malformed argv. */
+  R_ARG_PARSE_UNKNOWN_OPTION,                   /**< Unknown option encountered. */
+  R_ARG_PARSE_MISSING_OPTION,                   /**< Required option was absent. */
+  R_ARG_PARSE_VALUE_ERROR,                      /**< An option's value didn't parse. */
+  R_ARG_PARSE_MISSING_COMMAND,                  /**< Sub-command parser didn't see a command. */
+  R_ARG_PARSE_OOM,                              /**< Allocation failure. */
+  R_ARG_PARSE_ERROR,                            /**< Generic / internal error. */
 } RArgParseResult;
 
-typedef struct _RArgOptionGroup RArgOptionGroup;
-typedef struct _RArgParseCtx RArgParseCtx;
 
-
-/* RArgParser */
+/**
+ * @name Parser lifecycle
+ * @{
+ */
+/**
+ * @brief Create an empty parser.
+ *
+ * @param app      Program name shown in @c --help and the Usage line;
+ *                 @c NULL falls back to @c argv[0] at parse time.
+ * @param version  Version string returned by @c --version; @c NULL
+ *                 omits the auto-registered @c --version option.
+ * @return Newly-allocated parser; release with @c r_arg_parser_unref.
+ */
 R_API RArgParser * r_arg_parser_new (const rchar * app, const rchar * version) R_ATTR_MALLOC;
+/** @brief Increment the parser's refcount. */
 #define r_arg_parser_ref r_ref_ref
+/** @brief Decrement the parser's refcount; frees when it reaches zero. */
 #define r_arg_parser_unref r_ref_unref
+/** @} */
 
+/**
+ * @name Parser configuration
+ * @{
+ */
+/** @brief Set the prologue paragraph shown above option help. */
 R_API void r_arg_parser_set_summary (RArgParser * parser, const rchar * summary);
+/** @brief Set the epilogue paragraph shown below option help. */
 R_API void r_arg_parser_set_epilog (RArgParser * parser, const rchar * epilog);
-
+/** @brief Return the previously-set summary, or @c NULL. */
 R_API const rchar * r_arg_parser_get_summary (RArgParser * parser);
+/** @brief Return the previously-set epilog, or @c NULL. */
 R_API const rchar * r_arg_parser_get_epilog (RArgParser * parser);
+/** @} */
 
-R_ATTR_WARN_UNUSED_RESULT
-R_API rchar * r_arg_parser_get_help (RArgParser * parser, RArgParseFlags flags,
-    const rchar * appname) R_ATTR_MALLOC;
-R_ATTR_WARN_UNUSED_RESULT
-R_API rchar * r_arg_parser_get_version (RArgParser * parser) R_ATTR_MALLOC;
-
-/* Options */
+/**
+ * @name Option registration
+ * @{
+ */
+/**
+ * @brief Register an array of @c RArgOptionEntry rows in bulk.
+ *
+ * @param parser Target parser.
+ * @param args   Array of entries.
+ * @param count  Number of entries in @p args.
+ * @return @c TRUE on success; @c FALSE if any entry is invalid
+ *         (no longarg, unknown type, duplicate long / short name).
+ */
 R_API rboolean r_arg_parser_add_option_entries (RArgParser * parser,
     const RArgOptionEntry * args, rsize count);
+/**
+ * @brief Register a single option by spelling out its fields.
+ *
+ * Equivalent to @c add_option_entries with a one-element array;
+ * convenient at call sites where the description is dynamic.
+ */
 R_API rboolean r_arg_parser_add_option_entry (RArgParser * parser,
     const rchar * longarg, rchar shortarg,
     RArgOptionType type, RArgOptionFlags flags,
     const rchar * desc, const rchar * eqname);
+/**
+ * @brief Attach an option group's entries to the parser.
+ *
+ * Groups appear as a named subsection in @c --help; the parser
+ * retains a reference to @p group.
+ */
 R_API rboolean r_arg_parser_add_option_group (RArgParser * parser,
     RArgOptionGroup * group);
+/** @} */
 
-/* Commands */
+/**
+ * @brief Register a sub-command and return its own parser.
+ *
+ * The returned parser is owned by @p parser; configure it like a
+ * top-level parser (add options, etc.) but don't unref it directly.
+ *
+ * @param parser  Parent parser.
+ * @param cmd     Sub-command name as it appears in argv.
+ * @param desc    Description shown in the parent's command list.
+ */
 R_ATTR_WARN_UNUSED_RESULT
 R_API RArgParser * r_arg_parser_add_command (RArgParser * parser,
     const rchar * cmd, const rchar * desc);
 
-/* Parsing, help, version  */
+/**
+ * @name Help and version output
+ * @{
+ */
+/** @brief Render the help text as a newly-allocated string. */
+R_ATTR_WARN_UNUSED_RESULT
+R_API rchar * r_arg_parser_get_help (RArgParser * parser, RArgParseFlags flags,
+    const rchar * appname) R_ATTR_MALLOC;
+/** @brief Render the version line as a newly-allocated string. */
+R_ATTR_WARN_UNUSED_RESULT
+R_API rchar * r_arg_parser_get_version (RArgParser * parser) R_ATTR_MALLOC;
+/**
+ * @brief Print the version line to stdout.
+ *
+ * Honours @c R_ARG_PARSE_FLAG_DONT_PRINT_STDOUT (no-op then).
+ */
+R_API void r_arg_parser_print_version (RArgParser * parser, RArgParseFlags flags);
+/**
+ * @brief Print the help text to stdout and return @p exitval.
+ *
+ * Convenience for the common pattern of printing help and
+ * propagating an exit code back to @c main.
+ */
+R_API int r_arg_parser_print_help (RArgParser * parser, RArgParseFlags flags,
+    const rchar * appname, int exitval);
+/** @} */
+
+/**
+ * @brief Parse @p argv against @p parser, returning a context with
+ * the resolved option values.
+ *
+ * On success, @p argc / @p argv are advanced past consumed arguments
+ * and the returned context owns the parsed values. On failure (and
+ * with @c R_ARG_PARSE_FLAG_DONT_EXIT), the function returns @c NULL
+ * and writes a more specific code into @p res if non-NULL.
+ *
+ * Without @c R_ARG_PARSE_FLAG_DONT_EXIT, the parser calls @c exit on
+ * @c --help / @c --version / parse errors after printing.
+ *
+ * @return Owning context (release with @c r_arg_parse_ctx_unref) or
+ *         @c NULL on error / help / version.
+ */
 R_ATTR_WARN_UNUSED_RESULT
 R_API RArgParseCtx * r_arg_parser_parse (RArgParser * parser, RArgParseFlags flags,
     int * argc, const rchar *** argv, RArgParseResult * res) R_ATTR_MALLOC;
-R_API void r_arg_parser_print_version (RArgParser * parser, RArgParseFlags flags);
-R_API int r_arg_parser_print_help (RArgParser * parser, RArgParseFlags flags,
-    const rchar * appname, int exitval);
 
-/* RArgOptionGroup */
+/**
+ * @name Parse-context lifecycle
+ * @{
+ */
+/** @brief Increment the context's refcount. */
+#define r_arg_parse_ctx_ref r_ref_ref
+/** @brief Decrement the context's refcount; frees when it reaches zero. */
+#define r_arg_parse_ctx_unref r_ref_unref
+/** @} */
+
+/**
+ * @name Context inspection
+ * @{
+ */
+/** @brief Total number of options recorded in the context. */
+R_API rsize r_arg_parse_ctx_option_count (const RArgParseCtx * ctx);
+/** @brief Return @c TRUE if @p longarg was seen on the command line. */
+R_API rboolean r_arg_parse_ctx_has_option (RArgParseCtx * ctx, const rchar * longarg);
+/** @brief Return the declared @c RArgOptionType for @p longarg, or @c ERROR. */
+R_API RArgOptionType r_arg_parse_ctx_get_option_type (RArgParseCtx * ctx, const rchar * longarg);
+/** @} */
+
+/**
+ * @name Typed value retrieval
+ *
+ * Each helper reads the option named by @p longarg, using its
+ * registered @c RArgOptionType. The string / filename / string_array
+ * variants return freshly-allocated memory; release per their
+ * @c R_ATTR_MALLOC contract.
+ * @{
+ */
+/**
+ * @brief Generic getter dispatched by declared type.
+ *
+ * @param ctx      Parse context.
+ * @param longarg  Option long name.
+ * @param type     Expected type; must match the registration.
+ * @param val      Pointer to the destination variable
+ *                 (e.g. @c rboolean* for @c BOOL).
+ * @return @c TRUE if the option was present and parsed.
+ */
+R_API rboolean r_arg_parse_ctx_get_option_value (RArgParseCtx * ctx,
+    const rchar * longarg, RArgOptionType type, rpointer val);
+/** @brief @c BOOL value, or @c FALSE if absent. */
+R_API rboolean r_arg_parse_ctx_get_option_bool (RArgParseCtx * ctx, const rchar * longarg);
+/** @brief @c INT value, or 0 if absent. */
+R_API int r_arg_parse_ctx_get_option_int (RArgParseCtx * ctx, const rchar * longarg);
+/** @brief @c INT64 value, or 0 if absent. */
+R_API rint64 r_arg_parse_ctx_get_option_int64 (RArgParseCtx * ctx, const rchar * longarg);
+/** @brief @c DOUBLE value, or 0.0 if absent. */
+R_API rdouble r_arg_parse_ctx_get_option_double (RArgParseCtx * ctx, const rchar * longarg);
+/** @brief @c STRING value as a freshly-allocated string, or @c NULL if absent. */
+R_API rchar * r_arg_parse_ctx_get_option_string (RArgParseCtx * ctx, const rchar * longarg) R_ATTR_MALLOC;
+/** @brief @c FILENAME value as a freshly-allocated string, or @c NULL if absent. */
+R_API rchar * r_arg_parse_ctx_get_option_filename (RArgParseCtx * ctx, const rchar * longarg) R_ATTR_MALLOC;
+/**
+ * @brief @c STRING_ARRAY accumulated values as a freshly-allocated
+ * NULL-terminated @c rchar** (r_strv).
+ *
+ * Release with @c r_strv_free. Returns @c NULL if the option was
+ * absent.
+ */
+R_API rchar ** r_arg_parse_ctx_get_option_string_array (RArgParseCtx * ctx, const rchar * longarg) R_ATTR_MALLOC;
+/** @} */
+
+/**
+ * @name Sub-command access
+ * @{
+ */
+/** @brief Sub-command consumed from argv, or @c NULL. */
+R_API const rchar * r_arg_parse_ctx_get_command (const RArgParseCtx * ctx);
+/** @brief Sub-command's own parse context (borrowed), or @c NULL. */
+R_API RArgParseCtx * r_arg_parse_ctx_get_command_ctx (RArgParseCtx * ctx);
+/** @} */
+
+/**
+ * @name Option groups
+ *
+ * Option groups bundle a related subset of options under a named
+ * heading in the help output. Build a group with
+ * @c r_arg_option_group_new, fill it via @c r_arg_option_group_add_entries,
+ * then attach it to the parser with @c r_arg_parser_add_option_group.
+ * @{
+ */
+/**
+ * @brief Create an option group.
+ *
+ * @param name     Heading shown in @c --help.
+ * @param desc     One-line description shown under the heading.
+ * @param summary  Optional longer paragraph above the entries.
+ * @param user     Opaque user pointer attached to the group.
+ * @param notify   Destructor for @p user; called on group destroy.
+ */
 R_API RArgOptionGroup * r_arg_option_group_new (const rchar * name, const rchar * desc,
     const rchar * summary, rpointer user, RDestroyNotify notify);
+/** @brief Increment the group's refcount. */
 #define r_arg_option_group_ref r_ref_ref
+/** @brief Decrement the group's refcount; frees when it reaches zero. */
 #define r_arg_option_group_unref r_ref_unref
 
+/** @brief Register a bulk array of @c RArgOptionEntry rows on the group. */
 R_API rboolean r_arg_option_group_add_entries (RArgOptionGroup * group,
     const RArgOptionEntry * args, rsize count);
+/** @brief Register a single option entry by spelling out its fields. */
 R_API rboolean r_arg_option_group_add_entry (RArgOptionGroup * group,
     const rchar * longarg, rchar shortarg,
     RArgOptionType type, RArgOptionFlags flags,
     const rchar * desc, const rchar * eqname);
-
-/* RArgParseCtx */
-#define r_arg_parse_ctx_ref r_ref_ref
-#define r_arg_parse_ctx_unref r_ref_unref
-
-R_API rsize r_arg_parse_ctx_option_count (const RArgParseCtx * ctx);
-R_API rboolean r_arg_parse_ctx_has_option (RArgParseCtx * ctx, const rchar * longarg);
-
-R_API RArgOptionType r_arg_parse_ctx_get_option_type (RArgParseCtx * ctx, const rchar * longarg);
-R_API rboolean r_arg_parse_ctx_get_option_value (RArgParseCtx * ctx,
-    const rchar * longarg, RArgOptionType type, rpointer val);
-
-R_API rboolean r_arg_parse_ctx_get_option_bool (RArgParseCtx * ctx, const rchar * longarg);
-R_API int r_arg_parse_ctx_get_option_int (RArgParseCtx * ctx, const rchar * longarg);
-R_API rint64 r_arg_parse_ctx_get_option_int64 (RArgParseCtx * ctx, const rchar * longarg);
-R_API rdouble r_arg_parse_ctx_get_option_double (RArgParseCtx * ctx, const rchar * longarg);
-R_API rchar * r_arg_parse_ctx_get_option_string (RArgParseCtx * ctx, const rchar * longarg) R_ATTR_MALLOC;
-R_API rchar * r_arg_parse_ctx_get_option_filename (RArgParseCtx * ctx, const rchar * longarg) R_ATTR_MALLOC;
-R_API rchar ** r_arg_parse_ctx_get_option_string_array (RArgParseCtx * ctx, const rchar * longarg) R_ATTR_MALLOC;
-
-R_API const rchar * r_arg_parse_ctx_get_command (const RArgParseCtx * ctx);
-R_API RArgParseCtx * r_arg_parse_ctx_get_command_ctx (RArgParseCtx * ctx);
+/** @} */
 
 R_END_DECLS
+
+/** @} */ /* r_argparse group */
 
 #endif /* __R_ARGPARSE_H__ */

--- a/include/rlib/rtest.h
+++ b/include/rlib/rtest.h
@@ -430,7 +430,7 @@ int main (int argc, rchar ** argv) {                                            
       "Also run HEAVY_RTEST_* tests (slow but not broken)", NULL, NULL },       \
     { "broken",      'B', R_ARG_OPTION_TYPE_BOOL,     R_ARG_OPTION_FLAG_NONE,   \
       "Also run BROKEN_RTEST_* tests (likely to fail)", NULL, NULL },           \
-    { "filter",      'f', R_ARG_OPTION_TYPE_STRING,   R_ARG_OPTION_FLAG_NONE,   \
+    { "filter", 'f', R_ARG_OPTION_TYPE_STRING_ARRAY, R_ARG_OPTION_FLAG_NONE,    \
       "Filter on test path - default is * (\"/<suite>/<name>\")", NULL, NULL }, \
     { "output",      'o', R_ARG_OPTION_TYPE_FILENAME, R_ARG_OPTION_FLAG_NONE,   \
       "File to print results to, use - for stdout [default]", NULL, NULL },     \
@@ -444,7 +444,7 @@ int main (int argc, rchar ** argv) {                                            
     FILE * f = stdout;                                                          \
     RTestReportFlag report_flags = R_TEST_REPORT_FLAG_NONE;                     \
     RTestRunFlag run_flags = R_TEST_RUN_FLAG_NONE;                              \
-    rchar * output, * filter = NULL;                                            \
+    rchar * output, ** filters = NULL;                                          \
                                                                                 \
     if (r_arg_parse_ctx_get_option_bool (ctx, "verbose"))                       \
       report_flags |= R_TEST_REPORT_FLAG_VERBOSE;                               \
@@ -463,18 +463,18 @@ int main (int argc, rchar ** argv) {                                            
       r_free (output);                                                          \
     }                                                                           \
                                                                                 \
-    filter = r_arg_parse_ctx_get_option_string (ctx, "filter");                 \
+    filters = r_arg_parse_ctx_get_option_string_array (ctx, "filter");          \
     if ((tests = r_test_get_module_tests (NULL, &count)) != NULL &&             \
         (report = r_test_run_tests (tests, count, run_flags, f,                 \
-            R_TEST_ALL_MASK, filter)) != NULL) {                                \
+            R_TEST_ALL_MASK, filters)) != NULL) {                               \
       r_test_report_print (report, report_flags, f);                            \
-      ret = (int) (report->fail + report->error);                              \
+      ret = (int) (report->fail + report->error);                               \
       r_test_report_free (report);                                              \
     }                                                                           \
     if (f != stdout)                                                            \
       fclose (f);                                                               \
                                                                                 \
-    r_free (filter);                                                            \
+    r_strv_free (filters);                                                      \
     r_arg_parse_ctx_unref (ctx);                                                \
   } else {                                                                      \
     ret = r_arg_parser_print_help (parser, R_ARG_PARSE_FLAG_DONT_EXIT, NULL, 1);\
@@ -542,20 +542,24 @@ R_API RTestReport * r_test_run_tests_full (const RTest * tests, rsize count,
     RTestRunFlag flags, FILE * f, RTestFilterFunc filter, rpointer data);
 /**
  * @brief Convenience wrapper around @c r_test_run_tests_full that
- * filters by a type bitmask and a @c r_str_match_simple_pattern-
- * compatible path glob.
+ * filters by a type bitmask and a NULL-terminated array of
+ * @c r_str_match_simple_pattern-compatible path globs.
  *
- * @param tests   Array of tests (typically from @c r_test_get_module_tests).
- * @param count   Number of entries in @p tests.
- * @param flags   Run-time opt-in flags (@c R_TEST_RUN_FLAG_*).
- * @param f       Output FILE for live status lines.
- * @param type    Bitmask of @c R_TEST_TYPE_* base types to include;
- *                use @c R_TEST_ALL_MASK to accept everything.
- * @param filter  Wildcard pattern matched against @c /\<suite\>/\<name\>;
- *                @c NULL accepts every path.
+ * A test runs when its type matches @p type AND at least one of the
+ * @p filters patterns matches its @c /\<suite\>/\<name\> path
+ * (any-match OR semantics across the array).
+ *
+ * @param tests    Array of tests (typically from @c r_test_get_module_tests).
+ * @param count    Number of entries in @p tests.
+ * @param flags    Run-time opt-in flags (@c R_TEST_RUN_FLAG_*).
+ * @param f        Output FILE for live status lines.
+ * @param type     Bitmask of @c R_TEST_TYPE_* base types to include;
+ *                 use @c R_TEST_ALL_MASK to accept everything.
+ * @param filters  NULL-terminated array of wildcard patterns; @c NULL
+ *                 (or an empty array) accepts every path.
  */
 R_API RTestReport * r_test_run_tests (const RTest * tests, rsize count,
-    RTestRunFlag flags, FILE * f, RTestType type, const rchar * filter);
+    RTestRunFlag flags, FILE * f, RTestType type, rchar * const * filters);
 /** @brief Release a report returned by @c r_test_run_tests / _full. */
 #define r_test_report_free(report)  r_free (report)
 

--- a/include/rlib/rtest.h
+++ b/include/rlib/rtest.h
@@ -256,7 +256,11 @@ typedef enum {
  *    and @c skip_broken to recover the @c SKIP_RTEST_* (temporarily
  *    disabled) count.
  *  - @c filtered is the count of tests excluded by the -f filter or
- *    a type mask that weren't already gated.
+ *    a type mask that weren't already gated. The @c filtered_pattern
+ *    and @c filtered_type sub-buckets are populated only when the
+ *    default filter is in use (i.e. via @c r_test_run_tests); custom
+ *    filters via @c r_test_run_tests_full leave them at zero and only
+ *    the @c filtered total is meaningful.
  */
 typedef struct {
   rsize total;            /**< Number of tests considered. */
@@ -264,6 +268,8 @@ typedef struct {
   rsize skip_heavy;       /**< Subcount of @c skip - @c HEAVY_RTEST_* tests. */
   rsize skip_broken;      /**< Subcount of @c skip - @c BROKEN_RTEST_* tests. */
   rsize filtered;         /**< Tests excluded by -f / type mask. */
+  rsize filtered_pattern; /**< Subcount of @c filtered rejected by -f. */
+  rsize filtered_type;    /**< Subcount of @c filtered rejected by the type mask. */
   rsize success;          /**< Passed runs. */
   rsize fail;             /**< Failed runs (assertion). */
   rsize error;            /**< Errored runs (crash / timeout / unknown). */

--- a/include/rlib/rtest.h
+++ b/include/rlib/rtest.h
@@ -31,47 +31,123 @@
 
 #include <stdio.h>
 
+/**
+ * @defgroup r_test Unit testing
+ * @brief In-process unit-test framework: register tests with the
+ * @c RTEST family of macros, ship the binary, run with @c RTEST_MAIN.
+ * @{
+ */
+
+/**
+ * @file rlib/rtest.h
+ * @brief In-process unit-test framework.
+ *
+ * Tests are declared with one of the @c RTEST* macros at file scope -
+ * each one expands to a self-registering @c RTest descriptor that
+ * the runner picks up via @c r_test_get_module_tests. The framework
+ * forks per test (Unix) or runs an isolating thread (Windows) so that
+ * a crashing test reports as @c R_TEST_RUN_STATE_ERROR without taking
+ * the suite down.
+ *
+ * **Picking a macro:**
+ *  - @c RTEST / @c RTEST_F - default unit test, with or without a fixture.
+ *  - @c RTEST_LOOP / @c RTEST_LOOP_F - run the body @c [start, end)
+ *    times; the loop counter is exposed as @c __i.
+ *  - @c RTEST_STRESS / @c RTEST_STRESS_F - long-running concurrency
+ *    test, capped by @c RTEST_STRESS_TIMEOUT.
+ *  - @c RTEST_BENCH / @c RTEST_BENCH_F - benchmark; no timeout.
+ *  - @c SKIP_RTEST_* / @c HEAVY_RTEST_* / @c BROKEN_RTEST_* - the same
+ *    macros but gated out of the default run. See @c RTestSkipReason
+ *    for the difference between the three categories.
+ *
+ * **Type and flag classification (@c RTestType):** every test carries
+ * one of the @c R_TEST_TYPE_* base types (FAST, SLOW, INTEGR, SYSTEM)
+ * - which doubles as a per-test timeout multiplier - plus optional
+ * @c R_TEST_FLAG_* bits (LOOP, STRESS, BENCH, etc.).
+ *
+ * **Wire-up:** put @c RTEST_MAIN(version_str) at the bottom of your
+ * test runner source file; it expands to a @c main that parses the
+ * standard CLI options (@c -f, @c -p, @c --heavy, etc.) and prints
+ * a summary via @c r_test_report_print.
+ */
+
 R_BEGIN_DECLS
 
+/**
+ * @brief Default per-test timeout (multiplied by the test's base
+ * @c R_TEST_TYPE_* value to scale with FAST / SLOW / INTEGR / SYSTEM).
+ * Override at compile time by @c \#define-ing before including rlib.
+ */
 #ifndef RTEST_TIMEOUT
 #define RTEST_TIMEOUT   (4*R_SECOND)
 #endif
+/**
+ * @brief Derive a per-test timeout from a test's @c RTestType.
+ *
+ * Used by the @c RTEST* macros; rarely needed in user code.
+ */
 #define RTEST_TYPE_TIMEOUT(type)    (((type) & R_TEST_TYPE_MASK) * RTEST_TIMEOUT)
 
-/* Hard cap for RTEST_STRESS so deadlocked stress tests get reported by
- * rtest's own per-test timer rather than hanging the suite until meson's
- * outer timeout kills the runner. Override at compile time if a stress
- * test legitimately needs longer. */
+/**
+ * @brief Hard cap for @c RTEST_STRESS.
+ *
+ * Stress tests get this fixed budget rather than the type-derived one
+ * so deadlocked stress tests get reported by rtest's own per-test
+ * timer instead of hanging the suite until meson's outer timeout
+ * kills the runner. Override at compile time if a stress test
+ * legitimately needs longer.
+ */
 #ifndef RTEST_STRESS_TIMEOUT
 #define RTEST_STRESS_TIMEOUT  (30*R_SECOND)
 #endif
 
+/** @brief Opaque descriptor for a registered test. */
 typedef struct _RTest RTest;
+/**
+ * @brief Test body signature.
+ *
+ * @param __i      Loop iteration (0 for non-LOOP tests).
+ * @param fixture  Fixture-struct pointer; @c NULL for tests without
+ *                 @c RTEST_FIXTURE_*.
+ */
 typedef void (*RTestFunc) (rsize __i, rpointer fixture);
+/** @brief Fixture setup / teardown signature. */
 typedef void (*RTestFixtureFunc) (rpointer fixture);
+/**
+ * @brief Filter callback for @c r_test_run_tests_full.
+ *
+ * Return @c TRUE to keep the test, @c FALSE to skip it.
+ */
 typedef rboolean (*RTestFilterFunc) (const RTest * test, rsize __i, rpointer data);
 
+/**
+ * @brief Test classification: base type (FAST / SLOW / INTEGR / SYSTEM)
+ * plus orthogonal behaviour flags (STRESS, LOOP, BENCH, ...).
+ *
+ * The base type doubles as the per-test timeout multiplier
+ * (@c RTEST_TYPE_TIMEOUT); flags compose with it. The runner's
+ * @c -f / type-mask filter accepts a bitwise-OR of base-type bits.
+ */
 typedef enum {
   R_TEST_TYPE_NONE      = 0x00000000,
 
-  /* Test type */
-  R_TEST_TYPE_FAST      = 0x00000001, /* Fast unit-test */
-  R_TEST_TYPE_SLOW      = 0x00000002, /* Slow unit-test */
-  R_TEST_TYPE_FASTSLOW  = 0x00000003, /* Neither/Both Fast or Slow unit-test */
-  R_TEST_TYPE_INTEGR    = 0x00000004, /* Integration-test */
-  R_TEST_TYPE_SYSTEM    = 0x00000008, /* System-test */
-  R_TEST_TYPE_MASK      = 0x0000000F,
+  R_TEST_TYPE_FAST      = 0x00000001, /**< Fast unit-test. */
+  R_TEST_TYPE_SLOW      = 0x00000002, /**< Slow unit-test. */
+  R_TEST_TYPE_FASTSLOW  = 0x00000003, /**< Either fast or slow. */
+  R_TEST_TYPE_INTEGR    = 0x00000004, /**< Integration test. */
+  R_TEST_TYPE_SYSTEM    = 0x00000008, /**< System test. */
+  R_TEST_TYPE_MASK      = 0x0000000F, /**< Mask covering the base types. */
 
-  /* Flags                              Used for tests:             */
-  R_TEST_FLAG_STRESS    = 0x01000000, /*  that are run continously  */
-  R_TEST_FLAG_LOOP      = 0x02000000, /*  that are run x iterations */
-  R_TEST_FLAG_BENCH     = 0x20000000, /*  measuring performance     */
-  R_TEST_FLAG_FUZZY     = 0x40000000, /*  with random input         */
-  R_TEST_FLAG_NOFORK    = 0x80000000, /*  which shouldn't fork      */
-  R_TEST_FLAG_MASK      = 0xFF000000,
-  R_TEST_ALL_MASK       = 0xFFFFFFFF
+  R_TEST_FLAG_STRESS    = 0x01000000, /**< Long-running concurrency test. */
+  R_TEST_FLAG_LOOP      = 0x02000000, /**< Body runs N iterations. */
+  R_TEST_FLAG_BENCH     = 0x20000000, /**< Performance measurement, no timeout. */
+  R_TEST_FLAG_FUZZY     = 0x40000000, /**< Random input fuzz test. */
+  R_TEST_FLAG_NOFORK    = 0x80000000, /**< Run in-process; do not fork. */
+  R_TEST_FLAG_MASK      = 0xFF000000, /**< Mask covering the flag bits. */
+  R_TEST_ALL_MASK       = 0xFFFFFFFF  /**< Match every test. */
 } RTestType;
 
+/** @brief Wire size of @c RTest; used by the registration linker section. */
 #define RLIB_SIZEOF_RTEST   128
 
 struct R_ATTR_ALIGN (RLIB_SIZEOF_RTEST) _RTest {
@@ -91,147 +167,244 @@ struct R_ATTR_ALIGN (RLIB_SIZEOF_RTEST) _RTest {
     RTestFixtureFunc teardown;
 };
 
+/** @brief Outcome of a single test run. */
 typedef enum {
-  R_TEST_RUN_STATE_NONE       = 0,
-  R_TEST_RUN_STATE_RUNNING    = 1,
-  R_TEST_RUN_STATE_SKIP       = 2,
-  R_TEST_RUN_STATE_SUCCESS    = 3,
-  R_TEST_RUN_STATE_FAILED     = 4,
-  R_TEST_RUN_STATE_ERROR      = 5,
-  R_TEST_RUN_STATE_TIMEOUT    = 6
+  R_TEST_RUN_STATE_NONE       = 0, /**< Not yet attempted. */
+  R_TEST_RUN_STATE_RUNNING    = 1, /**< Currently in flight. */
+  R_TEST_RUN_STATE_SKIP       = 2, /**< Skipped (gated or filtered). */
+  R_TEST_RUN_STATE_SUCCESS    = 3, /**< Body returned without assertion failure. */
+  R_TEST_RUN_STATE_FAILED     = 4, /**< Body hit an @c r_assert*. */
+  R_TEST_RUN_STATE_ERROR      = 5, /**< Body crashed / killed / unknown exit. */
+  R_TEST_RUN_STATE_TIMEOUT    = 6  /**< Body exceeded the test's timeout. */
 } RTestRunState;
 
-/* Values for the `skip` field on RTest. Encodes the intent the source-
- * level SKIP_RTEST / HEAVY_RTEST / BROKEN_RTEST macros expressed, so
- * the runner can keep the three buckets separate in the final tally
- * and let callers opt into each category independently via the
- * matching R_TEST_RUN_FLAG_INCLUDE_* flag. */
+/**
+ * @brief Why a test isn't in the default run.
+ *
+ * Stored on @c RTest by the source-level @c SKIP_RTEST_* /
+ * @c HEAVY_RTEST_* / @c BROKEN_RTEST_* macros so the runner can keep
+ * the three buckets separate in the final tally and let callers opt
+ * into each category independently via the matching
+ * @c R_TEST_RUN_FLAG_INCLUDE_* flag.
+ */
 typedef enum {
-  R_TEST_NO_SKIP     = 0,
-  R_TEST_SKIP_TEMP   = 1, /* SKIP_RTEST_*   - temporarily disabled */
-  R_TEST_SKIP_HEAVY  = 2, /* HEAVY_RTEST_*  - too expensive for default */
-  R_TEST_SKIP_BROKEN = 3, /* BROKEN_RTEST_* - known broken, not under repair */
+  R_TEST_NO_SKIP     = 0, /**< Test runs in the default suite. */
+  R_TEST_SKIP_TEMP   = 1, /**< @c SKIP_RTEST_* - temporarily disabled. */
+  R_TEST_SKIP_HEAVY  = 2, /**< @c HEAVY_RTEST_* - too expensive for default. */
+  R_TEST_SKIP_BROKEN = 3, /**< @c BROKEN_RTEST_* - known broken, not under repair. */
 } RTestSkipReason;
 
+/**
+ * @brief Runtime opt-in flags for @c r_test_run_tests / _full.
+ *
+ * One @c INCLUDE_* bit per gated category; clearing the bit keeps
+ * that category out. Each bucket is independent (e.g. the nightly
+ * sweep can opt HEAVY in without dragging BROKEN along, which would
+ * fail by definition). To run all three, pass all three.
+ */
 typedef enum {
   R_TEST_RUN_FLAG_NONE           = 0,
-  /* One flag per skip category. Setting an INCLUDE_* bit opts that
-   * category into the run; clearing it keeps those tests gated out.
-   * Each bucket is independent so e.g. the nightly sweep can opt
-   * HEAVY in without dragging BROKEN along (which would fail by
-   * definition). To run all three, pass all three. */
-  R_TEST_RUN_FLAG_INCLUDE_SKIP   = 1 << 0,
-  R_TEST_RUN_FLAG_PRINT          = 1 << 1,
-  R_TEST_RUN_FLAG_INCLUDE_HEAVY  = 1 << 2,
-  R_TEST_RUN_FLAG_INCLUDE_BROKEN = 1 << 3,
+  R_TEST_RUN_FLAG_INCLUDE_SKIP   = 1 << 0, /**< Run @c SKIP_RTEST_* tests. */
+  R_TEST_RUN_FLAG_PRINT          = 1 << 1, /**< Print a status line per run. */
+  R_TEST_RUN_FLAG_INCLUDE_HEAVY  = 1 << 2, /**< Run @c HEAVY_RTEST_* tests. */
+  R_TEST_RUN_FLAG_INCLUDE_BROKEN = 1 << 3, /**< Run @c BROKEN_RTEST_* tests. */
 } RTestRunFlag;
 
+/**
+ * @brief Source-position snapshot recorded around an assertion or
+ * other rtest milestone.
+ *
+ * Populated by @c r_assert* and the diagnostic signal handlers; used
+ * by the report to point at the last point reached before a failure.
+ */
 typedef struct {
-  RClockTime ts;
-  const rchar * file;
-  const rchar * func;
-  ruint line;
-  rboolean assert;
+  RClockTime ts;          /**< Monotonic timestamp when captured. */
+  const rchar * file;     /**< Source file. */
+  const rchar * func;     /**< Function name. */
+  ruint line;             /**< Source line. */
+  rboolean assert;        /**< @c TRUE if the position came from an assertion. */
 } RTestLastPos;
 
+/** @brief Per-test row in @c RTestReport.runs. */
 typedef struct {
-  const RTest * test;
-  RTestRunState state;
-  rsize __i;
-  int pid;
-  int exitcode;
+  const RTest * test;       /**< Test descriptor. */
+  RTestRunState state;      /**< Outcome. */
+  rsize __i;                /**< Loop iteration (0 for non-LOOP tests). */
+  int pid;                  /**< Forked child PID, or 0 on no-fork paths. */
+  int exitcode;             /**< Child exit code; meaningful on FAILED / ERROR. */
 
-  RTestLastPos lastpos;
-  RTestLastPos failpos;
+  RTestLastPos lastpos;     /**< Most recently marked source position. */
+  RTestLastPos failpos;     /**< Position of the assertion that triggered FAILED. */
 
-  RClockTime start;
-  RClockTime end;
+  RClockTime start;         /**< Monotonic timestamp when the body started. */
+  RClockTime end;           /**< Monotonic timestamp when it finished. */
 } RTestRun;
 
+/** @brief Format flags for @c r_test_report_print. */
 typedef enum {
   R_TEST_REPORT_FLAG_NONE         = 0,
-  R_TEST_REPORT_FLAG_VERBOSE      = (1 << 0),
+  R_TEST_REPORT_FLAG_VERBOSE      = (1 << 0), /**< Print every run, not just failures. */
 } RTestReportFlag;
 
+/**
+ * @brief Aggregate report for one @c r_test_run_tests invocation.
+ *
+ * Counter relationships:
+ *  - @c run + @c skip + @c filtered + @c error == @c total.
+ *  - @c success + @c fail + @c error == number of tests actually run.
+ *  - @c skip is the grand total of gated tests; subtract @c skip_heavy
+ *    and @c skip_broken to recover the @c SKIP_RTEST_* (temporarily
+ *    disabled) count.
+ *  - @c filtered is the count of tests excluded by the -f filter or
+ *    a type mask that weren't already gated.
+ */
 typedef struct {
-  rsize total;
-  rsize run, skip;
-  /* skip is the grand total. skip_heavy / skip_broken are the
-   * subcounts for HEAVY_RTEST_* and BROKEN_RTEST_*; the temporarily-
-   * disabled SKIP_RTEST_* count is skip - skip_heavy - skip_broken. */
-  rsize skip_heavy, skip_broken;
-  /* Tests excluded by -f / type mask that aren't already counted in
-   * skip (i.e. tests with R_TEST_NO_SKIP that the filter rejected). */
-  rsize filtered;
-  rsize success, fail, error;
+  rsize total;            /**< Number of tests considered. */
+  rsize run, skip;        /**< Run / gated counts (see note above). */
+  rsize skip_heavy;       /**< Subcount of @c skip - @c HEAVY_RTEST_* tests. */
+  rsize skip_broken;      /**< Subcount of @c skip - @c BROKEN_RTEST_* tests. */
+  rsize filtered;         /**< Tests excluded by -f / type mask. */
+  rsize success;          /**< Passed runs. */
+  rsize fail;             /**< Failed runs (assertion). */
+  rsize error;            /**< Errored runs (crash / timeout / unknown). */
 
-  RClockTime start;
-  RClockTime end;
+  RClockTime start;       /**< Monotonic timestamp at suite start. */
+  RClockTime end;         /**< Monotonic timestamp at suite end. */
 
-  RTestRun runs[];
+  RTestRun runs[];        /**< Per-test results, @c total entries. */
 } RTestReport;
 
+/** @brief Short alias for @c R_TEST_TYPE_FAST. */
 #define RTEST_FAST      R_TEST_TYPE_FAST
+/** @brief Short alias for @c R_TEST_TYPE_SLOW. */
 #define RTEST_SLOW      R_TEST_TYPE_SLOW
+/** @brief Short alias for @c R_TEST_TYPE_FASTSLOW. */
 #define RTEST_FASTSLOW  R_TEST_TYPE_FASTSLOW
+/** @brief Short alias for @c R_TEST_TYPE_INTEGR. */
 #define RTEST_INTEGR    R_TEST_TYPE_INTEGR
+/** @brief Short alias for @c R_TEST_TYPE_SYSTEM. */
 #define RTEST_SYSTEM    R_TEST_TYPE_SYSTEM
 
-/* Start your test using one of these macros */
-#define RTEST(suite, name, type)                  RTEST_DEFINE_TEST (suite, name, 0, type, RTEST_TYPE_TIMEOUT(type), 0, 1)
-#define RTEST_F(suite, name, type)                RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, 0, type, RTEST_TYPE_TIMEOUT(type), 0, 1)
-#define RTEST_LOOP(suite, name, type, s,e)        RTEST_DEFINE_TEST (suite, name, 0, (type) | R_TEST_FLAG_LOOP, RTEST_TYPE_TIMEOUT(type), s, e)
-#define RTEST_LOOP_F(suite, name, type, s,e)      RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, 0, (type) | R_TEST_FLAG_LOOP, RTEST_TYPE_TIMEOUT(type), s, e)
-#define RTEST_STRESS(suite, name, type)           RTEST_DEFINE_TEST (suite, name, 0, (type) | R_TEST_FLAG_STRESS, RTEST_STRESS_TIMEOUT, 0, 1)
-#define RTEST_STRESS_F(suite, name,type)          RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, 0, (type) | R_TEST_FLAG_STRESS, RTEST_STRESS_TIMEOUT, 0, 1)
-#define RTEST_BENCH(suite, name, type)            RTEST_DEFINE_TEST (suite, name, 0, (type) | R_TEST_FLAG_BENCH, R_CLOCK_TIME_NONE, 0, 1)
-#define RTEST_BENCH_F(suite, name, type)          RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, 0, (type) | R_TEST_FLAG_BENCH, R_CLOCK_TIME_NONE, 0, 1)
-/* Or easily prefix with SKIP to easy disable it temporarily */
-#define SKIP_RTEST(suite, name, type)             RTEST_DEFINE_TEST (suite, name, 1, type, RTEST_TYPE_TIMEOUT(type), 0, 1)
-#define SKIP_RTEST_F(suite, name, type)           RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, 1, type, RTEST_TYPE_TIMEOUT(type), 0, 1)
-#define SKIP_RTEST_LOOP(suite, name, type, s,e)   RTEST_DEFINE_TEST (suite, name, 1, (type) | R_TEST_FLAG_LOOP, RTEST_TYPE_TIMEOUT(type), s, e)
-#define SKIP_RTEST_LOOP_F(suite, name,type, s,e)  RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, 1, (type) | R_TEST_FLAG_LOOP, RTEST_TYPE_TIMEOUT(type), s, e)
-#define SKIP_RTEST_STRESS(suite, name, type)      RTEST_DEFINE_TEST (suite, name, 1, (type) | R_TEST_FLAG_STRESS, RTEST_STRESS_TIMEOUT, 0, 1)
-#define SKIP_RTEST_STRESS_F(suite, name, type)    RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, 1, (type) | R_TEST_FLAG_STRESS, RTEST_STRESS_TIMEOUT, 0, 1)
-#define SKIP_RTEST_BENCH(suite, name, type)       RTEST_DEFINE_TEST (suite, name, 1, (type) | R_TEST_FLAG_BENCH, R_CLOCK_TIME_NONE, 0, 1)
-#define SKIP_RTEST_BENCH_F(suite, name, type)     RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, 1, (type) | R_TEST_FLAG_BENCH, R_CLOCK_TIME_NONE, 0, 1)
-/* HEAVY and BROKE share SKIP's runtime gating (don't run unless
- * the matching --include-skip / --heavy / --broken flag is passed) but carve out distinct
- * intents at the source level. Pick the macro that says why the test
- * isn't in the default suite:
+/**
+ * @name Test definition macros
  *
- *   SKIP_RTEST_*  - temporarily disabled, expected to come back soon
- *                   (work-in-progress, debugging, etc.)
- *   HEAVY_RTEST_* - works correctly but too expensive for the default
- *                   budget (Wycheproof corpora, slow prime generation,
- *                   anything else gated to the nightly / on-demand
- *                   sweep).
- *   BROKEN_RTEST_* - known-failing or known-flaky and not under active
- *                   repair. Carrying it in the source keeps the
- *                   regression visible without polluting the default
- *                   pass / fail tally.
+ * Each macro declares a self-registering @c RTest descriptor and
+ * opens a function body; close it with @c RTEST_END. The @c _F
+ * variants take a fixture - declare its struct via
+ * @c RTEST_FIXTURE_STRUCT and lifecycle via @c RTEST_FIXTURE_SETUP
+ * and @c RTEST_FIXTURE_TEARDOWN. The @c LOOP variants run the body
+ * for @c __i in @c [s,e); the iteration is visible inside the body
+ * as @c __i.
+ * @{
  */
+/** @brief Define a unit test. */
+#define RTEST(suite, name, type)                  RTEST_DEFINE_TEST (suite, name, 0, type, RTEST_TYPE_TIMEOUT(type), 0, 1)
+/** @brief Define a unit test that takes a fixture. */
+#define RTEST_F(suite, name, type)                RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, 0, type, RTEST_TYPE_TIMEOUT(type), 0, 1)
+/** @brief Define a unit test that runs @c [s,e) iterations. */
+#define RTEST_LOOP(suite, name, type, s,e)        RTEST_DEFINE_TEST (suite, name, 0, (type) | R_TEST_FLAG_LOOP, RTEST_TYPE_TIMEOUT(type), s, e)
+/** @brief Define a fixture-using unit test that runs @c [s,e) iterations. */
+#define RTEST_LOOP_F(suite, name, type, s,e)      RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, 0, (type) | R_TEST_FLAG_LOOP, RTEST_TYPE_TIMEOUT(type), s, e)
+/** @brief Define a stress test (capped by @c RTEST_STRESS_TIMEOUT). */
+#define RTEST_STRESS(suite, name, type)           RTEST_DEFINE_TEST (suite, name, 0, (type) | R_TEST_FLAG_STRESS, RTEST_STRESS_TIMEOUT, 0, 1)
+/** @brief Define a fixture-using stress test. */
+#define RTEST_STRESS_F(suite, name,type)          RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, 0, (type) | R_TEST_FLAG_STRESS, RTEST_STRESS_TIMEOUT, 0, 1)
+/** @brief Define a benchmark (no timeout). */
+#define RTEST_BENCH(suite, name, type)            RTEST_DEFINE_TEST (suite, name, 0, (type) | R_TEST_FLAG_BENCH, R_CLOCK_TIME_NONE, 0, 1)
+/** @brief Define a fixture-using benchmark. */
+#define RTEST_BENCH_F(suite, name, type)          RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, 0, (type) | R_TEST_FLAG_BENCH, R_CLOCK_TIME_NONE, 0, 1)
+/** @} */
+
+/**
+ * @name Gated test definition macros
+ *
+ * Same shape as the @c RTEST* macros but the test is excluded from
+ * the default run; opt back in with the matching
+ * @c --include-skip / @c --heavy / @c --broken CLI flag.
+ *
+ * Pick the macro that says why the test isn't in the default suite:
+ *  - @c SKIP_RTEST_*  - temporarily disabled, expected to come back soon
+ *                       (work-in-progress, debugging, etc.).
+ *  - @c HEAVY_RTEST_* - works correctly but too expensive for the
+ *                       default budget (Wycheproof corpora, slow
+ *                       prime generation, anything gated to the
+ *                       nightly / on-demand sweep).
+ *  - @c BROKEN_RTEST_* - known-failing or known-flaky and not under
+ *                       active repair. Carrying it in the source
+ *                       keeps the regression visible without
+ *                       polluting the default pass / fail tally.
+ * @{
+ */
+/** @brief @c RTEST gated as @c R_TEST_SKIP_TEMP. */
+#define SKIP_RTEST(suite, name, type)             RTEST_DEFINE_TEST (suite, name, 1, type, RTEST_TYPE_TIMEOUT(type), 0, 1)
+/** @brief @c RTEST_F gated as @c R_TEST_SKIP_TEMP. */
+#define SKIP_RTEST_F(suite, name, type)           RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, 1, type, RTEST_TYPE_TIMEOUT(type), 0, 1)
+/** @brief @c RTEST_LOOP gated as @c R_TEST_SKIP_TEMP. */
+#define SKIP_RTEST_LOOP(suite, name, type, s,e)   RTEST_DEFINE_TEST (suite, name, 1, (type) | R_TEST_FLAG_LOOP, RTEST_TYPE_TIMEOUT(type), s, e)
+/** @brief @c RTEST_LOOP_F gated as @c R_TEST_SKIP_TEMP. */
+#define SKIP_RTEST_LOOP_F(suite, name,type, s,e)  RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, 1, (type) | R_TEST_FLAG_LOOP, RTEST_TYPE_TIMEOUT(type), s, e)
+/** @brief @c RTEST_STRESS gated as @c R_TEST_SKIP_TEMP. */
+#define SKIP_RTEST_STRESS(suite, name, type)      RTEST_DEFINE_TEST (suite, name, 1, (type) | R_TEST_FLAG_STRESS, RTEST_STRESS_TIMEOUT, 0, 1)
+/** @brief @c RTEST_STRESS_F gated as @c R_TEST_SKIP_TEMP. */
+#define SKIP_RTEST_STRESS_F(suite, name, type)    RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, 1, (type) | R_TEST_FLAG_STRESS, RTEST_STRESS_TIMEOUT, 0, 1)
+/** @brief @c RTEST_BENCH gated as @c R_TEST_SKIP_TEMP. */
+#define SKIP_RTEST_BENCH(suite, name, type)       RTEST_DEFINE_TEST (suite, name, 1, (type) | R_TEST_FLAG_BENCH, R_CLOCK_TIME_NONE, 0, 1)
+/** @brief @c RTEST_BENCH_F gated as @c R_TEST_SKIP_TEMP. */
+#define SKIP_RTEST_BENCH_F(suite, name, type)     RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, 1, (type) | R_TEST_FLAG_BENCH, R_CLOCK_TIME_NONE, 0, 1)
+/** @brief @c RTEST gated as @c R_TEST_SKIP_HEAVY. */
 #define HEAVY_RTEST(suite, name, type)             RTEST_DEFINE_TEST (suite, name, R_TEST_SKIP_HEAVY, type, RTEST_TYPE_TIMEOUT(type), 0, 1)
+/** @brief @c RTEST_F gated as @c R_TEST_SKIP_HEAVY. */
 #define HEAVY_RTEST_F(suite, name, type)           RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, R_TEST_SKIP_HEAVY, type, RTEST_TYPE_TIMEOUT(type), 0, 1)
+/** @brief @c RTEST_LOOP gated as @c R_TEST_SKIP_HEAVY. */
 #define HEAVY_RTEST_LOOP(suite, name, type, s,e)   RTEST_DEFINE_TEST (suite, name, R_TEST_SKIP_HEAVY, (type) | R_TEST_FLAG_LOOP, RTEST_TYPE_TIMEOUT(type), s, e)
+/** @brief @c RTEST_LOOP_F gated as @c R_TEST_SKIP_HEAVY. */
 #define HEAVY_RTEST_LOOP_F(suite, name,type, s,e)  RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, R_TEST_SKIP_HEAVY, (type) | R_TEST_FLAG_LOOP, RTEST_TYPE_TIMEOUT(type), s, e)
+/** @brief @c RTEST gated as @c R_TEST_SKIP_BROKEN. */
 #define BROKEN_RTEST(suite, name, type)            RTEST_DEFINE_TEST (suite, name, R_TEST_SKIP_BROKEN, type, RTEST_TYPE_TIMEOUT(type), 0, 1)
+/** @brief @c RTEST_F gated as @c R_TEST_SKIP_BROKEN. */
 #define BROKEN_RTEST_F(suite, name, type)          RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, R_TEST_SKIP_BROKEN, type, RTEST_TYPE_TIMEOUT(type), 0, 1)
+/** @brief @c RTEST_LOOP gated as @c R_TEST_SKIP_BROKEN. */
 #define BROKEN_RTEST_LOOP(suite, name, type, s,e)  RTEST_DEFINE_TEST (suite, name, R_TEST_SKIP_BROKEN, (type) | R_TEST_FLAG_LOOP, RTEST_TYPE_TIMEOUT(type), s, e)
+/** @brief @c RTEST_LOOP_F gated as @c R_TEST_SKIP_BROKEN. */
 #define BROKEN_RTEST_LOOP_F(suite, name,type,s,e)  RTEST_DEFINE_TEST_WITH_FIXTURE (suite, name, R_TEST_SKIP_BROKEN, (type) | R_TEST_FLAG_LOOP, RTEST_TYPE_TIMEOUT(type), s, e)
-/* End your test with this macro! */
+/** @} */
+
+/**
+ * @brief Close a test body opened by any @c RTEST* macro.
+ *
+ * Required; the macro emits the closing brace plus a final source
+ * position marker so the reporter can point at "end of body".
+ */
 #define RTEST_END _r_test_mark_position (__FILE__, __LINE__, R_STRFUNC, FALSE); }
 
-/* Used for fixtures*/
+/**
+ * @name Fixtures
+ *
+ * Declare a per-test fixture so the body can carry state without
+ * relying on global variables. @c RTEST_FIXTURE_STRUCT declares the
+ * struct (use the suite name); @c RTEST_FIXTURE_SETUP and
+ * @c RTEST_FIXTURE_TEARDOWN open function bodies that the runner
+ * calls before / after each test using @c RTEST_F / @c RTEST_LOOP_F.
+ * @{
+ */
+/** @brief Open a @c struct definition for a suite's fixture. */
 #define RTEST_FIXTURE_STRUCT(suite)               _RTEST_FIXTURE_STRUCT (suite)
+/** @brief Open the fixture setup function body for a suite. */
 #define RTEST_FIXTURE_SETUP(suite)                                            \
   static void _RTEST_FIXTURE_SETUP_NAME (suite) (_RTEST_FIXTURE_ARG (suite))
+/** @brief Open the fixture teardown function body for a suite. */
 #define RTEST_FIXTURE_TEARDOWN(suite)                                         \
   static void _RTEST_FIXTURE_TEARDOWN_NAME (suite) (_RTEST_FIXTURE_ARG (suite))
+/** @} */
 
 
-/* Instead of defining main() yourself, just use RTEST_MAIN()
- * Usually at the bottom of your main test runner .c file.
+/**
+ * @brief Define a @c main() that parses the standard rlibtest CLI
+ * options, runs all registered tests, prints the summary, and
+ * returns the failure + error count as the process exit code.
+ *
+ * Use at the bottom of your test runner source file; @p version_str
+ * is reported by @c --version.
  */
 #define RTEST_MAIN(version_str)                                                 \
 int main (int argc, rchar ** argv) {                                            \
@@ -305,26 +478,94 @@ int main (int argc, rchar ** argv) {                                            
   return ret;                                                                   \
 }
 
+/**
+ * @brief Build the @c /\<suite\>/\<name\> path of a test as a fresh string.
+ *
+ * @return Newly-allocated string; free with @c r_free.
+ */
 R_API rchar * r_test_dup_path (const RTest * test) R_ATTR_MALLOC;
+/**
+ * @brief Write the @c /\<suite\>/\<name\> path of a test into a caller
+ * buffer.
+ *
+ * @param test  Test descriptor.
+ * @param path  Destination buffer.
+ * @param size  Capacity of @p path in bytes (including NUL).
+ * @return @c TRUE if the path fit in @p size, @c FALSE if truncated.
+ */
 R_API rboolean r_test_fill_path (const RTest * test, rchar * path, rsize size);
 
+/**
+ * @brief Enumerate tests registered by a module's linker section.
+ *
+ * @param mod    Module handle, or @c NULL for the running binary.
+ * @param count  Out: number of tests in the returned array.
+ * @return Pointer to the array, owned by the loader (no free).
+ */
 R_API const RTest * r_test_get_module_tests (RMODULE mod, rsize * count);
 
+/**
+ * @brief Run a single test in a forked child (Unix) / isolated
+ * thread (Windows), with the body's outcome reported via the pipe.
+ *
+ * Driver-level entry; user code typically calls @c r_test_run_tests.
+ */
 R_API RTestRunState r_test_run_fork (const RTest * test, rsize __i,
     rboolean notimeout, RTestLastPos * lastpos, RTestLastPos * failpos,
     int * pid, int * exitcode);
+/**
+ * @brief Run a single test in the current process. Used when
+ * @c RNOFORK is set in the environment or a debugger is attached;
+ * a crashing test takes the suite down.
+ */
 R_API RTestRunState r_test_run_nofork (const RTest * test, rsize __i,
     rboolean notimeout, RTestLastPos * lastpos, RTestLastPos * failpos,
     int * pid, int * exitcode);
+/**
+ * @brief Run a suite of tests filtered by an arbitrary callback.
+ *
+ * @param tests    Array of tests (typically from @c r_test_get_module_tests).
+ * @param count    Number of entries in @p tests.
+ * @param flags    Run-time opt-in flags (@c R_TEST_RUN_FLAG_*).
+ * @param f        Output FILE for live status lines.
+ * @param filter   Per-test predicate; @c NULL runs every test.
+ * @param data     Opaque cookie forwarded to @p filter.
+ * @return Heap-allocated report; free with @c r_test_report_free.
+ */
 R_API RTestReport * r_test_run_tests_full (const RTest * tests, rsize count,
     RTestRunFlag flags, FILE * f, RTestFilterFunc filter, rpointer data);
+/**
+ * @brief Convenience wrapper around @c r_test_run_tests_full that
+ * filters by a type bitmask and a @c r_str_match_simple_pattern-
+ * compatible path glob.
+ *
+ * @param tests   Array of tests (typically from @c r_test_get_module_tests).
+ * @param count   Number of entries in @p tests.
+ * @param flags   Run-time opt-in flags (@c R_TEST_RUN_FLAG_*).
+ * @param f       Output FILE for live status lines.
+ * @param type    Bitmask of @c R_TEST_TYPE_* base types to include;
+ *                use @c R_TEST_ALL_MASK to accept everything.
+ * @param filter  Wildcard pattern matched against @c /\<suite\>/\<name\>;
+ *                @c NULL accepts every path.
+ */
 R_API RTestReport * r_test_run_tests (const RTest * tests, rsize count,
     RTestRunFlag flags, FILE * f, RTestType type, const rchar * filter);
-
-R_API void r_test_report_print (RTestReport * report, RTestReportFlag flags, FILE * f);
+/** @brief Release a report returned by @c r_test_run_tests / _full. */
 #define r_test_report_free(report)  r_free (report)
 
+/**
+ * @brief Print the per-run details and aggregate summary to @p f.
+ *
+ * @param report  Report returned by @c r_test_run_tests / _full.
+ * @param flags   @c R_TEST_REPORT_FLAG_VERBOSE prints every run;
+ *                otherwise only failures appear in the per-run block.
+ * @param f       Destination FILE.
+ */
+R_API void r_test_report_print (RTestReport * report, RTestReportFlag flags, FILE * f);
+
 R_END_DECLS
+
+/** @} */ /* r_test group */
 
 #endif /* __R_TEST_H__ */
 

--- a/include/rlib/rtest.h
+++ b/include/rlib/rtest.h
@@ -160,6 +160,9 @@ typedef struct {
    * subcounts for HEAVY_RTEST_* and BROKEN_RTEST_*; the temporarily-
    * disabled SKIP_RTEST_* count is skip - skip_heavy - skip_broken. */
   rsize skip_heavy, skip_broken;
+  /* Tests excluded by -f / type mask that aren't already counted in
+   * skip (i.e. tests with R_TEST_NO_SKIP that the filter rejected). */
+  rsize filtered;
   rsize success, fail, error;
 
   RClockTime start;

--- a/rlib/rargparse.c
+++ b/rlib/rargparse.c
@@ -26,6 +26,7 @@
 #include <rlib/data/rdictionary.h>
 #include <rlib/data/rkvptrarray.h>
 #include <rlib/data/rlist.h>
+#include <rlib/data/rptrarray.h>
 #include <rlib/data/rstring.h>
 #include <rlib/rlog.h>
 #include <rlib/rmem.h>
@@ -70,12 +71,25 @@ struct _RArgParseCtx
   RArgParseCtx * cmdctx;
 };
 
+static void r_arg_parse_ctx_release_string_arrays_in_group (RArgParseCtx * ctx,
+    const RArgOptionGroup * group);
+
 static void
 r_arg_parse_ctx_free (RArgParseCtx * ctx)
 {
   if (ctx->cmdctx)
     r_arg_parse_ctx_unref (ctx->cmdctx);
   r_free (ctx->command);
+
+  /* Per-option STRING_ARRAY storage owns an RPtrArray, which the
+   * dictionary itself doesn't release on unref. Walk all option
+   * entries and unref any RPtrArray we stored. */
+  if (ctx->parser != NULL) {
+    RSList * it;
+    r_arg_parse_ctx_release_string_arrays_in_group (ctx, ctx->parser->main);
+    for (it = ctx->parser->groups; it != NULL; it = it->next)
+      r_arg_parse_ctx_release_string_arrays_in_group (ctx, it->data);
+  }
 
   r_dictionary_unref (ctx->options);
   r_free (ctx->appname);
@@ -115,6 +129,21 @@ struct _RArgOptionGroup
   RArgOptionEntry * entries;
   rsize count;
 };
+
+static void
+r_arg_parse_ctx_release_string_arrays_in_group (RArgParseCtx * ctx,
+    const RArgOptionGroup * group)
+{
+  rsize i;
+  for (i = 0; i < group->count; i++) {
+    if (group->entries[i].type == R_ARG_OPTION_TYPE_STRING_ARRAY) {
+      RPtrArray * arr = r_dictionary_lookup (ctx->options,
+          group->entries[i].longarg);
+      if (arr != NULL)
+        r_ptr_array_unref (arr);
+    }
+  }
+}
 
 
 static void
@@ -452,6 +481,9 @@ r_arg_option_entry_append_help (const RArgOptionEntry * opt, RString * str)
       case R_ARG_OPTION_TYPE_STRING:
         spacing -= r_string_append (str, "=STRING");
         break;
+      case R_ARG_OPTION_TYPE_STRING_ARRAY:
+        spacing -= r_string_append (str, "=STRING...");
+        break;
       default:
         spacing -= r_string_append (str, "=VALUE");
         break;
@@ -764,6 +796,7 @@ r_arg_parser_parse_option_ctx (RArgParser * parser, RArgParseCtx * ctx,
         break;
       case R_ARG_OPTION_TYPE_STRING:
       case R_ARG_OPTION_TYPE_FILENAME:
+      case R_ARG_OPTION_TYPE_STRING_ARRAY:
         ret = r_arg_option_parser_string (&end, NULL);
         break;
       default:
@@ -781,7 +814,16 @@ r_arg_parser_parse_option_ctx (RArgParser * parser, RArgParseCtx * ctx,
     }
   }
 
-  r_dictionary_insert (ctx->options, entry->longarg, (rpointer)str);
+  if (entry->type == R_ARG_OPTION_TYPE_STRING_ARRAY) {
+    RPtrArray * arr = r_dictionary_lookup (ctx->options, entry->longarg);
+    if (arr == NULL) {
+      arr = r_ptr_array_new ();
+      r_dictionary_insert (ctx->options, entry->longarg, arr);
+    }
+    r_ptr_array_add (arr, (rpointer) str, NULL);
+  } else {
+    r_dictionary_insert (ctx->options, entry->longarg, (rpointer)str);
+  }
 
   return ret;
 }
@@ -1215,6 +1257,28 @@ r_arg_parse_ctx_get_option_string (RArgParseCtx * ctx, const rchar * longarg)
     r_arg_parse_ctx_get_option_entry_value (ctx, entry, &ret);
   }
 
+  return ret;
+}
+
+rchar **
+r_arg_parse_ctx_get_option_string_array (RArgParseCtx * ctx, const rchar * longarg)
+{
+  RArgOptionEntry * entry;
+  RPtrArray * arr;
+  rchar ** ret;
+  rsize i, n;
+
+  if ((entry = r_arg_parser_find_entry_by_longarg (ctx->parser, longarg)) == NULL ||
+      entry->type != R_ARG_OPTION_TYPE_STRING_ARRAY)
+    return NULL;
+  if ((arr = r_dictionary_lookup (ctx->options, longarg)) == NULL)
+    return NULL;
+
+  n = r_ptr_array_size (arr);
+  ret = r_mem_new_n (rchar *, n + 1);
+  for (i = 0; i < n; i++)
+    ret[i] = r_strdup (r_ptr_array_get_const (arr, i));
+  ret[n] = NULL;
   return ret;
 }
 

--- a/rlib/rtest.c
+++ b/rlib/rtest.c
@@ -1285,6 +1285,13 @@ typedef struct {
   RTestType type;
   const rchar * filter;
   RTestRunFlag flags;
+  /* Side-channel for r_test_run_tests so it can publish a breakdown
+   * of which rejection source dropped each filtered test. Bumped only
+   * for tests the runner would itself count as filtered (i.e. those
+   * with R_TEST_NO_SKIP - skip-gated tests are counted as skip, not
+   * filtered, even when the default filter is what rejected them). */
+  rsize filtered_pattern;
+  rsize filtered_type;
 } RTestFilterCtx;
 
 static rboolean
@@ -1296,8 +1303,11 @@ r_test_filter_default (const RTest * test, rsize __i, rpointer data)
 
   (void)__i;
 
-  if ((ctx->type & test->type) == 0)
+  if ((ctx->type & test->type) == 0) {
+    if (test->skip == R_TEST_NO_SKIP)
+      ctx->filtered_type++;
     return FALSE;
+  }
   if (test->skip) {
     /* One INCLUDE_* flag per skip category, independently gated so
      * e.g. a --heavy nightly doesn't drag BROKEN tests in with it. */
@@ -1328,6 +1338,8 @@ r_test_filter_default (const RTest * test, rsize __i, rpointer data)
   ret = r_str_match_simple_pattern (fullname, -1, wf);
   r_free (wf);
 
+  if (!ret && test->skip == R_TEST_NO_SKIP)
+    ctx->filtered_pattern++;
   return ret;
 }
 
@@ -1335,8 +1347,14 @@ RTestReport *
 r_test_run_tests (const RTest * tests, rsize count, RTestRunFlag flags, FILE * f,
     RTestType type, const rchar * filter)
 {
-  RTestFilterCtx ctx = { type, filter, flags };
-  return r_test_run_tests_full (tests, count, flags, f, r_test_filter_default, &ctx);
+  RTestFilterCtx ctx = { type, filter, flags, 0, 0 };
+  RTestReport * ret = r_test_run_tests_full (tests, count, flags, f,
+      r_test_filter_default, &ctx);
+  if (ret != NULL) {
+    ret->filtered_pattern = ctx.filtered_pattern;
+    ret->filtered_type = ctx.filtered_type;
+  }
+  return ret;
 }
 
 void
@@ -1441,9 +1459,27 @@ r_test_report_print (RTestReport * report, RTestReportFlag flags, FILE * f)
       _TIME_CLR, R_TIME_ARGS (elapsed), _RESET_CLR);
 
   if (report->filtered > 0) {
-    r_fprintf (f,
-        "Filtered: %s%"RSIZE_FMT"%s   (by -f / type mask)\n",
-        _SKIP_ARGS (report->filtered));
+    /* Default filter populates the sub-buckets so we can name the
+     * rejection source; custom filters via r_test_run_tests_full
+     * leave both at zero - fall back to the plain total there. */
+    if (report->filtered_pattern + report->filtered_type ==
+        report->filtered) {
+      if (report->filtered_pattern > 0 && report->filtered_type > 0) {
+        r_fprintf (f,
+            "Filtered: %s%"RSIZE_FMT"%s by -f, %s%"RSIZE_FMT"%s by type mask\n",
+            _SKIP_ARGS (report->filtered_pattern),
+            _SKIP_ARGS (report->filtered_type));
+      } else if (report->filtered_pattern > 0) {
+        r_fprintf (f, "Filtered: %s%"RSIZE_FMT"%s by -f\n",
+            _SKIP_ARGS (report->filtered_pattern));
+      } else {
+        r_fprintf (f, "Filtered: %s%"RSIZE_FMT"%s by type mask\n",
+            _SKIP_ARGS (report->filtered_type));
+      }
+    } else {
+      r_fprintf (f, "Filtered: %s%"RSIZE_FMT"%s\n",
+          _SKIP_ARGS (report->filtered));
+    }
   }
 
   if (report->skip > 0) {

--- a/rlib/rtest.c
+++ b/rlib/rtest.c
@@ -1283,7 +1283,7 @@ r_test_run_tests_full (const RTest * tests, rsize count, RTestRunFlag flags, FIL
 
 typedef struct {
   RTestType type;
-  const rchar * filter;
+  rchar * const * filters;
   RTestRunFlag flags;
   /* Side-channel for r_test_run_tests so it can publish a breakdown
    * of which rejection source dropped each filtered test. Bumped only
@@ -1298,8 +1298,8 @@ static rboolean
 r_test_filter_default (const RTest * test, rsize __i, rpointer data)
 {
   RTestFilterCtx * ctx = data;
-  rchar fullname[1024], * wf;
-  rboolean ret;
+  rchar fullname[1024];
+  rsize i;
 
   (void)__i;
 
@@ -1329,25 +1329,29 @@ r_test_filter_default (const RTest * test, rsize __i, rpointer data)
     if (!include)
       return FALSE;
   }
-  if (ctx->filter == NULL)
+  if (ctx->filters == NULL || ctx->filters[0] == NULL)
     return TRUE;
 
   fullname[0] = 0;
   r_test_fill_path (test, fullname, sizeof (fullname));
-  wf = r_strprintf ("*%s*", ctx->filter);
-  ret = r_str_match_simple_pattern (fullname, -1, wf);
-  r_free (wf);
+  for (i = 0; ctx->filters[i] != NULL; i++) {
+    rchar * wf = r_strprintf ("*%s*", ctx->filters[i]);
+    rboolean matched = r_str_match_simple_pattern (fullname, -1, wf);
+    r_free (wf);
+    if (matched)
+      return TRUE;
+  }
 
-  if (!ret && test->skip == R_TEST_NO_SKIP)
+  if (test->skip == R_TEST_NO_SKIP)
     ctx->filtered_pattern++;
-  return ret;
+  return FALSE;
 }
 
 RTestReport *
 r_test_run_tests (const RTest * tests, rsize count, RTestRunFlag flags, FILE * f,
-    RTestType type, const rchar * filter)
+    RTestType type, rchar * const * filters)
 {
-  RTestFilterCtx ctx = { type, filter, flags, 0, 0 };
+  RTestFilterCtx ctx = { type, filters, flags, 0, 0 };
   RTestReport * ret = r_test_run_tests_full (tests, count, flags, f,
       r_test_filter_default, &ctx);
   if (ret != NULL) {

--- a/rlib/rtest.c
+++ b/rlib/rtest.c
@@ -1255,6 +1255,8 @@ r_test_run_tests_full (const RTest * tests, rsize count, RTestRunFlag flags, FIL
             ret->skip++;
             if (tests[i].skip == R_TEST_SKIP_HEAVY) ret->skip_heavy++;
             else if (tests[i].skip == R_TEST_SKIP_BROKEN) ret->skip_broken++;
+          } else {
+            ret->filtered++;
           }
         }
       }
@@ -1430,7 +1432,7 @@ r_test_report_print (RTestReport * report, RTestReportFlag flags, FILE * f)
    * gated, to keep the trivial case quiet. */
   r_fprintf (f,
       "%s\n"
-      "Result: %s%"RSIZE_FMT" passed%s, %s%"RSIZE_FMT" failed%s, "
+      "Result:   %s%"RSIZE_FMT" passed%s, %s%"RSIZE_FMT" failed%s, "
           "%s%"RSIZE_FMT" errors%s   [%s%"R_TIME_FORMAT"%s]\n",
       "================================================================================",
       _SUCC_ARGS (report->success),
@@ -1438,11 +1440,17 @@ r_test_report_print (RTestReport * report, RTestReportFlag flags, FILE * f)
       _ERR_ARGS (report->error),
       _TIME_CLR, R_TIME_ARGS (elapsed), _RESET_CLR);
 
+  if (report->filtered > 0) {
+    r_fprintf (f,
+        "Filtered: %s%"RSIZE_FMT"%s   (by -f / type mask)\n",
+        _SKIP_ARGS (report->filtered));
+  }
+
   if (report->skip > 0) {
     /* report->skip is the grand total. Subtract the sub-bucket
      * counters to recover the SKIP_RTEST_* (temp) count. */
     r_fprintf (f,
-        "Gated:  %s%"RSIZE_FMT" skip%s, %s%"RSIZE_FMT" heavy%s, "
+        "Gated:    %s%"RSIZE_FMT" skip%s, %s%"RSIZE_FMT" heavy%s, "
             "%s%"RSIZE_FMT" broken%s   (--include-skip / --heavy / --broken to opt in)\n",
         _SKIP_ARGS (report->skip - report->skip_heavy - report->skip_broken),
         _HEAVY_ARGS (report->skip_heavy),

--- a/rlib/rtest.c
+++ b/rlib/rtest.c
@@ -698,7 +698,7 @@ r_test_run_fork (const RTest * test, rsize __i, rboolean notimeout,
     if (r_io_write (fdp[1], failpos, sizeof (RTestLastPos)) != sizeof (RTestLastPos))
       R_LOG_ERROR ("Failed to write to pipe to parent (forker)");
     r_io_close (fdp[1]);
-    exit (0);
+    _exit (0);
   } else {
     R_LOG_ERROR ("Failed to fork test /%s/%s/%"RSIZE_FMT,
         test->suite, test->name, __i);

--- a/test/rargparse.c
+++ b/test/rargparse.c
@@ -1395,3 +1395,61 @@ RTEST (rargparse, required_without_default_still_required, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rargparse, parse_string_array, RTEST_FAST)
+{
+  static RArgOptionEntry entries[] = {
+    { "filter", 'f', R_ARG_OPTION_TYPE_STRING_ARRAY, R_ARG_OPTION_FLAG_NONE,
+        "Repeatable filter", NULL, NULL },
+  };
+  RArgParser * parser = r_arg_parser_new (NULL, NULL);
+  RArgParseCtx * ctx;
+  rchar ** strv, ** argv, ** got;
+  int argc;
+
+  r_assert (r_arg_parser_add_option_entries (parser, entries, R_N_ELEMENTS (entries)));
+
+  /* Absent option yields a NULL array. */
+  strv = argv = r_strv_new ("rlibtest", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, R_ARG_PARSE_FLAG_NONE,
+          &argc, (const rchar ***)&argv, NULL)), !=, NULL);
+  r_assert_cmpptr (r_arg_parse_ctx_get_option_string_array (ctx, "filter"),
+      ==, NULL);
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+
+  /* Single occurrence yields a one-entry array. */
+  strv = argv = r_strv_new ("rlibtest", "-f", "alpha", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, R_ARG_PARSE_FLAG_NONE,
+          &argc, (const rchar ***)&argv, NULL)), !=, NULL);
+  got = r_arg_parse_ctx_get_option_string_array (ctx, "filter");
+  r_assert_cmpptr (got, !=, NULL);
+  r_assert_cmpuint (r_strv_len (got), ==, 1);
+  r_assert_cmpstr (got[0], ==, "alpha");
+  r_strv_free (got);
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+
+  /* Multiple occurrences accumulate in argv order, mixing short and
+   * long, with and without =. */
+  strv = argv = r_strv_new ("rlibtest", "-f", "alpha", "--filter=beta",
+      "--filter", "gamma", "-f=delta", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, R_ARG_PARSE_FLAG_NONE,
+          &argc, (const rchar ***)&argv, NULL)), !=, NULL);
+  got = r_arg_parse_ctx_get_option_string_array (ctx, "filter");
+  r_assert_cmpptr (got, !=, NULL);
+  r_assert_cmpuint (r_strv_len (got), ==, 4);
+  r_assert_cmpstr (got[0], ==, "alpha");
+  r_assert_cmpstr (got[1], ==, "beta");
+  r_assert_cmpstr (got[2], ==, "gamma");
+  r_assert_cmpstr (got[3], ==, "delta");
+  r_strv_free (got);
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+


### PR DESCRIPTION
## Summary

Bundles two rtest fixes (#123, #124) with the supporting infrastructure: a Doxygen pass over rtest and rargparse, a new multi-value option type in rargparse, and a Doxyfile tweak to hide opaque-struct internals.

**Closes #123** — Use `_exit` in the forked child instead of `exit`, so it doesn't flush inherited stdio buffers and cumulatively duplicate `-p` status lines when stdout is piped.

**Closes #124** — Track tests excluded by `-f` or the type bitmask as a new `filtered` counter on `RTestReport`, and surface them on a `Filtered:` line in the summary. Broken down by rejection source: `Filtered: 1456 by -f`, `Filtered: 16 by type mask`, or both. Distinguishes "filter matched nothing" from "filter matched only gated tests" at a glance.

**rtest: repeatable `-f`** — Previously the second `-f X` silently overrode the first. Now `-f X -f Y` accumulates: a test is kept if any pattern matches its `/<suite>/<name>` path (OR semantics). Required adding a multi-value option type to rargparse first.

**Infrastructure:**
- `R_ARG_OPTION_TYPE_STRING_ARRAY` in rargparse — accumulates values across multiple occurrences; new `r_arg_parse_ctx_get_option_string_array` getter returns a NULL-terminated `rchar**`.
- Doxygen passes over `rtest.h` and `rargparse.h` (matching the established pattern from `rcpufeatures.h`, `rstr.h`, etc.).
- `EXCLUDE_SYMBOLS = _*` in Doxyfile to drop `_RFoo`-style opaque-handle struct definitions from the navtree.

## API change

`r_test_run_tests` final argument changed from `const rchar * filter` to `rchar * const * filters` (NULL-terminated). The only in-tree caller is `RTEST_MAIN`, which is updated.

## Test plan

- [x] New `/rargparse/parse_string_array` test exercises absent / single / multiple-occurrence cases.
- [x] Manual repro of `-p` over piped stdout — no longer duplicates.
- [x] Manual repro of `-f` typo case — now reports `Filtered: N by -f`.
- [x] Manual `-f /rcrc/* -f /raes/*` — accumulates correctly.
- [x] Full suite: 1527/1527 on x86_64 (native) and aarch64 (qemu-user).
- [x] Doxygen run produces no new warnings; class list / navtree no longer carry `_RFoo` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)