### PR TITLE
rmem: Inline byte-buffer primitives + Doxygen on the rmem*.h family

### DIFF
--- a/include/rlib/rmem.h
+++ b/include/rlib/rmem.h
@@ -90,28 +90,55 @@ R_API void r_mem_get_vtable (RMemVTable * out);
 R_API rboolean r_mem_using_system_default (void);
 
 
-/* Common memory operations */
-R_API int       r_memcmp (rconstpointer a, rconstpointer b, rsize size);
-/* Constant-time variant of r_memcmp: returns 0 iff every byte
- * matches, non-zero otherwise. No early-out on the first mismatch,
- * so the wall-clock latency depends only on `size` and not on which
- * bytes (if any) differ - suitable for comparing MAC tags, signature
- * digests, and similar secret-derived material against attacker-
- * supplied values. Does NOT preserve memcmp's sign semantics; only
- * the zero / non-zero distinction is meaningful. */
+/**
+ * @brief Constant-time variant of @c r_memcmp.
+ *
+ * Returns 0 iff every byte matches, non-zero otherwise. No early-out
+ * on the first mismatch, so wall-clock latency depends only on
+ * @p size and not on which bytes (if any) differ - suitable for
+ * comparing MAC tags, signature digests, and similar secret-derived
+ * material against attacker-supplied values.
+ *
+ * Does **not** preserve @c memcmp's sign semantics; only the zero /
+ * non-zero distinction is meaningful. Stays extern so the volatile-
+ * pointer loop in the implementation isn't sniffed apart by the
+ * optimiser.
+ *
+ * The non-constant-time @c r_memcmp / @c r_memset / @c r_memcpy /
+ * @c r_memmove inline primitives live in @c rlib/types/rmemops.h
+ * (transitively pulled in through this header) - that placement is
+ * forced by their use inside the @c rendianness.h load / store
+ * helpers, which are processed earlier in the include chain.
+ *
+ * @param a    First buffer (may be @c NULL).
+ * @param b    Second buffer (may be @c NULL).
+ * @param size Number of bytes to compare.
+ * @return 0 if @p a and @p b are byte-equal across @p size bytes,
+ *         non-zero otherwise.
+ */
 R_API int       r_memcmp_ct (rconstpointer a, rconstpointer b, rsize size);
-R_API rpointer  r_memset (rpointer a, int v, rsize size);
-#define r_memclear(ptr, size)   r_memset (ptr, 0, size)
-/* Zero `size` bytes at `ptr` in a way the compiler can't elide. A
- * regular memset before a free is provably unobservable from the
- * caller's perspective and gets removed by the optimiser ("dead
+
+/**
+ * @brief Zero @p size bytes at @p ptr in a way the compiler can't
+ * elide.
+ *
+ * A regular @c memset before a @c free is provably unobservable from
+ * the caller's perspective and gets removed by the optimiser ("dead
  * store elimination") - which is exactly the wrong outcome for
- * wiping secret material. Use this for buffers that contained
- * keys, scalars, nonces, plaintexts, etc. before they're released. */
+ * wiping secret material. Use this for buffers that contained keys,
+ * scalars, nonces, plaintexts, etc. before they're released.
+ *
+ * Stays extern so the platform-specific guarantees
+ * (@c SecureZeroMemory on Win32, @c explicit_bzero on glibc / *BSD /
+ * musl, volatile-loop fallback elsewhere) live in one place and the
+ * optimiser can't see through them.
+ *
+ * @param ptr  Destination buffer (may be @c NULL or @p size 0; both
+ *             are silent no-ops).
+ * @param size Number of bytes to wipe.
+ */
 R_API void      r_memclear_secure (rpointer ptr, rsize size);
-R_API rpointer  r_memcpy (void * R_ATTR_RESTRICT dst,
-    const void * R_ATTR_RESTRICT src, rsize size);
-R_API rpointer  r_memmove (rpointer dst, rconstpointer src, rsize size);
+
 R_API rpointer  r_memdup (rconstpointer src, rsize size) R_ATTR_MALLOC;
 R_API rsize     r_memagg (rpointer dst, rsize size, rsize * out, ...) R_ATTR_NULL_TERMINATED;
 R_API rsize     r_memaggv (rpointer dst, rsize size, rsize * out, va_list args);

--- a/include/rlib/rmem.h
+++ b/include/rlib/rmem.h
@@ -15,11 +15,39 @@
  * License along with this library.
  * See the COPYING file at the root of the source repository.
  */
+/**
+ * @defgroup r_mem Memory allocation and operations
+ * @brief Heap / stack allocators, byte-buffer operations, and
+ * pattern-based memory scanning.
+ * @{
+ */
+
+/**
+ * @file rlib/rmem.h
+ * @brief Memory allocation, byte-buffer operations, and pattern
+ * scanning.
+ *
+ * Contains:
+ *  - **Heap allocator wrappers** (@c r_malloc, @c r_calloc, ...)
+ *    routed through an installable @c RMemVTable so a process can
+ *    redirect every rlib allocation to a custom backend (test
+ *    harnesses, leak trackers, debug allocators).
+ *  - **Stack allocator macros** (@c r_alloca, @c r_mem_newa, ...)
+ *    that paper over the platform-specific @c alloca / @c _alloca /
+ *    @c __builtin_alloca declarations.
+ *  - **Byte-buffer ops** (@c r_memcpy, @c r_memset, ...) as static
+ *    inlines around the libc intrinsics, with NULL-pointer guards.
+ *    The constant-time variant @c r_memcmp_ct and the optimiser-
+ *    resistant @c r_memclear_secure live here too.
+ *  - **Variadic aggregator helpers** (@c r_memagg, @c r_memdup_agg)
+ *    that concatenate a NULL-terminated list of (ptr, size) pairs.
+ *  - **Byte / pattern scanners** for searching memory regions.
+ */
 #ifndef __R_MEM_H__
 #define __R_MEM_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rtypes.h>
@@ -47,46 +75,185 @@ R_END_DECLS
 
 R_BEGIN_DECLS
 
+/**
+ * @brief Pointer + length view of a memory region.
+ *
+ * Plain aggregate, no ownership semantics: callers manage @p data's
+ * lifetime themselves. Used as a value type in @c RMemScanToken.
+ */
 typedef struct {
-  ruint8 * data;
-  rsize size;
+  ruint8 * data;        /**< Pointer to the first byte of the region. */
+  rsize size;           /**< Region length in bytes. */
 } RMemChunk;
 
 
-/* Stack allocations */
+/* ----- Stack allocations ------------------------------------------- */
+
+/**
+ * @brief Allocate @p size bytes on the stack frame of the caller.
+ *
+ * Thin portability shim around @c alloca / @c _alloca /
+ * @c __builtin_alloca. Storage lives until the enclosing function
+ * returns; do not return or hand the pointer to code outside the
+ * caller's lifetime.
+ *
+ * @param size Number of bytes (typically a small constant - large
+ *             requests risk stack overflow).
+ */
 #define r_alloca(size)        alloca (size)
+
+/** @brief Stack-allocate @p size bytes and zero-fill them. */
 #define r_alloca0(size)       r_memclear (r_alloca (size), size)
+
+/** @brief Stack-allocate an array of @p n elements of @p type. */
 #define r_mem_newa_n(type, n) ((type*) r_alloca (sizeof (type) * (rsize) (n)))
+
+/** @brief Stack-allocate a zeroed array of @p n elements of @p type. */
 #define r_mem_newa0_n(type, n)((type*) (r_alloca0 (sizeof (type) * (rsize) (n)))
+
+/** @brief Stack-allocate a single instance of @p type. */
 #define r_mem_newa(type)      r_mem_newa_n (type, 1)
+
+/** @brief Stack-allocate a single zeroed instance of @p type. */
 #define r_mem_newa0(type)     r_mem_newa_n0 (type, 1)
 
-/* Heap allocations */
+
+/* ----- Heap allocations -------------------------------------------- */
+
+/**
+ * @brief Release a heap allocation obtained from @c r_malloc /
+ * @c r_malloc0 / @c r_calloc / @c r_realloc.
+ *
+ * Routes through the currently-installed @c RMemVTable. A @c NULL
+ * @p ptr is a no-op (matches libc @c free).
+ *
+ * @param ptr Allocation to release.
+ */
 R_API void     r_free     (rpointer ptr);
+
+/**
+ * @brief Allocate @p size uninitialised bytes on the heap.
+ *
+ * Routes through the currently-installed @c RMemVTable.
+ *
+ * @param size Number of bytes (zero is implementation-defined).
+ * @return Allocation pointer, or @c NULL on failure.
+ */
 R_API rpointer r_malloc   (rsize size) R_ATTR_MALLOC R_ATTR_ALLOC_SIZE_ARG(1);
+
+/**
+ * @brief Allocate @p size zero-initialised bytes on the heap.
+ *
+ * Implemented as @c calloc(1, size) through the active vtable.
+ *
+ * @param size Number of bytes.
+ * @return Allocation pointer, or @c NULL on failure.
+ */
 R_API rpointer r_malloc0  (rsize size) R_ATTR_MALLOC R_ATTR_ALLOC_SIZE_ARG(1);
