### PR TITLE
crypto: AES-GCM performance — 4-way CTR + HW GHASH + aggregation

### DIFF
--- a/config.h.meson
+++ b/config.h.meson
@@ -99,6 +99,7 @@
 #mesondefine HAVE_PTHREAD_ATTR_SETAFFINITY_NP
 
 #mesondefine HAVE_NMMINTRIN_H
+#mesondefine HAVE_TMMINTRIN_H
 #mesondefine HAVE_WMMINTRIN_H
 #mesondefine HAVE_ARM_NEON_H
 #mesondefine HAVE_ARM_ACLE_H

--- a/meson.build
+++ b/meson.build
@@ -280,7 +280,8 @@ endif
 if host_machine.cpu_family() in [ 'x86', 'x86_64' ]
   check_headers += [
     'nmmintrin.h',  # SSE4.2 (CRC32C)
-    'wmmintrin.h',  # AES-NI
+    'tmmintrin.h',  # SSSE3 (PSHUFB - used by the PCLMUL GHASH bit-reverse)
+    'wmmintrin.h',  # AES-NI + PCLMULQDQ
   ]
 elif host_machine.cpu_family() == 'aarch64'
   check_headers += [

--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -25,8 +25,10 @@
 #include <rlib/rstr.h>
 
 #ifdef HAVE_WMMINTRIN_H
-# include <tmmintrin.h>           /* SSSE3 (PSHUFB) */
 # include <wmmintrin.h>           /* AES-NI + PCLMULQDQ */
+#endif
+#ifdef HAVE_TMMINTRIN_H
+# include <tmmintrin.h>           /* SSSE3 (PSHUFB - PCLMUL GHASH bit-reverse) */
 #endif
 
 #ifdef HAVE_ARM_NEON_H
@@ -72,7 +74,8 @@ typedef rboolean (*RAesBlockFn) (const RAesCipher * aes,
 typedef void (*RAesBlocksFn) (const RAesCipher * aes,
     ruint8 * dst, const ruint8 * src);
 typedef void (*RAesGhashMulFn) (ruint8 y[R_AES_BLOCK_BYTES],
-    const RAesCipher * aes);
+    const RAesCipher * aes,
+    const ruint8 * data, rsize nblocks);
 
 /* 4-bit GHASH table (Shoup's method). Used by the SW kernel; HW
  * kernels (PCLMULQDQ / PMULL) work straight from ghash_h. */
@@ -105,8 +108,12 @@ struct _RAesCipher {
   /* GCM precomputed state - populated only when info->mode == GCM.
    * H = E_K(0^128), used by every GHASH multiplication; the 4-bit
    * table is built from H once when the SW kernel is in use. The
-   * HW kernels (PCLMULQDQ / PMULL) read H directly. */
+   * HW kernels (PCLMULQDQ / PMULL) read H directly. ghash_h_pow
+   * holds H^2, H^3, H^4 in the same representation as ghash_h,
+   * used by the HW kernels' 4-way aggregated path; unused when
+   * the SW kernel is selected. */
   ruint8 ghash_h[R_AES_BLOCK_BYTES];
+  ruint8 ghash_h_pow[3][R_AES_BLOCK_BYTES];
   RGhashTable ghash_t;
   RAesGhashMulFn ghash_mul;
 };
@@ -121,17 +128,22 @@ struct _RAesCipher {
 R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_encrypt_block_sw);
 R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_decrypt_block_sw);
 
+static void r_ghash_mul (ruint8 y[R_AES_BLOCK_BYTES],
+    const ruint8 h[R_AES_BLOCK_BYTES]);
 static void r_ghash_init_table (RGhashTable * t,
     const ruint8 h[R_AES_BLOCK_BYTES]);
 static void r_ghash_mul_4bit (ruint8 y[R_AES_BLOCK_BYTES],
-    const RAesCipher * aes);
-#ifdef HAVE_WMMINTRIN_H
+    const RAesCipher * aes,
+    const ruint8 * data, rsize nblocks);
+#if defined(HAVE_WMMINTRIN_H) && defined(HAVE_TMMINTRIN_H)
 static void r_ghash_mul_pclmul (ruint8 y[R_AES_BLOCK_BYTES],
-    const RAesCipher * aes);
+    const RAesCipher * aes,
+    const ruint8 * data, rsize nblocks);
 #endif
 #ifdef HAVE_ARM_NEON_H
 static void r_ghash_mul_pmull (ruint8 y[R_AES_BLOCK_BYTES],
-    const RAesCipher * aes);
+    const RAesCipher * aes,
+    const ruint8 * data, rsize nblocks);
 #endif
 
 #ifdef HAVE_WMMINTRIN_H
@@ -461,7 +473,7 @@ r_cipher_aes_new_with_info (const RCryptoCipherInfo * info, const ruint8 * key)
     ruint8 zero[R_AES_BLOCK_BYTES] = { 0 };
     ret->encrypt_block (ret, ret->ghash_h, zero);
     ret->ghash_mul = NULL;
-#ifdef HAVE_WMMINTRIN_H
+#if defined(HAVE_WMMINTRIN_H) && defined(HAVE_TMMINTRIN_H)
     if (r_cpu_has (R_CPU_FEATURE_PCLMUL))
       ret->ghash_mul = r_ghash_mul_pclmul;
 #elif defined(HAVE_ARM_NEON_H)
@@ -473,8 +485,26 @@ r_cipher_aes_new_with_info (const RCryptoCipherInfo * info, const ruint8 * key)
        * polynomial representation (bit i = x^i). rlib's NIST-style
        * H has byte-internal MSB = x^0, so per-byte bit-reverse H
        * once here; the kernel only has to bit-reverse y on entry
-       * and the result on exit. */
-      rsize idx;
+       * and the result on exit. The 4-way aggregated path also
+       * needs H^2, H^3, H^4 in the same representation - compute
+       * them via the SW reference (which expects NIST form) BEFORE
+       * the in-place bit-reverse of H. */
+      rsize idx, p;
+      r_memcpy (ret->ghash_h_pow[0], ret->ghash_h, R_AES_BLOCK_BYTES);
+      r_ghash_mul (ret->ghash_h_pow[0], ret->ghash_h);          /* H^2 */
+      r_memcpy (ret->ghash_h_pow[1], ret->ghash_h_pow[0], R_AES_BLOCK_BYTES);
+      r_ghash_mul (ret->ghash_h_pow[1], ret->ghash_h);          /* H^3 */
+      r_memcpy (ret->ghash_h_pow[2], ret->ghash_h_pow[1], R_AES_BLOCK_BYTES);
+      r_ghash_mul (ret->ghash_h_pow[2], ret->ghash_h);          /* H^4 */
+      for (p = 0; p < 3; p++) {
+        for (idx = 0; idx < R_AES_BLOCK_BYTES; idx++) {
+          ruint8 b = ret->ghash_h_pow[p][idx];
+          b = (ruint8) (((b & 0xf0) >> 4) | ((b & 0x0f) << 4));
+          b = (ruint8) (((b & 0xcc) >> 2) | ((b & 0x33) << 2));
+          b = (ruint8) (((b & 0xaa) >> 1) | ((b & 0x55) << 1));
+          ret->ghash_h_pow[p][idx] = b;
+        }
+      }
       for (idx = 0; idx < R_AES_BLOCK_BYTES; idx++) {
         ruint8 b = ret->ghash_h[idx];
         b = (ruint8) (((b & 0xf0) >> 4) | ((b & 0x0f) << 4));
@@ -799,7 +829,13 @@ R_AES_AESNI_BLOCKS_X4 (r_cipher_aes_ecb_decrypt_blocks_aesni_192, drk,
     _mm_aesdec_si128, _mm_aesdeclast_si128, 12)
 R_AES_AESNI_BLOCKS_X4 (r_cipher_aes_ecb_decrypt_blocks_aesni_256, drk,
     _mm_aesdec_si128, _mm_aesdeclast_si128, 14)
+#endif /* HAVE_WMMINTRIN_H (AES-NI block kernels) */
 
+/* PCLMUL GHASH kernel: needs PCLMULQDQ (wmmintrin.h) for the
+ * polynomial mul AND PSHUFB (tmmintrin.h, SSSE3) for the per-byte
+ * bit-reverse. Both header probes are independent so a (hypothetical)
+ * system with one but not the other falls back to SW. */
+#if defined(HAVE_WMMINTRIN_H) && defined(HAVE_TMMINTRIN_H)
 # if defined(__GNUC__) || defined(__clang__)
 #  define R_GHASH_X86_TARGET __attribute__((target("pclmul,ssse3")))
 # else
@@ -828,46 +864,35 @@ r_ghash_byte_bitrev (__m128i v)
   return _mm_or_si128 (_mm_slli_epi16 (lo_rev, 4), hi_rev);
 }
 
