### PR TITLE
crypto: AES-GCM and AES-CCM authenticated cipher modes

### DIFF
--- a/bench/raes.c
+++ b/bench/raes.c
@@ -179,3 +179,89 @@ RTEST_BENCH (raes, ofb_256_encrypt, RTEST_FAST | RTEST_SYSTEM)
   r_crypto_cipher_unref (c);
 }
 RTEST_END;
+
+/* AEAD bench: same loop / per-call buffer size as the non-AEAD modes
+ * so the headlines are directly comparable. GCM IV is 12 bytes,
+ * CCM IV is 13 bytes (max L=2 keeps the plaintext-size cap > 16 KiB).
+ * AAD is empty so the headline reflects pure encrypt + tag throughput;
+ * AAD overhead is a separate concern tracked elsewhere. */
+static void
+run_aes_aead_bench (RCryptoCipher * cipher, const rchar * label,
+    rsize ivsize)
+{
+  ruint8 * input;
+  ruint8 * output;
+  ruint8 iv[16];
+  ruint8 tag[16];
+  RClockTime start, end;
+  ruint i;
+
+  r_assert_cmpptr ((input = r_malloc (AES_BENCH_BLOCKSIZE)), !=, NULL);
+  r_assert_cmpptr ((output = r_malloc (AES_BENCH_BLOCKSIZE)), !=, NULL);
+  for (i = 0; i < AES_BENCH_BLOCKSIZE; i++)
+    input[i] = (ruint8)i;
+
+  for (i = 0; i < 5; i++) {
+    r_memset (iv, 0, sizeof (iv));
+    iv[0] = (ruint8)i;
+    r_assert_cmpint (r_crypto_cipher_encrypt_aead (cipher, output,
+          AES_BENCH_BLOCKSIZE, input, NULL, 0, iv, ivsize, tag, sizeof (tag)),
+        ==, R_CRYPTO_CIPHER_OK);
+  }
+
+  start = r_time_get_ts_monotonic ();
+  for (i = 0; i < AES_BENCH_ITERS; i++) {
+    r_memset (iv, 0, sizeof (iv));
+    iv[0] = (ruint8)(i & 0xff);
+    iv[1] = (ruint8)((i >> 8) & 0xff);
+    r_assert_cmpint (r_crypto_cipher_encrypt_aead (cipher, output,
+          AES_BENCH_BLOCKSIZE, input, NULL, 0, iv, ivsize, tag, sizeof (tag)),
+        ==, R_CRYPTO_CIPHER_OK);
+  }
+  end = r_time_get_ts_monotonic ();
+
+  print_aes_result (label, AES_BENCH_ITERS, AES_BENCH_BLOCKSIZE, end - start);
+
+  r_free (input);
+  r_free (output);
+}
+
+RTEST_BENCH (raes, gcm_128_encrypt, RTEST_FAST | RTEST_SYSTEM)
+{
+  RCryptoCipher * c;
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  r_assert_cmpptr ((c = r_cipher_aes_128_gcm_new (aes_bench_key)), !=, NULL);
+  run_aes_aead_bench (c, "128 GCM", 12);
+  r_crypto_cipher_unref (c);
+}
+RTEST_END;
+
+RTEST_BENCH (raes, gcm_256_encrypt, RTEST_FAST | RTEST_SYSTEM)
+{
+  RCryptoCipher * c;
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  r_assert_cmpptr ((c = r_cipher_aes_256_gcm_new (aes_bench_key)), !=, NULL);
+  run_aes_aead_bench (c, "256 GCM", 12);
+  r_crypto_cipher_unref (c);
+}
+RTEST_END;
+
+RTEST_BENCH (raes, ccm_128_encrypt, RTEST_FAST | RTEST_SYSTEM)
+{
+  RCryptoCipher * c;
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  r_assert_cmpptr ((c = r_cipher_aes_128_ccm_new (aes_bench_key)), !=, NULL);
+  run_aes_aead_bench (c, "128 CCM", 13);
+  r_crypto_cipher_unref (c);
+}
+RTEST_END;
+
+RTEST_BENCH (raes, ccm_256_encrypt, RTEST_FAST | RTEST_SYSTEM)
+{
+  RCryptoCipher * c;
+  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
+  r_assert_cmpptr ((c = r_cipher_aes_256_ccm_new (aes_bench_key)), !=, NULL);
+  run_aes_aead_bench (c, "256 CCM", 13);
+  r_crypto_cipher_unref (c);
+}
+RTEST_END;

--- a/include/rlib/crypto/raes.h
+++ b/include/rlib/crypto/raes.h
@@ -25,13 +25,68 @@
 #include <rlib/rtypes.h>
 #include <rlib/crypto/rcipher.h>
 
+/**
+ * @defgroup r_crypto_aes AES (FIPS 197)
+ * @brief AES cipher (128 / 192 / 256-bit keys) across ECB, CBC, CTR,
+ * CFB, OFB modes; built on the @c RCryptoCipher base.
+ * @{
+ */
+
+/**
+ * @file rlib/crypto/raes.h
+ * @brief AES block cipher and modes of operation.
+ *
+ * Wraps the 128 / 192 / 256-bit AES cipher in the modes of operation
+ * registered against @c RCryptoCipherInfo (ECB / CBC / CTR / CFB / OFB).
+ * A construction helper picks the right per-bits / HW-accelerated
+ * primitive once at @c r_cipher_aes_new and caches it on the cipher
+ * instance; the registered @c enc / @c dec operations then dispatch
+ * through that cached pointer per call.
+ *
+ * **Picking a constructor:**
+ *  - @c r_cipher_aes_new (mode, bits, key) - generic.
+ *  - @c r_cipher_aes_NNN_MMM_new (key)     - explicit (mode, key-size) form.
+ *  - @c r_cipher_aes_new_from_hex          - convenience for tests / config.
+ *
+ * **HW dispatch:** on x86 with AES-NI or on AArch64 with the +crypto
+ * extension, the per-block primitive runs in hardware; falls back to
+ * a constant-time-ish table implementation otherwise. Selection is
+ * automatic at construction.
+ */
+
 R_BEGIN_DECLS
 
+/** @brief Canonical algorithm name for @c r_crypto_cipher_find_by_str. */
 #define R_AES_STR           "AES"
+/** @brief AES block size in bytes (16, regardless of key length). */
 #define R_AES_BLOCK_BYTES   16
 
+/**
+ * @brief Create an AES cipher with explicit @p mode, @p bits, and @p key.
+ *
+ * @param mode  One of @c R_CRYPTO_CIPHER_MODE_ECB / CBC / CTR / CFB / OFB.
+ * @param bits  128, 192, or 256.
+ * @param key   @p bits / 8 key bytes.
+ * @return Cipher instance, or @c NULL on invalid arguments.
+ */
 R_API RCryptoCipher * r_cipher_aes_new (RCryptoCipherMode mode, ruint bits, const ruint8 * key) R_ATTR_MALLOC;
+/**
+ * @brief Create an AES cipher with @p mode and a hex-encoded key.
+ *
+ * The key-bit size is inferred from the length of @p hexkey
+ * (32 / 48 / 64 hex characters for 128 / 192 / 256 bits). Convenience
+ * for tests and configuration files; production code should prefer
+ * @c r_cipher_aes_new with raw bytes.
+ */
 R_API RCryptoCipher * r_cipher_aes_new_from_hex (RCryptoCipherMode mode, const rchar * hexkey) R_ATTR_MALLOC;
+
+/**
+ * @name Per-mode / per-size factories
+ *
+ * Each shorthand wraps @c r_cipher_aes_new with the matching mode and
+ * key size. Use these when the cipher choice is fixed at compile time.
+ * @{
+ */
 R_API RCryptoCipher * r_cipher_aes_128_ecb_new (const ruint8 * key) R_ATTR_MALLOC;
 R_API RCryptoCipher * r_cipher_aes_192_ecb_new (const ruint8 * key) R_ATTR_MALLOC;
 R_API RCryptoCipher * r_cipher_aes_256_ecb_new (const ruint8 * key) R_ATTR_MALLOC;
@@ -47,13 +102,48 @@ R_API RCryptoCipher * r_cipher_aes_256_cfb_new (const ruint8 * key) R_ATTR_MALLO
 R_API RCryptoCipher * r_cipher_aes_128_ofb_new (const ruint8 * key) R_ATTR_MALLOC;
 R_API RCryptoCipher * r_cipher_aes_192_ofb_new (const ruint8 * key) R_ATTR_MALLOC;
 R_API RCryptoCipher * r_cipher_aes_256_ofb_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @} */
 
 
+/**
+ * @name Single-block ECB primitive
+ *
+ * Low-level access to one AES block encrypt / decrypt. Exposed for
+ * callers that build their own mode of operation (e.g. KW, custom
+ * KDFs); ordinary use should go through the mode-aware
+ * @c r_crypto_cipher_encrypt entry point.
+ * @{
+ */
+/**
+ * @brief Encrypt one 16-byte block in ECB.
+ *
+ * @return @c TRUE on success.
+ */
 R_API rboolean r_cipher_aes_ecb_encrypt_block (const RCryptoCipher * cipher,
     ruint8 ciphertxt[R_AES_BLOCK_BYTES], const ruint8 plaintxt[R_AES_BLOCK_BYTES]);
+/**
+ * @brief Decrypt one 16-byte block in ECB.
+ *
+ * @return @c TRUE on success.
+ */
 R_API rboolean r_cipher_aes_ecb_decrypt_block (const RCryptoCipher * cipher,
     ruint8 plaintxt[R_AES_BLOCK_BYTES], const ruint8 ciphertxt[R_AES_BLOCK_BYTES]);
+/** @} */
 