+
+/**
+ * @brief Allocate @p count zero-initialised elements of @p size bytes.
+ *
+ * Mirrors libc @c calloc semantics: the allocation is zeroed and
+ * @c count * @c size is computed with overflow checking by the
+ * underlying allocator.
+ *
+ * @param count Number of elements.
+ * @param size  Size of each element in bytes.
+ * @return Allocation pointer, or @c NULL on failure.
+ */
 R_API rpointer r_calloc   (rsize count, rsize size) R_ATTR_ALLOC_SIZE_ARGS(1, 2);
+
+/**
+ * @brief Resize an existing allocation to @p size bytes.
+ *
+ * Mirrors libc @c realloc semantics, including the "@p ptr is
+ * @c NULL → fresh allocation" and "@p size is zero → may free"
+ * corners. The returned pointer is annotated
+ * @c R_ATTR_WARN_UNUSED_RESULT because forgetting to capture it
+ * leaks the prior allocation if @c realloc moved the block.
+ *
+ * @param ptr  Existing allocation (or @c NULL).
+ * @param size New size in bytes.
+ * @return New allocation pointer (which may equal @p ptr), or
+ *         @c NULL on failure (in which case @p ptr is untouched).
+ */
 R_API rpointer r_realloc  (rpointer ptr, rsize size) R_ATTR_WARN_UNUSED_RESULT;
+
+/** @brief Allocate an array of @p n elements of @p type. */
 #define r_mem_new_n(type, n)  ((type*) r_malloc (sizeof (type) * (rsize) (n)))
+
+/** @brief Allocate a zeroed array of @p n elements of @p type. */
 #define r_mem_new0_n(type, n) ((type*) r_malloc0 (sizeof (type) * (rsize) (n)))
+
+/** @brief Allocate a single instance of @p type. */
 #define r_mem_new(type)       r_mem_new_n (type, 1)
+
+/** @brief Allocate a single zeroed instance of @p type. */
 #define r_mem_new0(type)      r_mem_new0_n (type, 1)
 
+
+/* ----- Pluggable allocator vtable ---------------------------------- */
+
+/**
+ * @brief Allocator backend slots routed through by every rlib
+ * heap helper.
+ *
+ * The function-pointer signatures match libc @c malloc / @c calloc /
+ * @c realloc / @c free verbatim, so the default vtable is just the
+ * libc entries. A process may install a custom vtable (debug
+ * allocator, leak tracker, fixed-pool allocator, ...) at startup via
+ * @c r_mem_set_vtable.
+ */
 typedef struct {
-  rpointer (*malloc)  (rsize size);
-  rpointer (*calloc)  (rsize count, rsize size);
-  rpointer (*realloc) (rpointer ptr, rsize size);
-  void     (*free)    (rpointer ptr);
+  rpointer (*malloc)  (rsize size);                     /**< @c libc-malloc-equivalent slot. */
+  rpointer (*calloc)  (rsize count, rsize size);        /**< @c libc-calloc-equivalent slot. */
+  rpointer (*realloc) (rpointer ptr, rsize size);       /**< @c libc-realloc-equivalent slot. */
+  void     (*free)    (rpointer ptr);                   /**< @c libc-free-equivalent slot. */
 } RMemVTable;
 
+/**
+ * @brief Replace the active allocator vtable.
+ *
+ * Every subsequent @c r_malloc / @c r_calloc / @c r_realloc /
+ * @c r_free call routes through the new slots. Intended to be called
+ * once at process start; switching mid-flight risks freeing a pointer
+ * with a different backend than the one that allocated it.
+ *
+ * A @c NULL @p vtable, or a vtable with any @c NULL slot, is rejected
+ * (the active vtable is left untouched). This catches the otherwise-
+ * common bug of installing an incomplete vtable that crashes on the
+ * next allocation rather than at the install call.
+ *
+ * @param vtable Fully-populated vtable (must have all four slots
+ *               non-NULL).
+ */
 R_API void r_mem_set_vtable (RMemVTable * vtable);
-/* Copy the current vtable into *out. Pairs with r_mem_set_vtable so a
- * caller (typically a test) can save the active vtable, swap in its
- * own, then restore exactly the pointers it saw. Restoring via
- * r_mem_set_vtable with locally-typed { malloc, calloc, realloc, free }
- * is not safe across DLL boundaries on Windows - the test binary's
- * import thunks resolve to different addresses than the rlib DLL's. */
+
+/**
+ * @brief Copy the active vtable into @p *out.
+ *
+ * Pairs with @c r_mem_set_vtable so a caller (typically a test) can
+ * save the active vtable, swap in its own, then restore exactly the
+ * pointers it saw. Restoring via @c r_mem_set_vtable with locally-
+ * typed @c { malloc, @c calloc, @c realloc, @c free } is not safe
+ * across DLL boundaries on Windows - the test binary's import thunks
+ * resolve to different addresses than the rlib DLL's.
+ *
+ * @param out Destination vtable (must be non-NULL).
+ */
 R_API void r_mem_get_vtable (RMemVTable * out);
+
+/**
+ * @brief Whether the active vtable still points at libc.
+ *
+ * Useful as a sanity guard in code that absolutely must allocate
+ * through libc (e.g. interop with foreign code that will @c free
+ * the pointer itself).
+ *
+ * @return @c TRUE if the active vtable is the libc default,
+ *         @c FALSE if a custom vtable has been installed.
+ */
 R_API rboolean r_mem_using_system_default (void);
 
 
@@ -139,56 +306,222 @@ R_API int       r_memcmp_ct (rconstpointer a, rconstpointer b, rsize size);
  */
 R_API void      r_memclear_secure (rpointer ptr, rsize size);
 
+/**
+ * @brief Heap-allocate a copy of @p size bytes at @p src.
+ *
+ * Behaves like @c malloc + @c memcpy. A @c NULL @p src or zero
+ * @p size returns @c NULL (no allocation).
+ *
+ * @param src  Source bytes (may be @c NULL).
+ * @param size Number of bytes to duplicate.
+ * @return Newly-allocated copy, or @c NULL on @c NULL @p src,
+ *         zero @p size, or out-of-memory.
+ */
 R_API rpointer  r_memdup (rconstpointer src, rsize size) R_ATTR_MALLOC;
+
+/**
+ * @brief Aggregate (concatenate) a NULL-terminated list of byte
+ * chunks into @p dst.
+ *
+ * Variadic args are pairs of @c (rconstpointer, @c rsize) and the
+ * list terminates with a @c NULL pointer. Each chunk that fits within
+ * the remaining space in @p dst is copied and tallied; the first
+ * chunk that would overflow ends the aggregation. The total bytes
+ * written are returned via @p *out.
+ *
+ * @param dst  Destination buffer.
+ * @param size Capacity of @p dst in bytes.
+ * @param out  Receives the total bytes written (may be @c NULL).
+ * @return Number of chunks copied (which may be less than the number
+ *         supplied if @p dst filled up).
+ */
 R_API rsize     r_memagg (rpointer dst, rsize size, rsize * out, ...) R_ATTR_NULL_TERMINATED;
+
+/**
+ * @brief @c va_list variant of @c r_memagg.
+ *
+ * @param dst  Destination buffer.
+ * @param size Capacity of @p dst in bytes.
+ * @param out  Receives the total bytes written (may be @c NULL).
+ * @param args Pre-started @c va_list - the caller owns the
+ *             @c va_start / @c va_end book-keeping.
+ * @return Number of chunks copied.
+ */
 R_API rsize     r_memaggv (rpointer dst, rsize size, rsize * out, va_list args);
+
+/**
+ * @brief Aggregate a NULL-terminated list of byte chunks into a
+ * freshly-allocated buffer.
+ *
+ * The allocation is sized to exactly fit the supplied chunks (sum of
+ * all sizes in the variadic list). The total bytes written are
+ * returned via @p *out. Returns @c NULL on out-of-memory or if the
+ * list is empty.
+ *
+ * @param out Receives the total allocation size (may be @c NULL).
+ * @return Newly-allocated, fully-populated buffer, or @c NULL.
+ */
 R_API rpointer  r_memdup_agg (rsize * out, ...) R_ATTR_NULL_TERMINATED R_ATTR_MALLOC;
+
+/**
+ * @brief @c va_list variant of @c r_memdup_agg.
+ *
+ * @param out  Receives the total allocation size (may be @c NULL).
+ * @param args Pre-started @c va_list.
+ * @return Newly-allocated, fully-populated buffer, or @c NULL.
+ */
 R_API rpointer  r_memdup_aggv (rsize * out, va_list args) R_ATTR_MALLOC;
 
