### PR TITLE
crypto: AES-NI / ARMv8 8-way kernels, faster CTR overhead, 8-way GHASH

### DIFF
--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -85,18 +85,6 @@ typedef struct {
   ruint8 e[16][R_AES_BLOCK_BYTES];
 } RGhashTable;
 
-/* Inline 16-byte block copy. r_memcpy is an extern function the
- * compiler cannot inline (no body visible), so the per-iteration
- * staging sequence in CTR / CBC-dec / CFB-dec became a tight chain
- * of memcpy@plt calls. __builtin_memcpy with a constant size folds
- * to a movdqu / vld1q pair on every modern compiler. */
-static inline void
-r_aes_copy_block (ruint8 dst[R_AES_BLOCK_BYTES],
-    const ruint8 src[R_AES_BLOCK_BYTES])
-{
-  __builtin_memcpy (dst, src, R_AES_BLOCK_BYTES);
-}
-
 /* Big-endian counter add-by-n on a 16-byte AES counter block. Treat
  * the low 8 bytes as a 64-bit big-endian counter (the typical
  * working range for any sane CTR / GCM use): byte-swap to host, add,
@@ -557,10 +545,10 @@ r_cipher_aes_new_with_info (const RCryptoCipherInfo * info, const ruint8 * key)
        * them via the SW reference (which expects NIST form) BEFORE
        * the in-place bit-reverse of H. ghash_h_pow[i] = H^(i+2). */
       rsize idx, p;
-      r_aes_copy_block (ret->ghash_h_pow[0], ret->ghash_h);
+      r_memcpy (ret->ghash_h_pow[0], ret->ghash_h, R_AES_BLOCK_BYTES);
       r_ghash_mul (ret->ghash_h_pow[0], ret->ghash_h);          /* H^2 */
       for (p = 1; p < 7; p++) {
-        r_aes_copy_block (ret->ghash_h_pow[p], ret->ghash_h_pow[p - 1]);
+        r_memcpy (ret->ghash_h_pow[p], ret->ghash_h_pow[p - 1], R_AES_BLOCK_BYTES);
         r_ghash_mul (ret->ghash_h_pow[p], ret->ghash_h);        /* H^(p+2) */
       }
       for (p = 0; p < 7; p++) {
@@ -1414,10 +1402,10 @@ static __forceinline uint8x16_t
 r_pmull_p64 (uint64_t a, uint64_t b)
 {
   __n64 _a, _b;
-  /* r_memcpy is the portable type-pun. __n64 and uint64_t are both
-   * 8 bytes; MSVC optimises the copy away. */
-  r_memcpy (&_a, &a, sizeof (_a));
-  r_memcpy (&_b, &b, sizeof (_b));
+  /* Plain memcpy as the portable type-pun. __n64 and uint64_t are
+   * both 8 bytes; MSVC optimises the copy away. */
+  memcpy (&_a, &a, sizeof (_a));
+  memcpy (&_b, &b, sizeof (_b));
   return vmull_p64 (_a, _b);
 }
 #else
@@ -1808,7 +1796,7 @@ r_cipher_aes_cbc_encrypt (const RCryptoCipher * cipher,
     for (i = 0; i < R_AES_BLOCK_BYTES; i++)
         dst[i] = ptr[i] ^ iv[i];
     r_cipher_aes_ecb_encrypt_block (cipher, dst, dst);
-    r_aes_copy_block (iv, dst);
+    r_memcpy (iv, dst, R_AES_BLOCK_BYTES);
   }
 
   return R_CRYPTO_CIPHER_OK;
@@ -1849,7 +1837,7 @@ r_cipher_aes_cbc_decrypt (const RCryptoCipher * cipher,
         for (i = 0; i < R_AES_BLOCK_BYTES; i++)
           dst[i + R_AES_BLOCK_BYTES * w] ^= scratch[i + R_AES_BLOCK_BYTES * (w - 1)];
       }
-      r_aes_copy_block (iv, scratch + R_AES_BLOCK_BYTES * (R_AES_PARALLEL8_BLOCKS - 1));
+      r_memcpy (iv, scratch + R_AES_BLOCK_BYTES * (R_AES_PARALLEL8_BLOCKS - 1), R_AES_BLOCK_BYTES);
       ptr += R_AES_PARALLEL8_BYTES;
       dst += R_AES_PARALLEL8_BYTES;
     }
@@ -1863,18 +1851,18 @@ r_cipher_aes_cbc_decrypt (const RCryptoCipher * cipher,
         for (i = 0; i < R_AES_BLOCK_BYTES; i++)
           dst[i + R_AES_BLOCK_BYTES * w] ^= scratch[i + R_AES_BLOCK_BYTES * (w - 1)];
       }
-      r_aes_copy_block (iv, scratch + R_AES_BLOCK_BYTES * (R_AES_PARALLEL_BLOCKS - 1));
+      r_memcpy (iv, scratch + R_AES_BLOCK_BYTES * (R_AES_PARALLEL_BLOCKS - 1), R_AES_BLOCK_BYTES);
       ptr += R_AES_PARALLEL_BYTES;
       dst += R_AES_PARALLEL_BYTES;
     }
   }
 
   while (ptr < end) {
-    r_aes_copy_block (scratch, ptr);
+    r_memcpy (scratch, ptr, R_AES_BLOCK_BYTES);
     aes->decrypt_block (aes, dst, ptr);
     for (i = 0; i < R_AES_BLOCK_BYTES; i++)
         dst[i] ^= iv[i];
-    r_aes_copy_block (iv, scratch);
+    r_memcpy (iv, scratch, R_AES_BLOCK_BYTES);
     ptr += R_AES_BLOCK_BYTES;
     dst += R_AES_BLOCK_BYTES;
   }