+/**
+ * @name Mode operations
+ *
+ * Each pair is registered against an @c RCryptoCipherInfo so the
+ * generic @c r_crypto_cipher_encrypt / @c _decrypt dispatch via
+ * @c info->enc / @c _dec for that mode. They are also exported here
+ * for callers that already have a typed @c RCryptoCipher and want to
+ * skip the lookup.
+ *
+ * @c CTR and @c OFB are self-inverse - encrypt and decrypt are the
+ * same operation - so each is exposed once and the matching
+ * @c _decrypt alias resolves to its @c _encrypt sibling.
+ * @{
+ */
 R_API RCryptoCipherResult r_cipher_aes_ecb_encrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
 R_API RCryptoCipherResult r_cipher_aes_ecb_decrypt (const RCryptoCipher * cipher,
@@ -66,6 +156,7 @@ R_API RCryptoCipherResult r_cipher_aes_cbc_decrypt (const RCryptoCipher * cipher
 
 R_API RCryptoCipherResult r_cipher_aes_ctr_encrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
+/** @brief CTR is self-inverse; decrypt resolves to encrypt. */
 #define r_cipher_aes_ctr_decrypt r_cipher_aes_ctr_encrypt
 
 R_API RCryptoCipherResult r_cipher_aes_cfb_encrypt (const RCryptoCipher * cipher,
@@ -75,9 +166,13 @@ R_API RCryptoCipherResult r_cipher_aes_cfb_decrypt (const RCryptoCipher * cipher
 
 R_API RCryptoCipherResult r_cipher_aes_ofb_encrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
+/** @brief OFB is self-inverse; decrypt resolves to encrypt. */
 #define r_cipher_aes_ofb_decrypt r_cipher_aes_ofb_encrypt
+/** @} */
 
 R_END_DECLS
+
+/** @} */ /* r_crypto_aes group */
 
 #endif /* __R_CRYPTO_AES_H__ */
 

--- a/include/rlib/crypto/raes.h
+++ b/include/rlib/crypto/raes.h
@@ -105,6 +105,9 @@ R_API RCryptoCipher * r_cipher_aes_256_ofb_new (const ruint8 * key) R_ATTR_MALLO
 R_API RCryptoCipher * r_cipher_aes_128_gcm_new (const ruint8 * key) R_ATTR_MALLOC;
 R_API RCryptoCipher * r_cipher_aes_192_gcm_new (const ruint8 * key) R_ATTR_MALLOC;
 R_API RCryptoCipher * r_cipher_aes_256_gcm_new (const ruint8 * key) R_ATTR_MALLOC;
+R_API RCryptoCipher * r_cipher_aes_128_ccm_new (const ruint8 * key) R_ATTR_MALLOC;
+R_API RCryptoCipher * r_cipher_aes_192_ccm_new (const ruint8 * key) R_ATTR_MALLOC;
+R_API RCryptoCipher * r_cipher_aes_256_ccm_new (const ruint8 * key) R_ATTR_MALLOC;
 /** @} */
 
 
@@ -198,6 +201,38 @@ R_API RCryptoCipherResult r_cipher_aes_gcm_encrypt (const RCryptoCipher * cipher
  * @c R_CRYPTO_CIPHER_AUTH_FAILED and leaves @p dst untouched.
  */
 R_API RCryptoCipherResult r_cipher_aes_gcm_decrypt (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data,
+    rconstpointer aad, rsize aadsize,
+    ruint8 * iv, rsize ivsize,
+    ruint8 * tag, rsize tagsize);
+
+/**
+ * @brief AES-CCM authenticated encrypt (RFC 3610 / NIST SP 800-38C).
+ *
+ * CCM = CBC-MAC for integrity (over the formatted B0 / AAD / plaintext)
+ * plus CTR-mode encryption. The nonce length @p ivsize must be 7..13
+ * bytes; the resulting length-of-length field @c L = @c 15-ivsize
+ * bounds the plaintext to fewer than @c 2^(8L) bytes (e.g. 64 KiB
+ * at @c ivsize == 13, 16 MiB at @c ivsize == 12). Tag length must be
+ * an even number in @c [4, 16].
+ *
+ * Buffers may alias for in-place operation; @p iv is read-only.
+ */
+R_API RCryptoCipherResult r_cipher_aes_ccm_encrypt (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data,
+    rconstpointer aad, rsize aadsize,
+    ruint8 * iv, rsize ivsize,
+    ruint8 * tag, rsize tagsize);
+/**
+ * @brief AES-CCM authenticated decrypt with tag verification.
+ *
+ * Unlike GCM (where the tag is over ciphertext), CCM's tag is over
+ * plaintext, so verification requires decrypting first. On a tag
+ * mismatch this function returns @c R_CRYPTO_CIPHER_AUTH_FAILED and
+ * @p dst already contains the decrypted bytes; the caller must
+ * discard @p dst on auth failure.
+ */
+R_API RCryptoCipherResult r_cipher_aes_ccm_decrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data,
     rconstpointer aad, rsize aadsize,
     ruint8 * iv, rsize ivsize,

--- a/include/rlib/crypto/raes.h
+++ b/include/rlib/crypto/raes.h
@@ -102,6 +102,9 @@ R_API RCryptoCipher * r_cipher_aes_256_cfb_new (const ruint8 * key) R_ATTR_MALLO
 R_API RCryptoCipher * r_cipher_aes_128_ofb_new (const ruint8 * key) R_ATTR_MALLOC;
 R_API RCryptoCipher * r_cipher_aes_192_ofb_new (const ruint8 * key) R_ATTR_MALLOC;
 R_API RCryptoCipher * r_cipher_aes_256_ofb_new (const ruint8 * key) R_ATTR_MALLOC;
+R_API RCryptoCipher * r_cipher_aes_128_gcm_new (const ruint8 * key) R_ATTR_MALLOC;
+R_API RCryptoCipher * r_cipher_aes_192_gcm_new (const ruint8 * key) R_ATTR_MALLOC;
+R_API RCryptoCipher * r_cipher_aes_256_gcm_new (const ruint8 * key) R_ATTR_MALLOC;
 /** @} */
 
 
@@ -168,6 +171,37 @@ R_API RCryptoCipherResult r_cipher_aes_ofb_encrypt (const RCryptoCipher * cipher
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
 /** @brief OFB is self-inverse; decrypt resolves to encrypt. */
 #define r_cipher_aes_ofb_decrypt r_cipher_aes_ofb_encrypt
+
+/**
+ * @brief AES-GCM authenticated encrypt.
+ *
+ * GCM = CTR-mode encryption plus GHASH over AAD || ciphertext for the
+ * integrity tag. IV must be 12 bytes (96 bits, the recommended NIST
+ * size); other IV lengths return @c R_CRYPTO_CIPHER_INVAL. Tag length
+ * is 1..16 bytes; @c tagsize == 16 covers the full GMAC output.
+ *
+ * Buffers may alias for in-place operation. The @p iv is read-only
+ * (GCM's counter is internal); the parameter is kept read-write for
+ * signature symmetry with @c RCryptoCipherAeadOperation, but is not
+ * modified.
+ */
+R_API RCryptoCipherResult r_cipher_aes_gcm_encrypt (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data,
+    rconstpointer aad, rsize aadsize,
+    ruint8 * iv, rsize ivsize,
+    ruint8 * tag, rsize tagsize);
+/**
+ * @brief AES-GCM authenticated decrypt with tag verification.
+ *
+ * Computes the expected tag over @p aad and @p data, then compares
+ * (constant time) against @p tag. On mismatch returns
+ * @c R_CRYPTO_CIPHER_AUTH_FAILED and leaves @p dst untouched.
+ */
+R_API RCryptoCipherResult r_cipher_aes_gcm_decrypt (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data,
+    rconstpointer aad, rsize aadsize,
+    ruint8 * iv, rsize ivsize,
+    ruint8 * tag, rsize tagsize);
 /** @} */
 
 R_END_DECLS

--- a/include/rlib/crypto/raes.h
+++ b/include/rlib/crypto/raes.h
@@ -87,26 +87,47 @@ R_API RCryptoCipher * r_cipher_aes_new_from_hex (RCryptoCipherMode mode, const r
  * key size. Use these when the cipher choice is fixed at compile time.
  * @{
  */
+/** @brief Create an AES-128 ECB cipher. */
 R_API RCryptoCipher * r_cipher_aes_128_ecb_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-192 ECB cipher. */
 R_API RCryptoCipher * r_cipher_aes_192_ecb_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-256 ECB cipher. */
 R_API RCryptoCipher * r_cipher_aes_256_ecb_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-128 CBC cipher. */
 R_API RCryptoCipher * r_cipher_aes_128_cbc_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-192 CBC cipher. */
 R_API RCryptoCipher * r_cipher_aes_192_cbc_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-256 CBC cipher. */
 R_API RCryptoCipher * r_cipher_aes_256_cbc_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-128 CTR cipher. */
 R_API RCryptoCipher * r_cipher_aes_128_ctr_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-192 CTR cipher. */
 R_API RCryptoCipher * r_cipher_aes_192_ctr_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-256 CTR cipher. */
 R_API RCryptoCipher * r_cipher_aes_256_ctr_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-128 CFB cipher. */
 R_API RCryptoCipher * r_cipher_aes_128_cfb_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-192 CFB cipher. */
 R_API RCryptoCipher * r_cipher_aes_192_cfb_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-256 CFB cipher. */
 R_API RCryptoCipher * r_cipher_aes_256_cfb_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-128 OFB cipher. */
 R_API RCryptoCipher * r_cipher_aes_128_ofb_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-192 OFB cipher. */
 R_API RCryptoCipher * r_cipher_aes_192_ofb_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-256 OFB cipher. */
 R_API RCryptoCipher * r_cipher_aes_256_ofb_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-128 GCM cipher (AEAD). */
 R_API RCryptoCipher * r_cipher_aes_128_gcm_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-192 GCM cipher (AEAD). */
 R_API RCryptoCipher * r_cipher_aes_192_gcm_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-256 GCM cipher (AEAD). */
 R_API RCryptoCipher * r_cipher_aes_256_gcm_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-128 CCM cipher (AEAD). */
 R_API RCryptoCipher * r_cipher_aes_128_ccm_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-192 CCM cipher (AEAD). */
 R_API RCryptoCipher * r_cipher_aes_192_ccm_new (const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Create an AES-256 CCM cipher (AEAD). */
 R_API RCryptoCipher * r_cipher_aes_256_ccm_new (const ruint8 * key) R_ATTR_MALLOC;
 /** @} */
 
@@ -150,26 +171,34 @@ R_API rboolean r_cipher_aes_ecb_decrypt_block (const RCryptoCipher * cipher,
  * @c _decrypt alias resolves to its @c _encrypt sibling.
  * @{
  */
+/** @brief AES-ECB encrypt. */
 R_API RCryptoCipherResult r_cipher_aes_ecb_encrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
+/** @brief AES-ECB decrypt. */
 R_API RCryptoCipherResult r_cipher_aes_ecb_decrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
 
+/** @brief AES-CBC encrypt. */
 R_API RCryptoCipherResult r_cipher_aes_cbc_encrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
+/** @brief AES-CBC decrypt. */
 R_API RCryptoCipherResult r_cipher_aes_cbc_decrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
 
+/** @brief AES-CTR encrypt (also covers decrypt; see alias below). */
 R_API RCryptoCipherResult r_cipher_aes_ctr_encrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
 /** @brief CTR is self-inverse; decrypt resolves to encrypt. */
 #define r_cipher_aes_ctr_decrypt r_cipher_aes_ctr_encrypt
 
+/** @brief AES-CFB encrypt. */
 R_API RCryptoCipherResult r_cipher_aes_cfb_encrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
+/** @brief AES-CFB decrypt. */
 R_API RCryptoCipherResult r_cipher_aes_cfb_decrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
 
+/** @brief AES-OFB encrypt (also covers decrypt; see alias below). */
 R_API RCryptoCipherResult r_cipher_aes_ofb_encrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
 /** @brief OFB is self-inverse; decrypt resolves to encrypt. */

--- a/include/rlib/crypto/rcipher.h
+++ b/include/rlib/crypto/rcipher.h
@@ -107,6 +107,9 @@ typedef enum {
   R_CRYPTO_CIPHER_OOM,                  /**< Memory allocation failed. */
   R_CRYPTO_CIPHER_INVAL,                /**< Invalid argument (NULL, wrong size, etc.). */
   R_CRYPTO_CIPHER_WRONG_BLOCK_SIZE,     /**< Input not a multiple of @c blocksize for a block mode. */
+  R_CRYPTO_CIPHER_NEEDS_AEAD,           /**< Cipher mode is AEAD; use @c r_crypto_cipher_encrypt_aead. */
+  R_CRYPTO_CIPHER_NOT_AEAD,             /**< Cipher mode is not AEAD; use @c r_crypto_cipher_encrypt. */
+  R_CRYPTO_CIPHER_AUTH_FAILED,          /**< AEAD tag verification failed; plaintext must be discarded. */
 } RCryptoCipherResult;
 
 /** @brief Opaque cipher handle. */
@@ -133,6 +136,39 @@ typedef RCryptoCipherOperation RCryptoCipherEncrypt;
 typedef RCryptoCipherOperation RCryptoCipherDecrypt;
 
 /**
+ * @brief Operation function signature for AEAD encrypt / decrypt.
+ *
+ * Same as @c RCryptoCipherOperation but adds the AEAD-specific
+ * arguments: additional authenticated data (@p aad / @p aadsize) that
+ * is included in the tag computation but not encrypted, and the
+ * authentication tag (@p tag / @p tagsize). On encrypt the tag is
+ * written; on decrypt it is read, verified, and the function returns
+ * @c R_CRYPTO_CIPHER_AUTH_FAILED on mismatch.
+ *
+ * @param cipher   Cipher instance; must be an AEAD mode.
+ * @param dst      Output buffer; at least @p size bytes.
+ * @param size     Bytes of @p data to process.
+ * @param data     Input buffer; at least @p size bytes. May alias @p dst.
+ * @param aad      Additional authenticated data; may be @c NULL when
+ *                 @p aadsize is 0.
+ * @param aadsize  Bytes of @p aad to include in the tag computation.
+ * @param iv       Nonce; size dictated by @c info->ivsize.
+ * @param ivsize   Size of @p iv in bytes.
+ * @param tag      Tag buffer; @c tagsize bytes. Written on encrypt,
+ *                 read on decrypt.
+ * @param tagsize  Tag size in bytes.
+ */
+typedef RCryptoCipherResult (*RCryptoCipherAeadOperation) (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data,
+    rconstpointer aad, rsize aadsize,
+    ruint8 * iv, rsize ivsize,
+    ruint8 * tag, rsize tagsize);
+/** @brief AEAD encrypt operation alias. */
+typedef RCryptoCipherAeadOperation RCryptoCipherAeadEncrypt;
+/** @brief AEAD decrypt operation alias. */
+typedef RCryptoCipherAeadOperation RCryptoCipherAeadDecrypt;
+
+/**
  * @brief Static descriptor for a (algo, mode, key-bits) triple.
  *
  * Concrete cipher families publish a const array of these and the
@@ -148,8 +184,21 @@ typedef struct {
   rsize                   ivsize;      /**< Expected IV size in bytes (0 if N/A). */
   rsize                   blocksize;   /**< Native block size in bytes (1 for stream modes). */
 
-  RCryptoCipherEncrypt    enc;         /**< Encrypt operation. */
-  RCryptoCipherDecrypt    dec;         /**< Decrypt operation. */
+  /**
+   * Non-AEAD encrypt / decrypt operations. Filled for ECB / CBC / CTR
+   * / CFB / OFB; left @c NULL for AEAD modes (GCM, CCM), whose
+   * @c aead_enc / @c aead_dec slots carry the operations instead.
+   */
+  RCryptoCipherEncrypt    enc;         /**< Encrypt operation, or @c NULL on AEAD modes. */
+  RCryptoCipherDecrypt    dec;         /**< Decrypt operation, or @c NULL on AEAD modes. */
+
+  /**
+   * AEAD encrypt / decrypt operations. Filled for GCM / CCM; left
+   * @c NULL for non-AEAD modes. Exactly one of (@c enc, @c dec) and
+   * (@c aead_enc, @c aead_dec) must be set per info entry.
+   */
+  RCryptoCipherAeadEncrypt aead_enc;   /**< AEAD encrypt operation, or @c NULL on non-AEAD modes. */
+  RCryptoCipherAeadDecrypt aead_dec;   /**< AEAD decrypt operation, or @c NULL on non-AEAD modes. */
 } RCryptoCipherInfo;
 
 /**
@@ -215,7 +264,23 @@ R_API RCryptoCipher * r_crypto_cipher_new (const RCryptoCipherInfo * info,
 /** @} */
 
 /**
+ * @brief Return @c TRUE if @p cipher is an AEAD mode (GCM / CCM).
+ *
+ * AEAD ciphers must be driven through @c r_crypto_cipher_encrypt_aead
+ * / @c _decrypt_aead; non-AEAD ciphers through @c r_crypto_cipher_encrypt
+ * / @c _decrypt. The base entry points reject the wrong family with
+ * @c R_CRYPTO_CIPHER_NEEDS_AEAD / @c NOT_AEAD, so a runtime check is
+ * a safety net rather than a requirement, but exposing this helper
+ * lets callers branch on the contract without spelling out the mode.
+ */
+R_API rboolean r_crypto_cipher_is_aead (const RCryptoCipher * cipher);
+
+/**
  * @name One-shot encrypt / decrypt
+ *
+ * For non-AEAD modes (ECB / CBC / CTR / CFB / OFB). An AEAD-moded
+ * cipher rejects these entry points with
+ * @c R_CRYPTO_CIPHER_NEEDS_AEAD; use the @c _aead variants instead.
  * @{
  */
 /**
@@ -224,7 +289,7 @@ R_API RCryptoCipher * r_crypto_cipher_new (const RCryptoCipherInfo * info,
  * Buffers may alias for in-place operation. For block modes, @p size
  * must be a multiple of @c info->blocksize.
  *
- * @param cipher  Cipher instance.
+ * @param cipher  Cipher instance; must not be an AEAD mode.
  * @param dst     Output buffer; at least @p size bytes.
  * @param size    Number of input bytes.
  * @param data    Input buffer; at least @p size bytes.
@@ -241,6 +306,54 @@ R_API RCryptoCipherResult r_crypto_cipher_encrypt (const RCryptoCipher * cipher,
  */
 R_API RCryptoCipherResult r_crypto_cipher_decrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
+/** @} */
+
+/**
+ * @name One-shot AEAD encrypt / decrypt
+ *
+ * For AEAD modes (GCM / CCM). A non-AEAD cipher rejects these entry
+ * points with @c R_CRYPTO_CIPHER_NOT_AEAD; use @c r_crypto_cipher_encrypt
+ * / @c _decrypt instead. Tag is detached (separate buffer from
+ * @p dst); on decrypt, the function returns
+ * @c R_CRYPTO_CIPHER_AUTH_FAILED on tag mismatch and the caller must
+ * discard @p dst.
+ * @{
+ */
+/**
+ * @brief Authenticated encrypt with associated data.
+ *
+ * @param cipher   Cipher instance; must be an AEAD mode.
+ * @param dst      Output ciphertext buffer; at least @p size bytes.
+ * @param size     Plaintext length.
+ * @param data     Plaintext; at least @p size bytes. May alias @p dst.
+ * @param aad      Additional authenticated data (covered by the tag
+ *                 but not encrypted); may be @c NULL when @p aadsize
+ *                 is 0.
+ * @param aadsize  AAD length in bytes.
+ * @param iv       Nonce; size dictated by @c info->ivsize.
+ * @param ivsize   Size of @p iv in bytes.
+ * @param tag      Tag output buffer; @p tagsize bytes written.
+ * @param tagsize  Requested tag size; mode-specific (e.g. 16 for GCM).
+ */
+R_API RCryptoCipherResult r_crypto_cipher_encrypt_aead (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data,
+    rconstpointer aad, rsize aadsize,
+    ruint8 * iv, rsize ivsize,
+    ruint8 * tag, rsize tagsize);
+/**
+ * @brief Authenticated decrypt with associated data and tag verification.
+ *
+ * Same arguments as @c r_crypto_cipher_encrypt_aead, but @p tag is an
+ * input (the expected tag) and is compared in constant time against
+ * the value computed from @p data + @p aad. On mismatch, returns
+ * @c R_CRYPTO_CIPHER_AUTH_FAILED; @p dst contents are undefined and
+ * must be discarded.
+ */
+R_API RCryptoCipherResult r_crypto_cipher_decrypt_aead (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data,
+    rconstpointer aad, rsize aadsize,
+    ruint8 * iv, rsize ivsize,
+    ruint8 * tag, rsize tagsize);
 /** @} */
 
 R_END_DECLS

--- a/include/rlib/crypto/rcipher.h
+++ b/include/rlib/crypto/rcipher.h
@@ -25,88 +25,227 @@
 #include <rlib/rtypes.h>
 #include <rlib/rref.h>
 
+/**
+ * @defgroup r_crypto_cipher Block / stream cipher base
+ * @brief Algorithm-agnostic block / stream cipher interface; concrete
+ * cipher families (AES, ARC4, ...) plug into it via @c RCryptoCipherInfo.
+ * @{
+ */
+
+/**
+ * @file rlib/crypto/rcipher.h
+ * @brief Block / stream cipher base interface.
+ *
+ * Provides the algorithm- and mode-neutral surface every concrete
+ * cipher (AES, ARC4, ...) registers against. A cipher is a reference-
+ * counted @c RCryptoCipher whose @c info pointer carries the
+ * algorithm + mode + key size + operation function pointers; concrete
+ * families publish a static array of @c RCryptoCipherInfo entries (one
+ * per algo/mode/bits triple) and a matching factory.
+ *
+ * **Usage:**
+ *  - Look up an @c RCryptoCipherInfo by name or by tuple
+ *    (@c r_crypto_cipher_find_by_str / @c _find_by_type), or take one
+ *    from the algorithm-specific factory (e.g. @c r_cipher_aes_new).
+ *  - Create the cipher with @c r_crypto_cipher_new (or the family's
+ *    factory) - the new instance retains a borrowed pointer to @p info.
+ *  - Encrypt / decrypt one buffer per call with
+ *    @c r_crypto_cipher_encrypt / @c _decrypt. The @p iv argument is
+ *    read-write; chained-mode callers reuse it to chain successive
+ *    calls.
+ *  - Release with @c r_crypto_cipher_unref.
+ *
+ * The base API is one-shot only - there is no incremental
+ * @c init/update/final flow.
+ */
+
 R_BEGIN_DECLS
 
+/** @brief Cipher algorithm identity (algorithm family, not mode or size). */
 typedef enum {
   R_CRYPTO_CIPHER_ALGO_NONE = 0,
-  R_CRYPTO_CIPHER_ALGO_NULL,
-  R_CRYPTO_CIPHER_ALGO_AES,
-  R_CRYPTO_CIPHER_ALGO_ARC4,
-  R_CRYPTO_CIPHER_ALGO_BLOWFISH,
-  R_CRYPTO_CIPHER_ALGO_DES,
-  R_CRYPTO_CIPHER_ALGO_3DES,
-  R_CRYPTO_CIPHER_ALGO_CAMELLIA,
+  R_CRYPTO_CIPHER_ALGO_NULL,        /**< Pass-through cipher (for negotiation / testing). */
+  R_CRYPTO_CIPHER_ALGO_AES,         /**< AES (FIPS 197). */
+  R_CRYPTO_CIPHER_ALGO_ARC4,        /**< RC4 stream cipher. */
+  R_CRYPTO_CIPHER_ALGO_BLOWFISH,    /**< Blowfish. */
+  R_CRYPTO_CIPHER_ALGO_DES,         /**< Single DES. */
+  R_CRYPTO_CIPHER_ALGO_3DES,        /**< Triple DES. */
+  R_CRYPTO_CIPHER_ALGO_CAMELLIA,    /**< Camellia. */
 } RCryptoCipherAlgorithm;
 
+/**
+ * @brief Mode of operation for a block cipher (or stream-cipher marker).
+ *
+ * Combined with @c RCryptoCipherAlgorithm and a key-size in bits to
+ * uniquely identify an @c RCryptoCipherInfo.
+ */
 typedef enum {
   R_CRYPTO_CIPHER_MODE_NONE = 0,
-  R_CRYPTO_CIPHER_MODE_ECB,
-  R_CRYPTO_CIPHER_MODE_CBC,
-  R_CRYPTO_CIPHER_MODE_CFB,
-  R_CRYPTO_CIPHER_MODE_OFB,
-  R_CRYPTO_CIPHER_MODE_CTR,
-  R_CRYPTO_CIPHER_MODE_GCM,
-  R_CRYPTO_CIPHER_MODE_CCM,
-  R_CRYPTO_CIPHER_MODE_STREAM,
+  R_CRYPTO_CIPHER_MODE_ECB,         /**< Electronic Code Book. */
+  R_CRYPTO_CIPHER_MODE_CBC,         /**< Cipher Block Chaining. */
+  R_CRYPTO_CIPHER_MODE_CFB,         /**< Cipher Feedback. */
+  R_CRYPTO_CIPHER_MODE_OFB,         /**< Output Feedback. */
+  R_CRYPTO_CIPHER_MODE_CTR,         /**< Counter mode. */
+  R_CRYPTO_CIPHER_MODE_GCM,         /**< Galois / Counter Mode (AEAD; future). */
+  R_CRYPTO_CIPHER_MODE_CCM,         /**< Counter with CBC-MAC (AEAD; future). */
+  R_CRYPTO_CIPHER_MODE_STREAM,      /**< Generic stream cipher (no block boundary). */
 } RCryptoCipherMode;
 
+/** @brief Padding scheme for fixed-block modes that need to handle
+ * the residual partial block. Independent of mode dispatch. */
 typedef enum {
-  R_CRYPTO_CIPHER_PADDING_NONE,           /* complete blocks only */
-  R_CRYPTO_CIPHER_PADDING_PKCS7,
-  R_CRYPTO_CIPHER_PADDING_X923,           /* zeros and length     */
-  R_CRYPTO_CIPHER_PADDING_ISO_7816_4,     /* ISO/IEC 7816-4       */
-  R_CRYPTO_CIPHER_PADDING_ZEROS,
+  R_CRYPTO_CIPHER_PADDING_NONE,         /**< No padding; complete blocks only. */
+  R_CRYPTO_CIPHER_PADDING_PKCS7,        /**< PKCS#7 padding (RFC 5652). */
+  R_CRYPTO_CIPHER_PADDING_X923,         /**< ANSI X9.23: zero bytes plus length. */
+  R_CRYPTO_CIPHER_PADDING_ISO_7816_4,   /**< ISO/IEC 7816-4: 0x80 then zeros. */
+  R_CRYPTO_CIPHER_PADDING_ZEROS,        /**< Zero bytes only (length must be known out-of-band). */
 } RCryptoCipherPadding;
 
+/** @brief Result code returned by cipher operations. */
 typedef enum {
-  R_CRYPTO_CIPHER_OK = 0,
-  R_CRYPTO_CIPHER_OOM,
-  R_CRYPTO_CIPHER_INVAL,
-  R_CRYPTO_CIPHER_WRONG_BLOCK_SIZE,
+  R_CRYPTO_CIPHER_OK = 0,               /**< Operation succeeded. */
+  R_CRYPTO_CIPHER_OOM,                  /**< Memory allocation failed. */
+  R_CRYPTO_CIPHER_INVAL,                /**< Invalid argument (NULL, wrong size, etc.). */
+  R_CRYPTO_CIPHER_WRONG_BLOCK_SIZE,     /**< Input not a multiple of @c blocksize for a block mode. */
 } RCryptoCipherResult;
 
+/** @brief Opaque cipher handle. */
 typedef struct _RCryptoCipher RCryptoCipher;
 
+/**
+ * @brief Operation function signature for one-shot encrypt / decrypt.
+ *
+ * @param cipher  Cipher instance.
+ * @param dst     Output buffer; at least @p size bytes.
+ * @param size    Bytes of @p data to process.
+ * @param data    Input buffer; at least @p size bytes. May alias @p dst
+ *                for in-place operation.
+ * @param iv      Initialization vector / counter; read-write so chained
+ *                modes can advance it for the next call. @c NULL is
+ *                accepted only by modes that don't use an IV (ECB).
+ * @param ivsize  Size of @p iv in bytes; must match @c info->ivsize.
+ */
 typedef RCryptoCipherResult (*RCryptoCipherOperation) (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
+/** @brief Encrypt operation alias for @c RCryptoCipherOperation. */
 typedef RCryptoCipherOperation RCryptoCipherEncrypt;
+/** @brief Decrypt operation alias for @c RCryptoCipherOperation. */
 typedef RCryptoCipherOperation RCryptoCipherDecrypt;
 
+/**
+ * @brief Static descriptor for a (algo, mode, key-bits) triple.
+ *
+ * Concrete cipher families publish a const array of these and the
+ * lookup functions resolve them by name or by tuple. The matching
+ * @c r_<family>_new / @c r_crypto_cipher_new wires up the resulting
+ * @c RCryptoCipher instance to one of these descriptors.
+ */
 typedef struct {
-  const rchar *           strtype;
-  RCryptoCipherAlgorithm  type;
-  RCryptoCipherMode       mode;
-  ruint16                 keybits;
-  rsize                   ivsize;
-  rsize                   blocksize;
+  const rchar *           strtype;     /**< Canonical name, e.g. @c "AES-128-CBC". */
+  RCryptoCipherAlgorithm  type;        /**< Algorithm family. */
+  RCryptoCipherMode       mode;        /**< Mode of operation. */
+  ruint16                 keybits;     /**< Key size in bits. */
+  rsize                   ivsize;      /**< Expected IV size in bytes (0 if N/A). */
+  rsize                   blocksize;   /**< Native block size in bytes (1 for stream modes). */
 
-  /* Cipher operations */
-  RCryptoCipherEncrypt    enc;
-  RCryptoCipherDecrypt    dec;
+  RCryptoCipherEncrypt    enc;         /**< Encrypt operation. */
+  RCryptoCipherDecrypt    dec;         /**< Decrypt operation. */
 } RCryptoCipherInfo;
 
+/**
+ * @brief Concrete cipher instance.
+ *
+ * Concrete cipher families typically allocate a larger struct that
+ * embeds @c RCryptoCipher at the top, so the @c info pointer indexes
+ * into the family's static info array while the surrounding bytes
+ * carry the family-specific state (key schedule, etc.).
+ */
 struct _RCryptoCipher {
-  RRef ref;
-  const RCryptoCipherInfo * info;
+  RRef ref;                            /**< Reference counter. */
+  const RCryptoCipherInfo * info;      /**< Borrowed descriptor for this instance. */
 };
 
+/**
+ * @name Info lookup
+ * @{
+ */
+/**
+ * @brief Find a cipher descriptor by its canonical name (e.g. @c "AES-128-CBC").
+ *
+ * Case-insensitive; returns @c NULL if no registered cipher matches.
+ */
 R_API const RCryptoCipherInfo * r_crypto_cipher_find_by_str (const rchar * str);
+/**
+ * @brief Find a cipher descriptor by (algorithm, mode, key bits).
+ *
+ * @return Matching descriptor, or @c NULL if no cipher matches.
+ */
 R_API const RCryptoCipherInfo * r_crypto_cipher_find_by_type (
     RCryptoCipherAlgorithm algo, RCryptoCipherMode mode, ruint16 bits);
+/** @} */
 
+/**
+ * @name Cipher lifecycle
+ * @{
+ */
+/**
+ * @brief Pass-through "null" cipher.
+ *
+ * Returns ciphertext == plaintext; used to fill a NULL slot in cipher-
+ * suite negotiation and as a baseline for tests. No key is consumed.
+ */
 R_API RCryptoCipher * r_crypto_cipher_null_new (/* accept key */) R_ATTR_MALLOC;
 
+/**
+ * @brief Create a cipher instance for @p info using @p key.
+ *
+ * Dispatches to the algorithm family's factory; the returned cipher
+ * is bound to @p info for its lifetime.
+ *
+ * @param info  Descriptor selected via @c _find_by_str / @c _find_by_type.
+ * @param key   Key bytes; size dictated by @c info->keybits.
+ * @return Cipher instance; release with @c r_crypto_cipher_unref.
+ */
 R_API RCryptoCipher * r_crypto_cipher_new (const RCryptoCipherInfo * info,
     const ruint8 * key) R_ATTR_MALLOC;
+/** @brief Increment the cipher's refcount. */
 #define r_crypto_cipher_ref r_ref_ref
+/** @brief Decrement the cipher's refcount; frees when it reaches zero. */
 #define r_crypto_cipher_unref r_ref_unref
+/** @} */
 
+/**
+ * @name One-shot encrypt / decrypt
+ * @{
+ */
+/**
+ * @brief Encrypt @p size bytes from @p data into @p dst.
+ *
+ * Buffers may alias for in-place operation. For block modes, @p size
+ * must be a multiple of @c info->blocksize.
+ *
+ * @param cipher  Cipher instance.
+ * @param dst     Output buffer; at least @p size bytes.
+ * @param size    Number of input bytes.
+ * @param data    Input buffer; at least @p size bytes.
+ * @param iv      Initialization vector / counter (read-write); chained
+ *                modes update it in place.
+ * @param ivsize  Size of @p iv; must match @c info->ivsize.
+ */
 R_API RCryptoCipherResult r_crypto_cipher_encrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
+/**
+ * @brief Decrypt @p size bytes from @p data into @p dst.
+ *
+ * See @c r_crypto_cipher_encrypt for the buffer / IV contract.
+ */
 R_API RCryptoCipherResult r_crypto_cipher_decrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize);
+/** @} */
 
 R_END_DECLS
+
+/** @} */ /* r_crypto_cipher group */
 
 #endif /* __R_CRYPTO_CIPHER_H__ */
 

--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -223,6 +223,24 @@ const RCryptoCipherInfo g__r_crypto_cipher_aes_256_gcm = { "AES-256-GCM",
   r_cipher_aes_gcm_encrypt, r_cipher_aes_gcm_decrypt
 };
 
+/* CCM advertises ivsize == 0 because the nonce length is caller-
+ * chosen per call within 7..13; the AEAD ops validate it themselves. */
+const RCryptoCipherInfo g__r_crypto_cipher_aes_128_ccm = { "AES-128-CCM",
+  R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_CCM, 128, 0, 16,
+  NULL, NULL,
+  r_cipher_aes_ccm_encrypt, r_cipher_aes_ccm_decrypt
+};
+const RCryptoCipherInfo g__r_crypto_cipher_aes_192_ccm = { "AES-192-CCM",
+  R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_CCM, 192, 0, 16,
+  NULL, NULL,
+  r_cipher_aes_ccm_encrypt, r_cipher_aes_ccm_decrypt
+};
+const RCryptoCipherInfo g__r_crypto_cipher_aes_256_ccm = { "AES-256-CCM",
+  R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_CCM, 256, 0, 16,
+  NULL, NULL,
+  r_cipher_aes_ccm_encrypt, r_cipher_aes_ccm_decrypt
+};
+
 const RCryptoCipherInfo g__r_crypto_cipher_aes_256_ofb = { "AES-256-OFB",
   R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_OFB, 256, 16, 16,
   r_cipher_aes_ofb_encrypt, r_cipher_aes_ofb_decrypt,
@@ -518,6 +536,24 @@ r_cipher_aes_256_gcm_new (const ruint8 * key)
 }
 
 RCryptoCipher *
+r_cipher_aes_128_ccm_new (const ruint8 * key)
+{
+  return r_cipher_aes_new_with_info (&g__r_crypto_cipher_aes_128_ccm, key);
+}
+
+RCryptoCipher *
+r_cipher_aes_192_ccm_new (const ruint8 * key)
+{
+  return r_cipher_aes_new_with_info (&g__r_crypto_cipher_aes_192_ccm, key);
+}
+
+RCryptoCipher *
+r_cipher_aes_256_ccm_new (const ruint8 * key)
+{
+  return r_cipher_aes_new_with_info (&g__r_crypto_cipher_aes_256_ccm, key);
+}
+
+RCryptoCipher *
 r_cipher_aes_new (RCryptoCipherMode mode, ruint bits, const ruint8 * key)
 {
   switch (bits) {
@@ -535,6 +571,8 @@ r_cipher_aes_new (RCryptoCipherMode mode, ruint bits, const ruint8 * key)
           return r_cipher_aes_128_ofb_new (key);
         case R_CRYPTO_CIPHER_MODE_GCM:
           return r_cipher_aes_128_gcm_new (key);
+        case R_CRYPTO_CIPHER_MODE_CCM:
+          return r_cipher_aes_128_ccm_new (key);
         default:
           break;
       }
@@ -553,6 +591,8 @@ r_cipher_aes_new (RCryptoCipherMode mode, ruint bits, const ruint8 * key)
           return r_cipher_aes_192_ofb_new (key);
         case R_CRYPTO_CIPHER_MODE_GCM:
           return r_cipher_aes_192_gcm_new (key);
+        case R_CRYPTO_CIPHER_MODE_CCM:
+          return r_cipher_aes_192_ccm_new (key);
         default:
           break;
       }
@@ -571,6 +611,8 @@ r_cipher_aes_new (RCryptoCipherMode mode, ruint bits, const ruint8 * key)
           return r_cipher_aes_256_ofb_new (key);
         case R_CRYPTO_CIPHER_MODE_GCM:
           return r_cipher_aes_256_gcm_new (key);
+        case R_CRYPTO_CIPHER_MODE_CCM:
+          return r_cipher_aes_256_ccm_new (key);
         default:
           break;
       }
@@ -1540,6 +1582,263 @@ r_cipher_aes_gcm_decrypt (const RCryptoCipher * cipher,
     ruint8 * tag, rsize tagsize)
 {
   return r_aes_gcm_op (cipher, dst, size, data, aad, aadsize,
+      iv, ivsize, tag, tagsize, FALSE);
+}
+
+/******************************************************************************/
+/*  AES-CCM (RFC 3610 / NIST SP 800-38C)                                      */
+/******************************************************************************/
+
+/* CBC-MAC: x = E_K(x XOR block). */
+static inline void
+r_ccm_mac_block (const RAesCipher * aes, ruint8 x[R_AES_BLOCK_BYTES],
+    const ruint8 block[R_AES_BLOCK_BYTES])
+{
+  rsize i;
+  for (i = 0; i < R_AES_BLOCK_BYTES; i++)
+    x[i] ^= block[i];
+  aes->encrypt_block (aes, x, x);
+}
+
+/* Feed @p size bytes through CBC-MAC, zero-padding the trailing
+ * partial block (per RFC 3610 / SP 800-38C). */
+static void
+r_ccm_mac_feed (const RAesCipher * aes, ruint8 x[R_AES_BLOCK_BYTES],
+    const ruint8 * data, rsize size)
+{
+  ruint8 block[R_AES_BLOCK_BYTES];
+  while (size >= R_AES_BLOCK_BYTES) {
+    r_ccm_mac_block (aes, x, data);
+    data += R_AES_BLOCK_BYTES;
+    size -= R_AES_BLOCK_BYTES;
+  }
+  if (size > 0) {
+    r_memset (block, 0, R_AES_BLOCK_BYTES);
+    r_memcpy (block, data, size);
+    r_ccm_mac_block (aes, x, block);
+  }
+}
+
+/* CCM counter increment: only the trailing L bytes carry the
+ * counter; the leading flags + nonce stay fixed. */
+static void
+r_ccm_ctr_inc (ruint8 ctr[R_AES_BLOCK_BYTES], rsize L)
+{
+  rsize i;
+  for (i = 0; i < L; i++) {
+    if (++ctr[R_AES_BLOCK_BYTES - 1 - i] != 0)
+      break;
+  }
+}
+
+/* Build B0: flags || N || [size]_L. */
+static void
+r_ccm_build_b0 (ruint8 b0[R_AES_BLOCK_BYTES],
+    const ruint8 * nonce, rsize nonce_len, rsize L,
+    rboolean has_aad, rsize tag_len, rsize size)
+{
+  rsize i;
+  b0[0] = (has_aad ? 0x40 : 0)
+        | (ruint8) (((tag_len - 2) / 2) << 3)
+        | (ruint8) (L - 1);
+  r_memcpy (&b0[1], nonce, nonce_len);
+  for (i = 0; i < L; i++) {
+    rsize shift = 8 * (L - 1 - i);
+    b0[1 + nonce_len + i] = (shift >= 8 * sizeof (rsize))
+        ? 0
+        : (ruint8) ((size >> shift) & 0xff);
+  }
+}
+
+/* Build A0 (CTR starting block): flags = L-1, N, [0]_L. */
+static void
+r_ccm_build_a0 (ruint8 a0[R_AES_BLOCK_BYTES],
+    const ruint8 * nonce, rsize nonce_len, rsize L)
+{
+  a0[0] = (ruint8) (L - 1);
+  r_memcpy (&a0[1], nonce, nonce_len);
+  r_memset (&a0[1 + nonce_len], 0, L);
+}
+
+/* CTR-encrypt or -decrypt @p src into @p dst using @p ctr, advancing
+ * counter per block. The counter's L parameter is fixed by the
+ * caller's nonce length. */
+static void
+r_ccm_ctr_xor (const RAesCipher * aes, ruint8 ctr[R_AES_BLOCK_BYTES], rsize L,
+    ruint8 * dst, const ruint8 * src, rsize size)
+{
+  ruint8 ks[R_AES_BLOCK_BYTES];
+  rsize i;
+  while (size >= R_AES_BLOCK_BYTES) {
+    aes->encrypt_block (aes, ks, ctr);
+    for (i = 0; i < R_AES_BLOCK_BYTES; i++)
+      dst[i] = ks[i] ^ src[i];
+    r_ccm_ctr_inc (ctr, L);
+    dst += R_AES_BLOCK_BYTES;
+    src += R_AES_BLOCK_BYTES;
+    size -= R_AES_BLOCK_BYTES;
+  }
+  if (size > 0) {
+    aes->encrypt_block (aes, ks, ctr);
+    for (i = 0; i < size; i++)
+      dst[i] = ks[i] ^ src[i];
+  }
+  r_memclear_secure (ks, sizeof (ks));
+}
+
+/* Compute the CCM tag (full 16-byte CBC-MAC result, before truncation
+ * and XOR with S_0). Operates on a plaintext buffer so it works for
+ * both encrypt (input plaintext) and decrypt (recovered plaintext). */
+static void
+r_ccm_compute_mac (const RAesCipher * aes,
+    const ruint8 * nonce, rsize nonce_len, rsize L,
+    rconstpointer aad, rsize aadsize,
+    const ruint8 * plain, rsize size, rsize tag_len,
+    ruint8 x[R_AES_BLOCK_BYTES])
+{
+  ruint8 b0[R_AES_BLOCK_BYTES];
+
+  r_ccm_build_b0 (b0, nonce, nonce_len, L, aadsize > 0, tag_len, size);
+  aes->encrypt_block (aes, x, b0);
+
+  if (aadsize > 0) {
+    ruint8 block[R_AES_BLOCK_BYTES];
+    rsize prefix_len, block_off, i;
+    const ruint8 * aadp = aad;
+    rsize aadrem = aadsize;
+
+    /* Length-prefix the AAD per SP 800-38C A.2. */
+    if (aadsize < (rsize) ((1u << 16) - (1u << 8))) {
+      block[0] = (ruint8) ((aadsize >> 8) & 0xff);
+      block[1] = (ruint8) (aadsize & 0xff);
+      prefix_len = 2;
+    } else if (sizeof (rsize) <= 4 || aadsize < ((ruint64) 1 << 32)) {
+      block[0] = 0xff; block[1] = 0xfe;
+      block[2] = (ruint8) ((aadsize >> 24) & 0xff);
+      block[3] = (ruint8) ((aadsize >> 16) & 0xff);
+      block[4] = (ruint8) ((aadsize >>  8) & 0xff);
+      block[5] = (ruint8) (aadsize & 0xff);
+      prefix_len = 6;
+    } else {
+      block[0] = 0xff; block[1] = 0xff;
+      for (i = 0; i < 8; i++)
+        block[2 + i] = (ruint8) ((((ruint64) aadsize) >> (56 - i * 8)) & 0xff);
+      prefix_len = 10;
+    }
+
+    /* Fill the rest of the first block with AAD bytes, zero-pad if
+     * the AAD is short. */
+    block_off = prefix_len;
+    while (block_off < R_AES_BLOCK_BYTES && aadrem > 0) {
+      block[block_off++] = *aadp++;
+      aadrem--;
+    }
+    while (block_off < R_AES_BLOCK_BYTES)
+      block[block_off++] = 0;
+    r_ccm_mac_block (aes, x, block);
+
+    r_ccm_mac_feed (aes, x, aadp, aadrem);
+  }
+
+  r_ccm_mac_feed (aes, x, plain, size);
+}
+
+/* Shared encrypt/decrypt body, branched on @p generate_tag.
+ * encrypt: MAC over plaintext, then CTR-encrypt to dst, then tag.
+ * decrypt: CTR-decrypt into dst, then MAC over dst, then verify.
+ * On auth failure the decrypted bytes remain in @p dst per CCM's
+ * decrypt-then-verify shape; caller must discard. */
+static RCryptoCipherResult
+r_aes_ccm_op (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data,
+    rconstpointer aad, rsize aadsize,
+    const ruint8 * iv, rsize ivsize,
+    ruint8 * tag, rsize tagsize,
+    rboolean generate_tag)
+{
+  const RAesCipher * aes;
+  ruint8 a0[R_AES_BLOCK_BYTES];
+  ruint8 s0[R_AES_BLOCK_BYTES];
+  ruint8 ctr[R_AES_BLOCK_BYTES];
+  ruint8 x[R_AES_BLOCK_BYTES];
+  rsize L;
+  rsize i;
+
+  if (R_UNLIKELY (cipher == NULL || iv == NULL || tag == NULL))
+    return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (size > 0 && (data == NULL || dst == NULL)))
+    return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (aadsize > 0 && aad == NULL))
+    return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (ivsize < 7 || ivsize > 13))
+    return R_CRYPTO_CIPHER_INVAL;
+  /* CCM tag lengths: even, in [4, 16]. */
+  if (R_UNLIKELY (tagsize < 4 || tagsize > R_AES_BLOCK_BYTES || (tagsize & 1) != 0))
+    return R_CRYPTO_CIPHER_INVAL;
+
+  L = 15 - ivsize;
+  /* size < 2^(8L) when L < sizeof(rsize). */
+  if (L < sizeof (rsize) && size >= ((rsize) 1 << (8 * L)))
+    return R_CRYPTO_CIPHER_INVAL;
+
+  aes = (const RAesCipher *) cipher;
+
+  r_ccm_build_a0 (a0, iv, ivsize, L);
+  aes->encrypt_block (aes, s0, a0);
+  r_memcpy (ctr, a0, R_AES_BLOCK_BYTES);
+  r_ccm_ctr_inc (ctr, L);
+
+  if (generate_tag) {
+    /* Encrypt: MAC over plaintext, then CTR-encrypt to dst, then
+     * truncate-and-mask the tag. */
+    r_ccm_compute_mac (aes, iv, ivsize, L, aad, aadsize, data, size, tagsize, x);
+    r_ccm_ctr_xor (aes, ctr, L, dst, data, size);
+    for (i = 0; i < tagsize; i++)
+      tag[i] = x[i] ^ s0[i];
+  } else {
+    /* Decrypt: CTR into dst (recovers plaintext), MAC over dst,
+     * truncate-and-mask, constant-time compare against received tag. */
+    ruint8 tagcomputed[R_AES_BLOCK_BYTES];
+    ruint8 diff = 0;
+    r_ccm_ctr_xor (aes, ctr, L, dst, data, size);
+    r_ccm_compute_mac (aes, iv, ivsize, L, aad, aadsize, dst, size, tagsize, x);
+    for (i = 0; i < tagsize; i++)
+      tagcomputed[i] = x[i] ^ s0[i];
+    for (i = 0; i < tagsize; i++)
+      diff |= tagcomputed[i] ^ tag[i];
+    r_memclear_secure (tagcomputed, sizeof (tagcomputed));
+    if (diff != 0) {
+      r_memclear_secure (s0, sizeof (s0));
+      r_memclear_secure (x, sizeof (x));
+      return R_CRYPTO_CIPHER_AUTH_FAILED;
+    }
+  }
+
+  r_memclear_secure (s0, sizeof (s0));
+  r_memclear_secure (ctr, sizeof (ctr));
+  r_memclear_secure (x, sizeof (x));
+  return R_CRYPTO_CIPHER_OK;
+}
+
+RCryptoCipherResult
+r_cipher_aes_ccm_encrypt (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data,
+    rconstpointer aad, rsize aadsize,
+    ruint8 * iv, rsize ivsize,
+    ruint8 * tag, rsize tagsize)
+{
+  return r_aes_ccm_op (cipher, dst, size, data, aad, aadsize,
+      iv, ivsize, tag, tagsize, TRUE);
+}
+
+RCryptoCipherResult
+r_cipher_aes_ccm_decrypt (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data,
+    rconstpointer aad, rsize aadsize,
+    ruint8 * iv, rsize ivsize,
+    ruint8 * tag, rsize tagsize)
+{
+  return r_aes_ccm_op (cipher, dst, size, data, aad, aadsize,
       iv, ivsize, tag, tagsize, FALSE);
 }
 

--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -1356,11 +1356,9 @@ r_cipher_aes_ofb_encrypt (const RCryptoCipher * cipher,
  * SP 800-38D Section 6.3: byte[0] MSB carries the constant term x^0
  * and byte[15] LSB carries x^127. y is updated in place.
  *
- * Shift-and-XOR implementation: O(128) iterations per multiply,
- * not constant-time, slower than the 4-bit-table approach used in
- * production GHASH. Adequate for correctness and a baseline tests
- * can pin against; a faster implementation can land later without
- * changing this primitive's contract. */
+ * Bit-by-bit shift-and-XOR implementation. Used only to populate
+ * the 4-bit table once per GCM op; the hot path runs through
+ * r_ghash_mul_4bit. */
 static void
 r_ghash_mul (ruint8 y[R_AES_BLOCK_BYTES], const ruint8 h[R_AES_BLOCK_BYTES])
 {
@@ -1392,6 +1390,73 @@ r_ghash_mul (ruint8 y[R_AES_BLOCK_BYTES], const ruint8 h[R_AES_BLOCK_BYTES])
   r_memcpy (y, z, R_AES_BLOCK_BYTES);
 }
 
+/* 4-bit GHASH table (Shoup's method). e[n] holds (n * H) where the
+ * 4-bit value @c n encodes the polynomial chunk for x^0..x^3 in
+ * bit-reversed form (bit 3 of @c n = coefficient of x^0). */
+typedef struct {
+  ruint8 e[16][R_AES_BLOCK_BYTES];
+} RGhashTable;
+
+static void
+r_ghash_init_table (RGhashTable * t, const ruint8 h[R_AES_BLOCK_BYTES])
+{
+  rsize n;
+  r_memset (t->e[0], 0, R_AES_BLOCK_BYTES);
+  for (n = 1; n < 16; n++) {
+    r_memset (t->e[n], 0, R_AES_BLOCK_BYTES);
+    t->e[n][0] = (ruint8) (n << 4);
+    r_ghash_mul (t->e[n], h);
+  }
+}
+
+/* Reduction lookup for the four low-order bits that shift off the
+ * end during each nibble step of r_ghash_mul_4bit. R[rem] stores the
+ * bit-reversed reduction polynomial contributions for those four
+ * positions, spread across the new high-order bytes (z[0], z[1]). */
+static const ruint8 r_ghash_reduce_4bit[16][2] = {
+  { 0x00, 0x00 }, { 0x1c, 0x20 }, { 0x38, 0x40 }, { 0x24, 0x60 },
+  { 0x70, 0x80 }, { 0x6c, 0xa0 }, { 0x48, 0xc0 }, { 0x54, 0xe0 },
+  { 0xe1, 0x00 }, { 0xfd, 0x20 }, { 0xd9, 0x40 }, { 0xc5, 0x60 },
+  { 0x91, 0x80 }, { 0x8d, 0xa0 }, { 0xa9, 0xc0 }, { 0xb5, 0xe0 }
+};
+
+static void
+r_ghash_mul_4bit (ruint8 y[R_AES_BLOCK_BYTES], const RGhashTable * t)
+{
+  ruint8 z[R_AES_BLOCK_BYTES] = { 0 };
+  rssize byte_idx;
+  rsize k;
+  ruint8 n, rem;
+
+  for (byte_idx = R_AES_BLOCK_BYTES - 1; byte_idx >= 0; byte_idx--) {
+    /* Process the low nibble first (higher x position), then high.
+     * Each step is z = (z * x^4) XOR T[n], with z * x^4 done as a
+     * 4-bit right-shift plus the precomputed reduction for the four
+     * bits that fell off. */
+    n = y[byte_idx] & 0xf;
+    rem = z[R_AES_BLOCK_BYTES - 1] & 0xf;
+    for (k = R_AES_BLOCK_BYTES - 1; k > 0; k--)
+      z[k] = (ruint8) ((z[k] >> 4) | (z[k - 1] << 4));
+    z[0] >>= 4;
+    z[0] ^= r_ghash_reduce_4bit[rem][0];
+    z[1] ^= r_ghash_reduce_4bit[rem][1];
+    for (k = 0; k < R_AES_BLOCK_BYTES; k++)
+      z[k] ^= t->e[n][k];
+
+    n = y[byte_idx] >> 4;
+    rem = z[R_AES_BLOCK_BYTES - 1] & 0xf;
+    for (k = R_AES_BLOCK_BYTES - 1; k > 0; k--)
+      z[k] = (ruint8) ((z[k] >> 4) | (z[k - 1] << 4));
+    z[0] >>= 4;
+    z[0] ^= r_ghash_reduce_4bit[rem][0];
+    z[1] ^= r_ghash_reduce_4bit[rem][1];
+    for (k = 0; k < R_AES_BLOCK_BYTES; k++)
+      z[k] ^= t->e[n][k];
+  }
+
+  r_memcpy (y, z, R_AES_BLOCK_BYTES);
+}
+
 /* GCM-specific counter increment: only the low 32 bits advance; the
  * high 96 bits stay fixed at the IV value. */
 static void
@@ -1411,7 +1476,7 @@ r_gcm_ctr_inc32 (ruint8 ctr[R_AES_BLOCK_BYTES])
  * to a full block before mixing. */
 static void
 r_gcm_ghash_update (ruint8 y[R_AES_BLOCK_BYTES],
-    const ruint8 h[R_AES_BLOCK_BYTES],
+    const RGhashTable * t,
     const ruint8 * data, rsize size)
 {
   rsize k;
@@ -1419,7 +1484,7 @@ r_gcm_ghash_update (ruint8 y[R_AES_BLOCK_BYTES],
   while (size >= R_AES_BLOCK_BYTES) {
     for (k = 0; k < R_AES_BLOCK_BYTES; k++)
       y[k] ^= data[k];
-    r_ghash_mul (y, h);
+    r_ghash_mul_4bit (y, t);
     data += R_AES_BLOCK_BYTES;
     size -= R_AES_BLOCK_BYTES;
   }
@@ -1428,7 +1493,7 @@ r_gcm_ghash_update (ruint8 y[R_AES_BLOCK_BYTES],
     r_memcpy (block, data, size);
     for (k = 0; k < R_AES_BLOCK_BYTES; k++)
       y[k] ^= block[k];
-    r_ghash_mul (y, h);
+    r_ghash_mul_4bit (y, t);
   }
 }
 
@@ -1445,7 +1510,7 @@ r_gcm_be64 (ruint8 out[8], ruint64 v)
  * then XOR with E_K(J0) to form the GCM tag. */
 static void
 r_gcm_compute_tag (const RAesCipher * aes,
-    const ruint8 h[R_AES_BLOCK_BYTES],
+    const RGhashTable * t,
     const ruint8 j0[R_AES_BLOCK_BYTES],
     rconstpointer aad, rsize aadsize,
     const ruint8 * ciphertxt, rsize ctsize,
@@ -1456,14 +1521,14 @@ r_gcm_compute_tag (const RAesCipher * aes,
   ruint8 ek[R_AES_BLOCK_BYTES];
   rsize i;
 
-  r_gcm_ghash_update (y, h, aad, aadsize);
-  r_gcm_ghash_update (y, h, ciphertxt, ctsize);
+  r_gcm_ghash_update (y, t, aad, aadsize);
+  r_gcm_ghash_update (y, t, ciphertxt, ctsize);
 
   r_gcm_be64 (lenblock,     (ruint64) aadsize * 8);
   r_gcm_be64 (lenblock + 8, (ruint64) ctsize * 8);
   for (i = 0; i < R_AES_BLOCK_BYTES; i++)
     y[i] ^= lenblock[i];
-  r_ghash_mul (y, h);
+  r_ghash_mul_4bit (y, t);
 
   aes->encrypt_block (aes, ek, j0);
   for (i = 0; i < R_AES_BLOCK_BYTES; i++)
@@ -1488,6 +1553,7 @@ r_aes_gcm_op (const RCryptoCipher * cipher,
   ruint8 ctr[R_AES_BLOCK_BYTES];
   ruint8 ksblock[R_AES_BLOCK_BYTES];
   ruint8 tagcomputed[R_AES_BLOCK_BYTES];
+  RGhashTable ghash_t;
   const ruint8 * srcp;
   ruint8 * dstp;
   rsize remaining, i;
@@ -1507,23 +1573,26 @@ r_aes_gcm_op (const RCryptoCipher * cipher,
 
   aes = (const RAesCipher *) cipher;
 
-  /* H = E_K(0^128); J0 = IV || 0x00000001. */
+  /* H = E_K(0^128); J0 = IV || 0x00000001; precompute the GHASH
+   * 4-bit table once for this op. */
   aes->encrypt_block (aes, h, zero);
   r_memcpy (j0, iv, 12);
   j0[12] = 0; j0[13] = 0; j0[14] = 0; j0[15] = 1;
+  r_ghash_init_table (&ghash_t, h);
 
   /* For decrypt, verify the tag against the ciphertext BEFORE
    * touching @p dst. This way an auth failure leaves any previous
    * @p dst contents intact; the caller never sees released plaintext
    * from a forged input. */
   if (!generate_tag) {
-    r_gcm_compute_tag (aes, h, j0, aad, aadsize, data, size, tagcomputed);
+    r_gcm_compute_tag (aes, &ghash_t, j0, aad, aadsize, data, size, tagcomputed);
     {
       ruint8 diff = 0;
       for (i = 0; i < tagsize; i++)
         diff |= tagcomputed[i] ^ tag[i];
       if (diff != 0) {
         r_memclear_secure (h, sizeof (h));
+        r_memclear_secure (&ghash_t, sizeof (ghash_t));
         r_memclear_secure (tagcomputed, sizeof (tagcomputed));
         return R_CRYPTO_CIPHER_AUTH_FAILED;
       }
@@ -1552,10 +1621,11 @@ r_aes_gcm_op (const RCryptoCipher * cipher,
   }
 
   if (generate_tag) {
-    r_gcm_compute_tag (aes, h, j0, aad, aadsize, dst, size, tagcomputed);
+    r_gcm_compute_tag (aes, &ghash_t, j0, aad, aadsize, dst, size, tagcomputed);
     r_memcpy (tag, tagcomputed, tagsize);
   }
 
+  r_memclear_secure (&ghash_t, sizeof (ghash_t));
   r_memclear_secure (h, sizeof (h));
   r_memclear_secure (ctr, sizeof (ctr));
   r_memclear_secure (ksblock, sizeof (ksblock));

--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -136,66 +136,97 @@ R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks_armv8_256);
 
 const RCryptoCipherInfo g__r_crypto_cipher_aes_128_ecb =  { "AES-128-ECB",
   R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_ECB, 128, 16, 16,
-  r_cipher_aes_ecb_encrypt, r_cipher_aes_ecb_decrypt
+  r_cipher_aes_ecb_encrypt, r_cipher_aes_ecb_decrypt,
+  NULL, NULL
 };
 const RCryptoCipherInfo g__r_crypto_cipher_aes_192_ecb = { "AES-192-ECB",
   R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_ECB, 192, 16, 16,
-  r_cipher_aes_ecb_encrypt, r_cipher_aes_ecb_decrypt
+  r_cipher_aes_ecb_encrypt, r_cipher_aes_ecb_decrypt,
+  NULL, NULL
 };
 const RCryptoCipherInfo g__r_crypto_cipher_aes_256_ecb = { "AES-256-ECB",
   R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_ECB, 256, 16, 16,
-  r_cipher_aes_ecb_encrypt, r_cipher_aes_ecb_decrypt
+  r_cipher_aes_ecb_encrypt, r_cipher_aes_ecb_decrypt,
+  NULL, NULL
 };
 const RCryptoCipherInfo g__r_crypto_cipher_aes_128_cbc = { "AES-128-CBC",
   R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_CBC, 128, 16, 16,
-  r_cipher_aes_cbc_encrypt, r_cipher_aes_cbc_decrypt
+  r_cipher_aes_cbc_encrypt, r_cipher_aes_cbc_decrypt,
+  NULL, NULL
 };
 const RCryptoCipherInfo g__r_crypto_cipher_aes_192_cbc = { "AES-192-CBC",
   R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_CBC, 192, 16, 16,
-  r_cipher_aes_cbc_encrypt, r_cipher_aes_cbc_decrypt
+  r_cipher_aes_cbc_encrypt, r_cipher_aes_cbc_decrypt,
+  NULL, NULL
 };
 const RCryptoCipherInfo g__r_crypto_cipher_aes_256_cbc = { "AES-256-CBC",
   R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_CBC, 256, 16, 16,
-  r_cipher_aes_cbc_encrypt, r_cipher_aes_cbc_decrypt
+  r_cipher_aes_cbc_encrypt, r_cipher_aes_cbc_decrypt,
+  NULL, NULL
 };
 
 const RCryptoCipherInfo g__r_crypto_cipher_aes_128_ctr = { "AES-128-CTR",
   R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_CTR, 128, 16, 16,
-  r_cipher_aes_ctr_encrypt, r_cipher_aes_ctr_decrypt
+  r_cipher_aes_ctr_encrypt, r_cipher_aes_ctr_decrypt,
+  NULL, NULL
 };
 const RCryptoCipherInfo g__r_crypto_cipher_aes_192_ctr = { "AES-192-CTR",
   R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_CTR, 192, 16, 16,
-  r_cipher_aes_ctr_encrypt, r_cipher_aes_ctr_decrypt
+  r_cipher_aes_ctr_encrypt, r_cipher_aes_ctr_decrypt,
+  NULL, NULL
 };
 const RCryptoCipherInfo g__r_crypto_cipher_aes_256_ctr = { "AES-256-CTR",
   R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_CTR, 256, 16, 16,
-  r_cipher_aes_ctr_encrypt, r_cipher_aes_ctr_decrypt
+  r_cipher_aes_ctr_encrypt, r_cipher_aes_ctr_decrypt,
+  NULL, NULL
 };
 
 const RCryptoCipherInfo g__r_crypto_cipher_aes_128_cfb = { "AES-128-CFB",
   R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_CFB, 128, 16, 16,
-  r_cipher_aes_cfb_encrypt, r_cipher_aes_cfb_decrypt
+  r_cipher_aes_cfb_encrypt, r_cipher_aes_cfb_decrypt,
+  NULL, NULL
 };
 const RCryptoCipherInfo g__r_crypto_cipher_aes_192_cfb = { "AES-192-CFB",
   R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_CFB, 192, 16, 16,
-  r_cipher_aes_cfb_encrypt, r_cipher_aes_cfb_decrypt
+  r_cipher_aes_cfb_encrypt, r_cipher_aes_cfb_decrypt,
+  NULL, NULL
 };
 const RCryptoCipherInfo g__r_crypto_cipher_aes_256_cfb = { "AES-256-CFB",
   R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_CFB, 256, 16, 16,
-  r_cipher_aes_cfb_encrypt, r_cipher_aes_cfb_decrypt
+  r_cipher_aes_cfb_encrypt, r_cipher_aes_cfb_decrypt,
+  NULL, NULL
 };
 
 const RCryptoCipherInfo g__r_crypto_cipher_aes_128_ofb = { "AES-128-OFB",
   R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_OFB, 128, 16, 16,
-  r_cipher_aes_ofb_encrypt, r_cipher_aes_ofb_decrypt
+  r_cipher_aes_ofb_encrypt, r_cipher_aes_ofb_decrypt,
+  NULL, NULL
 };
 const RCryptoCipherInfo g__r_crypto_cipher_aes_192_ofb = { "AES-192-OFB",
   R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_OFB, 192, 16, 16,
-  r_cipher_aes_ofb_encrypt, r_cipher_aes_ofb_decrypt
+  r_cipher_aes_ofb_encrypt, r_cipher_aes_ofb_decrypt,
+  NULL, NULL
 };
+const RCryptoCipherInfo g__r_crypto_cipher_aes_128_gcm = { "AES-128-GCM",
+  R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_GCM, 128, 12, 16,
+  NULL, NULL,
+  r_cipher_aes_gcm_encrypt, r_cipher_aes_gcm_decrypt
+};
+const RCryptoCipherInfo g__r_crypto_cipher_aes_192_gcm = { "AES-192-GCM",
+  R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_GCM, 192, 12, 16,
+  NULL, NULL,
+  r_cipher_aes_gcm_encrypt, r_cipher_aes_gcm_decrypt
+};
+const RCryptoCipherInfo g__r_crypto_cipher_aes_256_gcm = { "AES-256-GCM",
+  R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_GCM, 256, 12, 16,
+  NULL, NULL,
+  r_cipher_aes_gcm_encrypt, r_cipher_aes_gcm_decrypt
+};
+
 const RCryptoCipherInfo g__r_crypto_cipher_aes_256_ofb = { "AES-256-OFB",
   R_CRYPTO_CIPHER_ALGO_AES, R_CRYPTO_CIPHER_MODE_OFB, 256, 16, 16,
-  r_cipher_aes_ofb_encrypt, r_cipher_aes_ofb_decrypt
+  r_cipher_aes_ofb_encrypt, r_cipher_aes_ofb_decrypt,
+  NULL, NULL
 };
 
 static void
@@ -469,6 +500,24 @@ r_cipher_aes_256_ofb_new (const ruint8 * key)
 }
 
 RCryptoCipher *
+r_cipher_aes_128_gcm_new (const ruint8 * key)
+{
+  return r_cipher_aes_new_with_info (&g__r_crypto_cipher_aes_128_gcm, key);
+}
+
+RCryptoCipher *
+r_cipher_aes_192_gcm_new (const ruint8 * key)
+{
+  return r_cipher_aes_new_with_info (&g__r_crypto_cipher_aes_192_gcm, key);
+}
+
+RCryptoCipher *
+r_cipher_aes_256_gcm_new (const ruint8 * key)
+{
+  return r_cipher_aes_new_with_info (&g__r_crypto_cipher_aes_256_gcm, key);
+}
+
+RCryptoCipher *
 r_cipher_aes_new (RCryptoCipherMode mode, ruint bits, const ruint8 * key)
 {
   switch (bits) {
@@ -484,6 +533,8 @@ r_cipher_aes_new (RCryptoCipherMode mode, ruint bits, const ruint8 * key)
           return r_cipher_aes_128_cfb_new (key);
         case R_CRYPTO_CIPHER_MODE_OFB:
           return r_cipher_aes_128_ofb_new (key);
+        case R_CRYPTO_CIPHER_MODE_GCM:
+          return r_cipher_aes_128_gcm_new (key);
         default:
           break;
       }
@@ -500,6 +551,8 @@ r_cipher_aes_new (RCryptoCipherMode mode, ruint bits, const ruint8 * key)
           return r_cipher_aes_192_cfb_new (key);
         case R_CRYPTO_CIPHER_MODE_OFB:
           return r_cipher_aes_192_ofb_new (key);
+        case R_CRYPTO_CIPHER_MODE_GCM:
+          return r_cipher_aes_192_gcm_new (key);
         default:
           break;
       }
@@ -516,6 +569,8 @@ r_cipher_aes_new (RCryptoCipherMode mode, ruint bits, const ruint8 * key)
           return r_cipher_aes_256_cfb_new (key);
         case R_CRYPTO_CIPHER_MODE_OFB:
           return r_cipher_aes_256_ofb_new (key);
+        case R_CRYPTO_CIPHER_MODE_GCM:
+          return r_cipher_aes_256_gcm_new (key);
         default:
           break;
       }
@@ -1248,5 +1303,243 @@ r_cipher_aes_ofb_encrypt (const RCryptoCipher * cipher,
   }
 
   return R_CRYPTO_CIPHER_OK;
+}
+
+/******************************************************************************/
+/*  AES-GCM (RFC 5288 / NIST SP 800-38D)                                      */
+/******************************************************************************/
+
+/* Multiply y by h in GF(2^128) with reducing polynomial
+ * x^128 + x^7 + x^2 + x + 1, bit-reversed representation per NIST
+ * SP 800-38D Section 6.3: byte[0] MSB carries the constant term x^0
+ * and byte[15] LSB carries x^127. y is updated in place.
+ *
+ * Shift-and-XOR implementation: O(128) iterations per multiply,
+ * not constant-time, slower than the 4-bit-table approach used in
+ * production GHASH. Adequate for correctness and a baseline tests
+ * can pin against; a faster implementation can land later without
+ * changing this primitive's contract. */
+static void
+r_ghash_mul (ruint8 y[R_AES_BLOCK_BYTES], const ruint8 h[R_AES_BLOCK_BYTES])
+{
+  ruint8 z[R_AES_BLOCK_BYTES] = { 0 };
+  ruint8 v[R_AES_BLOCK_BYTES];
+  rsize i, j, k;
+
+  r_memcpy (v, h, R_AES_BLOCK_BYTES);
+
+  for (i = 0; i < R_AES_BLOCK_BYTES; i++) {
+    for (j = 0; j < 8; j++) {
+      if (y[i] & (0x80 >> j)) {
+        for (k = 0; k < R_AES_BLOCK_BYTES; k++)
+          z[k] ^= v[k];
+      }
+      /* v = v * x mod poly: right-shift, conditionally XOR 0xe1 into
+       * v[0] (the bit-reversed reducing polynomial). */
+      {
+        ruint8 lsb = v[R_AES_BLOCK_BYTES - 1] & 1;
+        for (k = R_AES_BLOCK_BYTES - 1; k > 0; k--)
+          v[k] = (v[k] >> 1) | ((v[k - 1] & 1) << 7);
+        v[0] >>= 1;
+        if (lsb)
+          v[0] ^= 0xe1;
+      }
+    }
+  }
+
+  r_memcpy (y, z, R_AES_BLOCK_BYTES);
+}
+
+/* GCM-specific counter increment: only the low 32 bits advance; the
+ * high 96 bits stay fixed at the IV value. */
+static void
+r_gcm_ctr_inc32 (ruint8 ctr[R_AES_BLOCK_BYTES])
+{
+  ruint32 c = ((ruint32) ctr[12] << 24) | ((ruint32) ctr[13] << 16)
+            | ((ruint32) ctr[14] <<  8) |  (ruint32) ctr[15];
+  c++;
+  ctr[12] = (c >> 24) & 0xff;
+  ctr[13] = (c >> 16) & 0xff;
+  ctr[14] = (c >>  8) & 0xff;
+  ctr[15] =  c        & 0xff;
+}
+
+/* Fold @p data into the running GHASH state @p y, one 16-byte block
+ * at a time. The trailing partial block (if any) is zero-padded out
+ * to a full block before mixing. */
+static void
+r_gcm_ghash_update (ruint8 y[R_AES_BLOCK_BYTES],
+    const ruint8 h[R_AES_BLOCK_BYTES],
+    const ruint8 * data, rsize size)
+{
+  rsize k;
+
+  while (size >= R_AES_BLOCK_BYTES) {
+    for (k = 0; k < R_AES_BLOCK_BYTES; k++)
+      y[k] ^= data[k];
+    r_ghash_mul (y, h);
+    data += R_AES_BLOCK_BYTES;
+    size -= R_AES_BLOCK_BYTES;
+  }
+  if (size > 0) {
+    ruint8 block[R_AES_BLOCK_BYTES] = { 0 };
+    r_memcpy (block, data, size);
+    for (k = 0; k < R_AES_BLOCK_BYTES; k++)
+      y[k] ^= block[k];
+    r_ghash_mul (y, h);
+  }
+}
+
+/* Encode a 64-bit big-endian length-in-bits value into @p out. */
+static void
+r_gcm_be64 (ruint8 out[8], ruint64 v)
+{
+  rsize i;
+  for (i = 0; i < 8; i++)
+    out[i] = (ruint8) (v >> (56 - i * 8));
+}
+
+/* GHASH(H, AAD || pad || C || pad || [len(AAD)]_64 || [len(C)]_64),
+ * then XOR with E_K(J0) to form the GCM tag. */
+static void
+r_gcm_compute_tag (const RAesCipher * aes,
+    const ruint8 h[R_AES_BLOCK_BYTES],
+    const ruint8 j0[R_AES_BLOCK_BYTES],
+    rconstpointer aad, rsize aadsize,
+    const ruint8 * ciphertxt, rsize ctsize,
+    ruint8 tag[R_AES_BLOCK_BYTES])
+{
+  ruint8 y[R_AES_BLOCK_BYTES] = { 0 };
+  ruint8 lenblock[R_AES_BLOCK_BYTES];
+  ruint8 ek[R_AES_BLOCK_BYTES];
+  rsize i;
+
+  r_gcm_ghash_update (y, h, aad, aadsize);
+  r_gcm_ghash_update (y, h, ciphertxt, ctsize);
+
+  r_gcm_be64 (lenblock,     (ruint64) aadsize * 8);
+  r_gcm_be64 (lenblock + 8, (ruint64) ctsize * 8);
+  for (i = 0; i < R_AES_BLOCK_BYTES; i++)
+    y[i] ^= lenblock[i];
+  r_ghash_mul (y, h);
+
+  aes->encrypt_block (aes, ek, j0);
+  for (i = 0; i < R_AES_BLOCK_BYTES; i++)
+    tag[i] = ek[i] ^ y[i];
+}
+
+/* Shared encrypt/decrypt body. @p generate_tag controls whether the
+ * computed tag is written to @p tag (encrypt) or compared in constant
+ * time against the supplied @p tag (decrypt). */
+static RCryptoCipherResult
+r_aes_gcm_op (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data,
+    rconstpointer aad, rsize aadsize,
+    const ruint8 * iv, rsize ivsize,
+    ruint8 * tag, rsize tagsize,
+    rboolean generate_tag)
+{
+  const RAesCipher * aes;
+  ruint8 zero[R_AES_BLOCK_BYTES] = { 0 };
+  ruint8 h[R_AES_BLOCK_BYTES];
+  ruint8 j0[R_AES_BLOCK_BYTES];
+  ruint8 ctr[R_AES_BLOCK_BYTES];
+  ruint8 ksblock[R_AES_BLOCK_BYTES];
+  ruint8 tagcomputed[R_AES_BLOCK_BYTES];
+  const ruint8 * srcp;
+  ruint8 * dstp;
+  rsize remaining, i;
+
+  if (R_UNLIKELY (cipher == NULL || iv == NULL || tag == NULL))
+    return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (size > 0 && (data == NULL || dst == NULL)))
+    return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (aadsize > 0 && aad == NULL))
+    return R_CRYPTO_CIPHER_INVAL;
+  /* Only the recommended 96-bit IV is supported; longer / shorter IVs
+   * need the alternate J0 construction (GHASH over IV). */
+  if (R_UNLIKELY (ivsize != 12))
+    return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (tagsize == 0 || tagsize > R_AES_BLOCK_BYTES))
+    return R_CRYPTO_CIPHER_INVAL;
+
+  aes = (const RAesCipher *) cipher;
+
+  /* H = E_K(0^128); J0 = IV || 0x00000001. */
+  aes->encrypt_block (aes, h, zero);
+  r_memcpy (j0, iv, 12);
+  j0[12] = 0; j0[13] = 0; j0[14] = 0; j0[15] = 1;
+
+  /* For decrypt, verify the tag against the ciphertext BEFORE
+   * touching @p dst. This way an auth failure leaves any previous
+   * @p dst contents intact; the caller never sees released plaintext
+   * from a forged input. */
+  if (!generate_tag) {
+    r_gcm_compute_tag (aes, h, j0, aad, aadsize, data, size, tagcomputed);
+    {
+      ruint8 diff = 0;
+      for (i = 0; i < tagsize; i++)
+        diff |= tagcomputed[i] ^ tag[i];
+      if (diff != 0) {
+        r_memclear_secure (h, sizeof (h));
+        r_memclear_secure (tagcomputed, sizeof (tagcomputed));
+        return R_CRYPTO_CIPHER_AUTH_FAILED;
+      }
+    }
+  }
+
+  /* CTR-mode encrypt / decrypt starting at inc_32(J0). */
+  r_memcpy (ctr, j0, R_AES_BLOCK_BYTES);
+  r_gcm_ctr_inc32 (ctr);
+  srcp = data;
+  dstp = dst;
+  remaining = size;
+  while (remaining >= R_AES_BLOCK_BYTES) {
+    aes->encrypt_block (aes, ksblock, ctr);
+    for (i = 0; i < R_AES_BLOCK_BYTES; i++)
+      dstp[i] = ksblock[i] ^ srcp[i];
+    r_gcm_ctr_inc32 (ctr);
+    srcp += R_AES_BLOCK_BYTES;
+    dstp += R_AES_BLOCK_BYTES;
+    remaining -= R_AES_BLOCK_BYTES;
+  }
+  if (remaining > 0) {
+    aes->encrypt_block (aes, ksblock, ctr);
+    for (i = 0; i < remaining; i++)
+      dstp[i] = ksblock[i] ^ srcp[i];
+  }
+
+  if (generate_tag) {
+    r_gcm_compute_tag (aes, h, j0, aad, aadsize, dst, size, tagcomputed);
+    r_memcpy (tag, tagcomputed, tagsize);
+  }
+
+  r_memclear_secure (h, sizeof (h));
+  r_memclear_secure (ctr, sizeof (ctr));
+  r_memclear_secure (ksblock, sizeof (ksblock));
+  r_memclear_secure (tagcomputed, sizeof (tagcomputed));
+  return R_CRYPTO_CIPHER_OK;
+}
+
+RCryptoCipherResult
+r_cipher_aes_gcm_encrypt (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data,
+    rconstpointer aad, rsize aadsize,
+    ruint8 * iv, rsize ivsize,
+    ruint8 * tag, rsize tagsize)
+{
+  return r_aes_gcm_op (cipher, dst, size, data, aad, aadsize,
+      iv, ivsize, tag, tagsize, TRUE);
+}
+
+RCryptoCipherResult
+r_cipher_aes_gcm_decrypt (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data,
+    rconstpointer aad, rsize aadsize,
+    ruint8 * iv, rsize ivsize,
+    ruint8 * tag, rsize tagsize)
+{
+  return r_aes_gcm_op (cipher, dst, size, data, aad, aadsize,
+      iv, ivsize, tag, tagsize, FALSE);
 }
 

--- a/rlib/crypto/rcipher.c
+++ b/rlib/crypto/rcipher.c
@@ -37,7 +37,8 @@ r_crypto_cipher_null_func (const RCryptoCipher * cipher,
 
 const RCryptoCipherInfo g__r_crypto_null_cipher = { "NULL",
   R_CRYPTO_CIPHER_ALGO_NULL, R_CRYPTO_CIPHER_MODE_STREAM, 0, 0, 1,
-  r_crypto_cipher_null_func, r_crypto_cipher_null_func
+  r_crypto_cipher_null_func, r_crypto_cipher_null_func,
+  NULL, NULL
 };
 
 const RCryptoCipherInfo * g__r_crypto_ciphers[] = {
@@ -116,11 +117,21 @@ r_crypto_cipher_new (const RCryptoCipherInfo * info, const ruint8 * key)
   return NULL;
 }
 
+rboolean
+r_crypto_cipher_is_aead (const RCryptoCipher * cipher)
+{
+  if (R_UNLIKELY (cipher == NULL)) return FALSE;
+  return cipher->info->mode == R_CRYPTO_CIPHER_MODE_GCM ||
+         cipher->info->mode == R_CRYPTO_CIPHER_MODE_CCM;
+}
+
 RCryptoCipherResult
 r_crypto_cipher_encrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize)
 {
   if (R_UNLIKELY (cipher == NULL)) return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (r_crypto_cipher_is_aead (cipher)))
+    return R_CRYPTO_CIPHER_NEEDS_AEAD;
   return cipher->info->enc (cipher, dst, size, data, iv, ivsize);
 }
 
@@ -129,6 +140,36 @@ r_crypto_cipher_decrypt (const RCryptoCipher * cipher,
     ruint8 * dst, rsize size, rconstpointer data, ruint8 * iv, rsize ivsize)
 {
   if (R_UNLIKELY (cipher == NULL)) return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (r_crypto_cipher_is_aead (cipher)))
+    return R_CRYPTO_CIPHER_NEEDS_AEAD;
   return cipher->info->dec (cipher, dst, size, data, iv, ivsize);
+}
+
+RCryptoCipherResult
+r_crypto_cipher_encrypt_aead (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data,
+    rconstpointer aad, rsize aadsize,
+    ruint8 * iv, rsize ivsize,
+    ruint8 * tag, rsize tagsize)
+{
+  if (R_UNLIKELY (cipher == NULL)) return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (!r_crypto_cipher_is_aead (cipher)))
+    return R_CRYPTO_CIPHER_NOT_AEAD;
+  return cipher->info->aead_enc (cipher, dst, size, data,
+      aad, aadsize, iv, ivsize, tag, tagsize);
+}
+
+RCryptoCipherResult
+r_crypto_cipher_decrypt_aead (const RCryptoCipher * cipher,
+    ruint8 * dst, rsize size, rconstpointer data,
+    rconstpointer aad, rsize aadsize,
+    ruint8 * iv, rsize ivsize,
+    ruint8 * tag, rsize tagsize)
+{
+  if (R_UNLIKELY (cipher == NULL)) return R_CRYPTO_CIPHER_INVAL;
+  if (R_UNLIKELY (!r_crypto_cipher_is_aead (cipher)))
+    return R_CRYPTO_CIPHER_NOT_AEAD;
+  return cipher->info->aead_dec (cipher, dst, size, data,
+      aad, aadsize, iv, ivsize, tag, tagsize);
 }
 

--- a/rlib/crypto/rcipher.c
+++ b/rlib/crypto/rcipher.c
@@ -55,6 +55,9 @@ const RCryptoCipherInfo * g__r_crypto_ciphers[] = {
   &g__r_crypto_cipher_aes_128_gcm,
   &g__r_crypto_cipher_aes_192_gcm,
   &g__r_crypto_cipher_aes_256_gcm,
+  &g__r_crypto_cipher_aes_128_ccm,
+  &g__r_crypto_cipher_aes_192_ccm,
+  &g__r_crypto_cipher_aes_256_ccm,
 };
 
 const RCryptoCipherInfo *

--- a/rlib/crypto/rcipher.c
+++ b/rlib/crypto/rcipher.c
@@ -52,6 +52,9 @@ const RCryptoCipherInfo * g__r_crypto_ciphers[] = {
   &g__r_crypto_cipher_aes_128_ctr,
   &g__r_crypto_cipher_aes_192_ctr,
   &g__r_crypto_cipher_aes_256_ctr,
+  &g__r_crypto_cipher_aes_128_gcm,
+  &g__r_crypto_cipher_aes_192_gcm,
+  &g__r_crypto_cipher_aes_256_gcm,
 };
 
 const RCryptoCipherInfo *

--- a/rlib/crypto/rcrypto-private.h
+++ b/rlib/crypto/rcrypto-private.h
@@ -93,6 +93,9 @@ R_API_HIDDEN extern const RCryptoCipherInfo g__r_crypto_cipher_aes_256_cbc;
 R_API_HIDDEN extern const RCryptoCipherInfo g__r_crypto_cipher_aes_128_ctr;
 R_API_HIDDEN extern const RCryptoCipherInfo g__r_crypto_cipher_aes_192_ctr;
 R_API_HIDDEN extern const RCryptoCipherInfo g__r_crypto_cipher_aes_256_ctr;
+R_API_HIDDEN extern const RCryptoCipherInfo g__r_crypto_cipher_aes_128_gcm;
+R_API_HIDDEN extern const RCryptoCipherInfo g__r_crypto_cipher_aes_192_gcm;
+R_API_HIDDEN extern const RCryptoCipherInfo g__r_crypto_cipher_aes_256_gcm;
 
 R_END_DECLS
 

--- a/rlib/crypto/rcrypto-private.h
+++ b/rlib/crypto/rcrypto-private.h
@@ -96,6 +96,9 @@ R_API_HIDDEN extern const RCryptoCipherInfo g__r_crypto_cipher_aes_256_ctr;
 R_API_HIDDEN extern const RCryptoCipherInfo g__r_crypto_cipher_aes_128_gcm;
 R_API_HIDDEN extern const RCryptoCipherInfo g__r_crypto_cipher_aes_192_gcm;
 R_API_HIDDEN extern const RCryptoCipherInfo g__r_crypto_cipher_aes_256_gcm;
+R_API_HIDDEN extern const RCryptoCipherInfo g__r_crypto_cipher_aes_128_ccm;
+R_API_HIDDEN extern const RCryptoCipherInfo g__r_crypto_cipher_aes_192_ccm;
+R_API_HIDDEN extern const RCryptoCipherInfo g__r_crypto_cipher_aes_256_ccm;
 
 R_END_DECLS
 

--- a/test/raes.c
+++ b/test/raes.c
@@ -28,8 +28,10 @@ RTEST (raes, new_args, RTEST_FAST)
   r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_OFB, 129, key), ==, NULL);
   r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_OFB, 255, key), ==, NULL);
 