-/* GHASH single-block multiply via PCLMULQDQ.
- *
- * rlib stores GHASH polynomials with byte-internal MSB = x^0; PCLMUL
- * operates on the natural-LE form (bit i = x^i). Per-byte bit-
- * reverse bridges the two. H is pre-reversed once at cipher
- * construction; the per-call cost is one bit-reverse on entry and
- * one on exit.
- *
- * Multiplication: four PCLMULQDQ build the 256-bit product. The
- * cross-term pair is XORed before splitting across the 128-bit
- * boundary, giving @c lo (low 128) and @c hi (high 128).
- *
- * Reduction (mod g(z) = z^128 + z^7 + z^2 + z + 1): fold the high
- * half by multiplying with the low-order tap polynomial 0x87 =
- * z^7 + z^2 + z + 1, expressed as three 128-bit left shifts (by 1,
- * 2 and 7) plus the unshifted value, all XORed into @c lo. A second
- * pass folds the tiny overflow that those shifts pushed past bit
- * 127 - the topmost 7 bits of @c hi - back through the same tap
- * polynomial. Single-block path; aggregated multi-block GHASH is a
- * separate follow-up. */
+/* a * b in GF(2)[x] (no reduction) XOR-accumulated into the 256-bit
+ * register pair (@c *lo, @c *hi). Four PCLMULQDQ per call; the cross-
+ * term pair is XORed before splitting across the 128-bit boundary. */
 R_GHASH_X86_TARGET
-static void
-r_ghash_mul_pclmul (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes)
+static inline void
+r_ghash_poly_mul_acc (__m128i * lo, __m128i * hi, __m128i a, __m128i b)
 {
-  __m128i x = r_ghash_byte_bitrev (_mm_loadu_si128 ((const __m128i *) y));
-  __m128i h = _mm_loadu_si128 ((const __m128i *) aes->ghash_h);
-  __m128i t0, t1, t2, t3, lo, hi;
+  __m128i t0 = _mm_clmulepi64_si128 (a, b, 0x00);
+  __m128i t3 = _mm_clmulepi64_si128 (a, b, 0x11);
+  __m128i tm = _mm_xor_si128 (
+      _mm_clmulepi64_si128 (a, b, 0x10),
+      _mm_clmulepi64_si128 (a, b, 0x01));
+  *lo = _mm_xor_si128 (*lo, _mm_xor_si128 (t0, _mm_slli_si128 (tm, 8)));
+  *hi = _mm_xor_si128 (*hi, _mm_xor_si128 (t3, _mm_srli_si128 (tm, 8)));
+}
+
+/* Reduce a 256-bit polynomial (@c lo low, @c hi high) mod NIST g(z)
+ * = z^128 + z^7 + z^2 + z + 1. Fold the high half through the
+ * low-order tap polynomial 0x87 = z^7 + z^2 + z + 1, expressed as
+ * three 128-bit left shifts (by 1, 2 and 7) plus the unshifted
+ * value. A second pass folds the tiny overflow (the topmost 7 bits
+ * of @c hi that Phase 1's shifts pushed past bit 127) back through
+ * the same tap polynomial. */
+R_GHASH_X86_TARGET
+static inline __m128i
+r_ghash_reduce_pclmul (__m128i lo, __m128i hi)
+{
   __m128i s1, s2, s7, c1, c2, c7, over;
 
-  t0 = _mm_clmulepi64_si128 (x, h, 0x00);
-  t3 = _mm_clmulepi64_si128 (x, h, 0x11);
-  t1 = _mm_clmulepi64_si128 (x, h, 0x10);
-  t2 = _mm_clmulepi64_si128 (x, h, 0x01);
-  t1 = _mm_xor_si128 (t1, t2);
-  lo = _mm_xor_si128 (t0, _mm_slli_si128 (t1, 8));
-  hi = _mm_xor_si128 (t3, _mm_srli_si128 (t1, 8));
-
-  /* 128-bit left shift by N: each 32-bit lane shifts left by N; the
-   * top N bits of each lane carry into the next-higher lane via
-   * srli + 4-byte byte shift. */
 # define SHL128(out, src, n)                                                  \
   do {                                                                        \
     __m128i shifted = _mm_slli_epi32 ((src), (n));                            \
@@ -876,7 +901,6 @@ r_ghash_mul_pclmul (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes)
     (out) = _mm_or_si128 (shifted, carry);                                    \
   } while (0)
 
-  /* Phase 1: hi * 0x87 (low 128 bits) folded into lo. */
   SHL128 (s1, hi, 1);
   SHL128 (s2, hi, 2);
   SHL128 (s7, hi, 7);
@@ -885,11 +909,6 @@ r_ghash_mul_pclmul (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes)
   lo = _mm_xor_si128 (lo, s2);
   lo = _mm_xor_si128 (lo, s7);
 
-  /* Phase 2: the top {1,2,7} bits of hi shifted past bit 127 in
-   * Phase 1 - capture them via per-lane right shifts, keep only the
-   * top lane's contribution (the overflow lives there), then re-fold
-   * through the same tap polynomial. The overflow is at most 7 bits
-   * so its shifts can't themselves overflow. */
   c1 = _mm_srli_epi32 (hi, 31);
   c2 = _mm_srli_epi32 (hi, 30);
   c7 = _mm_srli_epi32 (hi, 25);
@@ -905,10 +924,77 @@ r_ghash_mul_pclmul (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes)
   lo = _mm_xor_si128 (lo, s7);
 # undef SHL128
 
-  lo = r_ghash_byte_bitrev (lo);
-  _mm_storeu_si128 ((__m128i *) y, lo);
+  return lo;
 }
-#endif
+
+/* GHASH multi-block update via PCLMULQDQ.
+ *
+ * Bridges rlib's "byte-internal MSB = x^0" representation to PCLMUL's
+ * natural-LE polynomial form via per-byte bit-reverse. H and its
+ * powers are pre-reversed once at cipher construction; @p y stays in
+ * the reversed form across iterations so we only bit-reverse on
+ * entry and exit, not per-block.
+ *
+ * For nblocks >= 4 the 4-way aggregated path runs: four polynomial
+ * multiplies feed one 256-bit accumulator, and a single reduction
+ * collapses it - amortising the reduction cost across 4 blocks. The
+ * formula (y_new = (y XOR b0)*H^4 + b1*H^3 + b2*H^2 + b3*H) makes
+ * the four mults independent, which the CPU schedules at PCLMULQDQ's
+ * 1-cycle throughput. Trailing blocks (< 4) fall through to the
+ * single-block path. */
+R_GHASH_X86_TARGET
+static void
+r_ghash_mul_pclmul (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes,
+    const ruint8 * data, rsize nblocks)
+{
+  __m128i y_br = r_ghash_byte_bitrev (_mm_loadu_si128 ((const __m128i *) y));
+  __m128i h1 = _mm_loadu_si128 ((const __m128i *) aes->ghash_h);
+  __m128i lo, hi;
+
+  if (nblocks >= 4) {
+    __m128i h2 = _mm_loadu_si128 ((const __m128i *) aes->ghash_h_pow[0]);
+    __m128i h3 = _mm_loadu_si128 ((const __m128i *) aes->ghash_h_pow[1]);
+    __m128i h4 = _mm_loadu_si128 ((const __m128i *) aes->ghash_h_pow[2]);
+
+    while (nblocks >= 4) {
+      __m128i b0 = r_ghash_byte_bitrev (
+          _mm_loadu_si128 ((const __m128i *) (data +  0)));
+      __m128i b1 = r_ghash_byte_bitrev (
+          _mm_loadu_si128 ((const __m128i *) (data + 16)));
+      __m128i b2 = r_ghash_byte_bitrev (
+          _mm_loadu_si128 ((const __m128i *) (data + 32)));
+      __m128i b3 = r_ghash_byte_bitrev (
+          _mm_loadu_si128 ((const __m128i *) (data + 48)));
+      __m128i a0 = _mm_xor_si128 (y_br, b0);
+
+      lo = _mm_setzero_si128 ();
+      hi = _mm_setzero_si128 ();
+      r_ghash_poly_mul_acc (&lo, &hi, a0, h4);
+      r_ghash_poly_mul_acc (&lo, &hi, b1, h3);
+      r_ghash_poly_mul_acc (&lo, &hi, b2, h2);
+      r_ghash_poly_mul_acc (&lo, &hi, b3, h1);
+      y_br = r_ghash_reduce_pclmul (lo, hi);
+
+      data += 64;
+      nblocks -= 4;
+    }
+  }
+
+  while (nblocks > 0) {
+    __m128i b = r_ghash_byte_bitrev (
+        _mm_loadu_si128 ((const __m128i *) data));
+    __m128i a = _mm_xor_si128 (y_br, b);
+    lo = _mm_setzero_si128 ();
+    hi = _mm_setzero_si128 ();
+    r_ghash_poly_mul_acc (&lo, &hi, a, h1);
+    y_br = r_ghash_reduce_pclmul (lo, hi);
+    data += R_AES_BLOCK_BYTES;
+    nblocks--;
+  }
+
+  _mm_storeu_si128 ((__m128i *) y, r_ghash_byte_bitrev (y_br));
+}
+#endif /* HAVE_WMMINTRIN_H && HAVE_TMMINTRIN_H (PCLMUL GHASH kernel) */
 
 #ifdef HAVE_ARM_NEON_H
 # if defined(__GNUC__) || defined(__clang__)