-/* memory scan operations */
+
+/* ----- Byte / pattern scanning ------------------------------------- */
+
+/**
+ * @brief Find the first occurrence of byte @p byte in @p mem.
+ *
+ * Equivalent in semantics to @c memchr but with rlib's NULL-tolerant
+ * convention.
+ *
+ * @param mem  Memory region (may be @c NULL).
+ * @param size Region length in bytes.
+ * @param byte Byte to search for.
+ * @return Pointer to the first match, or @c NULL if not found
+ *         (or @p mem is @c NULL).
+ */
 R_API rpointer r_mem_scan_byte (rconstpointer mem, rsize size, ruint8 byte);
+
+/**
+ * @brief Find the first byte in @p mem that matches any byte in the
+ * @p byte set.
+ *
+ * @param mem   Memory region (may be @c NULL).
+ * @param size  Region length in bytes.
+ * @param byte  Set of bytes to match (may be @c NULL).
+ * @param bytes Number of bytes in @p byte.
+ * @return Pointer to the first match, or @c NULL.
+ */
 R_API rpointer r_mem_scan_byte_any (rconstpointer mem, rsize size,
     const ruint8 * byte, rsize bytes);
+
+/**
+ * @brief Find the first occurrence of @p datasize-byte sequence
+ * @p data within @p mem.
+ *
+ * Naive byte-at-a-time search anchored on the first byte of @p data;
+ * suitable for small needles. For pattern matching with wildcards use
+ * @c r_mem_scan_pattern.
+ *
+ * @param mem      Haystack (may be @c NULL).
+ * @param size     Haystack length in bytes.
+ * @param data     Needle bytes (may be @c NULL).
+ * @param datasize Needle length in bytes.
+ * @return Pointer to the first match within @p mem, or @c NULL.
+ */
 R_API rpointer r_mem_scan_data (rconstpointer mem, rsize size,
     rconstpointer data, rsize datasize);
 
-/* memory scan for pattern */
+
+/**
+ * @brief Token classes produced by the @c r_mem_scan_pattern parser.
+ *
+ * The pattern grammar reads as ASCII tokens separated by whitespace:
+ *  - @c "AA" hex pair → @c R_MEM_TOKEN_BYTES (run of literal bytes)
+ *  - @c "??" → @c R_MEM_TOKEN_WILDCARD_SIZED (run of N wildcard bytes)
+ *  - @c "*" → @c R_MEM_TOKEN_WILDCARD (variable-length wildcard)
+ */
 typedef enum {
-  R_MEM_TOKEN_NONE = -1,
-  R_MEM_TOKEN_BYTES,
-  R_MEM_TOKEN_WILDCARD,
-  R_MEM_TOKEN_WILDCARD_SIZED,
+  R_MEM_TOKEN_NONE = -1,            /**< Pattern terminator / parse error. */
+  R_MEM_TOKEN_BYTES,                /**< Literal byte run (one or more hex pairs). */
+  R_MEM_TOKEN_WILDCARD,             /**< Variable-length wildcard (`*`). */
+  R_MEM_TOKEN_WILDCARD_SIZED,       /**< Fixed-length wildcard (run of `??`). */
   R_MEM_TOKEN_COUNT
 } RMemTokenType;
 
+/**
+ * @brief Status codes returned by @c r_mem_scan_pattern.
+ */
 typedef enum {
-  R_MEM_SCAN_RESULT_INVAL             = -4,
-  R_MEM_SCAN_RESULT_OOM               = -3,
-  R_MEM_SCAN_RESULT_INVALID_PATTERN   = -2,
-  R_MEM_SCAN_RESULT_PATTERN_NOT_IMPL  = -1,
-  R_MEM_SCAN_RESULT_OK                =  0,
-  R_MEM_SCAN_RESULT_NOT_FOUND
+  R_MEM_SCAN_RESULT_INVAL             = -4,   /**< @c NULL @p mem / @p pattern / @p result. */
+  R_MEM_SCAN_RESULT_OOM               = -3,   /**< Allocator returned @c NULL for the result struct. */
+  R_MEM_SCAN_RESULT_INVALID_PATTERN   = -2,   /**< Pattern failed to parse. */
+  R_MEM_SCAN_RESULT_PATTERN_NOT_IMPL  = -1,   /**< Pattern uses a feature not supported by this build. */
+  R_MEM_SCAN_RESULT_OK                =  0,   /**< Match found; @p *result populated. */
+  R_MEM_SCAN_RESULT_NOT_FOUND                 /**< Parsed cleanly, no match in @p mem. */
 } RMemScanResultType;
 
+/**
+ * @brief One token of a parsed scan pattern.
+ *
+ * @c type identifies the token class; @c pattern points back at the
+ * pattern string for the token's text; @c chunk locates the matching
+ * bytes inside the haystack once the scan succeeds.
+ */
 typedef struct _RMemScanToken {
-  RMemTokenType type;
-  const rchar * pattern;
-  RMemChunk chunk;
+  RMemTokenType type;               /**< Token class. */
+  const rchar * pattern;            /**< Borrowed pointer into the original pattern string. */
+  RMemChunk chunk;                  /**< Matched bytes inside the haystack. */
 } RMemScanToken;
 
+/**
+ * @brief Result of a successful @c r_mem_scan_pattern call.
+ *
+ * Allocated by @c r_mem_scan_pattern, owned by the caller -
+ * release with @c r_free. @c tokens is the parsed-token count; the
+ * variable-length @c token[] holds one @c RMemScanToken per pattern
+ * token, in order.
+ *
+ * @c ptr / @c end span the full match inside the haystack (closed-
+ * open interval).
+ */
 typedef struct _RMemScanResult {
-  rpointer ptr;
-  rpointer end;
-  rsize tokens;
-  RMemScanToken token[0];
+  rpointer ptr;                     /**< First byte of the overall match. */
+  rpointer end;                     /**< One past the last byte of the overall match. */
+  rsize tokens;                     /**< Number of entries in @c token[]. */
+  RMemScanToken token[0];           /**< Per-token chunks, length @c tokens. */
 } RMemScanResult;
 
+/**
+ * @brief Find the first match for @p pattern in @p mem (simple form).
+ *
+ * Wraps @c r_mem_scan_pattern for the common case where the caller
+ * only wants the match start (and optionally end) and doesn't need
+ * the per-token breakdown.
+ *
+ * @param mem     Haystack.
+ * @param size    Haystack length in bytes.
+ * @param pattern NUL-terminated pattern string.
+ * @param end     If non-NULL, receives one past the last byte of the
+ *                match.
+ * @return Pointer to the first byte of the match, or @c NULL on no
+ *         match / parse error / OOM.
+ */
 R_API rpointer r_mem_scan_simple_pattern (rconstpointer mem, rsize size,
     const rchar * pattern, rpointer * end);
+
+/**
+ * @brief Find the first match for @p pattern in @p mem, returning
+ * full per-token detail.
+ *
+ * Allocates an @c RMemScanResult sized to the parsed token count;
+ * the caller releases it with @c r_free. See @c RMemTokenType for the
+ * pattern grammar.
+ *
+ * @param mem     Haystack (must be non-NULL).
+ * @param size    Haystack length in bytes.
+ * @param pattern NUL-terminated pattern string (must be non-NULL).
+ * @param result  Receives the freshly-allocated result struct (must
+ *                be non-NULL). Set to @c NULL if no allocation was
+ *                attempted.
+ * @return @c R_MEM_SCAN_RESULT_OK on match,
+ *         @c R_MEM_SCAN_RESULT_NOT_FOUND if the pattern parsed but
+ *         didn't match,
+ *         a negative @c RMemScanResultType code on error.
+ */
 R_API RMemScanResultType r_mem_scan_pattern (rconstpointer mem, rsize size,
     const rchar * pattern, RMemScanResult ** result);
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_MEM_H__ */
 

--- a/include/rlib/rmemallocator.h
+++ b/include/rlib/rmemallocator.h
@@ -15,11 +15,45 @@
  * License along with this library.
  * See the COPYING file at the root of the source repository.
  */
+/**
+ * @defgroup r_mem_allocator Refcounted memory chunks and pluggable allocators
+ * @brief Abstract memory-chunk type (@c RMem) with a pluggable
+ * backend (@c RMemAllocator). Inspired by GStreamer's @c GstMemory /
+ * @c GstAllocator design.
+ * @{
+ */
+
+/**
+ * @file rlib/rmemallocator.h
+ * @brief Refcounted memory-chunk abstraction with allocator vtables.
+ *
+ * @c RMem wraps a byte region (with @p allocsize total bytes plus a
+ * visible @p offset / @p size window) and routes operations through
+ * an @c RMemAllocator vtable - so the same client-side API works on
+ * heap memory, shared memory, GPU-mapped buffers, file mappings,
+ * etc. Each chunk carries flags (read-only, view-prohibited, zero-
+ * prefixed / -padded) that the high-level helpers honour.
+ *
+ * Allocators are looked up by name (@c R_MEM_ALLOCATOR_SYSTEM is the
+ * default heap allocator). Custom allocators register themselves at
+ * init time and become discoverable via @c r_mem_allocator_find.
+ *
+ * **Reference counting**: both @c RMem and @c RMemAllocator are
+ * @c RRef-based; use the @c _ref / @c _unref helpers.
+ *
+ * **Mapping**: to read or write the underlying bytes, wrap accesses
+ * in @c r_mem_map / @c r_mem_unmap - the @c RMemMapInfo carries the
+ * data pointer plus the allocator-specific bookkeeping that
+ * @c unmap needs.
+ *
+ * The implementation of @c RMem and @c RMemAllocator is heavily
+ * inspired by the GStreamer equivalents.
+ */
 #ifndef __R_MEM_ALLOCATOR_H__
 #define __R_MEM_ALLOCATOR_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rtypes.h>