-  r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_GCM, 128, key), ==, NULL);
   r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_CCM, 128, key), ==, NULL);
+  r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_GCM, 0, key), ==, NULL);
+  r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_GCM, 129, key), ==, NULL);
+  r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_GCM, 255, key), ==, NULL);
 }
 RTEST_END;
 
@@ -384,6 +386,146 @@ RTEST_LOOP (raes, ofb, RTEST_FAST, 0, R_N_ELEMENTS (OFB_test_data))
   r_assert_cmpuint (r_str_hex_to_binary (data->iv, iv, R_AES_BLOCK_BYTES), ==, R_AES_BLOCK_BYTES);
   r_assert_cmpint (r_cipher_aes_ofb_decrypt (cipher, out, plainsize, ciphertxt, iv, sizeof (iv)), ==, R_CRYPTO_CIPHER_OK);
   r_assert_cmpmem (out, ==, plaintxt, plainsize);
+
+  r_crypto_cipher_unref (cipher);
+  r_free (plaintxt);
+  r_free (ciphertxt);
+  r_free (out);
+}
+RTEST_END;
+
+/* AES-GCM vectors from NIST SP 800-38D Appendix B. */
+typedef struct {
+  ruint16 keybits;
+  const rchar * key;
+  const rchar * iv;
+  const rchar * aad;
+  const rchar * plaintxt;
+  const rchar * ciphertxt;
+  const rchar * tag;
+} RAesGcmTestData;
+
+static const RAesGcmTestData GCM_test_data[] = {
+  { /* SP 800-38D test case 2 */
+    .keybits = 128,
+    .key = "00000000000000000000000000000000",
+    .iv  = "000000000000000000000000",
+    .aad = "",
+    .plaintxt  = "00000000000000000000000000000000",
+    .ciphertxt = "0388dace60b6a392f328c2b971b2fe78",
+    .tag = "ab6e47d42cec13bdf53a67b21257bddf"
+  },
+  { /* SP 800-38D test case 3 */
+    .keybits = 128,
+    .key = "feffe9928665731c6d6a8f9467308308",
+    .iv  = "cafebabefacedbaddecaf888",
+    .aad = "",
+    .plaintxt  = "d9313225f88406e5a55909c5aff5269a86a7a9531534f7da"
+                 "2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525"
+                 "b16aedf5aa0de657ba637b391aafd255",
+    .ciphertxt = "42831ec2217774244b7221b784d0d49ce3aa212f2c02a4e0"
+                 "35c17e2329aca12e21d514b25466931c7d8f6a5aac84aa05"
+                 "1ba30b396a0aac973d58e091473f5985",
+    .tag = "4d5c2af327cd64a62cf35abd2ba6fab4"
+  },
+  { /* SP 800-38D test case 4: AAD + partial last plaintext block */
+    .keybits = 128,
+    .key = "feffe9928665731c6d6a8f9467308308",
+    .iv  = "cafebabefacedbaddecaf888",
+    .aad = "feedfacedeadbeeffeedfacedeadbeefabaddad2",
+    .plaintxt  = "d9313225f88406e5a55909c5aff5269a86a7a9531534f7da"
+                 "2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525"
+                 "b16aedf5aa0de657ba637b39",
+    .ciphertxt = "42831ec2217774244b7221b784d0d49ce3aa212f2c02a4e0"
+                 "35c17e2329aca12e21d514b25466931c7d8f6a5aac84aa05"
+                 "1ba30b396a0aac973d58e091",
+    .tag = "5bc94fbc3221a5db94fae95ae7121a47"
+  },
+  { /* SP 800-38D test case 14 (AES-256, zero key, single-block zero plaintext) */
+    .keybits = 256,
+    .key = "00000000000000000000000000000000"
+           "00000000000000000000000000000000",
+    .iv  = "000000000000000000000000",
+    .aad = "",
+    .plaintxt  = "00000000000000000000000000000000",
+    .ciphertxt = "cea7403d4d606b6e074ec5d3baf39d18",
+    .tag = "d0d1c8a799996bf0265b98b5d48ab919"
+  },
+  { /* SP 800-38D test case 16 (AES-256 with AAD + partial block) */
+    .keybits = 256,
+    .key = "feffe9928665731c6d6a8f9467308308"
+           "feffe9928665731c6d6a8f9467308308",
+    .iv  = "cafebabefacedbaddecaf888",
+    .aad = "feedfacedeadbeeffeedfacedeadbeefabaddad2",
+    .plaintxt  = "d9313225f88406e5a55909c5aff5269a86a7a9531534f7da"
+                 "2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525"
+                 "b16aedf5aa0de657ba637b39",
+    .ciphertxt = "522dc1f099567d07f47f37a32a84427d643a8cdcbfe5c0c9"
+                 "7598a2bd2555d1aa8cb08e48590dbb3da7b08b1056828838"
+                 "c5f61e6393ba7a0abcc9f662",
+    .tag = "76fc6ece0f4e1768cddf8853bb2d551b"
+  }
+};
+
+RTEST_LOOP (raes, gcm, RTEST_FAST, 0, R_N_ELEMENTS (GCM_test_data))
+{
+  const RAesGcmTestData * data = &GCM_test_data[__i];
+  RCryptoCipher * cipher;
+  ruint8 key[32];
+  ruint8 iv[12];
+  ruint8 aad[64];
+  ruint8 * plaintxt;
+  ruint8 * ciphertxt;
+  ruint8 tag[16];
+  ruint8 outtag[16];
+  ruint8 * out;
+  rsize plainsize, aadsize, tagsize;
+  rsize keysize = data->keybits / 8;
+
+  plainsize  = r_strlen (data->plaintxt) / 2;
+  aadsize    = r_strlen (data->aad) / 2;
+  tagsize    = r_strlen (data->tag) / 2;
+  plaintxt   = r_malloc (plainsize);
+  ciphertxt  = r_malloc (plainsize);
+  out        = r_malloc (plainsize);
+  r_assert_cmpuint (r_str_hex_to_binary (data->key, key, keysize), ==, keysize);
+  r_assert_cmpuint (r_str_hex_to_binary (data->iv, iv, sizeof (iv)), ==, sizeof (iv));
+  if (aadsize > 0)
+    r_assert_cmpuint (r_str_hex_to_binary (data->aad, aad, aadsize), ==, aadsize);
+  r_assert_cmpuint (r_str_hex_to_binary (data->plaintxt, plaintxt, plainsize), ==, plainsize);
+  r_assert_cmpuint (r_str_hex_to_binary (data->ciphertxt, ciphertxt, plainsize), ==, plainsize);
+  r_assert_cmpuint (r_str_hex_to_binary (data->tag, tag, tagsize), ==, tagsize);
+
+  r_assert_cmpptr ((cipher = r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_GCM,
+          data->keybits, key)), !=, NULL);
+  r_assert (r_crypto_cipher_is_aead (cipher));
+
+  /* Encrypt: produces matching ciphertext + tag. */
+  r_assert_cmpint (r_crypto_cipher_encrypt_aead (cipher, out, plainsize, plaintxt,
+        aadsize > 0 ? aad : NULL, aadsize, iv, sizeof (iv),
+        outtag, tagsize), ==, R_CRYPTO_CIPHER_OK);
+  r_assert_cmpmem (out, ==, ciphertxt, plainsize);
+  r_assert_cmpmem (outtag, ==, tag, tagsize);
+
+  /* Decrypt: recovers plaintext and verifies tag. */
+  r_assert_cmpint (r_crypto_cipher_decrypt_aead (cipher, out, plainsize, ciphertxt,
+        aadsize > 0 ? aad : NULL, aadsize, iv, sizeof (iv),
+        tag, tagsize), ==, R_CRYPTO_CIPHER_OK);
+  r_assert_cmpmem (out, ==, plaintxt, plainsize);
+
+  /* Decrypt with a tampered tag fails with AUTH_FAILED. */
+  {
+    ruint8 badtag[16];
+    r_memcpy (badtag, tag, tagsize);
+    badtag[0] ^= 0x01;
+    r_assert_cmpint (r_crypto_cipher_decrypt_aead (cipher, out, plainsize, ciphertxt,
+          aadsize > 0 ? aad : NULL, aadsize, iv, sizeof (iv),
+          badtag, tagsize), ==, R_CRYPTO_CIPHER_AUTH_FAILED);
+  }
+
+  /* Calling the non-AEAD entry point on a GCM cipher is rejected. */
+  r_assert_cmpint (r_crypto_cipher_encrypt (cipher, out, plainsize, plaintxt,
+        iv, sizeof (iv)), ==, R_CRYPTO_CIPHER_NEEDS_AEAD);
 
   r_crypto_cipher_unref (cipher);
   r_free (plaintxt);