@@ -1041,49 +1127,63 @@ R_AES_ARMV8_BLOCKS_X4_DECRYPT (r_cipher_aes_ecb_decrypt_blocks_armv8_128, 10)
 R_AES_ARMV8_BLOCKS_X4_DECRYPT (r_cipher_aes_ecb_decrypt_blocks_armv8_192, 12)
 R_AES_ARMV8_BLOCKS_X4_DECRYPT (r_cipher_aes_ecb_decrypt_blocks_armv8_256, 14)
 
-/* GHASH single-block multiply via ARMv8 PMULL.
- *
- * Mirrors the x86 PCLMUL kernel - rlib's "byte-internal MSB = x^0"
- * representation gets per-byte bit-reversed (one RBIT, vrbitq_u8)
- * so the polynomial multiplier (vmull_p64) sees the natural-LE
- * polynomial. H is pre-reversed once at cipher construction; the
- * per-call cost is one vrbitq_u8 on entry and one on exit.
- *
- * Multiplication: four vmull_p64; the cross-term pair is XORed
- * before splitting across the 128-bit boundary. Reduction is the
- * same shift-based fold mod g(z) = z^128 + z^7 + z^2 + z + 1 the
- * x86 kernel uses, with a Phase 2 pass to handle the few bits the
- * Phase 1 shifts push past bit 127. Single-block path; aggregated
- * multi-block GHASH is a separate follow-up. */
+/* MSVC ARM64 declares vmull_p64 as taking __n64 (not poly64_t) and
+ * returning __n128 (no poly128_t typedef), so a straight ACLE call
+ * doesn't compile. Wrap the intrinsic once and return uint8x16_t -
+ * on MSVC that's the same underlying type as __n128, on GCC / clang
+ * we reinterpret from poly128_t. The rest of the kernel can stay in
+ * standard ACLE types. */
+#if defined(_MSC_VER) && !defined(__clang__)
 R_AES_ARM_TARGET
-static void
-r_ghash_mul_pmull (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes)
+static __forceinline uint8x16_t
+r_pmull_p64 (uint64_t a, uint64_t b)
 {
-  uint8x16_t x = vrbitq_u8 (vld1q_u8 (y));
-  uint8x16_t h = vld1q_u8 (aes->ghash_h);
-  poly64_t xlo, xhi, hlo, hhi;
-  poly128_t pmlo, pmhi, pmm1, pmm2;
-  uint8x16_t t1, lo, hi, over;
-  uint8x16_t s1, s2, s7, c1, c2, c7;
+  __n64 _a, _b;
+  /* r_memcpy is the portable type-pun. __n64 and uint64_t are both
+   * 8 bytes; MSVC optimises the copy away. */
+  r_memcpy (&_a, &a, sizeof (_a));
+  r_memcpy (&_b, &b, sizeof (_b));
+  return vmull_p64 (_a, _b);
+}
+#else
+R_AES_ARM_TARGET
+static inline uint8x16_t
+r_pmull_p64 (uint64_t a, uint64_t b)
+{
+  return vreinterpretq_u8_p128 (vmull_p64 ((poly64_t) a, (poly64_t) b));
+}
+#endif
 
-  xlo = vgetq_lane_p64 (vreinterpretq_p64_u8 (x), 0);
-  xhi = vgetq_lane_p64 (vreinterpretq_p64_u8 (x), 1);
-  hlo = vgetq_lane_p64 (vreinterpretq_p64_u8 (h), 0);
-  hhi = vgetq_lane_p64 (vreinterpretq_p64_u8 (h), 1);
+/* a * b in GF(2)[x] (no reduction) XOR-accumulated into the 256-bit
+ * register pair (@c *lo, @c *hi). Mirrors r_ghash_poly_mul_acc on
+ * the x86 side. */
+R_AES_ARM_TARGET
+static inline void
+r_ghash_poly_mul_acc_pmull (uint8x16_t * lo, uint8x16_t * hi,
+    uint8x16_t a, uint8x16_t b)
+{
+  uint64_t alo = vgetq_lane_u64 (vreinterpretq_u64_u8 (a), 0);
+  uint64_t ahi = vgetq_lane_u64 (vreinterpretq_u64_u8 (a), 1);
+  uint64_t blo = vgetq_lane_u64 (vreinterpretq_u64_u8 (b), 0);
+  uint64_t bhi = vgetq_lane_u64 (vreinterpretq_u64_u8 (b), 1);
+  uint8x16_t t0 = r_pmull_p64 (alo, blo);
+  uint8x16_t t3 = r_pmull_p64 (ahi, bhi);
+  uint8x16_t tm = veorq_u8 (r_pmull_p64 (ahi, blo),
+                            r_pmull_p64 (alo, bhi));
+  *lo = veorq_u8 (*lo,
+      veorq_u8 (t0, vextq_u8 (vdupq_n_u8 (0), tm, 8)));
+  *hi = veorq_u8 (*hi,
+      veorq_u8 (t3, vextq_u8 (tm, vdupq_n_u8 (0), 8)));
+}
 
