### PR TITLE
Ignore Claude Code local state directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /.waf*
 /_build*
 /docs/output/
+/.claude/


### PR DESCRIPTION
## Summary

Adds \`/.claude/\` to \`.gitignore\` so the Claude Code per-developer state directory doesn't show up as untracked in every git status.

Contents are:
- \`settings.local.json\` — per-developer Bash permission allowlist
- \`scheduled_tasks.lock\` — runtime PID / session state

Neither belongs in version control. Matches the existing anchored-to-root pattern used for \`/.lock*\`, \`/_build*\`, etc.

## Test plan

- [x] \`git status\` clean on a checkout that has a \`.claude/\` directory present