@@ -28,48 +62,86 @@
 
 #include <stdarg.h>
 
-/**
- * The implementation of RMem and RMemAllocator is heavily inspired by the
- * GStreamer equivalents.
- */
-
 R_BEGIN_DECLS
 
+/**
+ * @brief Per-chunk flags carried on every @c RMem.
+ *
+ * Combined as a bitmask in @c RMemFlags. Honoured by the high-level
+ * helpers (read-only chunks reject @c r_mem_resize and write
+ * mappings; view-prohibited chunks reject @c r_mem_view).
+ */
 typedef enum {
-  R_MEM_FLAG_NONE             = 0,
-  R_MEM_FLAG_READONLY         = (1 << 0),
-  R_MEM_FLAG_NO_VIEWS         = (1 << 1),
-  R_MEM_FLAG_ZERO_PREFIXED    = (1 << 2),
-  R_MEM_FLAG_ZERO_PADDED      = (1 << 3),
+  R_MEM_FLAG_NONE             = 0,            /**< No flags. */
+  R_MEM_FLAG_READONLY         = (1 << 0),     /**< Underlying bytes are immutable. */
+  R_MEM_FLAG_NO_VIEWS         = (1 << 1),     /**< @c r_mem_view will refuse to create aliased subviews. */
+  R_MEM_FLAG_ZERO_PREFIXED    = (1 << 2),     /**< The bytes before @p offset are known to be zero. */
+  R_MEM_FLAG_ZERO_PADDED      = (1 << 3),     /**< The bytes after @p offset+@p size are known to be zero. */
 } RMemFlag;
+
+/** @brief Bitmask of @c RMemFlag values. */
 typedef ruint32 RMemFlags;
 
+/**
+ * @brief Mapping-access flags passed to @c r_mem_map.
+ *
+ * Choose @c R_MEM_MAP_READ for read-only access, @c R_MEM_MAP_WRITE
+ * for write-only, or @c R_MEM_MAP_RW for both. Allocator-specific
+ * extensions may use bits up to @c R_MEM_MAP_FLAG_LAST.
+ */
 typedef enum {
-  R_MEM_MAP_READ      = (1 << 0),
-  R_MEM_MAP_WRITE     = (1 << 1),
-  R_MEM_MAP_FLAG_LAST = (1 << 8)
+  R_MEM_MAP_READ      = (1 << 0),             /**< Caller will read from the mapping. */
+  R_MEM_MAP_WRITE     = (1 << 1),             /**< Caller will write to the mapping. */
+  R_MEM_MAP_FLAG_LAST = (1 << 8)              /**< Reserved cutoff; allocator-specific bits live below. */
 } RMemMapFlag;
+
+/** @brief Convenience: read + write access. */
 #define R_MEM_MAP_RW    (R_MEM_MAP_READ | R_MEM_MAP_WRITE)
+
+/** @brief Bitmask of @c RMemMapFlag values. */
 typedef ruint32 RMemMapFlags;
 
+/** @brief Name of the built-in system / heap allocator. */
 #define R_MEM_ALLOCATOR_SYSTEM        "system"
+
+/** @brief Opaque handle to an allocator backend. */
 typedef struct _RMemAllocator         RMemAllocator;
+/** @brief Opaque handle to a refcounted memory chunk. */
 typedef struct _RMem                  RMem;
 
+/**
+ * @brief Allocation-time constraints passed to @c r_mem_allocator_alloc
+ * and the merge / take helpers.
+ *
+ * @c flags seed the resulting chunk; @c alignmask, @c prefix and
+ * @c padding constrain the layout (alignment of the visible region
+ * plus pad bytes before / after).
+ */
 typedef struct {
-  RMemFlags       flags;
-  rsize           alignmask;
-  rsize           prefix;
-  rsize           padding;
+  RMemFlags       flags;            /**< Initial flags on the produced chunk. */
+  rsize           alignmask;        /**< Power-of-two-minus-one alignment of the visible region (e.g. 0x0F = 16-byte aligned). */
+  rsize           prefix;           /**< Bytes of guaranteed-zero padding before the visible region. */
+  rsize           padding;          /**< Bytes of guaranteed-zero padding after the visible region. */
 } RMemAllocationParams;
 
+/** @brief Zero-init for an @c RMemMapInfo declared on the stack. */
 #define R_MEM_MAP_INFO_INIT { NULL, 0, 0, 0, NULL }
+
+/**
+ * @brief Scope object carried by an active mapping.
+ *
+ * Populated by @c r_mem_map, passed back unchanged to
+ * @c r_mem_unmap so the allocator can release whatever resources the
+ * mapping acquired (file handles, GPU sync points, etc.). @c data is
+ * the bytes the caller can touch; @c size is the visible-window
+ * length, @c allocsize is the underlying allocation length.
+ */
 typedef struct {
-  ruint8 *      data;
-  rsize         size;
-  rsize         allocsize;
-  RMemMapFlags  flags;
-  RMem *        mem;
+  ruint8 *      data;               /**< Pointer to the first visible byte. */
+  rsize         size;               /**< Visible window length in bytes. */
+  rsize         allocsize;          /**< Underlying allocation length in bytes. */
+  RMemMapFlags  flags;              /**< Mapping access flags supplied to @c r_mem_map. */
+  RMem *        mem;                /**< Owning chunk (refcounted by @c r_mem_map, released by @c r_mem_unmap). */
 } RMemMapInfo;
 
 