-  pmlo = vmull_p64 (xlo, hlo);
-  pmhi = vmull_p64 (xhi, hhi);
-  pmm1 = vmull_p64 (xhi, hlo);
-  pmm2 = vmull_p64 (xlo, hhi);
-  t1 = veorq_u8 (vreinterpretq_u8_p128 (pmm1),
-                 vreinterpretq_u8_p128 (pmm2));
-  lo = veorq_u8 (vreinterpretq_u8_p128 (pmlo),
-                 vextq_u8 (vdupq_n_u8 (0), t1, 8));
-  hi = veorq_u8 (vreinterpretq_u8_p128 (pmhi),
-                 vextq_u8 (t1, vdupq_n_u8 (0), 8));
+/* Reduce a 256-bit polynomial (@c lo low, @c hi high) mod NIST g(z)
+ * = z^128 + z^7 + z^2 + z + 1. Mirrors r_ghash_reduce_pclmul. */
+R_AES_ARM_TARGET
+static inline uint8x16_t
+r_ghash_reduce_pmull (uint8x16_t lo, uint8x16_t hi)
+{
+  uint8x16_t s1, s2, s7, c1, c2, c7, over;
 
-  /* 128-bit left shift by N: per-32-bit-lane shift plus a lane-
-   * shifted carry, matching the SHL128 macro on the x86 side. */
 # define SHL128(out, src, n)                                                  \
   do {                                                                        \
     uint32x4_t _sh = vshlq_n_u32 (vreinterpretq_u32_u8 (src), (n));           \
@@ -1093,7 +1193,6 @@ r_ghash_mul_pmull (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes)
     (out) = veorq_u8 (vreinterpretq_u8_u32 (_sh), _cab);                      \
   } while (0)
 
-  /* Phase 1: hi * 0x87 (low 128 bits) folded into lo. */
   SHL128 (s1, hi, 1);
   SHL128 (s2, hi, 2);
   SHL128 (s7, hi, 7);
@@ -1102,8 +1201,6 @@ r_ghash_mul_pmull (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes)
   lo = veorq_u8 (lo, s2);
   lo = veorq_u8 (lo, s7);
 
-  /* Phase 2: capture the top {1,2,7} bits of hi that shifted past
-   * bit 127 in Phase 1, then re-fold through the same tap. */
   c1 = vreinterpretq_u8_u32 (
         vshrq_n_u32 (vreinterpretq_u32_u8 (hi), 31));
   c2 = vreinterpretq_u8_u32 (
@@ -1111,7 +1208,6 @@ r_ghash_mul_pmull (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes)
   c7 = vreinterpretq_u8_u32 (
         vshrq_n_u32 (vreinterpretq_u32_u8 (hi), 25));
   over = veorq_u8 (veorq_u8 (c1, c2), c7);
-  /* keep only the top lane (the actual overflow), zero the rest. */
   over = vextq_u8 (over, vdupq_n_u8 (0), 12);
 
   SHL128 (s1, over, 1);
@@ -1123,8 +1219,59 @@ r_ghash_mul_pmull (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes)
   lo = veorq_u8 (lo, s7);
 # undef SHL128
 
-  lo = vrbitq_u8 (lo);
-  vst1q_u8 (y, lo);
+  return lo;
+}
+
+/* GHASH multi-block update via ARMv8 PMULL. Structurally identical
+ * to r_ghash_mul_pclmul: 4-way aggregated path for nblocks >= 4
+ * (four polynomial multiplies into one accumulator + one reduction),
+ * single-block fallback for the trailing remainder. */
+R_AES_ARM_TARGET
+static void
+r_ghash_mul_pmull (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes,
+    const ruint8 * data, rsize nblocks)
+{
+  uint8x16_t y_br = vrbitq_u8 (vld1q_u8 (y));
+  uint8x16_t h1 = vld1q_u8 (aes->ghash_h);
+  uint8x16_t lo, hi;
+
+  if (nblocks >= 4) {
+    uint8x16_t h2 = vld1q_u8 (aes->ghash_h_pow[0]);
+    uint8x16_t h3 = vld1q_u8 (aes->ghash_h_pow[1]);
+    uint8x16_t h4 = vld1q_u8 (aes->ghash_h_pow[2]);
+
+    while (nblocks >= 4) {
+      uint8x16_t b0 = vrbitq_u8 (vld1q_u8 (data +  0));
+      uint8x16_t b1 = vrbitq_u8 (vld1q_u8 (data + 16));
+      uint8x16_t b2 = vrbitq_u8 (vld1q_u8 (data + 32));
+      uint8x16_t b3 = vrbitq_u8 (vld1q_u8 (data + 48));
+      uint8x16_t a0 = veorq_u8 (y_br, b0);
+
+      lo = vdupq_n_u8 (0);
+      hi = vdupq_n_u8 (0);
+      r_ghash_poly_mul_acc_pmull (&lo, &hi, a0, h4);
+      r_ghash_poly_mul_acc_pmull (&lo, &hi, b1, h3);
+      r_ghash_poly_mul_acc_pmull (&lo, &hi, b2, h2);
+      r_ghash_poly_mul_acc_pmull (&lo, &hi, b3, h1);
+      y_br = r_ghash_reduce_pmull (lo, hi);
+
+      data += 64;
+      nblocks -= 4;
+    }
+  }
+
+  while (nblocks > 0) {
+    uint8x16_t b = vrbitq_u8 (vld1q_u8 (data));
+    uint8x16_t a = veorq_u8 (y_br, b);
+    lo = vdupq_n_u8 (0);
+    hi = vdupq_n_u8 (0);
+    r_ghash_poly_mul_acc_pmull (&lo, &hi, a, h1);
+    y_br = r_ghash_reduce_pmull (lo, hi);
+    data += R_AES_BLOCK_BYTES;
+    nblocks--;
+  }
+
+  vst1q_u8 (y, vrbitq_u8 (y_br));
 }
 
 #endif
@@ -1677,41 +1824,50 @@ static const ruint8 r_ghash_reduce_4bit[16][2] = {
 };
 
 static void
-r_ghash_mul_4bit (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes)
+r_ghash_mul_4bit (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes,
+    const ruint8 * data, rsize nblocks)
 {
   const RGhashTable * t = &aes->ghash_t;
-  ruint8 z[R_AES_BLOCK_BYTES] = { 0 };
+  ruint8 z[R_AES_BLOCK_BYTES];
   rssize byte_idx;
   rsize k;
   ruint8 n, rem;
 
-  for (byte_idx = R_AES_BLOCK_BYTES - 1; byte_idx >= 0; byte_idx--) {
-    /* Process the low nibble first (higher x position), then high.
-     * Each step is z = (z * x^4) XOR T[n], with z * x^4 done as a
-     * 4-bit right-shift plus the precomputed reduction for the four
-     * bits that fell off. */
-    n = y[byte_idx] & 0xf;
-    rem = z[R_AES_BLOCK_BYTES - 1] & 0xf;
-    for (k = R_AES_BLOCK_BYTES - 1; k > 0; k--)
-      z[k] = (ruint8) ((z[k] >> 4) | (z[k - 1] << 4));
-    z[0] >>= 4;
-    z[0] ^= r_ghash_reduce_4bit[rem][0];
-    z[1] ^= r_ghash_reduce_4bit[rem][1];
+  while (nblocks > 0) {
     for (k = 0; k < R_AES_BLOCK_BYTES; k++)
-      z[k] ^= t->e[n][k];
+      y[k] ^= data[k];
 
-    n = y[byte_idx] >> 4;
-    rem = z[R_AES_BLOCK_BYTES - 1] & 0xf;
-    for (k = R_AES_BLOCK_BYTES - 1; k > 0; k--)
-      z[k] = (ruint8) ((z[k] >> 4) | (z[k - 1] << 4));
-    z[0] >>= 4;
-    z[0] ^= r_ghash_reduce_4bit[rem][0];
-    z[1] ^= r_ghash_reduce_4bit[rem][1];
-    for (k = 0; k < R_AES_BLOCK_BYTES; k++)
-      z[k] ^= t->e[n][k];
+    r_memset (z, 0, R_AES_BLOCK_BYTES);
+    for (byte_idx = R_AES_BLOCK_BYTES - 1; byte_idx >= 0; byte_idx--) {
+      /* Process the low nibble first (higher x position), then high.
+       * Each step is z = (z * x^4) XOR T[n], with z * x^4 done as a
+       * 4-bit right-shift plus the precomputed reduction for the
+       * four bits that fell off. */
+      n = y[byte_idx] & 0xf;
+      rem = z[R_AES_BLOCK_BYTES - 1] & 0xf;
+      for (k = R_AES_BLOCK_BYTES - 1; k > 0; k--)
+        z[k] = (ruint8) ((z[k] >> 4) | (z[k - 1] << 4));
+      z[0] >>= 4;
+      z[0] ^= r_ghash_reduce_4bit[rem][0];
+      z[1] ^= r_ghash_reduce_4bit[rem][1];
+      for (k = 0; k < R_AES_BLOCK_BYTES; k++)
+        z[k] ^= t->e[n][k];
+
+      n = y[byte_idx] >> 4;
+      rem = z[R_AES_BLOCK_BYTES - 1] & 0xf;
+      for (k = R_AES_BLOCK_BYTES - 1; k > 0; k--)
+        z[k] = (ruint8) ((z[k] >> 4) | (z[k - 1] << 4));
+      z[0] >>= 4;
+      z[0] ^= r_ghash_reduce_4bit[rem][0];
+      z[1] ^= r_ghash_reduce_4bit[rem][1];
+      for (k = 0; k < R_AES_BLOCK_BYTES; k++)
+        z[k] ^= t->e[n][k];
+    }
+    r_memcpy (y, z, R_AES_BLOCK_BYTES);
+
+    data += R_AES_BLOCK_BYTES;
+    nblocks--;
   }
-
-  r_memcpy (y, z, R_AES_BLOCK_BYTES);
 }
 
 /* GCM-specific counter increment: only the low 32 bits advance; the
@@ -1750,21 +1906,15 @@ r_gcm_ghash_update (ruint8 y[R_AES_BLOCK_BYTES],
     const RAesCipher * aes,
     const ruint8 * data, rsize size)
 {
-  rsize k;
+  rsize nblocks = size / R_AES_BLOCK_BYTES;
+  rsize tail = size % R_AES_BLOCK_BYTES;
 
-  while (size >= R_AES_BLOCK_BYTES) {
-    for (k = 0; k < R_AES_BLOCK_BYTES; k++)
-      y[k] ^= data[k];
-    aes->ghash_mul (y, aes);
-    data += R_AES_BLOCK_BYTES;
-    size -= R_AES_BLOCK_BYTES;
-  }
-  if (size > 0) {
+  if (nblocks > 0)
+    aes->ghash_mul (y, aes, data, nblocks);
+  if (tail > 0) {
     ruint8 block[R_AES_BLOCK_BYTES] = { 0 };
-    r_memcpy (block, data, size);
-    for (k = 0; k < R_AES_BLOCK_BYTES; k++)
-      y[k] ^= block[k];
-    aes->ghash_mul (y, aes);
+    r_memcpy (block, data + nblocks * R_AES_BLOCK_BYTES, tail);
+    aes->ghash_mul (y, aes, block, 1);
   }
 }
 
@@ -1796,9 +1946,7 @@ r_gcm_compute_tag (const RAesCipher * aes,
 
   r_gcm_be64 (lenblock,     (ruint64) aadsize * 8);
   r_gcm_be64 (lenblock + 8, (ruint64) ctsize * 8);
-  for (i = 0; i < R_AES_BLOCK_BYTES; i++)
-    y[i] ^= lenblock[i];
-  aes->ghash_mul (y, aes);
+  aes->ghash_mul (y, aes, lenblock, 1);
 
   aes->encrypt_block (aes, ek, j0);
   for (i = 0; i < R_AES_BLOCK_BYTES; i++)

--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -1471,6 +1471,20 @@ r_gcm_ctr_inc32 (ruint8 ctr[R_AES_BLOCK_BYTES])
   ctr[15] =  c        & 0xff;
 }
 
+/* As r_gcm_ctr_inc32 but advances by @p n. ruint32 wraparound matches
+ * the GCM inc_32 spec naturally. */
+static void
+r_gcm_ctr_inc32_n (ruint8 ctr[R_AES_BLOCK_BYTES], ruint32 n)
+{
+  ruint32 c = ((ruint32) ctr[12] << 24) | ((ruint32) ctr[13] << 16)
+            | ((ruint32) ctr[14] <<  8) |  (ruint32) ctr[15];
+  c += n;
+  ctr[12] = (c >> 24) & 0xff;
+  ctr[13] = (c >> 16) & 0xff;
+  ctr[14] = (c >>  8) & 0xff;
+  ctr[15] =  c        & 0xff;
+}
+
 /* Fold @p data into the running GHASH state @p y, one 16-byte block
  * at a time. The trailing partial block (if any) is zero-padded out
  * to a full block before mixing. */
@@ -1605,6 +1619,32 @@ r_aes_gcm_op (const RCryptoCipher * cipher,
   srcp = data;
   dstp = dst;
   remaining = size;
+
+  /* 4-way path: build (ctr, ctr+1, ctr+2, ctr+3) in scratch, encrypt
+   * the four blocks in parallel via the SIMD-interleaved kernel, XOR
+   * with the source window, and advance ctr by 4. Mirrors the shape
+   * of r_cipher_aes_ctr_encrypt; the only twist is GCM's inc_32. */
+  if (aes->encrypt_blocks_x4 != NULL) {
+    ruint8 ks4[R_AES_PARALLEL_BYTES];
+    while (remaining >= R_AES_PARALLEL_BYTES) {
+      r_memcpy (ks4 + R_AES_BLOCK_BYTES * 0, ctr, R_AES_BLOCK_BYTES);
+      r_memcpy (ks4 + R_AES_BLOCK_BYTES * 1, ctr, R_AES_BLOCK_BYTES);
+      r_memcpy (ks4 + R_AES_BLOCK_BYTES * 2, ctr, R_AES_BLOCK_BYTES);
+      r_memcpy (ks4 + R_AES_BLOCK_BYTES * 3, ctr, R_AES_BLOCK_BYTES);
+      r_gcm_ctr_inc32_n (ks4 + R_AES_BLOCK_BYTES * 1, 1);
+      r_gcm_ctr_inc32_n (ks4 + R_AES_BLOCK_BYTES * 2, 2);
+      r_gcm_ctr_inc32_n (ks4 + R_AES_BLOCK_BYTES * 3, 3);
+      aes->encrypt_blocks_x4 (aes, ks4, ks4);
+      for (i = 0; i < R_AES_PARALLEL_BYTES; i++)
+        dstp[i] = ks4[i] ^ srcp[i];
+      r_gcm_ctr_inc32_n (ctr, R_AES_PARALLEL_BLOCKS);
+      srcp += R_AES_PARALLEL_BYTES;
+      dstp += R_AES_PARALLEL_BYTES;
+      remaining -= R_AES_PARALLEL_BYTES;
+    }
+    r_memclear_secure (ks4, sizeof (ks4));
+  }
+
   while (remaining >= R_AES_BLOCK_BYTES) {
     aes->encrypt_block (aes, ksblock, ctr);
     for (i = 0; i < R_AES_BLOCK_BYTES; i++)

--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -25,7 +25,8 @@
 #include <rlib/rstr.h>
 
 #ifdef HAVE_WMMINTRIN_H
-# include <wmmintrin.h>           /* AES-NI */
+# include <tmmintrin.h>           /* SSSE3 (PSHUFB) */
+# include <wmmintrin.h>           /* AES-NI + PCLMULQDQ */
 #endif
 
 #ifdef HAVE_ARM_NEON_H
@@ -70,6 +71,14 @@ typedef rboolean (*RAesBlockFn) (const RAesCipher * aes,
     ruint8 dst[R_AES_BLOCK_BYTES], const ruint8 src[R_AES_BLOCK_BYTES]);
 typedef void (*RAesBlocksFn) (const RAesCipher * aes,
     ruint8 * dst, const ruint8 * src);
+typedef void (*RAesGhashMulFn) (ruint8 y[R_AES_BLOCK_BYTES],
+    const RAesCipher * aes);
+
+/* 4-bit GHASH table (Shoup's method). Used by the SW kernel; HW
+ * kernels (PCLMULQDQ / PMULL) work straight from ghash_h. */
+typedef struct {
+  ruint8 e[16][R_AES_BLOCK_BYTES];
+} RGhashTable;
 
 struct _RAesCipher {
   RCryptoCipher cipher;
@@ -92,6 +101,14 @@ struct _RAesCipher {
    * that case. */
   RAesBlocksFn encrypt_blocks_x4;
   RAesBlocksFn decrypt_blocks_x4;
+
+  /* GCM precomputed state - populated only when info->mode == GCM.
+   * H = E_K(0^128), used by every GHASH multiplication; the 4-bit
+   * table is built from H once when the SW kernel is in use. The
+   * HW kernels (PCLMULQDQ / PMULL) read H directly. */
+  ruint8 ghash_h[R_AES_BLOCK_BYTES];
+  RGhashTable ghash_t;
+  RAesGhashMulFn ghash_mul;
 };
 
 #define R_AES_BLOCK_FN_DECL(name)                                              \
@@ -103,6 +120,19 @@ struct _RAesCipher {
 
 R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_encrypt_block_sw);
 R_AES_BLOCK_FN_DECL (r_cipher_aes_ecb_decrypt_block_sw);
+
+static void r_ghash_init_table (RGhashTable * t,
+    const ruint8 h[R_AES_BLOCK_BYTES]);
+static void r_ghash_mul_4bit (ruint8 y[R_AES_BLOCK_BYTES],
+    const RAesCipher * aes);
+#ifdef HAVE_WMMINTRIN_H
+static void r_ghash_mul_pclmul (ruint8 y[R_AES_BLOCK_BYTES],
+    const RAesCipher * aes);
+#endif
+#ifdef HAVE_ARM_NEON_H
+static void r_ghash_mul_pmull (ruint8 y[R_AES_BLOCK_BYTES],
+    const RAesCipher * aes);
+#endif
 
 #ifdef HAVE_WMMINTRIN_H
 R_AES_BLOCK_FN_DECL  (r_cipher_aes_ecb_encrypt_block_aesni_128);
@@ -424,6 +454,40 @@ r_cipher_aes_new_with_info (const RCryptoCipherInfo * info, const ruint8 * key)
     }
   }
 
+  /* GCM-specific setup: derive H = E_K(0^128) and pick a GHASH kernel.
+   * Done once per cipher so the per-op fast path is just a function-
+   * pointer dispatch. */
+  if (info->mode == R_CRYPTO_CIPHER_MODE_GCM) {
+    ruint8 zero[R_AES_BLOCK_BYTES] = { 0 };
+    ret->encrypt_block (ret, ret->ghash_h, zero);
+    ret->ghash_mul = NULL;
+#ifdef HAVE_WMMINTRIN_H
+    if (r_cpu_has (R_CPU_FEATURE_PCLMUL))
+      ret->ghash_mul = r_ghash_mul_pclmul;
+#elif defined(HAVE_ARM_NEON_H)
+    if (r_cpu_has (R_CPU_FEATURE_ARM_PMULL))
+      ret->ghash_mul = r_ghash_mul_pmull;
+#endif
+    if (ret->ghash_mul != NULL) {
+      /* HW kernels (PCLMULQDQ / PMULL) operate on the natural-LE
+       * polynomial representation (bit i = x^i). rlib's NIST-style
+       * H has byte-internal MSB = x^0, so per-byte bit-reverse H
+       * once here; the kernel only has to bit-reverse y on entry
+       * and the result on exit. */
+      rsize idx;
+      for (idx = 0; idx < R_AES_BLOCK_BYTES; idx++) {
+        ruint8 b = ret->ghash_h[idx];
+        b = (ruint8) (((b & 0xf0) >> 4) | ((b & 0x0f) << 4));
+        b = (ruint8) (((b & 0xcc) >> 2) | ((b & 0x33) << 2));
+        b = (ruint8) (((b & 0xaa) >> 1) | ((b & 0x55) << 1));
+        ret->ghash_h[idx] = b;
+      }
+    } else {
+      ret->ghash_mul = r_ghash_mul_4bit;
+      r_ghash_init_table (&ret->ghash_t, ret->ghash_h);
+    }
+  }
+
   return (RCryptoCipher *)ret;
 }
 
@@ -735,6 +799,115 @@ R_AES_AESNI_BLOCKS_X4 (r_cipher_aes_ecb_decrypt_blocks_aesni_192, drk,
     _mm_aesdec_si128, _mm_aesdeclast_si128, 12)
 R_AES_AESNI_BLOCKS_X4 (r_cipher_aes_ecb_decrypt_blocks_aesni_256, drk,
     _mm_aesdec_si128, _mm_aesdeclast_si128, 14)
+
+# if defined(__GNUC__) || defined(__clang__)
+#  define R_GHASH_X86_TARGET __attribute__((target("pclmul,ssse3")))
+# else
+#  define R_GHASH_X86_TARGET
+# endif
+
+/* Per-byte bit-reverse via two PSHUFB lookups on the nibble-rev
+ * table. Converts between rlib's "byte-internal MSB = x^0" GHASH
+ * representation and the natural-LE polynomial representation
+ * (bit i = x^i) that PCLMULQDQ operates on. */
+R_GHASH_X86_TARGET
+static inline __m128i
+r_ghash_byte_bitrev (__m128i v)
+{
+  const __m128i lo_mask = _mm_set1_epi8 ((char) 0x0f);
+  /* rev_nibble[n] = bit-reverse of the 4-bit value n. */
+  const __m128i lut = _mm_setr_epi8 (
+      0x0, 0x8, 0x4, 0xc, 0x2, 0xa, 0x6, 0xe,
+      0x1, 0x9, 0x5, 0xd, 0x3, 0xb, 0x7, 0xf);
+  __m128i lo_nib = _mm_and_si128 (v, lo_mask);
+  __m128i hi_nib = _mm_and_si128 (_mm_srli_epi16 (v, 4), lo_mask);
+  /* Bit-reverse of the original low nibble lands in the result's
+   * high nibble, and vice versa. */
+  __m128i lo_rev = _mm_shuffle_epi8 (lut, lo_nib);
+  __m128i hi_rev = _mm_shuffle_epi8 (lut, hi_nib);
+  return _mm_or_si128 (_mm_slli_epi16 (lo_rev, 4), hi_rev);
+}
+
+/* GHASH single-block multiply via PCLMULQDQ.
+ *
+ * rlib stores GHASH polynomials with byte-internal MSB = x^0; PCLMUL
+ * operates on the natural-LE form (bit i = x^i). Per-byte bit-
+ * reverse bridges the two. H is pre-reversed once at cipher
+ * construction; the per-call cost is one bit-reverse on entry and
+ * one on exit.
+ *
+ * Multiplication: four PCLMULQDQ build the 256-bit product. The
+ * cross-term pair is XORed before splitting across the 128-bit
+ * boundary, giving @c lo (low 128) and @c hi (high 128).
+ *
+ * Reduction (mod g(z) = z^128 + z^7 + z^2 + z + 1): fold the high
+ * half by multiplying with the low-order tap polynomial 0x87 =
+ * z^7 + z^2 + z + 1, expressed as three 128-bit left shifts (by 1,
+ * 2 and 7) plus the unshifted value, all XORed into @c lo. A second
+ * pass folds the tiny overflow that those shifts pushed past bit
+ * 127 - the topmost 7 bits of @c hi - back through the same tap
+ * polynomial. Single-block path; aggregated multi-block GHASH is a
+ * separate follow-up. */
+R_GHASH_X86_TARGET
+static void
+r_ghash_mul_pclmul (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes)
+{
+  __m128i x = r_ghash_byte_bitrev (_mm_loadu_si128 ((const __m128i *) y));
+  __m128i h = _mm_loadu_si128 ((const __m128i *) aes->ghash_h);
+  __m128i t0, t1, t2, t3, lo, hi;
+  __m128i s1, s2, s7, c1, c2, c7, over;
+
+  t0 = _mm_clmulepi64_si128 (x, h, 0x00);
+  t3 = _mm_clmulepi64_si128 (x, h, 0x11);
+  t1 = _mm_clmulepi64_si128 (x, h, 0x10);
+  t2 = _mm_clmulepi64_si128 (x, h, 0x01);
+  t1 = _mm_xor_si128 (t1, t2);
+  lo = _mm_xor_si128 (t0, _mm_slli_si128 (t1, 8));
+  hi = _mm_xor_si128 (t3, _mm_srli_si128 (t1, 8));
+
+  /* 128-bit left shift by N: each 32-bit lane shifts left by N; the
+   * top N bits of each lane carry into the next-higher lane via
+   * srli + 4-byte byte shift. */
+# define SHL128(out, src, n)                                                  \
+  do {                                                                        \
+    __m128i shifted = _mm_slli_epi32 ((src), (n));                            \
+    __m128i carry = _mm_srli_epi32 ((src), 32 - (n));                         \
+    carry = _mm_slli_si128 (carry, 4);                                        \
+    (out) = _mm_or_si128 (shifted, carry);                                    \
+  } while (0)
+
+  /* Phase 1: hi * 0x87 (low 128 bits) folded into lo. */
+  SHL128 (s1, hi, 1);
+  SHL128 (s2, hi, 2);
+  SHL128 (s7, hi, 7);
+  lo = _mm_xor_si128 (lo, hi);
+  lo = _mm_xor_si128 (lo, s1);
+  lo = _mm_xor_si128 (lo, s2);
+  lo = _mm_xor_si128 (lo, s7);
+
+  /* Phase 2: the top {1,2,7} bits of hi shifted past bit 127 in
+   * Phase 1 - capture them via per-lane right shifts, keep only the
+   * top lane's contribution (the overflow lives there), then re-fold
+   * through the same tap polynomial. The overflow is at most 7 bits
+   * so its shifts can't themselves overflow. */
+  c1 = _mm_srli_epi32 (hi, 31);
+  c2 = _mm_srli_epi32 (hi, 30);
+  c7 = _mm_srli_epi32 (hi, 25);
+  over = _mm_xor_si128 (_mm_xor_si128 (c1, c2), c7);
+  over = _mm_srli_si128 (over, 12);
+
+  SHL128 (s1, over, 1);
+  SHL128 (s2, over, 2);
+  SHL128 (s7, over, 7);
+  lo = _mm_xor_si128 (lo, over);
+  lo = _mm_xor_si128 (lo, s1);
+  lo = _mm_xor_si128 (lo, s2);
+  lo = _mm_xor_si128 (lo, s7);
+# undef SHL128
+
+  lo = r_ghash_byte_bitrev (lo);
+  _mm_storeu_si128 ((__m128i *) y, lo);
+}
 #endif
 
 #ifdef HAVE_ARM_NEON_H
@@ -867,6 +1040,92 @@ R_AES_ARMV8_BLOCKS_X4_ENCRYPT (r_cipher_aes_ecb_encrypt_blocks_armv8_256, 14)
 R_AES_ARMV8_BLOCKS_X4_DECRYPT (r_cipher_aes_ecb_decrypt_blocks_armv8_128, 10)
 R_AES_ARMV8_BLOCKS_X4_DECRYPT (r_cipher_aes_ecb_decrypt_blocks_armv8_192, 12)
 R_AES_ARMV8_BLOCKS_X4_DECRYPT (r_cipher_aes_ecb_decrypt_blocks_armv8_256, 14)
+
+/* GHASH single-block multiply via ARMv8 PMULL.
+ *
+ * Mirrors the x86 PCLMUL kernel - rlib's "byte-internal MSB = x^0"
+ * representation gets per-byte bit-reversed (one RBIT, vrbitq_u8)
+ * so the polynomial multiplier (vmull_p64) sees the natural-LE
+ * polynomial. H is pre-reversed once at cipher construction; the
+ * per-call cost is one vrbitq_u8 on entry and one on exit.
+ *
+ * Multiplication: four vmull_p64; the cross-term pair is XORed
+ * before splitting across the 128-bit boundary. Reduction is the
+ * same shift-based fold mod g(z) = z^128 + z^7 + z^2 + z + 1 the
+ * x86 kernel uses, with a Phase 2 pass to handle the few bits the
+ * Phase 1 shifts push past bit 127. Single-block path; aggregated
+ * multi-block GHASH is a separate follow-up. */
+R_AES_ARM_TARGET
+static void
+r_ghash_mul_pmull (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes)
+{
+  uint8x16_t x = vrbitq_u8 (vld1q_u8 (y));
+  uint8x16_t h = vld1q_u8 (aes->ghash_h);
+  poly64_t xlo, xhi, hlo, hhi;
+  poly128_t pmlo, pmhi, pmm1, pmm2;
+  uint8x16_t t1, lo, hi, over;
+  uint8x16_t s1, s2, s7, c1, c2, c7;
+
+  xlo = vgetq_lane_p64 (vreinterpretq_p64_u8 (x), 0);
+  xhi = vgetq_lane_p64 (vreinterpretq_p64_u8 (x), 1);
+  hlo = vgetq_lane_p64 (vreinterpretq_p64_u8 (h), 0);
+  hhi = vgetq_lane_p64 (vreinterpretq_p64_u8 (h), 1);
+
+  pmlo = vmull_p64 (xlo, hlo);
+  pmhi = vmull_p64 (xhi, hhi);
+  pmm1 = vmull_p64 (xhi, hlo);
+  pmm2 = vmull_p64 (xlo, hhi);
+  t1 = veorq_u8 (vreinterpretq_u8_p128 (pmm1),
+                 vreinterpretq_u8_p128 (pmm2));
+  lo = veorq_u8 (vreinterpretq_u8_p128 (pmlo),
+                 vextq_u8 (vdupq_n_u8 (0), t1, 8));
+  hi = veorq_u8 (vreinterpretq_u8_p128 (pmhi),
+                 vextq_u8 (t1, vdupq_n_u8 (0), 8));
+
+  /* 128-bit left shift by N: per-32-bit-lane shift plus a lane-
+   * shifted carry, matching the SHL128 macro on the x86 side. */
+# define SHL128(out, src, n)                                                  \
+  do {                                                                        \
+    uint32x4_t _sh = vshlq_n_u32 (vreinterpretq_u32_u8 (src), (n));           \
+    uint32x4_t _ca = vshrq_n_u32 (vreinterpretq_u32_u8 (src), 32 - (n));      \
+    uint8x16_t _cab = vextq_u8 (vdupq_n_u8 (0),                               \
+        vreinterpretq_u8_u32 (_ca), 12);                                      \
+    (out) = veorq_u8 (vreinterpretq_u8_u32 (_sh), _cab);                      \
+  } while (0)
+
+  /* Phase 1: hi * 0x87 (low 128 bits) folded into lo. */
+  SHL128 (s1, hi, 1);
+  SHL128 (s2, hi, 2);
+  SHL128 (s7, hi, 7);
+  lo = veorq_u8 (lo, hi);
+  lo = veorq_u8 (lo, s1);
+  lo = veorq_u8 (lo, s2);
+  lo = veorq_u8 (lo, s7);
+
+  /* Phase 2: capture the top {1,2,7} bits of hi that shifted past
+   * bit 127 in Phase 1, then re-fold through the same tap. */
+  c1 = vreinterpretq_u8_u32 (
+        vshrq_n_u32 (vreinterpretq_u32_u8 (hi), 31));
+  c2 = vreinterpretq_u8_u32 (
+        vshrq_n_u32 (vreinterpretq_u32_u8 (hi), 30));
+  c7 = vreinterpretq_u8_u32 (
+        vshrq_n_u32 (vreinterpretq_u32_u8 (hi), 25));
+  over = veorq_u8 (veorq_u8 (c1, c2), c7);
+  /* keep only the top lane (the actual overflow), zero the rest. */
+  over = vextq_u8 (over, vdupq_n_u8 (0), 12);
+
+  SHL128 (s1, over, 1);
+  SHL128 (s2, over, 2);
+  SHL128 (s7, over, 7);
+  lo = veorq_u8 (lo, over);
+  lo = veorq_u8 (lo, s1);
+  lo = veorq_u8 (lo, s2);
+  lo = veorq_u8 (lo, s7);
+# undef SHL128
+
+  lo = vrbitq_u8 (lo);
+  vst1q_u8 (y, lo);
+}
 
 #endif
 
@@ -1390,13 +1649,10 @@ r_ghash_mul (ruint8 y[R_AES_BLOCK_BYTES], const ruint8 h[R_AES_BLOCK_BYTES])
   r_memcpy (y, z, R_AES_BLOCK_BYTES);
 }
 
-/* 4-bit GHASH table (Shoup's method). e[n] holds (n * H) where the
- * 4-bit value @c n encodes the polynomial chunk for x^0..x^3 in
- * bit-reversed form (bit 3 of @c n = coefficient of x^0). */
-typedef struct {
-  ruint8 e[16][R_AES_BLOCK_BYTES];
-} RGhashTable;
-
+/* Build the 4-bit GHASH table (Shoup's method) into @p t. e[n] holds
+ * (n * H) where the 4-bit value @c n encodes the polynomial chunk for
+ * x^0..x^3 in bit-reversed form (bit 3 of @c n = coefficient of
+ * x^0). */
 static void
 r_ghash_init_table (RGhashTable * t, const ruint8 h[R_AES_BLOCK_BYTES])
 {
@@ -1421,8 +1677,9 @@ static const ruint8 r_ghash_reduce_4bit[16][2] = {
 };
 
 static void
-r_ghash_mul_4bit (ruint8 y[R_AES_BLOCK_BYTES], const RGhashTable * t)
+r_ghash_mul_4bit (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes)
 {
+  const RGhashTable * t = &aes->ghash_t;
   ruint8 z[R_AES_BLOCK_BYTES] = { 0 };
   rssize byte_idx;
   rsize k;
@@ -1490,7 +1747,7 @@ r_gcm_ctr_inc32_n (ruint8 ctr[R_AES_BLOCK_BYTES], ruint32 n)
  * to a full block before mixing. */
 static void
 r_gcm_ghash_update (ruint8 y[R_AES_BLOCK_BYTES],
-    const RGhashTable * t,
+    const RAesCipher * aes,
     const ruint8 * data, rsize size)
 {
   rsize k;
@@ -1498,7 +1755,7 @@ r_gcm_ghash_update (ruint8 y[R_AES_BLOCK_BYTES],
   while (size >= R_AES_BLOCK_BYTES) {
     for (k = 0; k < R_AES_BLOCK_BYTES; k++)
       y[k] ^= data[k];
-    r_ghash_mul_4bit (y, t);
+    aes->ghash_mul (y, aes);
     data += R_AES_BLOCK_BYTES;
     size -= R_AES_BLOCK_BYTES;
   }
@@ -1507,7 +1764,7 @@ r_gcm_ghash_update (ruint8 y[R_AES_BLOCK_BYTES],
     r_memcpy (block, data, size);
     for (k = 0; k < R_AES_BLOCK_BYTES; k++)
       y[k] ^= block[k];
-    r_ghash_mul_4bit (y, t);
+    aes->ghash_mul (y, aes);
   }
 }
 
@@ -1524,7 +1781,6 @@ r_gcm_be64 (ruint8 out[8], ruint64 v)
  * then XOR with E_K(J0) to form the GCM tag. */
 static void
 r_gcm_compute_tag (const RAesCipher * aes,
-    const RGhashTable * t,
     const ruint8 j0[R_AES_BLOCK_BYTES],
     rconstpointer aad, rsize aadsize,
     const ruint8 * ciphertxt, rsize ctsize,
@@ -1535,14 +1791,14 @@ r_gcm_compute_tag (const RAesCipher * aes,
   ruint8 ek[R_AES_BLOCK_BYTES];
   rsize i;
 
-  r_gcm_ghash_update (y, t, aad, aadsize);
-  r_gcm_ghash_update (y, t, ciphertxt, ctsize);
+  r_gcm_ghash_update (y, aes, aad, aadsize);
+  r_gcm_ghash_update (y, aes, ciphertxt, ctsize);
 
   r_gcm_be64 (lenblock,     (ruint64) aadsize * 8);
   r_gcm_be64 (lenblock + 8, (ruint64) ctsize * 8);
   for (i = 0; i < R_AES_BLOCK_BYTES; i++)
     y[i] ^= lenblock[i];
-  r_ghash_mul_4bit (y, t);
+  aes->ghash_mul (y, aes);
 
   aes->encrypt_block (aes, ek, j0);
   for (i = 0; i < R_AES_BLOCK_BYTES; i++)
@@ -1561,13 +1817,10 @@ r_aes_gcm_op (const RCryptoCipher * cipher,
     rboolean generate_tag)
 {
   const RAesCipher * aes;
-  ruint8 zero[R_AES_BLOCK_BYTES] = { 0 };
-  ruint8 h[R_AES_BLOCK_BYTES];
   ruint8 j0[R_AES_BLOCK_BYTES];
   ruint8 ctr[R_AES_BLOCK_BYTES];
   ruint8 ksblock[R_AES_BLOCK_BYTES];
   ruint8 tagcomputed[R_AES_BLOCK_BYTES];
-  RGhashTable ghash_t;
   const ruint8 * srcp;
   ruint8 * dstp;
   rsize remaining, i;
@@ -1587,26 +1840,22 @@ r_aes_gcm_op (const RCryptoCipher * cipher,
 
   aes = (const RAesCipher *) cipher;
 
-  /* H = E_K(0^128); J0 = IV || 0x00000001; precompute the GHASH
-   * 4-bit table once for this op. */
-  aes->encrypt_block (aes, h, zero);
+  /* J0 = IV || 0x00000001. H and the GHASH kernel are precomputed on
+   * the cipher at construction time. */
   r_memcpy (j0, iv, 12);
   j0[12] = 0; j0[13] = 0; j0[14] = 0; j0[15] = 1;
-  r_ghash_init_table (&ghash_t, h);
 
   /* For decrypt, verify the tag against the ciphertext BEFORE
    * touching @p dst. This way an auth failure leaves any previous
    * @p dst contents intact; the caller never sees released plaintext
    * from a forged input. */
   if (!generate_tag) {
-    r_gcm_compute_tag (aes, &ghash_t, j0, aad, aadsize, data, size, tagcomputed);
+    r_gcm_compute_tag (aes, j0, aad, aadsize, data, size, tagcomputed);
     {
       ruint8 diff = 0;
       for (i = 0; i < tagsize; i++)
         diff |= tagcomputed[i] ^ tag[i];
       if (diff != 0) {
-        r_memclear_secure (h, sizeof (h));
-        r_memclear_secure (&ghash_t, sizeof (ghash_t));
         r_memclear_secure (tagcomputed, sizeof (tagcomputed));
         return R_CRYPTO_CIPHER_AUTH_FAILED;
       }
@@ -1661,12 +1910,10 @@ r_aes_gcm_op (const RCryptoCipher * cipher,
   }
 
   if (generate_tag) {
-    r_gcm_compute_tag (aes, &ghash_t, j0, aad, aadsize, dst, size, tagcomputed);
+    r_gcm_compute_tag (aes, j0, aad, aadsize, dst, size, tagcomputed);
     r_memcpy (tag, tagcomputed, tagsize);
   }
 
-  r_memclear_secure (&ghash_t, sizeof (ghash_t));
-  r_memclear_secure (h, sizeof (h));
   r_memclear_secure (ctr, sizeof (ctr));
   r_memclear_secure (ksblock, sizeof (ksblock));
   r_memclear_secure (tagcomputed, sizeof (tagcomputed));

--- a/test/raes.c
+++ b/test/raes.c
@@ -467,6 +467,29 @@ static const RAesGcmTestData GCM_test_data[] = {
                  "7598a2bd2555d1aa8cb08e48590dbb3da7b08b1056828838"
                  "c5f61e6393ba7a0abcc9f662",
     .tag = "76fc6ece0f4e1768cddf8853bb2d551b"
+  },
+  { /* 200-byte AES-256-GCM, exercises 3 full 4-way CTR iterations +
+     * trailing partial block. Generated with pyca/cryptography. */
+    .keybits = 256,
+    .key = "feffe9928665731c6d6a8f9467308308"
+           "feffe9928665731c6d6a8f9467308308",
+    .iv  = "cafebabefacedbaddecaf888",
+    .aad = "feedfacedeadbeeffeedfacedeadbeefabaddad2",
+    .plaintxt  = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+                 "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+                 "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f"
+                 "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f"
+                 "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f"
+                 "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf"
+                 "c0c1c2c3c4c5c6c7",
+    .ciphertxt = "8b1df1d665d77de5592f346d897c6ae8f28c379cbec4210443cd889bb37945c7"
+                 "b0ada0fee8409449a056af1f3309133244adc1a50d82aa6a3e93b760af12f9c7"
+                 "24ee3915a4a83b0d00dcc456bab5aea08ccfbce7bf43ff5e032e478d049947aa"
+                 "079af6eb7e11f5143d36b7161c5aa3c2f0ff1bcc1abe72b8d64a51d469f49a2c"
+                 "3c18b3626061aba40267453583a5c2d0dac05bf17b416ca2cf8fea3aa56510e6"
+                 "5c50d9373ca33d90f9bc09db6a51d324fdeeabe11aefcba64855a71ec040796d"
+                 "18dde7d762c2ca65",
+    .tag = "bf064656ce9919b2c9df3879f520e4d5"
   }
 };
 


### PR DESCRIPTION
## Summary

Three-step lift of AES-GCM throughput on this PR's host (Zen3): ~80 MiB/s → ~2.0 GiB/s, roughly 26x.

- **4-way batched CTR pass** in AES-GCM, copying the shape `r_cipher_aes_ctr_encrypt` already uses for plain CTR. No standalone speedup before GHASH is fixed, but the path is in place.
- **HW-accelerated GHASH** via PCLMULQDQ (x86) and PMULL (aarch64), function-pointer dispatch picked once at cipher construction. SW 4-bit Shoup table remains as the fallback. Per-byte bit-reverse bridges rlib's "byte-internal MSB = x^0" representation to the natural-LE form the carry-less multipliers want — H is pre-reversed at construction so the per-call cost is one bitrev on entry and one on exit.
- **4-way aggregated GHASH** on top: four polynomial multiplies feed one accumulator, single reduction at the end (`y_new = (y XOR b0)*H^4 + b1*H^3 + b2*H^2 + b3*H`). H², H³, H⁴ precomputed at construction. Amortises the reduction cost that single-block PCLMUL was bottlenecked on.

Added a `tmmintrin.h` header probe (SSSE3 / PSHUFB, needed by the bit-reverse) — the PCLMUL GHASH kernel only compiles in when both `HAVE_WMMINTRIN_H` and `HAVE_TMMINTRIN_H` are set, so a system with one but not the other falls through to SW.

## Test plan

- [x] `meson test -C build-debug-test` — full suite 1537/1537 pass; 6 NIST GCM vectors (the existing five plus a new 200-byte AES-256-GCM that exercises three 4-way CTR iterations + partial tail + the 4-way GHASH path several times)
- [x] ASAN build — same suite, clean
- [x] `qemu-aarch64 -cpu max` (which exposes ARMv8 crypto extensions) — 143/143 AES tests pass through the PMULL kernel; confirmed via temporary debug print (removed) that the HW path is the one taken
- [x] `-O3 -Werror` clean on both x86 native and aarch64 cross
- [x] Bench: `bench/rlibbench -p -f '/raes/gcm*'`

## Performance (Zen3, 32 MiB @ 16 KiB blocks, median of 5)

| Kernel | gcm_128 (MiB/s) | gcm_256 (MiB/s) | vs baseline |
| --- | --- | --- | --- |
| SW 4-bit (master) | ~80 | ~84 | — |
| HW single-block | ~770 | ~720 | ~10x |
| HW 4-way aggregated | ~2100 | ~1900 | ~26x |

For reference, raw AES-NI CTR (`/raes/ctr_128_encrypt`) on this host is ~2.4 GiB/s — GCM is now within ~10–15% of the raw cipher ceiling.

Closes #171
Closes #172