@@ -1914,7 +1902,7 @@ r_cipher_aes_ctr_encrypt (const RCryptoCipher * cipher,
   if (aes->encrypt_blocks_x8 != NULL) {
     while (ptr + R_AES_PARALLEL8_BYTES <= end) {
       for (w = 0; w < R_AES_PARALLEL8_BLOCKS; w++)
-        r_aes_copy_block (scratch + R_AES_BLOCK_BYTES * w, iv);
+        r_memcpy (scratch + R_AES_BLOCK_BYTES * w, iv, R_AES_BLOCK_BYTES);
       for (w = 1; w < R_AES_PARALLEL8_BLOCKS; w++)
         r_aes_ctr_add (scratch + R_AES_BLOCK_BYTES * w, (ruint32) w);
       aes->encrypt_blocks_x8 (aes, scratch, scratch);
@@ -1928,7 +1916,7 @@ r_cipher_aes_ctr_encrypt (const RCryptoCipher * cipher,
   if (aes->encrypt_blocks_x4 != NULL) {
     while (ptr + R_AES_PARALLEL_BYTES <= end) {
       for (w = 0; w < R_AES_PARALLEL_BLOCKS; w++)
-        r_aes_copy_block (scratch + R_AES_BLOCK_BYTES * w, iv);
+        r_memcpy (scratch + R_AES_BLOCK_BYTES * w, iv, R_AES_BLOCK_BYTES);
       for (w = 1; w < R_AES_PARALLEL_BLOCKS; w++)
         r_aes_ctr_add (scratch + R_AES_BLOCK_BYTES * w, (ruint32) w);
       aes->encrypt_blocks_x4 (aes, scratch, scratch);
@@ -1983,7 +1971,7 @@ r_cipher_aes_cfb_encrypt (const RCryptoCipher * cipher,
       dst[i] = scratch[i] ^ ptr[i];
     /* CFB feedback: encrypt() input for the next block is the just-produced
      * ciphertext, not the plaintext. */
-    r_aes_copy_block (iv, dst);
+    r_memcpy (iv, dst, R_AES_BLOCK_BYTES);
   }
 
   if (size > 0) {
@@ -2027,14 +2015,14 @@ r_cipher_aes_cfb_decrypt (const RCryptoCipher * cipher,
   if (aes->encrypt_blocks_x8 != NULL) {
     while (ptr + R_AES_PARALLEL8_BYTES <= end) {
       r_memcpy (ctsave, ptr, R_AES_PARALLEL8_BYTES);
-      r_aes_copy_block (scratch, iv);
+      r_memcpy (scratch, iv, R_AES_BLOCK_BYTES);
       for (w = 1; w < R_AES_PARALLEL8_BLOCKS; w++)
-        r_aes_copy_block (scratch + R_AES_BLOCK_BYTES * w,
-            ctsave + R_AES_BLOCK_BYTES * (w - 1));
+        r_memcpy (scratch + R_AES_BLOCK_BYTES * w,
+            ctsave + R_AES_BLOCK_BYTES * (w - 1), R_AES_BLOCK_BYTES);
       aes->encrypt_blocks_x8 (aes, scratch, scratch);
       for (i = 0; i < R_AES_PARALLEL8_BYTES; i++)
         dst[i] = scratch[i] ^ ctsave[i];
-      r_aes_copy_block (iv, ctsave + R_AES_BLOCK_BYTES * (R_AES_PARALLEL8_BLOCKS - 1));
+      r_memcpy (iv, ctsave + R_AES_BLOCK_BYTES * (R_AES_PARALLEL8_BLOCKS - 1), R_AES_BLOCK_BYTES);
       ptr += R_AES_PARALLEL8_BYTES;
       dst += R_AES_PARALLEL8_BYTES;
     }
@@ -2042,25 +2030,25 @@ r_cipher_aes_cfb_decrypt (const RCryptoCipher * cipher,
   if (aes->encrypt_blocks_x4 != NULL) {
     while (ptr + R_AES_PARALLEL_BYTES <= end) {
       r_memcpy (ctsave, ptr, R_AES_PARALLEL_BYTES);
-      r_aes_copy_block (scratch, iv);
+      r_memcpy (scratch, iv, R_AES_BLOCK_BYTES);
       for (w = 1; w < R_AES_PARALLEL_BLOCKS; w++)
-        r_aes_copy_block (scratch + R_AES_BLOCK_BYTES * w,
-            ctsave + R_AES_BLOCK_BYTES * (w - 1));
+        r_memcpy (scratch + R_AES_BLOCK_BYTES * w,
+            ctsave + R_AES_BLOCK_BYTES * (w - 1), R_AES_BLOCK_BYTES);
       aes->encrypt_blocks_x4 (aes, scratch, scratch);
       for (i = 0; i < R_AES_PARALLEL_BYTES; i++)
         dst[i] = scratch[i] ^ ctsave[i];
-      r_aes_copy_block (iv, ctsave + R_AES_BLOCK_BYTES * (R_AES_PARALLEL_BLOCKS - 1));
+      r_memcpy (iv, ctsave + R_AES_BLOCK_BYTES * (R_AES_PARALLEL_BLOCKS - 1), R_AES_BLOCK_BYTES);
       ptr += R_AES_PARALLEL_BYTES;
       dst += R_AES_PARALLEL_BYTES;
     }
   }
 
   while (ptr < end) {
-    r_aes_copy_block (ctsave, ptr);
+    r_memcpy (ctsave, ptr, R_AES_BLOCK_BYTES);
     aes->encrypt_block (aes, scratch, iv);
     for (i = 0; i < R_AES_BLOCK_BYTES; i++)
       dst[i] = scratch[i] ^ ptr[i];
-    r_aes_copy_block (iv, ctsave);
+    r_memcpy (iv, ctsave, R_AES_BLOCK_BYTES);
     ptr += R_AES_BLOCK_BYTES;
     dst += R_AES_BLOCK_BYTES;
   }
@@ -2128,7 +2116,7 @@ r_ghash_mul (ruint8 y[R_AES_BLOCK_BYTES], const ruint8 h[R_AES_BLOCK_BYTES])
   ruint8 v[R_AES_BLOCK_BYTES];
   rsize i, j, k;
 
-  r_aes_copy_block (v, h);
+  r_memcpy (v, h, R_AES_BLOCK_BYTES);
 
   for (i = 0; i < R_AES_BLOCK_BYTES; i++) {
     for (j = 0; j < 8; j++) {
@@ -2149,7 +2137,7 @@ r_ghash_mul (ruint8 y[R_AES_BLOCK_BYTES], const ruint8 h[R_AES_BLOCK_BYTES])
     }
   }
 
-  r_aes_copy_block (y, z);
+  r_memcpy (y, z, R_AES_BLOCK_BYTES);
 }
 
 /* Build the 4-bit GHASH table (Shoup's method) into @p t. e[n] holds
@@ -2219,7 +2207,7 @@ r_ghash_mul_4bit (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes,
       for (k = 0; k < R_AES_BLOCK_BYTES; k++)
         z[k] ^= t->e[n][k];
     }
-    r_aes_copy_block (y, z);
+    r_memcpy (y, z, R_AES_BLOCK_BYTES);
 
     data += R_AES_BLOCK_BYTES;
     nblocks--;
@@ -2367,7 +2355,7 @@ r_aes_gcm_op (const RCryptoCipher * cipher,
   }
 
   /* CTR-mode encrypt / decrypt starting at inc_32(J0). */
-  r_aes_copy_block (ctr, j0);
+  r_memcpy (ctr, j0, R_AES_BLOCK_BYTES);
   r_gcm_ctr_inc32 (ctr);
   srcp = data;
   dstp = dst;
@@ -2383,7 +2371,7 @@ r_aes_gcm_op (const RCryptoCipher * cipher,
     rsize w;
     while (remaining >= R_AES_PARALLEL8_BYTES) {
       for (w = 0; w < R_AES_PARALLEL8_BLOCKS; w++)
-        r_aes_copy_block (ks8 + R_AES_BLOCK_BYTES * w, ctr);
+        r_memcpy (ks8 + R_AES_BLOCK_BYTES * w, ctr, R_AES_BLOCK_BYTES);
       for (w = 1; w < R_AES_PARALLEL8_BLOCKS; w++)
         r_gcm_ctr_inc32_n (ks8 + R_AES_BLOCK_BYTES * w, (ruint32) w);
       aes->encrypt_blocks_x8 (aes, ks8, ks8);
@@ -2401,7 +2389,7 @@ r_aes_gcm_op (const RCryptoCipher * cipher,
     rsize w;
     while (remaining >= R_AES_PARALLEL_BYTES) {
       for (w = 0; w < R_AES_PARALLEL_BLOCKS; w++)
-        r_aes_copy_block (ks4 + R_AES_BLOCK_BYTES * w, ctr);
+        r_memcpy (ks4 + R_AES_BLOCK_BYTES * w, ctr, R_AES_BLOCK_BYTES);
       for (w = 1; w < R_AES_PARALLEL_BLOCKS; w++)
         r_gcm_ctr_inc32_n (ks4 + R_AES_BLOCK_BYTES * w, (ruint32) w);
       aes->encrypt_blocks_x4 (aes, ks4, ks4);
@@ -2663,7 +2651,7 @@ r_aes_ccm_op (const RCryptoCipher * cipher,
 
   r_ccm_build_a0 (a0, iv, ivsize, L);
   aes->encrypt_block (aes, s0, a0);
-  r_aes_copy_block (ctr, a0);
+  r_memcpy (ctr, a0, R_AES_BLOCK_BYTES);
   r_ccm_ctr_inc (ctr, L);
 
   if (generate_tag) {

--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -67,6 +67,8 @@
 
 #define R_AES_PARALLEL_BLOCKS  4
 #define R_AES_PARALLEL_BYTES   (R_AES_PARALLEL_BLOCKS * R_AES_BLOCK_BYTES)
+#define R_AES_PARALLEL8_BLOCKS 8
+#define R_AES_PARALLEL8_BYTES  (R_AES_PARALLEL8_BLOCKS * R_AES_BLOCK_BYTES)
 
 typedef struct _RAesCipher RAesCipher;
 typedef rboolean (*RAesBlockFn) (const RAesCipher * aes,
@@ -98,12 +100,16 @@ struct _RAesCipher {
   RAesBlockFn encrypt_block;
   RAesBlockFn decrypt_block;
 
-  /* 4-way parallel kernels used by the parallelizable mode loops
-   * (ECB, CTR, CBC-decrypt, CFB-decrypt). NULL on the SW path -
-   * mode loops fall back to encrypt_block / decrypt_block in
-   * that case. */
+  /* 4-way and 8-way parallel kernels used by the parallelizable mode
+   * loops (ECB, CTR, CBC-decrypt, CFB-decrypt). NULL on the SW path -
+   * mode loops fall back to a narrower kernel or single-block. The
+   * 8-way kernel is preferred when the remaining run is >= 8 blocks;
+   * it amortises load/store and key-schedule pressure better at the
+   * cost of a larger register footprint. */
   RAesBlocksFn encrypt_blocks_x4;
   RAesBlocksFn decrypt_blocks_x4;
+  RAesBlocksFn encrypt_blocks_x8;
+  RAesBlocksFn decrypt_blocks_x8;
 
   /* GCM precomputed state - populated only when info->mode == GCM.
    * H = E_K(0^128), used by every GHASH multiplication; the 4-bit
@@ -159,6 +165,12 @@ R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_encrypt_blocks_aesni_256);
 R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks_aesni_128);
 R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks_aesni_192);
 R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks_aesni_256);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_encrypt_blocks8_aesni_128);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_encrypt_blocks8_aesni_192);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_encrypt_blocks8_aesni_256);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks8_aesni_128);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks8_aesni_192);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks8_aesni_256);
 #endif
 
 #ifdef HAVE_ARM_NEON_H
@@ -174,6 +186,12 @@ R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_encrypt_blocks_armv8_256);
 R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks_armv8_128);
 R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks_armv8_192);
 R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks_armv8_256);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_encrypt_blocks8_armv8_128);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_encrypt_blocks8_armv8_192);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_encrypt_blocks8_armv8_256);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks8_armv8_128);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks8_armv8_192);
+R_AES_BLOCKS_FN_DECL (r_cipher_aes_ecb_decrypt_blocks8_armv8_256);
 #endif
 
 const RCryptoCipherInfo g__r_crypto_cipher_aes_128_ecb =  { "AES-128-ECB",
@@ -419,18 +437,24 @@ r_cipher_aes_new_with_info (const RCryptoCipherInfo * info, const ruint8 * key)
           ret->decrypt_block      = r_cipher_aes_ecb_decrypt_block_aesni_128;
           ret->encrypt_blocks_x4  = r_cipher_aes_ecb_encrypt_blocks_aesni_128;
           ret->decrypt_blocks_x4  = r_cipher_aes_ecb_decrypt_blocks_aesni_128;
+          ret->encrypt_blocks_x8  = r_cipher_aes_ecb_encrypt_blocks8_aesni_128;
+          ret->decrypt_blocks_x8  = r_cipher_aes_ecb_decrypt_blocks8_aesni_128;
           break;
         case 12:
           ret->encrypt_block      = r_cipher_aes_ecb_encrypt_block_aesni_192;
           ret->decrypt_block      = r_cipher_aes_ecb_decrypt_block_aesni_192;
           ret->encrypt_blocks_x4  = r_cipher_aes_ecb_encrypt_blocks_aesni_192;
           ret->decrypt_blocks_x4  = r_cipher_aes_ecb_decrypt_blocks_aesni_192;
+          ret->encrypt_blocks_x8  = r_cipher_aes_ecb_encrypt_blocks8_aesni_192;
+          ret->decrypt_blocks_x8  = r_cipher_aes_ecb_decrypt_blocks8_aesni_192;
           break;
         default: /* 14 = AES-256 */
           ret->encrypt_block      = r_cipher_aes_ecb_encrypt_block_aesni_256;
           ret->decrypt_block      = r_cipher_aes_ecb_decrypt_block_aesni_256;
           ret->encrypt_blocks_x4  = r_cipher_aes_ecb_encrypt_blocks_aesni_256;
           ret->decrypt_blocks_x4  = r_cipher_aes_ecb_decrypt_blocks_aesni_256;
+          ret->encrypt_blocks_x8  = r_cipher_aes_ecb_encrypt_blocks8_aesni_256;
+          ret->decrypt_blocks_x8  = r_cipher_aes_ecb_decrypt_blocks8_aesni_256;
           break;
       }
     } else
@@ -442,18 +466,24 @@ r_cipher_aes_new_with_info (const RCryptoCipherInfo * info, const ruint8 * key)
           ret->decrypt_block      = r_cipher_aes_ecb_decrypt_block_armv8_128;
           ret->encrypt_blocks_x4  = r_cipher_aes_ecb_encrypt_blocks_armv8_128;
           ret->decrypt_blocks_x4  = r_cipher_aes_ecb_decrypt_blocks_armv8_128;
+          ret->encrypt_blocks_x8  = r_cipher_aes_ecb_encrypt_blocks8_armv8_128;
+          ret->decrypt_blocks_x8  = r_cipher_aes_ecb_decrypt_blocks8_armv8_128;
           break;
         case 12:
           ret->encrypt_block      = r_cipher_aes_ecb_encrypt_block_armv8_192;
           ret->decrypt_block      = r_cipher_aes_ecb_decrypt_block_armv8_192;
           ret->encrypt_blocks_x4  = r_cipher_aes_ecb_encrypt_blocks_armv8_192;
           ret->decrypt_blocks_x4  = r_cipher_aes_ecb_decrypt_blocks_armv8_192;
+          ret->encrypt_blocks_x8  = r_cipher_aes_ecb_encrypt_blocks8_armv8_192;
+          ret->decrypt_blocks_x8  = r_cipher_aes_ecb_decrypt_blocks8_armv8_192;
           break;
         default: /* 14 = AES-256 */
           ret->encrypt_block      = r_cipher_aes_ecb_encrypt_block_armv8_256;
           ret->decrypt_block      = r_cipher_aes_ecb_decrypt_block_armv8_256;
           ret->encrypt_blocks_x4  = r_cipher_aes_ecb_encrypt_blocks_armv8_256;
           ret->decrypt_blocks_x4  = r_cipher_aes_ecb_decrypt_blocks_armv8_256;
+          ret->encrypt_blocks_x8  = r_cipher_aes_ecb_encrypt_blocks8_armv8_256;
+          ret->decrypt_blocks_x8  = r_cipher_aes_ecb_decrypt_blocks8_armv8_256;
           break;
       }
     } else
@@ -463,6 +493,8 @@ r_cipher_aes_new_with_info (const RCryptoCipherInfo * info, const ruint8 * key)
       ret->decrypt_block      = r_cipher_aes_ecb_decrypt_block_sw;
       ret->encrypt_blocks_x4  = NULL;  /* mode loops fall back to single-block */
       ret->decrypt_blocks_x4  = NULL;
+      ret->encrypt_blocks_x8  = NULL;
+      ret->decrypt_blocks_x8  = NULL;
     }
   }
 
@@ -829,6 +861,68 @@ R_AES_AESNI_BLOCKS_X4 (r_cipher_aes_ecb_decrypt_blocks_aesni_192, drk,
     _mm_aesdec_si128, _mm_aesdeclast_si128, 12)
 R_AES_AESNI_BLOCKS_X4 (r_cipher_aes_ecb_decrypt_blocks_aesni_256, drk,
     _mm_aesdec_si128, _mm_aesdeclast_si128, 14)
+
+/* 8-way variant: doubles the block count to better hide the AES
+ * round chain on cores where AESENC is dual-issue (Zen+ has 0.5-
+ * cycle throughput, so 4-way already saturates - but the wider
+ * window gives the compiler more scheduling room and amortises the
+ * load/store and key-broadcast pressure across more bytes per
+ * loop iteration. On older Intel (Westmere-Haswell, single-issue
+ * AESENC) it's a more direct ~2x. */
+# define R_AES_AESNI_BLOCKS_X8(name, key_arr, op_round, op_last, rounds)     \
+  R_AES_X86_TARGET                                                           \
+  static void                                                                \
+  name (const RAesCipher * aes, ruint8 * dst, const ruint8 * src)            \
+  {                                                                          \
+    __m128i b0 = _mm_loadu_si128 ((const __m128i *)(src      ));             \
+    __m128i b1 = _mm_loadu_si128 ((const __m128i *)(src +  16));             \
+    __m128i b2 = _mm_loadu_si128 ((const __m128i *)(src +  32));             \
+    __m128i b3 = _mm_loadu_si128 ((const __m128i *)(src +  48));             \
+    __m128i b4 = _mm_loadu_si128 ((const __m128i *)(src +  64));             \
+    __m128i b5 = _mm_loadu_si128 ((const __m128i *)(src +  80));             \
+    __m128i b6 = _mm_loadu_si128 ((const __m128i *)(src +  96));             \
+    __m128i b7 = _mm_loadu_si128 ((const __m128i *)(src + 112));             \
+    const __m128i * rk = (const __m128i *)aes->key_arr;                      \
+    __m128i k = _mm_loadu_si128 (rk++);                                      \
+    ruint8 i;                                                                \
+    b0 = _mm_xor_si128 (b0, k); b1 = _mm_xor_si128 (b1, k);                  \
+    b2 = _mm_xor_si128 (b2, k); b3 = _mm_xor_si128 (b3, k);                  \
+    b4 = _mm_xor_si128 (b4, k); b5 = _mm_xor_si128 (b5, k);                  \
+    b6 = _mm_xor_si128 (b6, k); b7 = _mm_xor_si128 (b7, k);                  \
+    for (i = 1; i < (rounds); i++, rk++) {                                   \
+      k = _mm_loadu_si128 (rk);                                              \
+      b0 = op_round (b0, k); b1 = op_round (b1, k);                          \
+      b2 = op_round (b2, k); b3 = op_round (b3, k);                          \
+      b4 = op_round (b4, k); b5 = op_round (b5, k);                          \
+      b6 = op_round (b6, k); b7 = op_round (b7, k);                          \
+    }                                                                        \
+    k = _mm_loadu_si128 (rk);                                                \
+    b0 = op_last (b0, k); b1 = op_last (b1, k);                              \
+    b2 = op_last (b2, k); b3 = op_last (b3, k);                              \
+    b4 = op_last (b4, k); b5 = op_last (b5, k);                              \
+    b6 = op_last (b6, k); b7 = op_last (b7, k);                              \
+    _mm_storeu_si128 ((__m128i *)(dst      ), b0);                           \
+    _mm_storeu_si128 ((__m128i *)(dst +  16), b1);                           \
+    _mm_storeu_si128 ((__m128i *)(dst +  32), b2);                           \
+    _mm_storeu_si128 ((__m128i *)(dst +  48), b3);                           \
+    _mm_storeu_si128 ((__m128i *)(dst +  64), b4);                           \
+    _mm_storeu_si128 ((__m128i *)(dst +  80), b5);                           \
+    _mm_storeu_si128 ((__m128i *)(dst +  96), b6);                           \
+    _mm_storeu_si128 ((__m128i *)(dst + 112), b7);                           \
+  }
+
+R_AES_AESNI_BLOCKS_X8 (r_cipher_aes_ecb_encrypt_blocks8_aesni_128, erk,
+    _mm_aesenc_si128, _mm_aesenclast_si128, 10)
+R_AES_AESNI_BLOCKS_X8 (r_cipher_aes_ecb_encrypt_blocks8_aesni_192, erk,
+    _mm_aesenc_si128, _mm_aesenclast_si128, 12)
+R_AES_AESNI_BLOCKS_X8 (r_cipher_aes_ecb_encrypt_blocks8_aesni_256, erk,
+    _mm_aesenc_si128, _mm_aesenclast_si128, 14)
+R_AES_AESNI_BLOCKS_X8 (r_cipher_aes_ecb_decrypt_blocks8_aesni_128, drk,
+    _mm_aesdec_si128, _mm_aesdeclast_si128, 10)
+R_AES_AESNI_BLOCKS_X8 (r_cipher_aes_ecb_decrypt_blocks8_aesni_192, drk,
+    _mm_aesdec_si128, _mm_aesdeclast_si128, 12)
+R_AES_AESNI_BLOCKS_X8 (r_cipher_aes_ecb_decrypt_blocks8_aesni_256, drk,
+    _mm_aesdec_si128, _mm_aesdeclast_si128, 14)
 #endif /* HAVE_WMMINTRIN_H (AES-NI block kernels) */
 
 /* PCLMUL GHASH kernel: needs PCLMULQDQ (wmmintrin.h) for the
@@ -1127,6 +1221,103 @@ R_AES_ARMV8_BLOCKS_X4_DECRYPT (r_cipher_aes_ecb_decrypt_blocks_armv8_128, 10)
 R_AES_ARMV8_BLOCKS_X4_DECRYPT (r_cipher_aes_ecb_decrypt_blocks_armv8_192, 12)
 R_AES_ARMV8_BLOCKS_X4_DECRYPT (r_cipher_aes_ecb_decrypt_blocks_armv8_256, 14)
 
+/* 8-way variant: same rationale as the AES-NI x8 - more independent
+ * blocks in flight to hide AESE/AESMC latency (Cortex-A class chips
+ * tend to have 1-cycle throughput / 3-cycle latency on AESE+AESMC
+ * pairs, so the wider window is meaningful here). */
+# define R_AES_ARMV8_BLOCKS_X8_ENCRYPT(name, rounds)                          \
+  R_AES_ARM_TARGET                                                            \
+  static void                                                                 \
+  name (const RAesCipher * aes, ruint8 * dst, const ruint8 * src)             \
+  {                                                                           \
+    uint8x16_t b0 = vld1q_u8 (src       );                                    \
+    uint8x16_t b1 = vld1q_u8 (src +  16);                                     \
+    uint8x16_t b2 = vld1q_u8 (src +  32);                                     \
+    uint8x16_t b3 = vld1q_u8 (src +  48);                                     \
+    uint8x16_t b4 = vld1q_u8 (src +  64);                                     \
+    uint8x16_t b5 = vld1q_u8 (src +  80);                                     \
+    uint8x16_t b6 = vld1q_u8 (src +  96);                                     \
+    uint8x16_t b7 = vld1q_u8 (src + 112);                                     \
+    const ruint8 * rk = (const ruint8 *)aes->erk;                             \
+    uint8x16_t k;                                                             \
+    ruint8 i;                                                                 \
+    for (i = 0; i < (rounds) - 1; i++, rk += 16) {                            \
+      k = vld1q_u8 (rk);                                                      \
+      b0 = vaeseq_u8 (b0, k); b0 = vaesmcq_u8 (b0);                           \
+      b1 = vaeseq_u8 (b1, k); b1 = vaesmcq_u8 (b1);                           \
+      b2 = vaeseq_u8 (b2, k); b2 = vaesmcq_u8 (b2);                           \
+      b3 = vaeseq_u8 (b3, k); b3 = vaesmcq_u8 (b3);                           \
+      b4 = vaeseq_u8 (b4, k); b4 = vaesmcq_u8 (b4);                           \
+      b5 = vaeseq_u8 (b5, k); b5 = vaesmcq_u8 (b5);                           \
+      b6 = vaeseq_u8 (b6, k); b6 = vaesmcq_u8 (b6);                           \
+      b7 = vaeseq_u8 (b7, k); b7 = vaesmcq_u8 (b7);                           \
+    }                                                                         \
+    k = vld1q_u8 (rk); rk += 16;                                              \
+    b0 = vaeseq_u8 (b0, k); b1 = vaeseq_u8 (b1, k);                           \
+    b2 = vaeseq_u8 (b2, k); b3 = vaeseq_u8 (b3, k);                           \
+    b4 = vaeseq_u8 (b4, k); b5 = vaeseq_u8 (b5, k);                           \
+    b6 = vaeseq_u8 (b6, k); b7 = vaeseq_u8 (b7, k);                           \
+    k = vld1q_u8 (rk);                                                        \
+    b0 = veorq_u8 (b0, k); b1 = veorq_u8 (b1, k);                             \
+    b2 = veorq_u8 (b2, k); b3 = veorq_u8 (b3, k);                             \
+    b4 = veorq_u8 (b4, k); b5 = veorq_u8 (b5, k);                             \
+    b6 = veorq_u8 (b6, k); b7 = veorq_u8 (b7, k);                             \
+    vst1q_u8 (dst       , b0); vst1q_u8 (dst +  16, b1);                      \
+    vst1q_u8 (dst +  32, b2); vst1q_u8 (dst +  48, b3);                       \
+    vst1q_u8 (dst +  64, b4); vst1q_u8 (dst +  80, b5);                       \
+    vst1q_u8 (dst +  96, b6); vst1q_u8 (dst + 112, b7);                       \
+  }
+
+# define R_AES_ARMV8_BLOCKS_X8_DECRYPT(name, rounds)                          \
+  R_AES_ARM_TARGET                                                            \
+  static void                                                                 \
+  name (const RAesCipher * aes, ruint8 * dst, const ruint8 * src)             \
+  {                                                                           \
+    uint8x16_t b0 = vld1q_u8 (src       );                                    \
+    uint8x16_t b1 = vld1q_u8 (src +  16);                                     \
+    uint8x16_t b2 = vld1q_u8 (src +  32);                                     \
+    uint8x16_t b3 = vld1q_u8 (src +  48);                                     \
+    uint8x16_t b4 = vld1q_u8 (src +  64);                                     \
+    uint8x16_t b5 = vld1q_u8 (src +  80);                                     \
+    uint8x16_t b6 = vld1q_u8 (src +  96);                                     \
+    uint8x16_t b7 = vld1q_u8 (src + 112);                                     \
+    const ruint8 * rk = (const ruint8 *)aes->drk;                             \
+    uint8x16_t k;                                                             \
+    ruint8 i;                                                                 \
+    for (i = 0; i < (rounds) - 1; i++, rk += 16) {                            \
+      k = vld1q_u8 (rk);                                                      \
+      b0 = vaesdq_u8 (b0, k); b0 = vaesimcq_u8 (b0);                          \
+      b1 = vaesdq_u8 (b1, k); b1 = vaesimcq_u8 (b1);                          \
+      b2 = vaesdq_u8 (b2, k); b2 = vaesimcq_u8 (b2);                          \
+      b3 = vaesdq_u8 (b3, k); b3 = vaesimcq_u8 (b3);                          \
+      b4 = vaesdq_u8 (b4, k); b4 = vaesimcq_u8 (b4);                          \
+      b5 = vaesdq_u8 (b5, k); b5 = vaesimcq_u8 (b5);                          \
+      b6 = vaesdq_u8 (b6, k); b6 = vaesimcq_u8 (b6);                          \
+      b7 = vaesdq_u8 (b7, k); b7 = vaesimcq_u8 (b7);                          \
+    }                                                                         \
+    k = vld1q_u8 (rk); rk += 16;                                              \
+    b0 = vaesdq_u8 (b0, k); b1 = vaesdq_u8 (b1, k);                           \
+    b2 = vaesdq_u8 (b2, k); b3 = vaesdq_u8 (b3, k);                           \
+    b4 = vaesdq_u8 (b4, k); b5 = vaesdq_u8 (b5, k);                           \
+    b6 = vaesdq_u8 (b6, k); b7 = vaesdq_u8 (b7, k);                           \
+    k = vld1q_u8 (rk);                                                        \
+    b0 = veorq_u8 (b0, k); b1 = veorq_u8 (b1, k);                             \
+    b2 = veorq_u8 (b2, k); b3 = veorq_u8 (b3, k);                             \
+    b4 = veorq_u8 (b4, k); b5 = veorq_u8 (b5, k);                             \
+    b6 = veorq_u8 (b6, k); b7 = veorq_u8 (b7, k);                             \
+    vst1q_u8 (dst       , b0); vst1q_u8 (dst +  16, b1);                      \
+    vst1q_u8 (dst +  32, b2); vst1q_u8 (dst +  48, b3);                       \
+    vst1q_u8 (dst +  64, b4); vst1q_u8 (dst +  80, b5);                       \
+    vst1q_u8 (dst +  96, b6); vst1q_u8 (dst + 112, b7);                       \
+  }
+
+R_AES_ARMV8_BLOCKS_X8_ENCRYPT (r_cipher_aes_ecb_encrypt_blocks8_armv8_128, 10)
+R_AES_ARMV8_BLOCKS_X8_ENCRYPT (r_cipher_aes_ecb_encrypt_blocks8_armv8_192, 12)
+R_AES_ARMV8_BLOCKS_X8_ENCRYPT (r_cipher_aes_ecb_encrypt_blocks8_armv8_256, 14)
+R_AES_ARMV8_BLOCKS_X8_DECRYPT (r_cipher_aes_ecb_decrypt_blocks8_armv8_128, 10)
+R_AES_ARMV8_BLOCKS_X8_DECRYPT (r_cipher_aes_ecb_decrypt_blocks8_armv8_192, 12)
+R_AES_ARMV8_BLOCKS_X8_DECRYPT (r_cipher_aes_ecb_decrypt_blocks8_armv8_256, 14)
+
 /* MSVC ARM64 declares vmull_p64 as taking __n64 (not poly64_t) and
  * returning __n128 (no poly128_t typedef), so a straight ACLE call
  * doesn't compile. Wrap the intrinsic once and return uint8x16_t -
@@ -1413,6 +1604,13 @@ r_cipher_aes_ecb_encrypt (const RCryptoCipher * cipher,
   aes = (const RAesCipher *)cipher;
   ptr = data;
   end = ptr + size;
+  if (aes->encrypt_blocks_x8 != NULL) {
+    while (ptr + R_AES_PARALLEL8_BYTES <= end) {
+      aes->encrypt_blocks_x8 (aes, dst, ptr);
+      ptr += R_AES_PARALLEL8_BYTES;
+      dst += R_AES_PARALLEL8_BYTES;
+    }
+  }
   if (aes->encrypt_blocks_x4 != NULL) {
     while (ptr + R_AES_PARALLEL_BYTES <= end) {
       aes->encrypt_blocks_x4 (aes, dst, ptr);
@@ -1448,6 +1646,13 @@ r_cipher_aes_ecb_decrypt (const RCryptoCipher * cipher,
   aes = (const RAesCipher *)cipher;
   ptr = data;
   end = ptr + size;
+  if (aes->decrypt_blocks_x8 != NULL) {
+    while (ptr + R_AES_PARALLEL8_BYTES <= end) {
+      aes->decrypt_blocks_x8 (aes, dst, ptr);
+      ptr += R_AES_PARALLEL8_BYTES;
+      dst += R_AES_PARALLEL8_BYTES;
+    }
+  }
   if (aes->decrypt_blocks_x4 != NULL) {
     while (ptr + R_AES_PARALLEL_BYTES <= end) {
       aes->decrypt_blocks_x4 (aes, dst, ptr);
@@ -1494,8 +1699,9 @@ r_cipher_aes_cbc_decrypt (const RCryptoCipher * cipher,
   const RAesCipher * aes;
   const ruint8 * ptr;
   const ruint8 * end;
-  ruint8 scratch[R_AES_PARALLEL_BYTES];
+  ruint8 scratch[R_AES_PARALLEL8_BYTES];
   int i;
+  rsize w;
 
   if (R_UNLIKELY (cipher == NULL)) return R_CRYPTO_CIPHER_INVAL;
   if (R_UNLIKELY (data == NULL)) return R_CRYPTO_CIPHER_INVAL;
@@ -1507,20 +1713,37 @@ r_cipher_aes_cbc_decrypt (const RCryptoCipher * cipher,
   ptr = data;
   end = ptr + size;
 
-  /* 4-way path: snapshot the 4-block ciphertext window (decryption
-   * can be in-place so the original ct must be saved before the
-   * dst write), decrypt all 4 in parallel, then XOR each plaintext
+  /* 8-way / 4-way path: snapshot the window's ciphertext (decryption
+   * can be in-place so the original ct must be saved before the dst
+   * write), decrypt N blocks in parallel, then XOR each plaintext
    * with its chain predecessor (iv for the first, ct[i-1] for the
    * rest). iv is updated to the last ciphertext of the window. */
+  if (aes->decrypt_blocks_x8 != NULL) {
+    while (ptr + R_AES_PARALLEL8_BYTES <= end) {
+      r_memcpy (scratch, ptr, R_AES_PARALLEL8_BYTES);
+      aes->decrypt_blocks_x8 (aes, dst, ptr);
+      for (i = 0; i < R_AES_BLOCK_BYTES; i++) dst[i] ^= iv[i];
+      for (w = 1; w < R_AES_PARALLEL8_BLOCKS; w++) {
+        for (i = 0; i < R_AES_BLOCK_BYTES; i++)
+          dst[i + R_AES_BLOCK_BYTES * w] ^= scratch[i + R_AES_BLOCK_BYTES * (w - 1)];
+      }
+      r_memcpy (iv, scratch + R_AES_BLOCK_BYTES * (R_AES_PARALLEL8_BLOCKS - 1),
+          R_AES_BLOCK_BYTES);
+      ptr += R_AES_PARALLEL8_BYTES;
+      dst += R_AES_PARALLEL8_BYTES;
+    }
+  }
   if (aes->decrypt_blocks_x4 != NULL) {
     while (ptr + R_AES_PARALLEL_BYTES <= end) {
       r_memcpy (scratch, ptr, R_AES_PARALLEL_BYTES);
       aes->decrypt_blocks_x4 (aes, dst, ptr);
-      for (i = 0; i < R_AES_BLOCK_BYTES; i++) dst[i               ] ^= iv[i];
-      for (i = 0; i < R_AES_BLOCK_BYTES; i++) dst[i + R_AES_BLOCK_BYTES    ] ^= scratch[i                          ];
-      for (i = 0; i < R_AES_BLOCK_BYTES; i++) dst[i + R_AES_BLOCK_BYTES * 2] ^= scratch[i + R_AES_BLOCK_BYTES      ];
-      for (i = 0; i < R_AES_BLOCK_BYTES; i++) dst[i + R_AES_BLOCK_BYTES * 3] ^= scratch[i + R_AES_BLOCK_BYTES * 2  ];
-      r_memcpy (iv, scratch + R_AES_BLOCK_BYTES * 3, R_AES_BLOCK_BYTES);
+      for (i = 0; i < R_AES_BLOCK_BYTES; i++) dst[i] ^= iv[i];
+      for (w = 1; w < R_AES_PARALLEL_BLOCKS; w++) {
+        for (i = 0; i < R_AES_BLOCK_BYTES; i++)
+          dst[i + R_AES_BLOCK_BYTES * w] ^= scratch[i + R_AES_BLOCK_BYTES * (w - 1)];
+      }
+      r_memcpy (iv, scratch + R_AES_BLOCK_BYTES * (R_AES_PARALLEL_BLOCKS - 1),
+          R_AES_BLOCK_BYTES);
       ptr += R_AES_PARALLEL_BYTES;
       dst += R_AES_PARALLEL_BYTES;
     }
@@ -1565,7 +1788,8 @@ r_cipher_aes_ctr_encrypt (const RCryptoCipher * cipher,
   const ruint8 * end;
   int i;
   rsize bsize = size;
-  ruint8 scratch[R_AES_PARALLEL_BYTES];
+  rsize w;
+  ruint8 scratch[R_AES_PARALLEL8_BYTES];
 
   if (R_UNLIKELY (cipher == NULL)) return R_CRYPTO_CIPHER_INVAL;
   if (R_UNLIKELY (data == NULL)) return R_CRYPTO_CIPHER_INVAL;
@@ -1579,18 +1803,29 @@ r_cipher_aes_ctr_encrypt (const RCryptoCipher * cipher,
   ptr = data;
   end = ptr + bsize;
 
-  /* 4-way path: build 4 consecutive counter blocks (iv, iv+1,
-   * iv+2, iv+3) in scratch, encrypt all 4 in parallel, XOR with
-   * the plaintext window, and advance iv by 4. */
+  /* 8-way / 4-way path: build N consecutive counter blocks (iv, iv+1,
+   * ..., iv+N-1) in scratch, encrypt all N in parallel, XOR with the
+   * plaintext window, and advance iv by N. */
+  if (aes->encrypt_blocks_x8 != NULL) {
+    while (ptr + R_AES_PARALLEL8_BYTES <= end) {
+      for (w = 0; w < R_AES_PARALLEL8_BLOCKS; w++)
+        r_memcpy (scratch + R_AES_BLOCK_BYTES * w, iv, R_AES_BLOCK_BYTES);
+      for (w = 1; w < R_AES_PARALLEL8_BLOCKS; w++)
+        r_aes_ctr_add (scratch + R_AES_BLOCK_BYTES * w, (ruint32) w);
+      aes->encrypt_blocks_x8 (aes, scratch, scratch);
+      for (i = 0; i < R_AES_PARALLEL8_BYTES; i++)
+        dst[i] = scratch[i] ^ ptr[i];
+      r_aes_ctr_add (iv, R_AES_PARALLEL8_BLOCKS);
+      ptr += R_AES_PARALLEL8_BYTES;
+      dst += R_AES_PARALLEL8_BYTES;
+    }
+  }
   if (aes->encrypt_blocks_x4 != NULL) {
     while (ptr + R_AES_PARALLEL_BYTES <= end) {
-      r_memcpy (scratch + R_AES_BLOCK_BYTES * 0, iv, R_AES_BLOCK_BYTES);
-      r_memcpy (scratch + R_AES_BLOCK_BYTES * 1, iv, R_AES_BLOCK_BYTES);
-      r_memcpy (scratch + R_AES_BLOCK_BYTES * 2, iv, R_AES_BLOCK_BYTES);
-      r_memcpy (scratch + R_AES_BLOCK_BYTES * 3, iv, R_AES_BLOCK_BYTES);
-      r_aes_ctr_add (scratch + R_AES_BLOCK_BYTES * 1, 1);
-      r_aes_ctr_add (scratch + R_AES_BLOCK_BYTES * 2, 2);
-      r_aes_ctr_add (scratch + R_AES_BLOCK_BYTES * 3, 3);
+      for (w = 0; w < R_AES_PARALLEL_BLOCKS; w++)
+        r_memcpy (scratch + R_AES_BLOCK_BYTES * w, iv, R_AES_BLOCK_BYTES);
+      for (w = 1; w < R_AES_PARALLEL_BLOCKS; w++)
+        r_aes_ctr_add (scratch + R_AES_BLOCK_BYTES * w, (ruint32) w);
       aes->encrypt_blocks_x4 (aes, scratch, scratch);
       for (i = 0; i < R_AES_PARALLEL_BYTES; i++)
         dst[i] = scratch[i] ^ ptr[i];
@@ -1665,8 +1900,9 @@ r_cipher_aes_cfb_decrypt (const RCryptoCipher * cipher,
   const ruint8 * end;
   int i;
   rsize bsize = size;
-  ruint8 scratch[R_AES_PARALLEL_BYTES];
-  ruint8 ctsave[R_AES_PARALLEL_BYTES];
+  rsize w;
+  ruint8 scratch[R_AES_PARALLEL8_BYTES];
+  ruint8 ctsave[R_AES_PARALLEL8_BYTES];
 
   if (R_UNLIKELY (cipher == NULL)) return R_CRYPTO_CIPHER_INVAL;
   if (R_UNLIKELY (data == NULL)) return R_CRYPTO_CIPHER_INVAL;
@@ -1680,20 +1916,37 @@ r_cipher_aes_cfb_decrypt (const RCryptoCipher * cipher,
   ptr = data;
   end = ptr + bsize;
 
-  /* 4-way path: encrypt the 4 chain inputs (iv, ct[0], ct[1], ct[2])
-   * in parallel into a keystream, then XOR with the ciphertext window.
-   * iv is updated to ct[3] for the next iteration. */
+  /* 8-way / 4-way path: encrypt the N chain inputs (iv, ct[0],
+   * ..., ct[N-2]) in parallel into a keystream, XOR with the
+   * ciphertext window. iv is updated to ct[N-1] for next iteration. */
+  if (aes->encrypt_blocks_x8 != NULL) {
+    while (ptr + R_AES_PARALLEL8_BYTES <= end) {
+      r_memcpy (ctsave, ptr, R_AES_PARALLEL8_BYTES);
+      r_memcpy (scratch, iv, R_AES_BLOCK_BYTES);
+      for (w = 1; w < R_AES_PARALLEL8_BLOCKS; w++)
+        r_memcpy (scratch + R_AES_BLOCK_BYTES * w,
+            ctsave + R_AES_BLOCK_BYTES * (w - 1), R_AES_BLOCK_BYTES);
+      aes->encrypt_blocks_x8 (aes, scratch, scratch);
+      for (i = 0; i < R_AES_PARALLEL8_BYTES; i++)
+        dst[i] = scratch[i] ^ ctsave[i];
+      r_memcpy (iv, ctsave + R_AES_BLOCK_BYTES * (R_AES_PARALLEL8_BLOCKS - 1),
+          R_AES_BLOCK_BYTES);
+      ptr += R_AES_PARALLEL8_BYTES;
+      dst += R_AES_PARALLEL8_BYTES;
+    }
+  }
   if (aes->encrypt_blocks_x4 != NULL) {
     while (ptr + R_AES_PARALLEL_BYTES <= end) {
       r_memcpy (ctsave, ptr, R_AES_PARALLEL_BYTES);
-      r_memcpy (scratch + R_AES_BLOCK_BYTES * 0, iv, R_AES_BLOCK_BYTES);
-      r_memcpy (scratch + R_AES_BLOCK_BYTES * 1, ctsave + R_AES_BLOCK_BYTES * 0, R_AES_BLOCK_BYTES);
-      r_memcpy (scratch + R_AES_BLOCK_BYTES * 2, ctsave + R_AES_BLOCK_BYTES * 1, R_AES_BLOCK_BYTES);
-      r_memcpy (scratch + R_AES_BLOCK_BYTES * 3, ctsave + R_AES_BLOCK_BYTES * 2, R_AES_BLOCK_BYTES);
+      r_memcpy (scratch, iv, R_AES_BLOCK_BYTES);
+      for (w = 1; w < R_AES_PARALLEL_BLOCKS; w++)
+        r_memcpy (scratch + R_AES_BLOCK_BYTES * w,
+            ctsave + R_AES_BLOCK_BYTES * (w - 1), R_AES_BLOCK_BYTES);
       aes->encrypt_blocks_x4 (aes, scratch, scratch);
       for (i = 0; i < R_AES_PARALLEL_BYTES; i++)
         dst[i] = scratch[i] ^ ctsave[i];
-      r_memcpy (iv, ctsave + R_AES_BLOCK_BYTES * 3, R_AES_BLOCK_BYTES);
+      r_memcpy (iv, ctsave + R_AES_BLOCK_BYTES * (R_AES_PARALLEL_BLOCKS - 1),
+          R_AES_BLOCK_BYTES);
       ptr += R_AES_PARALLEL_BYTES;
       dst += R_AES_PARALLEL_BYTES;
     }
@@ -2017,20 +2270,37 @@ r_aes_gcm_op (const RCryptoCipher * cipher,
   dstp = dst;
   remaining = size;
 
-  /* 4-way path: build (ctr, ctr+1, ctr+2, ctr+3) in scratch, encrypt
-   * the four blocks in parallel via the SIMD-interleaved kernel, XOR
-   * with the source window, and advance ctr by 4. Mirrors the shape
-   * of r_cipher_aes_ctr_encrypt; the only twist is GCM's inc_32. */
+  /* 8-way / 4-way path: stage N consecutive GCM counter blocks
+   * (ctr, ctr+1, ..., ctr+N-1) in scratch, encrypt all N in parallel
+   * via the SIMD-interleaved kernel, XOR with the source window, and
+   * advance ctr by N. Mirrors the shape of r_cipher_aes_ctr_encrypt;
+   * the only twist is GCM's inc_32 wrap behaviour. */
+  if (aes->encrypt_blocks_x8 != NULL) {
+    ruint8 ks8[R_AES_PARALLEL8_BYTES];
+    rsize w;
+    while (remaining >= R_AES_PARALLEL8_BYTES) {
+      for (w = 0; w < R_AES_PARALLEL8_BLOCKS; w++)
+        r_memcpy (ks8 + R_AES_BLOCK_BYTES * w, ctr, R_AES_BLOCK_BYTES);
+      for (w = 1; w < R_AES_PARALLEL8_BLOCKS; w++)
+        r_gcm_ctr_inc32_n (ks8 + R_AES_BLOCK_BYTES * w, (ruint32) w);
+      aes->encrypt_blocks_x8 (aes, ks8, ks8);
+      for (i = 0; i < R_AES_PARALLEL8_BYTES; i++)
+        dstp[i] = ks8[i] ^ srcp[i];
+      r_gcm_ctr_inc32_n (ctr, R_AES_PARALLEL8_BLOCKS);
+      srcp += R_AES_PARALLEL8_BYTES;
+      dstp += R_AES_PARALLEL8_BYTES;
+      remaining -= R_AES_PARALLEL8_BYTES;
+    }
+    r_memclear_secure (ks8, sizeof (ks8));
+  }
   if (aes->encrypt_blocks_x4 != NULL) {
     ruint8 ks4[R_AES_PARALLEL_BYTES];
+    rsize w;
     while (remaining >= R_AES_PARALLEL_BYTES) {
-      r_memcpy (ks4 + R_AES_BLOCK_BYTES * 0, ctr, R_AES_BLOCK_BYTES);
-      r_memcpy (ks4 + R_AES_BLOCK_BYTES * 1, ctr, R_AES_BLOCK_BYTES);
-      r_memcpy (ks4 + R_AES_BLOCK_BYTES * 2, ctr, R_AES_BLOCK_BYTES);
-      r_memcpy (ks4 + R_AES_BLOCK_BYTES * 3, ctr, R_AES_BLOCK_BYTES);
-      r_gcm_ctr_inc32_n (ks4 + R_AES_BLOCK_BYTES * 1, 1);
-      r_gcm_ctr_inc32_n (ks4 + R_AES_BLOCK_BYTES * 2, 2);
-      r_gcm_ctr_inc32_n (ks4 + R_AES_BLOCK_BYTES * 3, 3);
+      for (w = 0; w < R_AES_PARALLEL_BLOCKS; w++)
+        r_memcpy (ks4 + R_AES_BLOCK_BYTES * w, ctr, R_AES_BLOCK_BYTES);
+      for (w = 1; w < R_AES_PARALLEL_BLOCKS; w++)
+        r_gcm_ctr_inc32_n (ks4 + R_AES_BLOCK_BYTES * w, (ruint32) w);
       aes->encrypt_blocks_x4 (aes, ks4, ks4);
       for (i = 0; i < R_AES_PARALLEL_BYTES; i++)
         dstp[i] = ks4[i] ^ srcp[i];

--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -149,12 +149,12 @@ struct _RAesCipher {
   /* GCM precomputed state - populated only when info->mode == GCM.
    * H = E_K(0^128), used by every GHASH multiplication; the 4-bit
    * table is built from H once when the SW kernel is in use. The
-   * HW kernels (PCLMULQDQ / PMULL) read H directly. ghash_h_pow
-   * holds H^2, H^3, H^4 in the same representation as ghash_h,
-   * used by the HW kernels' 4-way aggregated path; unused when
-   * the SW kernel is selected. */
+   * HW kernels (PCLMULQDQ / PMULL) read H directly. ghash_h_pow[i]
+   * holds H^(i+2) in the same representation as ghash_h - H^2..H^8
+   * fuel the HW kernels' 4-way / 8-way aggregated paths; unused
+   * when the SW kernel is selected. */
   ruint8 ghash_h[R_AES_BLOCK_BYTES];
-  ruint8 ghash_h_pow[3][R_AES_BLOCK_BYTES];
+  ruint8 ghash_h_pow[7][R_AES_BLOCK_BYTES];
   RGhashTable ghash_t;
   RAesGhashMulFn ghash_mul;
 };
@@ -552,18 +552,18 @@ r_cipher_aes_new_with_info (const RCryptoCipherInfo * info, const ruint8 * key)
        * polynomial representation (bit i = x^i). rlib's NIST-style
        * H has byte-internal MSB = x^0, so per-byte bit-reverse H
        * once here; the kernel only has to bit-reverse y on entry
-       * and the result on exit. The 4-way aggregated path also
-       * needs H^2, H^3, H^4 in the same representation - compute
+       * and the result on exit. The 4-way / 8-way aggregated paths
+       * also need H^2..H^8 in the same representation - compute
        * them via the SW reference (which expects NIST form) BEFORE
-       * the in-place bit-reverse of H. */
+       * the in-place bit-reverse of H. ghash_h_pow[i] = H^(i+2). */
       rsize idx, p;
       r_aes_copy_block (ret->ghash_h_pow[0], ret->ghash_h);
       r_ghash_mul (ret->ghash_h_pow[0], ret->ghash_h);          /* H^2 */
-      r_aes_copy_block (ret->ghash_h_pow[1], ret->ghash_h_pow[0]);
-      r_ghash_mul (ret->ghash_h_pow[1], ret->ghash_h);          /* H^3 */
-      r_aes_copy_block (ret->ghash_h_pow[2], ret->ghash_h_pow[1]);
-      r_ghash_mul (ret->ghash_h_pow[2], ret->ghash_h);          /* H^4 */
-      for (p = 0; p < 3; p++) {
+      for (p = 1; p < 7; p++) {
+        r_aes_copy_block (ret->ghash_h_pow[p], ret->ghash_h_pow[p - 1]);
+        r_ghash_mul (ret->ghash_h_pow[p], ret->ghash_h);        /* H^(p+2) */
+      }
+      for (p = 0; p < 7; p++) {
         for (idx = 0; idx < R_AES_BLOCK_BYTES; idx++) {
           ruint8 b = ret->ghash_h_pow[p][idx];
           b = (ruint8) (((b & 0xf0) >> 4) | ((b & 0x0f) << 4));
@@ -1080,33 +1080,82 @@ r_ghash_mul_pclmul (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes,
   __m128i h1 = _mm_loadu_si128 ((const __m128i *) aes->ghash_h);
   __m128i lo, hi;
 
+  /* 8-way aggregated path: matches the 4-way shape but stretches the
+   * formula to eight blocks per reduction:
+   *   y_new = (y XOR b0)*H^8 + b1*H^7 + b2*H^6 + b3*H^5
+   *         + b4*H^4 + b5*H^3 + b6*H^2 + b7*H
+   * All eight polynomial multiplies are independent, which PCLMULQDQ
+   * issues at 1/cycle. */
+  if (nblocks >= 8) {
+    __m128i h2 = _mm_loadu_si128 ((const __m128i *) aes->ghash_h_pow[0]);
+    __m128i h3 = _mm_loadu_si128 ((const __m128i *) aes->ghash_h_pow[1]);
+    __m128i h4 = _mm_loadu_si128 ((const __m128i *) aes->ghash_h_pow[2]);
+    __m128i h5 = _mm_loadu_si128 ((const __m128i *) aes->ghash_h_pow[3]);
+    __m128i h6 = _mm_loadu_si128 ((const __m128i *) aes->ghash_h_pow[4]);
+    __m128i h7 = _mm_loadu_si128 ((const __m128i *) aes->ghash_h_pow[5]);
+    __m128i h8 = _mm_loadu_si128 ((const __m128i *) aes->ghash_h_pow[6]);
+
+    while (nblocks >= 8) {
+      __m128i b0 = r_ghash_byte_bitrev (
+          _mm_loadu_si128 ((const __m128i *) (data +   0)));
+      __m128i b1 = r_ghash_byte_bitrev (
+          _mm_loadu_si128 ((const __m128i *) (data +  16)));
+      __m128i b2 = r_ghash_byte_bitrev (
+          _mm_loadu_si128 ((const __m128i *) (data +  32)));
+      __m128i b3 = r_ghash_byte_bitrev (
+          _mm_loadu_si128 ((const __m128i *) (data +  48)));
+      __m128i b4 = r_ghash_byte_bitrev (
+          _mm_loadu_si128 ((const __m128i *) (data +  64)));
+      __m128i b5 = r_ghash_byte_bitrev (
+          _mm_loadu_si128 ((const __m128i *) (data +  80)));
+      __m128i b6 = r_ghash_byte_bitrev (
+          _mm_loadu_si128 ((const __m128i *) (data +  96)));
+      __m128i b7 = r_ghash_byte_bitrev (
+          _mm_loadu_si128 ((const __m128i *) (data + 112)));
+      __m128i a0 = _mm_xor_si128 (y_br, b0);
+
+      lo = _mm_setzero_si128 ();
+      hi = _mm_setzero_si128 ();
+      r_ghash_poly_mul_acc (&lo, &hi, a0, h8);
+      r_ghash_poly_mul_acc (&lo, &hi, b1, h7);
+      r_ghash_poly_mul_acc (&lo, &hi, b2, h6);
+      r_ghash_poly_mul_acc (&lo, &hi, b3, h5);
+      r_ghash_poly_mul_acc (&lo, &hi, b4, h4);
+      r_ghash_poly_mul_acc (&lo, &hi, b5, h3);
+      r_ghash_poly_mul_acc (&lo, &hi, b6, h2);
+      r_ghash_poly_mul_acc (&lo, &hi, b7, h1);
+      y_br = r_ghash_reduce_pclmul (lo, hi);
+
+      data += 128;
+      nblocks -= 8;
+    }
+  }
+
   if (nblocks >= 4) {
     __m128i h2 = _mm_loadu_si128 ((const __m128i *) aes->ghash_h_pow[0]);
     __m128i h3 = _mm_loadu_si128 ((const __m128i *) aes->ghash_h_pow[1]);
     __m128i h4 = _mm_loadu_si128 ((const __m128i *) aes->ghash_h_pow[2]);
 
-    while (nblocks >= 4) {
-      __m128i b0 = r_ghash_byte_bitrev (
-          _mm_loadu_si128 ((const __m128i *) (data +  0)));
-      __m128i b1 = r_ghash_byte_bitrev (
-          _mm_loadu_si128 ((const __m128i *) (data + 16)));
-      __m128i b2 = r_ghash_byte_bitrev (
-          _mm_loadu_si128 ((const __m128i *) (data + 32)));
-      __m128i b3 = r_ghash_byte_bitrev (
-          _mm_loadu_si128 ((const __m128i *) (data + 48)));
-      __m128i a0 = _mm_xor_si128 (y_br, b0);
+    __m128i b0 = r_ghash_byte_bitrev (
+        _mm_loadu_si128 ((const __m128i *) (data +  0)));
+    __m128i b1 = r_ghash_byte_bitrev (
+        _mm_loadu_si128 ((const __m128i *) (data + 16)));
+    __m128i b2 = r_ghash_byte_bitrev (
+        _mm_loadu_si128 ((const __m128i *) (data + 32)));
+    __m128i b3 = r_ghash_byte_bitrev (
+        _mm_loadu_si128 ((const __m128i *) (data + 48)));
+    __m128i a0 = _mm_xor_si128 (y_br, b0);
 
-      lo = _mm_setzero_si128 ();
-      hi = _mm_setzero_si128 ();
-      r_ghash_poly_mul_acc (&lo, &hi, a0, h4);
-      r_ghash_poly_mul_acc (&lo, &hi, b1, h3);
-      r_ghash_poly_mul_acc (&lo, &hi, b2, h2);
-      r_ghash_poly_mul_acc (&lo, &hi, b3, h1);
-      y_br = r_ghash_reduce_pclmul (lo, hi);
+    lo = _mm_setzero_si128 ();
+    hi = _mm_setzero_si128 ();
+    r_ghash_poly_mul_acc (&lo, &hi, a0, h4);
+    r_ghash_poly_mul_acc (&lo, &hi, b1, h3);
+    r_ghash_poly_mul_acc (&lo, &hi, b2, h2);
+    r_ghash_poly_mul_acc (&lo, &hi, b3, h1);
+    y_br = r_ghash_reduce_pclmul (lo, hi);
 
-      data += 64;
-      nblocks -= 4;
-    }
+    data += 64;
+    nblocks -= 4;
   }
 
   while (nblocks > 0) {
@@ -1461,29 +1510,67 @@ r_ghash_mul_pmull (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes,
   uint8x16_t h1 = vld1q_u8 (aes->ghash_h);
   uint8x16_t lo, hi;
 
+  /* 8-way aggregated path: same formula and instruction shape as
+   * the PCLMUL kernel - eight independent vmull_p64 streams feed
+   * one accumulator, single reduction at the end. */
+  if (nblocks >= 8) {
+    uint8x16_t h2 = vld1q_u8 (aes->ghash_h_pow[0]);
+    uint8x16_t h3 = vld1q_u8 (aes->ghash_h_pow[1]);
+    uint8x16_t h4 = vld1q_u8 (aes->ghash_h_pow[2]);
+    uint8x16_t h5 = vld1q_u8 (aes->ghash_h_pow[3]);
+    uint8x16_t h6 = vld1q_u8 (aes->ghash_h_pow[4]);
+    uint8x16_t h7 = vld1q_u8 (aes->ghash_h_pow[5]);
+    uint8x16_t h8 = vld1q_u8 (aes->ghash_h_pow[6]);
+
+    while (nblocks >= 8) {
+      uint8x16_t b0 = vrbitq_u8 (vld1q_u8 (data +   0));
+      uint8x16_t b1 = vrbitq_u8 (vld1q_u8 (data +  16));
+      uint8x16_t b2 = vrbitq_u8 (vld1q_u8 (data +  32));
+      uint8x16_t b3 = vrbitq_u8 (vld1q_u8 (data +  48));
+      uint8x16_t b4 = vrbitq_u8 (vld1q_u8 (data +  64));
+      uint8x16_t b5 = vrbitq_u8 (vld1q_u8 (data +  80));
+      uint8x16_t b6 = vrbitq_u8 (vld1q_u8 (data +  96));
+      uint8x16_t b7 = vrbitq_u8 (vld1q_u8 (data + 112));
+      uint8x16_t a0 = veorq_u8 (y_br, b0);
+
+      lo = vdupq_n_u8 (0);
+      hi = vdupq_n_u8 (0);
+      r_ghash_poly_mul_acc_pmull (&lo, &hi, a0, h8);
+      r_ghash_poly_mul_acc_pmull (&lo, &hi, b1, h7);
+      r_ghash_poly_mul_acc_pmull (&lo, &hi, b2, h6);
+      r_ghash_poly_mul_acc_pmull (&lo, &hi, b3, h5);
+      r_ghash_poly_mul_acc_pmull (&lo, &hi, b4, h4);
+      r_ghash_poly_mul_acc_pmull (&lo, &hi, b5, h3);
+      r_ghash_poly_mul_acc_pmull (&lo, &hi, b6, h2);
+      r_ghash_poly_mul_acc_pmull (&lo, &hi, b7, h1);
+      y_br = r_ghash_reduce_pmull (lo, hi);
+
+      data += 128;
+      nblocks -= 8;
+    }
+  }
+
   if (nblocks >= 4) {
     uint8x16_t h2 = vld1q_u8 (aes->ghash_h_pow[0]);
     uint8x16_t h3 = vld1q_u8 (aes->ghash_h_pow[1]);
     uint8x16_t h4 = vld1q_u8 (aes->ghash_h_pow[2]);
 
-    while (nblocks >= 4) {
-      uint8x16_t b0 = vrbitq_u8 (vld1q_u8 (data +  0));
-      uint8x16_t b1 = vrbitq_u8 (vld1q_u8 (data + 16));
-      uint8x16_t b2 = vrbitq_u8 (vld1q_u8 (data + 32));
-      uint8x16_t b3 = vrbitq_u8 (vld1q_u8 (data + 48));
-      uint8x16_t a0 = veorq_u8 (y_br, b0);
+    uint8x16_t b0 = vrbitq_u8 (vld1q_u8 (data +  0));
+    uint8x16_t b1 = vrbitq_u8 (vld1q_u8 (data + 16));
+    uint8x16_t b2 = vrbitq_u8 (vld1q_u8 (data + 32));
+    uint8x16_t b3 = vrbitq_u8 (vld1q_u8 (data + 48));
+    uint8x16_t a0 = veorq_u8 (y_br, b0);
 
-      lo = vdupq_n_u8 (0);
-      hi = vdupq_n_u8 (0);
-      r_ghash_poly_mul_acc_pmull (&lo, &hi, a0, h4);
-      r_ghash_poly_mul_acc_pmull (&lo, &hi, b1, h3);
-      r_ghash_poly_mul_acc_pmull (&lo, &hi, b2, h2);
-      r_ghash_poly_mul_acc_pmull (&lo, &hi, b3, h1);
-      y_br = r_ghash_reduce_pmull (lo, hi);
+    lo = vdupq_n_u8 (0);
+    hi = vdupq_n_u8 (0);
+    r_ghash_poly_mul_acc_pmull (&lo, &hi, a0, h4);
+    r_ghash_poly_mul_acc_pmull (&lo, &hi, b1, h3);
+    r_ghash_poly_mul_acc_pmull (&lo, &hi, b2, h2);
+    r_ghash_poly_mul_acc_pmull (&lo, &hi, b3, h1);
+    y_br = r_ghash_reduce_pmull (lo, hi);
 
-      data += 64;
-      nblocks -= 4;
-    }
+    data += 64;
+    nblocks -= 4;
   }
 
   while (nblocks > 0) {

--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -85,6 +85,41 @@ typedef struct {
   ruint8 e[16][R_AES_BLOCK_BYTES];
 } RGhashTable;
 
+/* Inline 16-byte block copy. r_memcpy is an extern function the
+ * compiler cannot inline (no body visible), so the per-iteration
+ * staging sequence in CTR / CBC-dec / CFB-dec became a tight chain
+ * of memcpy@plt calls. __builtin_memcpy with a constant size folds
+ * to a movdqu / vld1q pair on every modern compiler. */
+static inline void
+r_aes_copy_block (ruint8 dst[R_AES_BLOCK_BYTES],
+    const ruint8 src[R_AES_BLOCK_BYTES])
+{
+  __builtin_memcpy (dst, src, R_AES_BLOCK_BYTES);
+}
+
+/* Big-endian counter add-by-n on a 16-byte AES counter block. Treat
+ * the low 8 bytes as a 64-bit big-endian counter (the typical
+ * working range for any sane CTR / GCM use): byte-swap to host, add,
+ * byte-swap back - which the compiler folds to a BSWAP / ADD / BSWAP
+ * sequence vs the prior byte-by-byte carry chain. The overflow into
+ * the high 8 bytes is handled with a tail byte-by-byte chain but is
+ * essentially unreachable in practice: NIST caps CTR / GCM at 2^48
+ * blocks per IV, and our low half doesn't wrap until 2^64. */
+static inline void
+r_aes_ctr_add (ruint8 iv[R_AES_BLOCK_BYTES], ruint32 n)
+{
+  ruint64 lo = r_load_be64 (iv + 8);
+  ruint64 new_lo = lo + n;
+  if (R_UNLIKELY (new_lo < lo)) {
+    int i;
+    for (i = 7; i >= 0; i--) {
+      iv[i]++;
+      if (iv[i] != 0) break;
+    }
+  }
+  r_store_be64 (iv + 8, new_lo);
+}
+
 struct _RAesCipher {
   RCryptoCipher cipher;
 
@@ -522,11 +557,11 @@ r_cipher_aes_new_with_info (const RCryptoCipherInfo * info, const ruint8 * key)
        * them via the SW reference (which expects NIST form) BEFORE
        * the in-place bit-reverse of H. */
       rsize idx, p;
-      r_memcpy (ret->ghash_h_pow[0], ret->ghash_h, R_AES_BLOCK_BYTES);
+      r_aes_copy_block (ret->ghash_h_pow[0], ret->ghash_h);
       r_ghash_mul (ret->ghash_h_pow[0], ret->ghash_h);          /* H^2 */
-      r_memcpy (ret->ghash_h_pow[1], ret->ghash_h_pow[0], R_AES_BLOCK_BYTES);
+      r_aes_copy_block (ret->ghash_h_pow[1], ret->ghash_h_pow[0]);
       r_ghash_mul (ret->ghash_h_pow[1], ret->ghash_h);          /* H^3 */
-      r_memcpy (ret->ghash_h_pow[2], ret->ghash_h_pow[1], R_AES_BLOCK_BYTES);
+      r_aes_copy_block (ret->ghash_h_pow[2], ret->ghash_h_pow[1]);
       r_ghash_mul (ret->ghash_h_pow[2], ret->ghash_h);          /* H^4 */
       for (p = 0; p < 3; p++) {
         for (idx = 0; idx < R_AES_BLOCK_BYTES; idx++) {
@@ -1686,7 +1721,7 @@ r_cipher_aes_cbc_encrypt (const RCryptoCipher * cipher,
     for (i = 0; i < R_AES_BLOCK_BYTES; i++)
         dst[i] = ptr[i] ^ iv[i];
     r_cipher_aes_ecb_encrypt_block (cipher, dst, dst);
-    r_memcpy (iv, dst, R_AES_BLOCK_BYTES);
+    r_aes_copy_block (iv, dst);
   }
 
   return R_CRYPTO_CIPHER_OK;
@@ -1727,8 +1762,7 @@ r_cipher_aes_cbc_decrypt (const RCryptoCipher * cipher,
         for (i = 0; i < R_AES_BLOCK_BYTES; i++)
           dst[i + R_AES_BLOCK_BYTES * w] ^= scratch[i + R_AES_BLOCK_BYTES * (w - 1)];
       }
-      r_memcpy (iv, scratch + R_AES_BLOCK_BYTES * (R_AES_PARALLEL8_BLOCKS - 1),
-          R_AES_BLOCK_BYTES);
+      r_aes_copy_block (iv, scratch + R_AES_BLOCK_BYTES * (R_AES_PARALLEL8_BLOCKS - 1));
       ptr += R_AES_PARALLEL8_BYTES;
       dst += R_AES_PARALLEL8_BYTES;
     }
@@ -1742,19 +1776,18 @@ r_cipher_aes_cbc_decrypt (const RCryptoCipher * cipher,
         for (i = 0; i < R_AES_BLOCK_BYTES; i++)
           dst[i + R_AES_BLOCK_BYTES * w] ^= scratch[i + R_AES_BLOCK_BYTES * (w - 1)];
       }
-      r_memcpy (iv, scratch + R_AES_BLOCK_BYTES * (R_AES_PARALLEL_BLOCKS - 1),
-          R_AES_BLOCK_BYTES);
+      r_aes_copy_block (iv, scratch + R_AES_BLOCK_BYTES * (R_AES_PARALLEL_BLOCKS - 1));
       ptr += R_AES_PARALLEL_BYTES;
       dst += R_AES_PARALLEL_BYTES;
     }
   }
 
   while (ptr < end) {
-    r_memcpy (scratch, ptr, R_AES_BLOCK_BYTES);
+    r_aes_copy_block (scratch, ptr);
     aes->decrypt_block (aes, dst, ptr);
     for (i = 0; i < R_AES_BLOCK_BYTES; i++)
         dst[i] ^= iv[i];
-    r_memcpy (iv, scratch, R_AES_BLOCK_BYTES);
+    r_aes_copy_block (iv, scratch);
     ptr += R_AES_BLOCK_BYTES;
     dst += R_AES_BLOCK_BYTES;
   }
@@ -1763,21 +1796,6 @@ r_cipher_aes_cbc_decrypt (const RCryptoCipher * cipher,
   return R_CRYPTO_CIPHER_OK;
 }
 
-/* Big-endian counter add-by-n on a 16-byte AES counter block.
- * n is small (1..R_AES_PARALLEL_BLOCKS) in our callers, so the
- * carry stops within a few bytes; the early-exit on no-carry
- * keeps the cost equivalent to the existing byte-by-byte ++iv. */
-static void
-r_aes_ctr_add (ruint8 iv[R_AES_BLOCK_BYTES], ruint32 n)
-{
-  int i;
-  ruint32 carry = n;
-  for (i = R_AES_BLOCK_BYTES; i > 0 && carry != 0; i--) {
-    ruint32 sum = (ruint32) iv[i - 1] + (carry & 0xff);
-    iv[i - 1] = (ruint8) sum;
-    carry = (carry >> 8) + (sum >> 8);
-  }
-}
 
 RCryptoCipherResult
 r_cipher_aes_ctr_encrypt (const RCryptoCipher * cipher,
@@ -1809,7 +1827,7 @@ r_cipher_aes_ctr_encrypt (const RCryptoCipher * cipher,
   if (aes->encrypt_blocks_x8 != NULL) {
     while (ptr + R_AES_PARALLEL8_BYTES <= end) {
       for (w = 0; w < R_AES_PARALLEL8_BLOCKS; w++)
-        r_memcpy (scratch + R_AES_BLOCK_BYTES * w, iv, R_AES_BLOCK_BYTES);
+        r_aes_copy_block (scratch + R_AES_BLOCK_BYTES * w, iv);
       for (w = 1; w < R_AES_PARALLEL8_BLOCKS; w++)
         r_aes_ctr_add (scratch + R_AES_BLOCK_BYTES * w, (ruint32) w);
       aes->encrypt_blocks_x8 (aes, scratch, scratch);
@@ -1823,7 +1841,7 @@ r_cipher_aes_ctr_encrypt (const RCryptoCipher * cipher,
   if (aes->encrypt_blocks_x4 != NULL) {
     while (ptr + R_AES_PARALLEL_BYTES <= end) {
       for (w = 0; w < R_AES_PARALLEL_BLOCKS; w++)
-        r_memcpy (scratch + R_AES_BLOCK_BYTES * w, iv, R_AES_BLOCK_BYTES);
+        r_aes_copy_block (scratch + R_AES_BLOCK_BYTES * w, iv);
       for (w = 1; w < R_AES_PARALLEL_BLOCKS; w++)
         r_aes_ctr_add (scratch + R_AES_BLOCK_BYTES * w, (ruint32) w);
       aes->encrypt_blocks_x4 (aes, scratch, scratch);
@@ -1878,7 +1896,7 @@ r_cipher_aes_cfb_encrypt (const RCryptoCipher * cipher,
       dst[i] = scratch[i] ^ ptr[i];
     /* CFB feedback: encrypt() input for the next block is the just-produced
      * ciphertext, not the plaintext. */
-    r_memcpy (iv, dst, R_AES_BLOCK_BYTES);
+    r_aes_copy_block (iv, dst);
   }
 
   if (size > 0) {
@@ -1922,15 +1940,14 @@ r_cipher_aes_cfb_decrypt (const RCryptoCipher * cipher,
   if (aes->encrypt_blocks_x8 != NULL) {
     while (ptr + R_AES_PARALLEL8_BYTES <= end) {
       r_memcpy (ctsave, ptr, R_AES_PARALLEL8_BYTES);
-      r_memcpy (scratch, iv, R_AES_BLOCK_BYTES);
+      r_aes_copy_block (scratch, iv);
       for (w = 1; w < R_AES_PARALLEL8_BLOCKS; w++)
-        r_memcpy (scratch + R_AES_BLOCK_BYTES * w,
-            ctsave + R_AES_BLOCK_BYTES * (w - 1), R_AES_BLOCK_BYTES);
+        r_aes_copy_block (scratch + R_AES_BLOCK_BYTES * w,
+            ctsave + R_AES_BLOCK_BYTES * (w - 1));
       aes->encrypt_blocks_x8 (aes, scratch, scratch);
       for (i = 0; i < R_AES_PARALLEL8_BYTES; i++)
         dst[i] = scratch[i] ^ ctsave[i];
-      r_memcpy (iv, ctsave + R_AES_BLOCK_BYTES * (R_AES_PARALLEL8_BLOCKS - 1),
-          R_AES_BLOCK_BYTES);
+      r_aes_copy_block (iv, ctsave + R_AES_BLOCK_BYTES * (R_AES_PARALLEL8_BLOCKS - 1));
       ptr += R_AES_PARALLEL8_BYTES;
       dst += R_AES_PARALLEL8_BYTES;
     }
@@ -1938,26 +1955,25 @@ r_cipher_aes_cfb_decrypt (const RCryptoCipher * cipher,
   if (aes->encrypt_blocks_x4 != NULL) {
     while (ptr + R_AES_PARALLEL_BYTES <= end) {
       r_memcpy (ctsave, ptr, R_AES_PARALLEL_BYTES);
-      r_memcpy (scratch, iv, R_AES_BLOCK_BYTES);
+      r_aes_copy_block (scratch, iv);
       for (w = 1; w < R_AES_PARALLEL_BLOCKS; w++)
-        r_memcpy (scratch + R_AES_BLOCK_BYTES * w,
-            ctsave + R_AES_BLOCK_BYTES * (w - 1), R_AES_BLOCK_BYTES);
+        r_aes_copy_block (scratch + R_AES_BLOCK_BYTES * w,
+            ctsave + R_AES_BLOCK_BYTES * (w - 1));
       aes->encrypt_blocks_x4 (aes, scratch, scratch);
       for (i = 0; i < R_AES_PARALLEL_BYTES; i++)
         dst[i] = scratch[i] ^ ctsave[i];
-      r_memcpy (iv, ctsave + R_AES_BLOCK_BYTES * (R_AES_PARALLEL_BLOCKS - 1),
-          R_AES_BLOCK_BYTES);
+      r_aes_copy_block (iv, ctsave + R_AES_BLOCK_BYTES * (R_AES_PARALLEL_BLOCKS - 1));
       ptr += R_AES_PARALLEL_BYTES;
       dst += R_AES_PARALLEL_BYTES;
     }
   }
 
   while (ptr < end) {
-    r_memcpy (ctsave, ptr, R_AES_BLOCK_BYTES);
+    r_aes_copy_block (ctsave, ptr);
     aes->encrypt_block (aes, scratch, iv);
     for (i = 0; i < R_AES_BLOCK_BYTES; i++)
       dst[i] = scratch[i] ^ ptr[i];
-    r_memcpy (iv, ctsave, R_AES_BLOCK_BYTES);
+    r_aes_copy_block (iv, ctsave);
     ptr += R_AES_BLOCK_BYTES;
     dst += R_AES_BLOCK_BYTES;
   }
@@ -2025,7 +2041,7 @@ r_ghash_mul (ruint8 y[R_AES_BLOCK_BYTES], const ruint8 h[R_AES_BLOCK_BYTES])
   ruint8 v[R_AES_BLOCK_BYTES];
   rsize i, j, k;
 
-  r_memcpy (v, h, R_AES_BLOCK_BYTES);
+  r_aes_copy_block (v, h);
 
   for (i = 0; i < R_AES_BLOCK_BYTES; i++) {
     for (j = 0; j < 8; j++) {
@@ -2046,7 +2062,7 @@ r_ghash_mul (ruint8 y[R_AES_BLOCK_BYTES], const ruint8 h[R_AES_BLOCK_BYTES])
     }
   }
 
-  r_memcpy (y, z, R_AES_BLOCK_BYTES);
+  r_aes_copy_block (y, z);
 }
 
 /* Build the 4-bit GHASH table (Shoup's method) into @p t. e[n] holds
@@ -2116,7 +2132,7 @@ r_ghash_mul_4bit (ruint8 y[R_AES_BLOCK_BYTES], const RAesCipher * aes,
       for (k = 0; k < R_AES_BLOCK_BYTES; k++)
         z[k] ^= t->e[n][k];
     }
-    r_memcpy (y, z, R_AES_BLOCK_BYTES);
+    r_aes_copy_block (y, z);
 
     data += R_AES_BLOCK_BYTES;
     nblocks--;
@@ -2264,7 +2280,7 @@ r_aes_gcm_op (const RCryptoCipher * cipher,
   }
 
   /* CTR-mode encrypt / decrypt starting at inc_32(J0). */
-  r_memcpy (ctr, j0, R_AES_BLOCK_BYTES);
+  r_aes_copy_block (ctr, j0);
   r_gcm_ctr_inc32 (ctr);
   srcp = data;
   dstp = dst;
@@ -2280,7 +2296,7 @@ r_aes_gcm_op (const RCryptoCipher * cipher,
     rsize w;
     while (remaining >= R_AES_PARALLEL8_BYTES) {
       for (w = 0; w < R_AES_PARALLEL8_BLOCKS; w++)
-        r_memcpy (ks8 + R_AES_BLOCK_BYTES * w, ctr, R_AES_BLOCK_BYTES);
+        r_aes_copy_block (ks8 + R_AES_BLOCK_BYTES * w, ctr);
       for (w = 1; w < R_AES_PARALLEL8_BLOCKS; w++)
         r_gcm_ctr_inc32_n (ks8 + R_AES_BLOCK_BYTES * w, (ruint32) w);
       aes->encrypt_blocks_x8 (aes, ks8, ks8);
@@ -2298,7 +2314,7 @@ r_aes_gcm_op (const RCryptoCipher * cipher,
     rsize w;
     while (remaining >= R_AES_PARALLEL_BYTES) {
       for (w = 0; w < R_AES_PARALLEL_BLOCKS; w++)
-        r_memcpy (ks4 + R_AES_BLOCK_BYTES * w, ctr, R_AES_BLOCK_BYTES);
+        r_aes_copy_block (ks4 + R_AES_BLOCK_BYTES * w, ctr);
       for (w = 1; w < R_AES_PARALLEL_BLOCKS; w++)
         r_gcm_ctr_inc32_n (ks4 + R_AES_BLOCK_BYTES * w, (ruint32) w);
       aes->encrypt_blocks_x4 (aes, ks4, ks4);
@@ -2560,7 +2576,7 @@ r_aes_ccm_op (const RCryptoCipher * cipher,
 
   r_ccm_build_a0 (a0, iv, ivsize, L);
   aes->encrypt_block (aes, s0, a0);
-  r_memcpy (ctr, a0, R_AES_BLOCK_BYTES);
+  r_aes_copy_block (ctr, a0);
   r_ccm_ctr_inc (ctr, L);
 
   if (generate_tag) {


### PR DESCRIPTION
## Summary

Three perf-focused changes to AES on the existing function-pointer-dispatch path. Numbers below are 16 KiB blocks, median of 5 runs, Zen3 @ ~4 GHz.

- **8-way AES kernels** (AES-NI + ARMv8) alongside the existing 4-way. Mode loops (ECB, CTR, CBC-decrypt, CFB-decrypt, GCM's CTR pass) prefer x8 when the remaining run is ≥ 8 blocks, fall back to x4 for the 4–7 trailing, then single-block. On Zen3 the wider AES kernel is essentially neutral for raw ECB (AESENC is already throughput-bound at 4-way thanks to its 0.5-cycle throughput) but CTR / GCM benefit because the per-batch overhead (counter staging, XOR, ctr_add) amortises over twice the bytes per iteration. On older Intel (single-issue AESENC) the wider AES kernel itself is the win.
- **Inline 16-byte block copy + bswap-based `r_aes_ctr_add`**. `r_memcpy` is an extern function the compiler can't inline, so the CTR / CBC-dec / CFB-dec staging loops were emitting `memcpy@plt` calls in a tight chain. A `static inline` wrapper around `__builtin_memcpy` folds those to `movdqu` / `vld1q` pairs. `r_aes_ctr_add` rewritten to BSWAP-uint64-add-BSWAP instead of byte-by-byte carry chain.
- **8-way aggregated GHASH** (PCLMULQDQ + PMULL). Doubles the aggregation width from 4 to 8 blocks per reduction: `y_new = (y XOR b0)·H⁸ + b1·H⁷ + … + b7·H`. `H⁵..H⁸` precomputed at construction. Kernel grows a 3-tier dispatch (8-way ≥ 8, then one 4-way batch for the 4–7 remainder, then single-block).

## Performance

Cumulative across the three commits:

| Mode | Before this PR | After | Δ | vs OpenSSL 3.6.2 |
|---|---|---|---|---|
| AES-128-CTR | 2.85 GiB/s | 5.21 GiB/s | **+83%** | was 21% → now 39% |
| AES-256-CTR | 2.51 GiB/s | 4.68 GiB/s | **+86%** | was 25% → now 48% |
| AES-128-GCM | 2.01 GiB/s | 3.29 GiB/s | **+64%** | was 22% → now 36% |
| AES-256-GCM | 1.90 GiB/s | 2.93 GiB/s | **+54%** | was 24% → now 37% |
| ECB / OFB | unchanged on Zen3 | | | 77–94% of OpenSSL |
| CBC / CFB-encrypt | unchanged (sequential) | | | 41–77% of OpenSSL |
| CCM | unchanged (sequential CBC-MAC) | | | 23–26% of OpenSSL |

Remaining gap to OpenSSL on CTR / GCM is OpenSSL's fused asm kernel that merges counter staging, AESENC rounds and the XOR — that's a substantially larger lift than this PR and is left for a follow-up.

## Test plan

- [x] `meson test -C build-asan` — full 1537/1537 pass, ASAN clean
- [x] `qemu-aarch64 -cpu max` on the cross-compiled aarch64 binary — full 1537/1537 pass through the ARMv8 AES + PMULL kernels
- [x] Existing 200-byte AES-256-GCM test vector exercises all three GHASH dispatch tiers (8-way + 4-way + single-block) in one call
- [x] `-O3 -Werror` clean on both x86 (cc) and aarch64 (gcc cross)
- [x] Disassembly check: CTR loop emits inline `movdqu` for block copies and `bswap` for counter advance (no `memcpy@plt` left)