@@ -77,9 +149,37 @@ typedef struct {
 /* RMem - Memory chunks                                                       */
 /******************************************************************************/
 
-/* Convenience for wrapping normal system memory */
+/**
+ * @brief Wrap an existing pointer in an @c RMem without copying.
+ *
+ * Used to hand raw bytes to a system that expects @c RMem-shaped
+ * input (e.g. zero-copy ingestion of a parsed file). The
+ * @p usernotify callback runs (with @p user as argument) when the
+ * last reference drops, so the caller controls cleanup.
+ *
+ * @param flags      Initial @c RMemFlags (typically @c R_MEM_FLAG_READONLY
+ *                   for borrowed buffers).
+ * @param data       Pointer to the first byte.
+ * @param allocsize  Underlying allocation length in bytes.
+ * @param size       Visible window length in bytes.
+ * @param offset     Visible window offset within @p data.
+ * @param user       Cookie passed to @p usernotify on free.
+ * @param usernotify Destroy callback (may be @c NULL for borrowed memory).
+ * @return New @c RMem reference, or @c NULL on allocation failure.
+ */
 R_API RMem * r_mem_new_wrapped (RMemFlags flags, rpointer data, rsize allocsize,
     rsize size, rsize offset, rpointer user, RDestroyNotify usernotify) R_ATTR_WARN_UNUSED_RESULT;
+
+/**
+ * @brief Wrap an existing heap allocation in an @c RMem and transfer
+ * ownership.
+ *
+ * Convenience for the common case where the wrapped buffer was
+ * obtained from @c r_malloc: when the last reference drops the
+ * wrapper calls @c r_free on @p data. Equivalent to
+ * @c r_mem_new_wrapped @c (flags, data, allocsize, size, offset,
+ * data, r_free).
+ */
 static inline RMem * r_mem_new_take(RMemFlags flags, rpointer data,
     rsize allocsize, rsize size, rsize offset)
 {
@@ -88,46 +188,197 @@ static inline RMem * r_mem_new_take(RMemFlags flags, rpointer data,
 
 /* Abstract RMem functionality */
 
+/** @brief Acquire a new reference to an @c RMem. */
 #define r_mem_ref     r_ref_ref
+
+/** @brief Release a reference; frees the chunk when the last drops. */
 #define r_mem_unref   r_ref_unref
+
+/**
+ * @brief Adjust the visible window inside @p mem.
+ *
+ * Moves @p offset and / or shrinks / grows @p size within the
+ * underlying allocation. Refuses to operate on read-only chunks or
+ * to expand past the allocation bounds. Clears
+ * @c R_MEM_FLAG_ZERO_PREFIXED / @c R_MEM_FLAG_ZERO_PADDED when the
+ * window moves over the corresponding zero region.
+ *
+ * @param mem    Chunk to resize (must be writable).
+ * @param offset New visible-window offset (bytes from start of
+ *               allocation).
+ * @param size   New visible-window size in bytes.
+ * @return @c TRUE on success, @c FALSE on read-only chunk or
+ *         out-of-bounds @p offset + @p size.
+ */
 R_API rboolean  r_mem_resize (RMem * mem, rsize offset, rsize size);
+
+/**
+ * @brief Open a scoped mapping over @p mem's bytes.
+ *
+ * Acquires an extra reference on @p mem (released by
+ * @c r_mem_unmap) and populates @p info with a pointer the caller
+ * may read from / write to per @p flags. Write mappings are refused
+ * on read-only chunks.
+ *
+ * @param mem   Chunk to map.
+ * @param info  Output @c RMemMapInfo - typically stack-allocated and
+ *              initialised with @c R_MEM_MAP_INFO_INIT.
+ * @param flags Access flags (@c R_MEM_MAP_READ, @c R_MEM_MAP_WRITE,
+ *              or @c R_MEM_MAP_RW).
+ * @return @c TRUE on success, @c FALSE on conflicting flags or
+ *         allocator-level mapping failure.
+ */
 R_API rboolean  r_mem_map   (RMem * mem, RMemMapInfo * info, RMemMapFlags flags);
+
+/**
+ * @brief Close a mapping previously opened with @c r_mem_map.
+ *
+ * Calls the allocator's @c unmap callback and releases the @c RMem
+ * reference recorded in @p info.
+ *
+ * @param mem  Chunk that was mapped (must match @p info->mem).
+ * @param info The same @c RMemMapInfo that @c r_mem_map populated.
+ * @return @c TRUE on successful release, @c FALSE if the allocator
+ *         refused (rare; typically a programming error).
+ */
 R_API rboolean  r_mem_unmap (RMem * mem, RMemMapInfo * info);
+
+/**
+ * @brief Deep-copy a byte range from @p mem into a fresh @c RMem.
+ *
+ * Negative @p offset / @p size are interpreted relative to the
+ * chunk's bounds (allocator-specific convention; commonly @p size
+ * < 0 means "to end").
+ *
+ * @param mem    Source chunk.
+ * @param offset Offset within @p mem (signed).
+ * @param size   Length (signed; negative often means "to end").
+ * @return Newly-allocated chunk, or @c NULL on failure.
+ */
 R_API RMem *    r_mem_copy  (RMem * mem, rssize offset, rssize size) R_ATTR_WARN_UNUSED_RESULT;
+
+/**
+ * @brief Create an aliased view onto a byte range of @p mem.
+ *
+ * The view shares the underlying allocation with @p mem (no copy).
+ * Refused if @p mem has @c R_MEM_FLAG_NO_VIEWS.
+ *
+ * @param mem    Source chunk.
+ * @param offset Offset within @p mem (signed).
+ * @param size   Length (signed; negative often means "to end").
+ * @return New @c RMem reference aliasing @p mem, or @c NULL.
+ */
 R_API RMem *    r_mem_view  (RMem * mem, rssize offset, rssize size) R_ATTR_WARN_UNUSED_RESULT;
+
+/**
+ * @brief Concatenate two or more chunks into a fresh @c RMem.
+ *
+ * Variadic args are @c RMem* terminated by @c NULL. The inputs are
+ * left unchanged (their refcounts are unaffected). Use @c r_mem_take
+ * for the equivalent that consumes the inputs.
+ *
+ * @param params Allocation constraints for the result (may be @c NULL
+ *               for defaults).
+ * @param a      First chunk (must be non-NULL).
+ * @param ...    Remaining chunks, terminated by @c NULL.
+ * @return Newly-allocated, fully-populated chunk, or @c NULL.
+ */
 R_API RMem *    r_mem_merge (const RMemAllocationParams * params,
     RMem * a, ...) R_ATTR_NULL_TERMINATED R_ATTR_WARN_UNUSED_RESULT;
+
+/** @brief @c va_list variant of @c r_mem_merge. */
 R_API RMem *    r_mem_mergev (const RMemAllocationParams * params,
     RMem * a, va_list args) R_ATTR_WARN_UNUSED_RESULT;
+
+/** @brief Array variant of @c r_mem_merge - @p mems is a @p count-long array of chunk pointers. */
 R_API RMem *    r_mem_merge_array (const RMemAllocationParams * params,
     RMem ** mems, ruint count) R_ATTR_WARN_UNUSED_RESULT;
+
+/**
+ * @brief Concatenate chunks (as @c r_mem_merge) but @c unref the inputs.
+ *
+ * Transfers ownership: on success the supplied chunks are
+ * @c r_mem_unref'd. Convenient pattern for assembling a buffer from
+ * intermediate scratch chunks the caller doesn't want to keep.
+ *
+ * @param params Allocation constraints for the result (may be @c NULL).
+ * @param a      First chunk.
+ * @param ...    Remaining chunks, terminated by @c NULL.
+ * @return Newly-allocated chunk, or @c NULL (in which case input
+ *         refcounts are untouched).
+ */
 R_API RMem *    r_mem_take (const RMemAllocationParams * params,
     RMem * a, ...) R_ATTR_NULL_TERMINATED R_ATTR_WARN_UNUSED_RESULT;
+
+/** @brief @c va_list variant of @c r_mem_take. */
 R_API RMem *    r_mem_takev (const RMemAllocationParams * params,
     RMem * a, va_list args) R_ATTR_WARN_UNUSED_RESULT;
+
+/** @brief Array variant of @c r_mem_take - consumes references in @p mems on success. */
 R_API RMem *    r_mem_take_array (const RMemAllocationParams * params,
     RMem ** mems, ruint count) R_ATTR_WARN_UNUSED_RESULT;
+
+/** @brief @c TRUE if @p mem carries @c R_MEM_FLAG_READONLY. */
 #define r_mem_is_readonly(mem)        (mem->flags & R_MEM_FLAG_READONLY)
+
+/** @brief @c TRUE if @p mem can accept writes. */
 #define r_mem_is_writable(mem)       ((mem->flags & R_MEM_FLAG_READONLY) == 0)
+
+/** @brief @c TRUE if @p mem carries @c R_MEM_FLAG_ZERO_PREFIXED. */
 #define r_mem_is_zero_prefixed(mem)   (mem->flags & R_MEM_FLAG_ZERO_PREFIXED)
+
+/** @brief @c TRUE if @p mem carries @c R_MEM_FLAG_ZERO_PADDED. */
 #define r_mem_is_zero_padded(mem)     (mem->flags & R_MEM_FLAG_ZERO_PADDED)
 
+/**
+ * @brief Concrete layout of an @c RMem chunk.
+ *
+ * Fields are visible because allocator implementations need to fill
+ * them in; client code should treat the struct as opaque and use the
+ * accessor macros (@c r_mem_is_*).
+ */
 struct _RMem {
-  RRef            ref;
-  RMemFlags       flags;
-  RMemAllocator * allocator;
-  RMem *          parent;
+  RRef            ref;              /**< Refcount base (handled by @c r_ref_ref / @c r_ref_unref). */
+  RMemFlags       flags;            /**< @c RMemFlag bitmask. */
+  RMemAllocator * allocator;        /**< Backend that produced this chunk. */
+  RMem *          parent;           /**< Parent chunk for view aliases, @c NULL otherwise. */
 
-  rsize           allocsize;
-  rsize           size;
-  rsize           alignmask;
-  rsize           offset;
+  rsize           allocsize;        /**< Total underlying allocation length. */
+  rsize           size;             /**< Visible window length. */
+  rsize           alignmask;        /**< Alignment guarantee on the visible region (power-of-two minus one). */
+  rsize           offset;           /**< Visible window offset within @c allocsize. */
 };
 
-/* Theses should only be called from the spesific RMem implementations */
+/**
+ * @brief Allocator-implementation helper: populate an @c RMem's
+ * common fields and arm its destructor.
+ *
+ * Intended only for use inside an @c RMemAllocator's @c alloc
+ * callback. Not part of the public client API.
+ *
+ * @param mem        Memory chunk to initialise.
+ * @param notify     Destroy callback invoked when the last reference drops.
+ * @param flags      Initial @c RMemFlags.
+ * @param allocator  Owning allocator (must be ref-counted).
+ * @param parent     Parent chunk for view aliases, @c NULL otherwise.
+ * @param allocsize  Underlying allocation length.
+ * @param size       Visible window length.
+ * @param alignmask  Alignment guarantee on the visible region.
+ * @param offset     Visible window offset within @p allocsize.
+ */
 R_API void      r_mem_init  (RMem * mem, RDestroyNotify notify,
     RMemFlags flags, RMemAllocator * allocator, RMem * parent,
     rsize allocsize, rsize size, rsize alignmask, rsize offset);
+
+/**
+ * @brief Allocator-implementation helper: release the references an
+ * @c RMem holds (parent, allocator).
+ *
+ * Intended only for use inside an @c RMemAllocator's @c free
+ * callback before it releases the chunk's backing storage.
+ *
+ * @param mem Memory chunk being torn down.
+ */
 R_API void      r_mem_clear (RMem * mem);
 
 
@@ -135,16 +386,61 @@ R_API void      r_mem_clear (RMem * mem);
 /* RMemAllocator - Memory allocator                                           */
 /******************************************************************************/
 
-/* Getting/finding and registering allocators */
+/**
+ * @brief Convenience for the built-in system / heap allocator.
+ *
+ * Equivalent to @c r_mem_allocator_find(@c R_MEM_ALLOCATOR_SYSTEM).
+ */
 #define r_mem_allocator_default() r_mem_allocator_find (R_MEM_ALLOCATOR_SYSTEM)
+
+/**
+ * @brief Look up a registered allocator by name.
+ *
+ * Returns a new reference on success (caller releases with
+ * @c r_mem_allocator_unref).
+ *
+ * @param name Allocator name (e.g. @c R_MEM_ALLOCATOR_SYSTEM).
+ * @return New allocator reference, or @c NULL if no allocator with
+ *         that name is registered.
+ */
 R_API RMemAllocator * r_mem_allocator_find            (const rchar * name) R_ATTR_WARN_UNUSED_RESULT;
+
+/**
+ * @brief Register an allocator so it can be looked up by name.
+ *
+ * Adds @p allocator to the process-wide registry under @p allocator->mem_type.
+ * The registry takes a reference; the caller may safely drop its
+ * own reference afterwards.
+ *
+ * @param allocator Allocator to register (must have a non-NULL
+ *                  @c mem_type).
+ */
 R_API void            r_mem_allocator_register        (RMemAllocator * allocator);
 
 /* Abstract RMemAllocator functionality */
+
+/** @brief Acquire a new reference to an @c RMemAllocator. */
 #define r_mem_allocator_ref   r_ref_ref
+
+/** @brief Release a reference to an @c RMemAllocator. */
 #define r_mem_allocator_unref r_ref_unref
+
+/**
+ * @brief Allocate a new @c RMem chunk via @p allocator.
+ *
+ * @param allocator Allocator to use (must be non-NULL).
+ * @param size      Visible window size in bytes.
+ * @param params    Allocation constraints (alignment, prefix /
+ *                  padding, initial flags).
+ * @return New chunk reference, or @c NULL on failure.
+ */
 R_API RMem * r_mem_allocator_alloc_full (RMemAllocator * allocator, rsize size,
     const RMemAllocationParams * params) R_ATTR_WARN_UNUSED_RESULT;
+
+/**
+ * @brief Convenience for @c r_mem_allocator_alloc_full with the
+ * params spelled out as individual arguments.
+ */
 static inline RMem *
 r_mem_allocator_alloc (RMemAllocator * allocator, RMemFlags flags, rsize size,
     rsize prefix, rsize padding, rsize alignmask)
@@ -153,22 +449,31 @@ r_mem_allocator_alloc (RMemAllocator * allocator, RMemFlags flags, rsize size,
   return r_mem_allocator_alloc_full (allocator, size, &params);
 }
 
+/**
+ * @brief Concrete layout of an @c RMemAllocator.
+ *
+ * Allocator implementations fill in the @c mem_type / @c alignmask
+ * fields and the seven vtable slots. Client code treats the struct
+ * as opaque and goes through the helpers above.
+ */
 struct _RMemAllocator {
-  RRef            ref;
-  const rchar *   mem_type;
-  rsize           alignmask;
+  RRef            ref;              /**< Refcount base. */
+  const rchar *   mem_type;         /**< Registry name (e.g. @c R_MEM_ALLOCATOR_SYSTEM). */
+  rsize           alignmask;        /**< Native alignment guarantee of this allocator. */
 
-  RMem *    (*alloc)  (RMemAllocator * allocator, rsize size, const RMemAllocationParams * params);
-  rboolean  (*free)   (RMemAllocator * allocator, RMem * mem);
-  rpointer  (*map)    (RMem * mem, const RMemMapInfo * info);
-  rboolean  (*unmap)  (RMem * mem, const RMemMapInfo * info);
-  RMem *    (*merge)  (const RMemAllocationParams * params, RMem ** mems, ruint count);
-  RMem *    (*copy)   (RMem * mem, rssize offset, rssize size);
-  RMem *    (*view)   (RMem * mem, rssize offset, rssize size);
+  RMem *    (*alloc)  (RMemAllocator * allocator, rsize size, const RMemAllocationParams * params);  /**< Produce a new chunk. */
+  rboolean  (*free)   (RMemAllocator * allocator, RMem * mem);                                       /**< Release a chunk's backing storage. */
+  rpointer  (*map)    (RMem * mem, const RMemMapInfo * info);                                        /**< Acquire a data pointer for @c r_mem_map. */
+  rboolean  (*unmap)  (RMem * mem, const RMemMapInfo * info);                                        /**< Release the data pointer for @c r_mem_unmap. */
+  RMem *    (*merge)  (const RMemAllocationParams * params, RMem ** mems, ruint count);              /**< Concatenate @p mems into a fresh chunk. */
+  RMem *    (*copy)   (RMem * mem, rssize offset, rssize size);                                      /**< Deep-copy a byte range. */
+  RMem *    (*view)   (RMem * mem, rssize offset, rssize size);                                      /**< Create an aliased view. */
 };
 
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_MEM_ALLOCATOR_H__ */
 

--- a/include/rlib/rmemfile.h
+++ b/include/rlib/rmemfile.h
@@ -15,11 +15,31 @@
  * License along with this library.
  * See the COPYING file at the root of the source repository.
  */
+/**
+ * @defgroup r_mem_file Memory-mapped file regions
+ * @brief Map a whole file (or an open file handle) into the process
+ * address space as a single contiguous byte buffer.
+ * @{
+ */
+
+/**
+ * @file rlib/rmemfile.h
+ * @brief Memory-mapped file API.
+ *
+ * Thin portability wrapper around @c mmap on POSIX and
+ * @c CreateFileMapping / @c MapViewOfFile on Win32. Maps the entire
+ * file at construction time; the resulting @c RMemFile is a
+ * refcounted view (use @c r_mem_file_ref / @c r_mem_file_unref).
+ *
+ * Useful for read-only parsing of file-backed binary formats (ELF,
+ * PE, PDF, etc.) where you want a single pointer + length to feed
+ * into a streaming parser instead of doing buffered @c read calls.
+ */
 #ifndef __R_MEM_FILE_H__
 #define __R_MEM_FILE_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rtypes.h>
@@ -27,24 +47,92 @@
 
 R_BEGIN_DECLS
 
+/**
+ * @brief Opaque handle to a memory-mapped file region.
+ *
+ * Refcounted; obtain a new reference with @c r_mem_file_ref, release
+ * with @c r_mem_file_unref. The underlying mapping is torn down when
+ * the last reference drops.
+ */
 typedef struct _RMemFile RMemFile;
 
+/**
+ * @brief Page-level protection flags for the mapping.
+ *
+ * Combined with bitwise-OR. Mirrors POSIX @c PROT_* and Win32
+ * @c PAGE_* semantics. @c R_MEM_PROT_WRITE on its own is rarely
+ * useful - pair with @c R_MEM_PROT_READ.
+ */
 typedef enum {
-  R_MEM_PROT_NONE   = 0x0,
-  R_MEM_PROT_READ   = 0x1,
-  R_MEM_PROT_WRITE  = 0x2,
-  R_MEM_PROT_EXEC   = 0x4,
+  R_MEM_PROT_NONE   = 0x0,          /**< No access. */
+  R_MEM_PROT_READ   = 0x1,          /**< Pages may be read. */
+  R_MEM_PROT_WRITE  = 0x2,          /**< Pages may be written. */
+  R_MEM_PROT_EXEC   = 0x4,          /**< Pages may be executed. */
 } RMemProt;
 
+/**
+ * @brief Map @p file into memory by pathname.
+ *
+ * Opens @p file, maps it, and closes the file handle (the kernel
+ * keeps the mapping alive). Equivalent to @c r_mem_file_new_from_handle
+ * with the file-open step folded in.
+ *
+ * @param file      Filesystem path.
+ * @param prot      Page-protection flags (see @c RMemProt).
+ * @param writeback If @c TRUE and @p prot includes @c R_MEM_PROT_WRITE,
+ *                  writes propagate back to the file
+ *                  (@c MAP_SHARED on POSIX). If @c FALSE writes go to
+ *                  a private copy (@c MAP_PRIVATE).
+ * @return A new @c RMemFile reference, or @c NULL on open / map
+ *         failure.
+ */
 R_API RMemFile * r_mem_file_new (const rchar * file, RMemProt prot, rboolean writeback) R_ATTR_MALLOC;
+
+/**
+ * @brief Map an already-opened file handle into memory.
+ *
+ * Lets the caller control the open flags (e.g. unicode paths,
+ * @c O_DIRECT, OS-specific share modes). The mapping outlives the
+ * handle's open state - on Win32 the @c CreateFileMapping object
+ * keeps the file alive; on POSIX the kernel reference counts the
+ * inode.
+ *
+ * @param handle    An open file handle (rlib's @c RIOHandle type).
+ * @param prot      Page-protection flags.
+ * @param writeback Write-back behaviour (see @c r_mem_file_new).
+ * @return A new @c RMemFile reference, or @c NULL on map failure.
+ */
 R_API RMemFile * r_mem_file_new_from_handle (RIOHandle handle, RMemProt prot, rboolean writeback) R_ATTR_MALLOC;
+
+/** @brief Acquire a new reference to @p file. */
 #define r_mem_file_ref r_ref_ref
+
+/** @brief Release a reference to @p file; unmaps when the last drops. */
 #define r_mem_file_unref r_ref_unref
 
+/**
+ * @brief Size of the mapped region in bytes.
+ *
+ * @param file Mapped file (may be @c NULL, returns 0).
+ * @return File size in bytes.
+ */
 R_API rsize r_mem_file_get_size (RMemFile * file);
+
+/**
+ * @brief Pointer to the first byte of the mapped region.
+ *
+ * The returned pointer is valid until the last @c RMemFile reference
+ * is dropped. May be @c NULL for empty files or if the mapping
+ * failed silently (e.g. platform without @c mmap and no Win32 path).
+ *
+ * @param file Mapped file (may be @c NULL, returns @c NULL).
+ * @return Pointer to the first mapped byte.
+ */
 R_API rpointer r_mem_file_get_mem (RMemFile * file);
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_MEM_FILE_H__ */
 

--- a/include/rlib/rtypes.h
+++ b/include/rlib/rtypes.h
@@ -348,6 +348,7 @@ R_END_DECLS
 
 /** @} */ /* r_types group */
 
+#include <rlib/types/rmemops.h>
 #include <rlib/types/rendianness.h>
 #include <rlib/types/rbitops.h>
 

--- a/include/rlib/types/rendianness.h
+++ b/include/rlib/types/rendianness.h
@@ -210,68 +210,68 @@ R_BEGIN_DECLS
 static inline ruint16 r_load_be16 (const void * p)
 {
   ruint16 v;
-  r_memcpy_inline (&v, p, sizeof (v));
+  memcpy (&v, p, sizeof (v));
   return RUINT16_FROM_BE (v);
 }
 static inline ruint32 r_load_be32 (const void * p)
 {
   ruint32 v;
-  r_memcpy_inline (&v, p, sizeof (v));
+  memcpy (&v, p, sizeof (v));
   return RUINT32_FROM_BE (v);
 }
 static inline ruint64 r_load_be64 (const void * p)
 {
   ruint64 v;
-  r_memcpy_inline (&v, p, sizeof (v));
+  memcpy (&v, p, sizeof (v));
   return RUINT64_FROM_BE (v);
 }
 static inline ruint16 r_load_le16 (const void * p)
 {
   ruint16 v;
-  r_memcpy_inline (&v, p, sizeof (v));
+  memcpy (&v, p, sizeof (v));
   return RUINT16_FROM_LE (v);
 }
 static inline ruint32 r_load_le32 (const void * p)
 {
   ruint32 v;
-  r_memcpy_inline (&v, p, sizeof (v));
+  memcpy (&v, p, sizeof (v));
   return RUINT32_FROM_LE (v);
 }
 static inline ruint64 r_load_le64 (const void * p)
 {
   ruint64 v;
-  r_memcpy_inline (&v, p, sizeof (v));
+  memcpy (&v, p, sizeof (v));
   return RUINT64_FROM_LE (v);
 }
 static inline void r_store_be16 (void * p, ruint16 v)
 {
   ruint16 be = RUINT16_TO_BE (v);
-  r_memcpy_inline (p, &be, sizeof (be));
+  memcpy (p, &be, sizeof (be));
 }
 static inline void r_store_be32 (void * p, ruint32 v)
 {
   ruint32 be = RUINT32_TO_BE (v);
-  r_memcpy_inline (p, &be, sizeof (be));
+  memcpy (p, &be, sizeof (be));
 }
 static inline void r_store_be64 (void * p, ruint64 v)
 {
   ruint64 be = RUINT64_TO_BE (v);
-  r_memcpy_inline (p, &be, sizeof (be));
+  memcpy (p, &be, sizeof (be));
 }
 static inline void r_store_le16 (void * p, ruint16 v)
 {
   ruint16 le = RUINT16_TO_LE (v);
-  r_memcpy_inline (p, &le, sizeof (le));
+  memcpy (p, &le, sizeof (le));
 }
 static inline void r_store_le32 (void * p, ruint32 v)
 {
   ruint32 le = RUINT32_TO_LE (v);
-  r_memcpy_inline (p, &le, sizeof (le));
+  memcpy (p, &le, sizeof (le));
 }
 static inline void r_store_le64 (void * p, ruint64 v)
 {
   ruint64 le = RUINT64_TO_LE (v);
-  r_memcpy_inline (p, &le, sizeof (le));
+  memcpy (p, &le, sizeof (le));
 }
 
 R_END_DECLS

--- a/include/rlib/types/rmacros.h
+++ b/include/rlib/types/rmacros.h
@@ -144,16 +144,6 @@
 #define R_UNLIKELY(expr)    (expr)
 #endif
 
-/* Inline byte-copy intrinsic intended for compile-time-sized copies that
- * the compiler can fold to a single load/store. Use this in inline helpers
- * where calling the out-of-line r_memcpy() would defeat the point. */
-#if defined(__GNUC__) || defined(__clang__)
-#define r_memcpy_inline(dst, src, n) __builtin_memcpy ((dst), (src), (n))
-#else
-#include <string.h>
-#define r_memcpy_inline(dst, src, n) memcpy ((dst), (src), (n))
-#endif
-
 #if defined(__GNUC__)
 #if __MACH__
 #define R_ATTR_DATA_SECTION(sec)   __attribute__((section("__DATA,"sec)))

--- a/include/rlib/types/rmemops.h
+++ b/include/rlib/types/rmemops.h
@@ -1,0 +1,153 @@
+/* RLIB - Convenience library for useful things
+ * Copyright (C) 2026  Haakon Sporsheim <haakon.sporsheim@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ * See the COPYING file at the root of the source repository.
+ */
+
+/**
+ * @defgroup r_mem_ops Inline byte-buffer primitives
+ * @ingroup r_mem
+ * @brief Inline @c memcmp / @c memcpy / @c memmove / @c memset
+ * wrappers with rlib's NULL-tolerant convention.
+ *
+ * These live in @c rlib/types/ rather than @c rlib/rmem.h because
+ * @c rendianness.h's load / store helpers (@c r_load_be{16,32,64} et
+ * al.) need them, and that header is processed earlier in the
+ * include chain than @c rmem.h. The bulk of @c rmem.h's API
+ * (allocators, vtables, scanners) continues to live there.
+ *
+ * Each function is a @c static @c inline wrapper around the
+ * corresponding libc primitive plus rlib's NULL-tolerant convention.
+ * The libc primitive is a "magic" intrinsic on every modern compiler
+ * that gets replaced with inline @c movdqu / @c vld1q / @c rep
+ * @c movs for known constant sizes, so wrapping the call site behind
+ * a function-pointer indirection (or an extern @c R_API symbol)
+ * would defeat the point.
+ *
+ * For the non-inline cousins:
+ *  - @c r_memcmp_ct — constant-time compare, stays extern
+ *  - @c r_memclear_secure — optimiser-resistant zero, stays extern
+ *
+ * both live in @c rmem.h.
+ * @{
+ */
+
+/**
+ * @file rlib/types/rmemops.h
+ * @brief Inline byte-buffer primitives (see @ref r_mem_ops).
+ */
+#ifndef __R_MEM_OPS_H__
+#define __R_MEM_OPS_H__
+
+#if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
+#error "#include <rlib.h> only please."
+#endif
+
+#include <string.h>
+
+R_BEGIN_DECLS
+
+/**
+ * @brief Lexicographically compare @p size bytes of @p a and @p b.
+ *
+ * Thin wrapper around libc @c memcmp with NULL-tolerant semantics:
+ * a NULL pointer compares less than a non-NULL pointer, two NULLs
+ * compare equal. For constant-time tag / digest comparison use
+ * @c r_memcmp_ct from @c rmem.h instead.
+ *
+ * @param a    First buffer (may be @c NULL).
+ * @param b    Second buffer (may be @c NULL).
+ * @param size Number of bytes to compare.
+ * @return Negative if @c a<b, positive if @c a>b, zero if equal.
+ */
+static inline int
+r_memcmp (rconstpointer a, rconstpointer b, rsize size)
+{
+  if (R_UNLIKELY (a == NULL)) return -(a != b);
+  if (R_UNLIKELY (b == NULL)) return a != b;
+  return memcmp (a, b, size);
+}
+
+/**
+ * @brief Fill @p size bytes at @p a with byte value @p v.
+ *
+ * Thin wrapper around libc @c memset. A @c NULL @p a is a no-op
+ * (returns @c NULL). For wiping secret material use
+ * @c r_memclear_secure from @c rmem.h - the optimiser is free to
+ * elide regular @c r_memset on a buffer that's about to be freed.
+ *
+ * @param a    Destination buffer (may be @c NULL).
+ * @param v    Byte value to write (low 8 bits used).
+ * @param size Number of bytes to write.
+ * @return @p a.
+ */
+static inline rpointer
+r_memset (rpointer a, int v, rsize size)
+{
+  if (a != NULL)
+    memset (a, v, size);
+  return a;
+}
+
+/** @brief Convenience wrapper: @c r_memset @c (ptr, @c 0, @c size). */
+#define r_memclear(ptr, size)   r_memset (ptr, 0, size)
+
+/**
+ * @brief Copy @p size bytes from @p src to @p dst.
+ *
+ * Thin wrapper around libc @c memcpy. Requires @p src and @p dst not
+ * to overlap (use @c r_memmove if they might). A @c NULL @p src or
+ * @c NULL @p dst is a no-op (returns @c NULL); otherwise returns
+ * @p dst.
+ *
+ * @param dst  Destination buffer (may be @c NULL).
+ * @param src  Source buffer (may be @c NULL).
+ * @param size Number of bytes to copy.
+ * @return @p dst if both pointers were non-NULL, @c NULL otherwise.
+ */
+static inline rpointer
+r_memcpy (void * R_ATTR_RESTRICT dst,
+    const void * R_ATTR_RESTRICT src, rsize size)
+{
+  if (dst != NULL && src != NULL)
+    return memcpy (dst, src, size);
+  return NULL;
+}
+
+/**
+ * @brief Copy @p size bytes from @p src to @p dst, allowing overlap.
+ *
+ * Thin wrapper around libc @c memmove. Use when @p src and @p dst
+ * may overlap; @c r_memcpy is faster when they're known disjoint.
+ * A @c NULL pointer on either side is a no-op (returns @c NULL).
+ *
+ * @param dst  Destination buffer (may be @c NULL).
+ * @param src  Source buffer (may be @c NULL).
+ * @param size Number of bytes to copy.
+ * @return @p dst if both pointers were non-NULL, @c NULL otherwise.
+ */
+static inline rpointer
+r_memmove (rpointer dst, rconstpointer src, rsize size)
+{
+  if (dst != NULL && src != NULL)
+    return memmove (dst, src, size);
+  return NULL;
+}
+
+R_END_DECLS
+
+/** @} */
+
+#endif /* __R_MEM_OPS_H__ */

--- a/rlib/crypto/rrsa.c
+++ b/rlib/crypto/rrsa.c
@@ -1176,7 +1176,7 @@ r_rsa_oid_from_msg_digest (RMsgDigestType mdtype, ruint8 oid[16])
       r_memcpy (oid, "\x2a\x86\x48\x86\xf7\x0d\x01\x01\x04", 9);
       return 9;
     case R_MSG_DIGEST_TYPE_SHA1: /* 1.3.14.3.2.26  */
-      r_memcpy (oid, "\x2b\x0e\x03\x02\x1a", 9);
+      r_memcpy (oid, "\x2b\x0e\x03\x02\x1a", 5);
       return 5;
     case R_MSG_DIGEST_TYPE_SHA256: /* 2.16.840.1.101.3.4.2.1  */
       r_memcpy (oid, "\x60\x86\x48\x01\x65\x03\x04\x02\x01", 9);

--- a/rlib/rcrc.c
+++ b/rlib/rcrc.c
@@ -175,7 +175,7 @@ r_crc32c_update_sse42 (ruint32 crc, rconstpointer buffer, rsize size)
     ruint64 q;
     /* memcpy avoids the unaligned-load UB a direct (ruint64*)ptr
      * cast carries; compilers fold it into a single mov. */
-    r_memcpy (&q, ptr, sizeof (q));
+    memcpy (&q, ptr, sizeof (q));
     c = (ruint32) _mm_crc32_u64 (c, q);
     ptr += 8;
     size -= 8;
@@ -183,7 +183,7 @@ r_crc32c_update_sse42 (ruint32 crc, rconstpointer buffer, rsize size)
 # endif
   while (size >= 4) {
     ruint32 d;
-    r_memcpy (&d, ptr, sizeof (d));
+    memcpy (&d, ptr, sizeof (d));
     c = _mm_crc32_u32 (c, d);
     ptr += 4;
     size -= 4;
@@ -208,14 +208,14 @@ r_crc32c_update_armv8 (ruint32 crc, rconstpointer buffer, rsize size)
   ruint32 c = ~crc;
   while (size >= 8) {
     ruint64 q;
-    r_memcpy (&q, ptr, sizeof (q));
+    memcpy (&q, ptr, sizeof (q));
     c = __crc32cd (c, q);
     ptr += 8;
     size -= 8;
   }
   while (size >= 4) {
     ruint32 d;
-    r_memcpy (&d, ptr, sizeof (d));
+    memcpy (&d, ptr, sizeof (d));
     c = __crc32cw (c, d);
     ptr += 4;
     size -= 4;

--- a/rlib/rmem.c
+++ b/rlib/rmem.c
@@ -100,14 +100,6 @@ r_mem_using_system_default (void)
 }
 
 int
-r_memcmp (rconstpointer a, rconstpointer b, rsize size)
-{
-  if (R_UNLIKELY (a == NULL)) return -(a != b);
-  if (R_UNLIKELY (b == NULL)) return a != b;
-  return memcmp (a, b, size);
-}
-
-int
 r_memcmp_ct (rconstpointer a, rconstpointer b, rsize size)
 {
   const volatile ruint8 * pa = a;
@@ -127,14 +119,6 @@ r_memcmp_ct (rconstpointer a, rconstpointer b, rsize size)
     diff |= pa[i] ^ pb[i];
 
   return diff;
-}
-
-rpointer
-r_memset (rpointer a, int v, rsize size)
-{
-  if (a != NULL)
-    memset (a, v, size);
-  return a;
 }
 
 void
@@ -183,24 +167,6 @@ r_memclear_secure (rpointer ptr, rsize size)
       *pb++ = 0;
   }
 #endif
-}
-
-rpointer
-r_memcpy (void * dst, const void *src, rsize size)
-{
-  if (dst != NULL && src != NULL)
-    return memcpy (dst, src, size);
-
-  return NULL;
-}
-
-rpointer
-r_memmove (rpointer dst, rconstpointer src, rsize size)
-{
-  if (dst != NULL && src != NULL)
-    return memmove (dst, src, size);
-
-  return NULL;
 }
 
 rpointer


### PR DESCRIPTION
## Summary

Move the byte-buffer primitives (`r_memcpy`, `r_memmove`, `r_memset`, `r_memcmp`) from extern `R_API` wrappers to `static inline` definitions in a new `rlib/types/rmemops.h`, so the compiler can fold constant-size copies to `movdqu` / `vld1q` instead of routing every call through `memcpy@plt`. Drop the duplicate `r_memcpy_inline` macro from `rmacros.h`. Bring the entire `rmem*.h` header family up to full Doxygen coverage.

## What changes

**`rlib/types/rmemops.h`** (new):
- `r_memcpy`, `r_memmove`, `r_memset`, `r_memcmp` as `static inline` wrappers around the libc intrinsics, with rlib's NULL-tolerant guards intact.
- Placed in `rlib/types/` rather than `rlib/rmem.h` because `rendianness.h`'s `r_load_be{16,32,64}` / `r_store_be*` inline helpers need them, and `rendianness.h` is processed earlier in the include chain than `rmem.h`. `rtypes.h` pulls in `rmemops.h` just before `rendianness.h` so everyone downstream sees the canonical `r_memcpy`.
- `r_memcpy_inline` from `rmacros.h` goes away — its 12 call sites in `rendianness.h` switch to `r_memcpy`.

**`rlib/rmem.h`**: keeps `r_memcmp_ct` and `r_memclear_secure` extern (both rely on the optimizer NOT seeing through them: constant-time semantics and anti-elision semantics). Cross-references `rmemops.h` so a reader landing here knows where the inline primitives live.

**Doxygen**: full `@file` / `@defgroup` / per-symbol `@brief` / `@param` / `@return` coverage on:
- `rlib/rmem.h` (heap allocators, vtable plumbing, scanners, scan-pattern types)
- `rlib/types/rmemops.h` (inline primitives — own `@defgroup r_mem_ops` under `@ingroup r_mem`)
- `rlib/rmemfile.h` (memory-mapped files)
- `rlib/rmemallocator.h` (refcounted `RMem` chunks + pluggable `RMemAllocator` vtable)

Drive-by typo fix: `"#include <rlib.h> only pelase."` → `"… only please."` on the four headers.

## ABI

Drops the extern symbols for `r_memcpy` / `r_memmove` / `r_memset` / `r_memcmp`. Downstream binaries that linked against them dynamically will need to recompile. rlib doesn't carry a symbol-versioning commitment, and these were trivial libc wrappers anyway.

## Test plan

- [x] Full suite: 1537/1537 on x86 ASAN
- [x] Full suite: 1537/1537 on aarch64 via `qemu-aarch64 -cpu max`
- [x] First commit (combined inlining + consolidation) bisects clean — 1537/1537 on its own
- [x] `-O3 -Werror` clean on x86 (cc) and aarch64 (gcc cross) for the touched compilation units
- [x] Disassembly confirms small constant `r_memcpy(...)` calls in the AES CTR loop fold to inline `movdqu` (no `memcpy@plt`)