--- a/test/raes.c
+++ b/test/raes.c
@@ -28,10 +28,13 @@ RTEST (raes, new_args, RTEST_FAST)
   r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_OFB, 129, key), ==, NULL);
   r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_OFB, 255, key), ==, NULL);
 
-  r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_CCM, 128, key), ==, NULL);
   r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_GCM, 0, key), ==, NULL);
   r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_GCM, 129, key), ==, NULL);
   r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_GCM, 255, key), ==, NULL);
+
+  r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_CCM, 0, key), ==, NULL);
+  r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_CCM, 129, key), ==, NULL);
+  r_assert_cmpptr (r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_CCM, 255, key), ==, NULL);
 }
 RTEST_END;
 
@@ -526,6 +529,109 @@ RTEST_LOOP (raes, gcm, RTEST_FAST, 0, R_N_ELEMENTS (GCM_test_data))
   /* Calling the non-AEAD entry point on a GCM cipher is rejected. */
   r_assert_cmpint (r_crypto_cipher_encrypt (cipher, out, plainsize, plaintxt,
         iv, sizeof (iv)), ==, R_CRYPTO_CIPHER_NEEDS_AEAD);
+
+  r_crypto_cipher_unref (cipher);
+  r_free (plaintxt);
+  r_free (ciphertxt);
+  r_free (out);
+}
+RTEST_END;
+
+/* AES-CCM vectors from RFC 3610 §8 (test packet vectors 1-2) and
+ * NIST SP 800-38C Appendix C (examples 1-3). */
+typedef struct {
+  ruint16 keybits;
+  const rchar * key;
+  const rchar * iv;
+  const rchar * aad;
+  const rchar * plaintxt;
+  const rchar * ciphertxt;
+  const rchar * tag;
+} RAesCcmTestData;
+
+static const RAesCcmTestData CCM_test_data[] = {
+  { /* NIST SP 800-38C example 1: N=7, M=4 */
+    .keybits = 128,
+    .key = "404142434445464748494a4b4c4d4e4f",
+    .iv  = "10111213141516",
+    .aad = "0001020304050607",
+    .plaintxt  = "20212223",
+    .ciphertxt = "7162015b",
+    .tag = "4dac255d"
+  },
+  { /* NIST SP 800-38C example 2: N=8, M=6 */
+    .keybits = 128,
+    .key = "404142434445464748494a4b4c4d4e4f",
+    .iv  = "1011121314151617",
+    .aad = "000102030405060708090a0b0c0d0e0f",
+    .plaintxt  = "202122232425262728292a2b2c2d2e2f",
+    .ciphertxt = "d2a1f0e051ea5f62081a7792073d593d",
+    .tag = "1fc64fbfaccd"
+  },
+  { /* RFC 3610 test vector 1: N=13, M=8 */
+    .keybits = 128,
+    .key = "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf",
+    .iv  = "00000003020100a0a1a2a3a4a5",
+    .aad = "0001020304050607",
+    .plaintxt  = "08090a0b0c0d0e0f101112131415161718191a1b1c1d1e",
+    .ciphertxt = "588c979a61c663d2f066d0c2c0f989806d5f6b61dac384",
+    .tag = "17e8d12cfdf926e0"
+  }
+};
+
+RTEST_LOOP (raes, ccm, RTEST_FAST, 0, R_N_ELEMENTS (CCM_test_data))
+{
+  const RAesCcmTestData * data = &CCM_test_data[__i];
+  RCryptoCipher * cipher;
+  ruint8 key[32];
+  ruint8 iv[16];
+  ruint8 aad[64];
+  ruint8 * plaintxt;
+  ruint8 * ciphertxt;
+  ruint8 tag[16];
+  ruint8 outtag[16];
+  ruint8 * out;
+  rsize plainsize, aadsize, ivsize, tagsize;
+  rsize keysize = data->keybits / 8;
+
+  plainsize  = r_strlen (data->plaintxt) / 2;
+  aadsize    = r_strlen (data->aad) / 2;
+  ivsize     = r_strlen (data->iv) / 2;
+  tagsize    = r_strlen (data->tag) / 2;
+  plaintxt   = r_malloc (plainsize);
+  ciphertxt  = r_malloc (plainsize);
+  out        = r_malloc (plainsize);
+  r_assert_cmpuint (r_str_hex_to_binary (data->key, key, keysize), ==, keysize);
+  r_assert_cmpuint (r_str_hex_to_binary (data->iv, iv, ivsize), ==, ivsize);
+  if (aadsize > 0)
+    r_assert_cmpuint (r_str_hex_to_binary (data->aad, aad, aadsize), ==, aadsize);
+  r_assert_cmpuint (r_str_hex_to_binary (data->plaintxt, plaintxt, plainsize), ==, plainsize);
+  r_assert_cmpuint (r_str_hex_to_binary (data->ciphertxt, ciphertxt, plainsize), ==, plainsize);
+  r_assert_cmpuint (r_str_hex_to_binary (data->tag, tag, tagsize), ==, tagsize);
+
+  r_assert_cmpptr ((cipher = r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_CCM,
+          data->keybits, key)), !=, NULL);
+  r_assert (r_crypto_cipher_is_aead (cipher));
+
+  r_assert_cmpint (r_crypto_cipher_encrypt_aead (cipher, out, plainsize, plaintxt,
+        aadsize > 0 ? aad : NULL, aadsize, iv, ivsize,
+        outtag, tagsize), ==, R_CRYPTO_CIPHER_OK);
+  r_assert_cmpmem (out, ==, ciphertxt, plainsize);
+  r_assert_cmpmem (outtag, ==, tag, tagsize);
+
+  r_assert_cmpint (r_crypto_cipher_decrypt_aead (cipher, out, plainsize, ciphertxt,
+        aadsize > 0 ? aad : NULL, aadsize, iv, ivsize,
+        tag, tagsize), ==, R_CRYPTO_CIPHER_OK);
+  r_assert_cmpmem (out, ==, plaintxt, plainsize);
+
+  {
+    ruint8 badtag[16];
+    r_memcpy (badtag, tag, tagsize);
+    badtag[0] ^= 0x01;
+    r_assert_cmpint (r_crypto_cipher_decrypt_aead (cipher, out, plainsize, ciphertxt,
+          aadsize > 0 ? aad : NULL, aadsize, iv, ivsize,
+          badtag, tagsize), ==, R_CRYPTO_CIPHER_AUTH_FAILED);
+  }
 
   r_crypto_cipher_unref (cipher);
   r_free (plaintxt);

--- a/test/rcryptocipher.c
+++ b/test/rcryptocipher.c
@@ -44,6 +44,40 @@ RTEST (rcipher, find_by_str, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rcipher, aead_misuse_guards, RTEST_FAST)
+{
+  RCryptoCipher * cipher;
+  const ruint8 key[128 / 8] = { 0 };
+  ruint8 iv[R_AES_BLOCK_BYTES] = { 0 };
+  ruint8 dst[R_AES_BLOCK_BYTES];
+  ruint8 src[R_AES_BLOCK_BYTES] = { 0 };
+  ruint8 tag[R_AES_BLOCK_BYTES];
+
+  cipher = r_cipher_aes_128_cbc_new (key);
+  r_assert_cmpptr (cipher, !=, NULL);
+
+  /* Non-AEAD cipher reports is_aead = FALSE. */
+  r_assert (!r_crypto_cipher_is_aead (cipher));
+
+  /* Calling the AEAD entry points on a non-AEAD cipher returns
+   * NOT_AEAD rather than silently dropping authentication. */
+  r_assert_cmpint (r_crypto_cipher_encrypt_aead (cipher, dst, sizeof (dst),
+        src, NULL, 0, iv, sizeof (iv), tag, sizeof (tag)),
+      ==, R_CRYPTO_CIPHER_NOT_AEAD);
+  r_assert_cmpint (r_crypto_cipher_decrypt_aead (cipher, dst, sizeof (dst),
+        src, NULL, 0, iv, sizeof (iv), tag, sizeof (tag)),
+      ==, R_CRYPTO_CIPHER_NOT_AEAD);
+
+  /* NULL cipher hits the parameter guard first. */
+  r_assert (!r_crypto_cipher_is_aead (NULL));
+  r_assert_cmpint (r_crypto_cipher_encrypt_aead (NULL, dst, sizeof (dst),
+        src, NULL, 0, iv, sizeof (iv), tag, sizeof (tag)),
+      ==, R_CRYPTO_CIPHER_INVAL);
+
+  r_crypto_cipher_unref (cipher);
+}
+RTEST_END;
+
 RTEST (rcipher, null, RTEST_FAST)
 {
   RCryptoCipher * cipher;


### PR DESCRIPTION
## Summary

Adds AEAD support to the cipher base and implements AES-GCM and AES-CCM against it.

Closes #64.

**API shape** (option 2 from the design discussion): unified `RCryptoCipher` type with dedicated `_aead` entry points. Existing modes stay on `r_crypto_cipher_encrypt` / `_decrypt`; AEAD modes use `r_crypto_cipher_encrypt_aead` / `_decrypt_aead` which take AAD + a detached tag buffer. Mutual-exclusion guards on all four entry points reject the wrong family with `R_CRYPTO_CIPHER_NEEDS_AEAD` / `_NOT_AEAD`. This matches mbedTLS's contract and avoids the OpenSSL footgun where `EVP_EncryptUpdate` on a GCM cipher silently drops AAD/tag handling.

**AES-GCM (SW)**: GHASH (4-bit table, Shoup's method) + CTR-mode encryption. 12-byte IV (NIST recommendation). Tag length 1..16 bytes. Verify-first on decrypt — plaintext never released on forged input.

**AES-CCM (SW)**: CBC-MAC over formatted B0 / AAD / plaintext + CTR. Nonce length 7..13 bytes (per RFC 3610); resulting L bounds plaintext to 2^(8L) bytes. Tag length even in [4, 16]. CCM's tag is over plaintext, so decrypt-then-verify; auth failure leaves dst written with decrypted bytes (caller must discard — documented in the header).

Both use constant-time tag compare and secure-clear of intermediates.

## Test plan

- [x] NIST SP 800-38D Appendix B vectors for GCM (5 cases, AES-128 + AES-256, empty + non-empty AAD, full + partial trailing blocks).
- [x] NIST SP 800-38C Appendix C + RFC 3610 vectors for CCM (3 cases covering N=7/8/13, M=4/6/8).
- [x] Each AEAD vector verifies encrypt, decrypt + tag verify, and decrypt-with-tampered-tag returning AUTH_FAILED.
- [x] AEAD-misuse guards exercised on both directions.
- [x] x86_64 native, aarch64 (qemu-user), ASan+UBSan, TSan: 1536/1536 across the board.
- [x] Doxygen: zero warnings; every member-decl row in the AES and cipher group pages carries a description.

## Performance

Microbench numbers (16 KiB / call x 2000 iters, debug-optimized x86_64, AES-NI hardware path):

| Mode | MiB/s |
|---|---|
| ECB-128 | 2328 |
| CTR-128 | 558 |
| OFB-128 | 328 |
| CFB-128 | 277 |
| CBC-128 | 290 |
| **CCM-128** | **123** |
| **CCM-256** | **130** |
| **GCM-128** | **9.5** |
| **GCM-256** | **9.5** |

CCM lands at roughly half CTR throughput, as expected from doing both the CBC-MAC and CTR passes. GCM was 3.0 MiB/s before the 4-bit GHASH table; the table lifts it 3.2x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)