### PR TITLE
charset: UTF-32 conversions, validation API, and RFC 3629 conformance pass

### DIFF
--- a/include/rlib/charset/runicode.h
+++ b/include/rlib/charset/runicode.h
@@ -44,6 +44,17 @@
  * Code units are counted in their respective natural element type:
  * UTF-8 in @c rchar bytes, UTF-16 in @c runichar2 code units, and
  * UTF-32 in @c runichar4 code units.
+ *
+ * @note The in-buffer converters stop scanning the source when
+ * they encounter an embedded zero code unit (@c '\0' for UTF-8 /
+ * @c U+0000 for UTF-16 / UTF-32), even though @c U+0000 is a
+ * valid Unicode scalar. This matches the C-string convention the
+ * caller-supplied destination buffers are sized against: the
+ * output is always NUL-terminated, and asking the converter to
+ * pass through embedded @c U+0000 would make that contract
+ * ambiguous. Callers that need to encode a literal @c U+0000
+ * inside a string must split the input around the NUL and
+ * convert each segment.
  */
 
 R_BEGIN_DECLS

--- a/include/rlib/charset/runicode.h
+++ b/include/rlib/charset/runicode.h
@@ -219,6 +219,66 @@ R_API runichar2 * r_utf32_to_utf16_dup (const runichar4 * src, rsize srcsize,
 
 /** @} */
 
+/**
+ * @name Encoding validation
+ *
+ * Scan-only counterparts to the conversion functions. They apply the
+ * same rejection rules - RFC 3629 §3 for UTF-8 (overlong / surrogate-
+ * codepoint / out-of-range), surrogate-pairing for UTF-16, codepoint
+ * range and surrogate-half for UTF-32 - but allocate nothing and
+ * write no output. Useful when a caller already has the bytes in
+ * their target encoding and only needs to confirm they are
+ * well-formed before storing or forwarding them.
+ *
+ * On success returns @c R_UNICODE_OK and @c *endptr (when non-NULL)
+ * points to the byte / code unit one past the input. On
+ * @c R_UNICODE_INCOMPLETE_CODE_POINT @c *endptr points at the start
+ * of the truncated sequence (resumable). On
+ * @c R_UNICODE_INVALID_CODE_POINT @c *endptr points at the byte /
+ * unit that triggered the rejection.
+ * @{
+ */
+
+/**
+ * @brief Validate a UTF-8 byte sequence per RFC 3629.
+ *
+ * @param src     UTF-8 bytes.
+ * @param size    Bytes in @p src, or -1 to fall back to @c r_strlen.
+ * @param endptr  Optional out-pointer; receives the consumed-source
+ *                position per the rules above.
+ */
+R_API RUnicodeResult r_utf8_validate (const rchar * src, rssize size,
+    rchar ** endptr);
+
+/**
+ * @brief Validate a UTF-16 code-unit sequence.
+ *
+ * Rejects lone high surrogates as @c R_UNICODE_INCOMPLETE_CODE_POINT
+ * and lone low surrogates as @c R_UNICODE_INVALID_CODE_POINT, same
+ * as @c r_utf16_to_utf8.
+ *
+ * @param src     UTF-16 code units.
+ * @param size    Code units in @p src.
+ * @param endptr  Optional out-pointer.
+ */
+R_API RUnicodeResult r_utf16_validate (const runichar2 * src, rsize size,
+    runichar2 ** endptr);
+
+/**
+ * @brief Validate a UTF-32 code-point sequence.
+ *
+ * Rejects values >= 0x110000 and surrogate-half codepoints
+ * (@c U+D800..U+DFFF) as @c R_UNICODE_INVALID_CODE_POINT.
+ *
+ * @param src     UTF-32 code points.
+ * @param size    Code points in @p src.
+ * @param endptr  Optional out-pointer.
+ */
+R_API RUnicodeResult r_utf32_validate (const runichar4 * src, rsize size,
+    runichar4 ** endptr);
+
+/** @} */
+
 R_END_DECLS
 
 /** @} */ /* r_unicode group */

--- a/include/rlib/charset/runicode.h
+++ b/include/rlib/charset/runicode.h
@@ -26,13 +26,13 @@
 
 /**
  * @defgroup r_unicode Unicode conversion
- * @brief UTF-8 / UTF-16 encoding conversions.
+ * @brief UTF-8 / UTF-16 / UTF-32 encoding conversions.
  * @{
  */
 
 /**
  * @file rlib/charset/runicode.h
- * @brief UTF-8 / UTF-16 conversions.
+ * @brief UTF-8 / UTF-16 / UTF-32 conversions.
  *
  * Two flavours of conversion: an in-buffer pair (caller supplies
  * the destination) and an allocating pair (returns a fresh buffer
@@ -42,7 +42,8 @@
  * from the last @c srcendptr.
  *
  * Code units are counted in their respective natural element type:
- * UTF-8 in @c rchar bytes, UTF-16 in @c runichar2 code units.
+ * UTF-8 in @c rchar bytes, UTF-16 in @c runichar2 code units, and
+ * UTF-32 in @c runichar4 code units.
  */
 
 R_BEGIN_DECLS
@@ -107,6 +108,64 @@ R_API RUnicodeResult r_utf8_to_utf16 (runichar2 * dst, rsize dstsize,
 R_API RUnicodeResult r_utf16_to_utf8 (rchar * dst, rsize dstsize,
     const runichar2 * src, rsize srcsize, rsize * dstoutsize, runichar2 ** srcendptr);
 
+/**
+ * @brief Encode UTF-8 @p src into UTF-32 @p dst.
+ *
+ * @param dst        Destination UTF-32 buffer.
+ * @param dstsize    Capacity of @p dst in @c runichar4 code units
+ *                   (one codepoint per unit, plus one for the
+ *                   trailing NUL terminator).
+ * @param src        UTF-8 source bytes.
+ * @param srcsize    Bytes in @p src, or -1 to fall back to @c r_strlen.
+ * @param dstoutsize Receives the number of code units written
+ *                   (excluding the trailing NUL).
+ * @param srcendptr  Receives a pointer one past the last consumed byte.
+ */
+R_API RUnicodeResult r_utf8_to_utf32 (runichar4 * dst, rsize dstsize,
+    const rchar * src, rssize srcsize, rsize * dstoutsize, rchar ** srcendptr);
+/**
+ * @brief Decode UTF-32 @p src into UTF-8 @p dst.
+ *
+ * @param dst        Destination UTF-8 buffer.
+ * @param dstsize    Capacity of @p dst in bytes (room for up to 4
+ *                   bytes per codepoint plus the trailing NUL).
+ * @param src        UTF-32 source code units.
+ * @param srcsize    Code units in @p src.
+ * @param dstoutsize Receives the number of bytes written.
+ * @param srcendptr  Receives a pointer one past the last consumed code unit.
+ */
+R_API RUnicodeResult r_utf32_to_utf8 (rchar * dst, rsize dstsize,
+    const runichar4 * src, rsize srcsize, rsize * dstoutsize, runichar4 ** srcendptr);
+/**
+ * @brief Encode UTF-16 @p src into UTF-32 @p dst.
+ *
+ * @param dst        Destination UTF-32 buffer.
+ * @param dstsize    Capacity of @p dst in @c runichar4 code units
+ *                   (plus one for the trailing NUL).
+ * @param src        UTF-16 source code units.
+ * @param srcsize    Code units in @p src.
+ * @param dstoutsize Receives the number of code units written.
+ * @param srcendptr  Receives a pointer one past the last consumed code unit.
+ */
+R_API RUnicodeResult r_utf16_to_utf32 (runichar4 * dst, rsize dstsize,
+    const runichar2 * src, rsize srcsize, rsize * dstoutsize, runichar2 ** srcendptr);
+/**
+ * @brief Decode UTF-32 @p src into UTF-16 @p dst.
+ *
+ * Codepoints outside the BMP produce a surrogate pair.
+ *
+ * @param dst        Destination UTF-16 buffer.
+ * @param dstsize    Capacity of @p dst in @c runichar2 code units
+ *                   (room for up to 2 units per codepoint plus the
+ *                   trailing NUL).
+ * @param src        UTF-32 source code units.
+ * @param srcsize    Code units in @p src.
+ * @param dstoutsize Receives the number of code units written.
+ * @param srcendptr  Receives a pointer one past the last consumed code unit.
+ */
+R_API RUnicodeResult r_utf32_to_utf16 (runichar2 * dst, rsize dstsize,
+    const runichar4 * src, rsize srcsize, rsize * dstoutsize, runichar4 ** srcendptr);
+
 /** @} */
 
 /**
@@ -133,22 +192,32 @@ R_API runichar2 * r_utf8_to_utf16_dup (const rchar * src, rssize srcsize,
 R_API rchar * r_utf16_to_utf8_dup (const runichar2 * src, rsize srcsize,
     RUnicodeResult * res, rsize * retsize, runichar2 ** endptr) R_ATTR_MALLOC;
 
+/**
+ * @brief Allocate and encode UTF-8 @p src as UTF-32.
+ * @return Freshly allocated UTF-32 buffer, or NULL on failure.
+ */
+R_API runichar4 * r_utf8_to_utf32_dup (const rchar * src, rssize srcsize,
+    RUnicodeResult * res, rsize * retsize, rchar ** endptr) R_ATTR_MALLOC;
+/**
+ * @brief Allocate and decode UTF-32 @p src as UTF-8.
+ * @return Freshly allocated UTF-8 buffer, or NULL on failure.
+ */
+R_API rchar * r_utf32_to_utf8_dup (const runichar4 * src, rsize srcsize,
+    RUnicodeResult * res, rsize * retsize, runichar4 ** endptr) R_ATTR_MALLOC;
+/**
+ * @brief Allocate and encode UTF-16 @p src as UTF-32.
+ * @return Freshly allocated UTF-32 buffer, or NULL on failure.
+ */
+R_API runichar4 * r_utf16_to_utf32_dup (const runichar2 * src, rsize srcsize,
+    RUnicodeResult * res, rsize * retsize, runichar2 ** endptr) R_ATTR_MALLOC;
+/**
+ * @brief Allocate and decode UTF-32 @p src as UTF-16.
+ * @return Freshly allocated UTF-16 buffer, or NULL on failure.
+ */
+R_API runichar2 * r_utf32_to_utf16_dup (const runichar4 * src, rsize srcsize,
+    RUnicodeResult * res, rsize * retsize, runichar4 ** endptr) R_ATTR_MALLOC;
+
 /** @} */
-
-#if 0
-/* TODO: UTF-32 conversions - prototypes sketched but not yet
- * implemented. Left as a placeholder so the namespace shape stays
- * visible. */
-R_API runichar * r_utf8_to_uft32 (const rchar * str, rlong len,
-    rboolean * error, rlong * inlen, rlong * retlen) R_ATTR_MALLOC;
-R_API rchar * r_utf32_to_uft8 (const runichar *, rlong len,
-    rboolean * error, rlong * inlen, rlong * retlen) R_ATTR_MALLOC;
-
-R_API runichar * r_utf16_to_uft32 (const runichar2 * str, rlong len,
-    rboolean * error, rlong * inlen, rlong * retlen) R_ATTR_MALLOC;
-R_API runichar2 * r_utf32_to_uft16 (const runichar *, rlong len,
-    rboolean * error, rlong * inlen, rlong * retlen) R_ATTR_MALLOC;
-#endif
 
 R_END_DECLS
 

--- a/rlib/asn1/rasn1bin.c
+++ b/rlib/asn1/rasn1bin.c
@@ -366,11 +366,16 @@ r_asn1_bin_tlv_parse_string (const RAsn1BinTLV * tlv, rchar ** str)
     return R_ASN1_DECODER_INVALID_ARG;
 
   switch (R_ASN1_BIN_TLV_ID_TAG (tlv)) {
-    /* Byte-encoded string types pass through verbatim.  Callers that
-     * care about the restricted character sets (e.g. PrintableString,
-     * NumericString) have to validate themselves -- see the TODO
-     * below. */
+    /* UTF8String: X.680 requires the encoded value to be valid UTF-8.
+     * Validate the bytes before strdup'ing them. The other byte-
+     * encoded string types pass through verbatim - their character-
+     * set restrictions are still TODO (see below). */
     case R_ASN1_ID_UTF8_STRING:
+      if (r_utf8_validate ((const rchar *)tlv->value, (rssize)tlv->len,
+            NULL) != R_UNICODE_OK)
+        return R_ASN1_DECODER_PARSE_ERROR;
+      *str = r_strdup_size ((const rchar *) tlv->value, (rssize) tlv->len);
+      break;
     case R_ASN1_ID_NUMERIC_STRING:
     case R_ASN1_ID_PRINTABLE_STRING:
     case R_ASN1_ID_T61_STRING:

--- a/rlib/charset/runicode.c
+++ b/rlib/charset/runicode.c
@@ -329,3 +329,359 @@ r_utf16_to_utf8_dup (const runichar2 * src, rsize srcsize,
   return ret;
 }
 
+
+/* ---- UTF-32 conversions -------------------------------------------- */
+
+/* UTF-32 is one codepoint per code unit, so the conversions are
+ * straightforward: pair (decode-from-N, encode-as-32) or (decode-
+ * from-32, encode-as-N). The only validation specific to the UTF-32
+ * side is rejecting out-of-range (>= 0x110000) and surrogate-half
+ * (0xD800..0xDFFF) values - both flagged as
+ * R_UNICODE_INVALID_CODE_POINT. */
+
+RUnicodeResult
+r_utf8_to_utf32 (runichar4 * dst, rsize dstsize, const rchar * src,
+    rssize srcsize, rsize * dstoutsize, rchar ** srcendptr)
+{
+  RUnicodeResult ret = R_UNICODE_OK;
+  runichar4 * dstptr, * dstend;
+  rssize i, r;
+
+  if (R_UNLIKELY (dst == NULL || dstsize == 0 || src == NULL))
+    return R_UNICODE_INVAL;
+  if (R_UNLIKELY (dstsize == 1)) {
+    dst[0] = 0;
+    return R_UNICODE_OVERFLOW;
+  }
+
+  if (srcsize < 0)
+    srcsize = r_strlen (src);
+
+  /* Strip a leading UTF-8 BOM (EF BB BF). */
+  if (srcsize >= 3 &&
+      (ruint8) src[0] == 0xef &&
+      (ruint8) src[1] == 0xbb &&
+      (ruint8) src[2] == 0xbf) {
+    src += 3;
+    srcsize -= 3;
+  }
+
+  for (i = 0, dstptr = dst, dstend = dst + dstsize - 1;
+      i < srcsize && src[i] != 0;
+      i += r) {
+    runichar uc;
+
+    if ((r = r_utf8_to_unichar (&src[i], srcsize - i, &uc)) > 0) {
+      if (uc >= 0x110000 || (uc >= 0xd800 && uc < 0xe000)) {
+        ret = R_UNICODE_INVALID_CODE_POINT;
+        break;
+      }
+      if (dstptr >= dstend) {
+        ret = R_UNICODE_OVERFLOW;
+        break;
+      }
+      *dstptr++ = (runichar4)uc;
+    } else if (r == 0) {
+      break;
+    } else {
+      ret = R_UNICODE_INCOMPLETE_CODE_POINT;
+      break;
+    }
+  }
+
+  *dstptr = 0;
+
+  if (dstoutsize != NULL)
+    *dstoutsize = dstptr - dst;
+  if (srcendptr != NULL)
+    *srcendptr = (rchar *)&src[i];
+
+  return ret;
+}
+
+RUnicodeResult
+r_utf32_to_utf8 (rchar * dst, rsize dstsize, const runichar4 * src,
+    rsize srcsize, rsize * dstoutsize, runichar4 ** srcendptr)
+{
+  RUnicodeResult ret = R_UNICODE_OK;
+  rchar * dstptr, * dstend;
+  rsize i;
+  rssize r = 0;
+
+  if (R_UNLIKELY (dst == NULL || dstsize == 0 || src == NULL))
+    return R_UNICODE_INVAL;
+  if (R_UNLIKELY (dstsize == 1)) {
+    dst[0] = 0;
+    return R_UNICODE_OVERFLOW;
+  }
+
+  /* Optional UTF-32 BOM at the start (single 0xFEFF code unit). */
+  if (srcsize > 0 && src[0] == R_UTF16_BOM) {
+    src++;
+    srcsize--;
+  }
+
+  for (i = 0, dstptr = dst, dstend = dst + dstsize - 1;
+      i < srcsize && src[i] != 0;
+      i++, dstptr += r) {
+    runichar uc = (runichar)src[i];
+
+    if (uc >= 0x110000 || (uc >= 0xd800 && uc < 0xe000)) {
+      ret = R_UNICODE_INVALID_CODE_POINT;
+      break;
+    }
+    r = r_unichar_to_utf8 (uc, dstptr, dstend - dstptr);
+    if (r <= 0) {
+      ret = R_UNICODE_OVERFLOW;
+      break;
+    }
+  }
+
+  *dstptr = 0;
+
+  if (dstoutsize != NULL)
+    *dstoutsize = dstptr - dst;
+  if (srcendptr != NULL)
+    *srcendptr = (runichar4 *)&src[i];
+
+  return ret;
+}
+
+RUnicodeResult
+r_utf16_to_utf32 (runichar4 * dst, rsize dstsize, const runichar2 * src,
+    rsize srcsize, rsize * dstoutsize, runichar2 ** srcendptr)
+{
+  RUnicodeResult ret = R_UNICODE_OK;
+  runichar4 * dstptr, * dstend;
+  rsize i;
+
+  if (R_UNLIKELY (dst == NULL || dstsize == 0 || src == NULL))
+    return R_UNICODE_INVAL;
+  if (R_UNLIKELY (dstsize == 1)) {
+    dst[0] = 0;
+    return R_UNICODE_OVERFLOW;
+  }
+
+  if (srcsize > 0) {
+    if (src[0] == R_UTF16_BOM_SWAP)
+      return R_UNICODE_INVAL;
+    if (src[0] == R_UTF16_BOM) {
+      src++;
+      srcsize--;
+    }
+  }
+
+  for (i = 0, dstptr = dst, dstend = dst + dstsize - 1;
+      i < srcsize && src[i] > 0;
+      ) {
+    runichar uc;
+
+    if (src[i] < 0xd800 || src[i] >= 0xe000) {
+      uc = (runichar)src[i];
+      i++;
+    } else if (src[i] < 0xdc00) {
+      runichar2 hc = src[i] - 0xd800;
+      if (i + 1 < srcsize && src[i + 1] >= 0xdc00 && src[i + 1] < 0xe000) {
+        uc = (runichar)src[i + 1] - 0xdc00 + 0x10000 + ((runichar)hc << 10);
+        i += 2;
+      } else {
+        ret = R_UNICODE_INCOMPLETE_CODE_POINT;
+        break;
+      }
+    } else {
+      ret = R_UNICODE_INVALID_CODE_POINT;
+      break;
+    }
+
+    if (dstptr >= dstend) {
+      ret = R_UNICODE_OVERFLOW;
+      break;
+    }
+    *dstptr++ = (runichar4)uc;
+  }
+
+  *dstptr = 0;
+
+  if (dstoutsize != NULL)
+    *dstoutsize = dstptr - dst;
+  if (srcendptr != NULL)
+    *srcendptr = (runichar2 *)&src[i];
+
+  return ret;
+}
+
+RUnicodeResult
+r_utf32_to_utf16 (runichar2 * dst, rsize dstsize, const runichar4 * src,
+    rsize srcsize, rsize * dstoutsize, runichar4 ** srcendptr)
+{
+  RUnicodeResult ret = R_UNICODE_OK;
+  runichar2 * dstptr, * dstend;
+  rsize i;
+
+  if (R_UNLIKELY (dst == NULL || dstsize == 0 || src == NULL))
+    return R_UNICODE_INVAL;
+  if (R_UNLIKELY (dstsize == 1)) {
+    dst[0] = 0;
+    return R_UNICODE_OVERFLOW;
+  }
+
+  if (srcsize > 0 && src[0] == R_UTF16_BOM) {
+    src++;
+    srcsize--;
+  }
+
+  for (i = 0, dstptr = dst, dstend = dst + dstsize - 1;
+      i < srcsize && src[i] != 0;
+      i++) {
+    runichar uc = (runichar)src[i];
+
+    if (uc >= 0x110000 || (uc >= 0xd800 && uc < 0xe000)) {
+      ret = R_UNICODE_INVALID_CODE_POINT;
+      break;
+    }
+
+    if (uc < 0x10000) {
+      if (dstptr >= dstend) {
+        ret = R_UNICODE_OVERFLOW;
+        break;
+      }
+      *dstptr++ = (runichar2)uc;
+    } else {
+      if (dstptr + 1 >= dstend) {
+        ret = R_UNICODE_OVERFLOW;
+        break;
+      }
+      *dstptr++ = ((uc - 0x10000) / 0x400) | 0xd800;
+      *dstptr++ = ((uc - 0x10000) % 0x400) | 0xdc00;
+    }
+  }
+
+  *dstptr = 0;
+
+  if (dstoutsize != NULL)
+    *dstoutsize = dstptr - dst;
+  if (srcendptr != NULL)
+    *srcendptr = (runichar4 *)&src[i];
+
+  return ret;
+}
+
+runichar4 *
+r_utf8_to_utf32_dup (const rchar * src, rssize srcsize, RUnicodeResult * res,
+    rsize * retsize, rchar ** endptr)
+{
+  runichar4 * ret;
+  RUnicodeResult r;
+
+  if (srcsize < 0)
+    srcsize = r_strlen (src);
+
+  /* Worst case: one UTF-32 unit per source byte (ASCII fast path),
+   * plus the NUL terminator. */
+  if ((ret = r_mem_new_n (runichar4, srcsize + 1)) != NULL) {
+    if ((r = r_utf8_to_utf32 (ret, srcsize + 1, src, srcsize, retsize, endptr))
+        != R_UNICODE_OK) {
+      r_free (ret);
+      ret = NULL;
+    }
+  } else {
+    r = R_UNICODE_OOM;
+  }
+
+  if (res != NULL)
+    *res = r;
+  return ret;
+}
+
+rchar *
+r_utf32_to_utf8_dup (const runichar4 * src, rsize srcsize,
+    RUnicodeResult * res, rsize * retsize, runichar4 ** endptr)
+{
+  rchar * ret;
+  RUnicodeResult r;
+  rsize dstsize;
+
+  if (R_UNLIKELY (src == NULL || srcsize == 0)) {
+    if (res != NULL) *res = R_UNICODE_INVAL;
+    return NULL;
+  }
+
+  /* Codepoints in [0, 0x10FFFF] encode to at most 4 UTF-8 bytes,
+   * plus the trailing NUL. */
+  dstsize = srcsize * 4 + 1;
+
+  if ((ret = r_mem_new_n (rchar, dstsize)) != NULL) {
+    if ((r = r_utf32_to_utf8 (ret, dstsize, src, srcsize, retsize, endptr))
+        != R_UNICODE_OK) {
+      r_free (ret);
+      ret = NULL;
+    }
+  } else {
+    r = R_UNICODE_OOM;
+  }
+
+  if (res != NULL)
+    *res = r;
+  return ret;
+}
+
+runichar4 *
+r_utf16_to_utf32_dup (const runichar2 * src, rsize srcsize,
+    RUnicodeResult * res, rsize * retsize, runichar2 ** endptr)
+{
+  runichar4 * ret;
+  RUnicodeResult r;
+
+  if (R_UNLIKELY (src == NULL || srcsize == 0)) {
+    if (res != NULL) *res = R_UNICODE_INVAL;
+    return NULL;
+  }
+
+  /* Worst case: one UTF-32 unit per UTF-16 unit (no surrogate
+   * pairs), plus the NUL terminator. */
+  if ((ret = r_mem_new_n (runichar4, srcsize + 1)) != NULL) {
+    if ((r = r_utf16_to_utf32 (ret, srcsize + 1, src, srcsize, retsize, endptr))
+        != R_UNICODE_OK) {
+      r_free (ret);
+      ret = NULL;
+    }
+  } else {
+    r = R_UNICODE_OOM;
+  }
+
+  if (res != NULL)
+    *res = r;
+  return ret;
+}
+
+runichar2 *
+r_utf32_to_utf16_dup (const runichar4 * src, rsize srcsize,
+    RUnicodeResult * res, rsize * retsize, runichar4 ** endptr)
+{
+  runichar2 * ret;
+  RUnicodeResult r;
+  rsize dstsize;
+
+  if (R_UNLIKELY (src == NULL || srcsize == 0)) {
+    if (res != NULL) *res = R_UNICODE_INVAL;
+    return NULL;
+  }
+
+  /* Codepoints outside the BMP encode to a surrogate pair (2 units),
+   * plus the trailing NUL. */
+  dstsize = srcsize * 2 + 1;
+
+  if ((ret = r_mem_new_n (runichar2, dstsize)) != NULL) {
+    if ((r = r_utf32_to_utf16 (ret, dstsize, src, srcsize, retsize, endptr))
+        != R_UNICODE_OK) {
+      r_free (ret);
+      ret = NULL;
+    }
+  } else {
+    r = R_UNICODE_OOM;
+  }
+
+  if (res != NULL)
+    *res = r;
+  return ret;
+}

--- a/rlib/charset/runicode.c
+++ b/rlib/charset/runicode.c
@@ -84,6 +84,12 @@ r_unichar_to_utf8 (runichar c, rchar * str, rsize size)
   return 6;
 }
 
+/* Sentinel returned by r_utf8_to_unichar for sequences that decode
+ * to a valid bit pattern but whose canonical form would be shorter
+ * (RFC 3629 §3 overlong forms). Caller flags as
+ * R_UNICODE_INVALID_CODE_POINT. */
+#define R_UTF8_OVERLONG  (-2)
+
 static inline rssize
 r_utf8_to_unichar (const rchar * utf8, rsize size, runichar * uc)
 {
@@ -101,6 +107,9 @@ r_utf8_to_unichar (const rchar * utf8, rsize size, runichar * uc)
       return -1;
     *uc  = (utf8[0] & 0x1f) << 6;
     *uc |= (utf8[1] & 0x3f);
+    /* Overlong: a 2-byte encoding of U+0000..U+007F (RFC 3629 §3). */
+    if (*uc < 0x80)
+      return R_UTF8_OVERLONG;
     return 2;
   } else if ((utf8[0] & 0xf0) == 0xe0) {
     if (size < 3 || (utf8[1] & 0xc0) != 0x80 || (utf8[2] & 0xc0) != 0x80)
@@ -108,6 +117,8 @@ r_utf8_to_unichar (const rchar * utf8, rsize size, runichar * uc)
     *uc  = (utf8[0] & 0x0f) << 12;
     *uc |= (utf8[1] & 0x3f) <<  6;
     *uc |= (utf8[2] & 0x3f);
+    if (*uc < 0x800)
+      return R_UTF8_OVERLONG;
     return 3;
   } else if ((utf8[0] & 0xf8) == 0xf0) {
     if (size < 4 || (utf8[1] & 0xc0) != 0x80 || (utf8[2] & 0xc0) != 0x80 ||
@@ -117,6 +128,8 @@ r_utf8_to_unichar (const rchar * utf8, rsize size, runichar * uc)
     *uc |= (utf8[1] & 0x3f) << 12;
     *uc |= (utf8[2] & 0x3f) <<  6;
     *uc |= (utf8[3] & 0x3f);
+    if (*uc < 0x10000)
+      return R_UTF8_OVERLONG;
     return 4;
   } else if ((utf8[0] & 0xfc) == 0xf8) {
     if (size < 5 || (utf8[1] & 0xc0) != 0x80 || (utf8[2] & 0xc0) != 0x80 ||
@@ -127,9 +140,16 @@ r_utf8_to_unichar (const rchar * utf8, rsize size, runichar * uc)
     *uc |= (utf8[2] & 0x3f) << 12;
     *uc |= (utf8[3] & 0x3f) <<  6;
     *uc |= (utf8[4] & 0x3f);
+    if (*uc < 0x200000)
+      return R_UTF8_OVERLONG;
     return 5;
   }
 
+  /* Pre-RFC-3629 legacy 6-byte sequence. RFC 3629 forbids these,
+   * but the rest of the decoder accepts them and lets the caller
+   * reject via the canonical >= 0x110000 check. Stay backwards-
+   * compatible here; the overlong-vs-canonical distinction still
+   * applies. */
   if (size < 6 || (utf8[1] & 0xc0) != 0x80 || (utf8[2] & 0xc0) != 0x80 ||
       (utf8[3] & 0xc0) != 0x80 || (utf8[4] & 0xc0) != 0x80 ||
       (utf8[5] & 0xc0) != 0x80)
@@ -140,7 +160,9 @@ r_utf8_to_unichar (const rchar * utf8, rsize size, runichar * uc)
   *uc |= (utf8[3] & 0x3f) << 12;
   *uc |= (utf8[4] & 0x3f) <<  6;
   *uc |= (utf8[5] & 0x3f);
-  return 5;
+  if (*uc < 0x4000000)
+    return R_UTF8_OVERLONG;
+  return 6;
 }
 
 
@@ -177,24 +199,30 @@ r_utf8_to_utf16 (runichar2 * dst, rsize dstsize, const rchar * src, rssize srcsi
     runichar uc;
 
     if ((r = r_utf8_to_unichar (&src[i], srcsize - i, &uc)) > 0) {
+      /* Reject UTF-8-encoded UTF-16 surrogates and non-Unicode
+       * codepoints (RFC 3629 §3 / Unicode Standard §3.9). */
+      if ((uc >= 0xd800 && uc < 0xe000) || uc >= 0x110000) {
+        ret = R_UNICODE_INVALID_CODE_POINT;
+        break;
+      }
       if (uc <= 0xffff) {
         if (dstptr + 1 > dstend) {
           ret = R_UNICODE_OVERFLOW;
           break;
         }
         *dstptr++ = (runichar2)uc & 0xffff;
-      } else if (uc < 0x110000) {
+      } else {
         if (dstptr + 2 > dstend) {
           ret = R_UNICODE_OVERFLOW;
           break;
         }
         *dstptr++ = ((uc - 0x10000) / 0x400) | 0xd800;
         *dstptr++ = ((uc - 0x10000) % 0x400) | 0xdc00;
-      } else {
-        ret = R_UNICODE_INVALID_CODE_POINT;
-        break;
       }
     } else if (r == 0) {
+      break;
+    } else if (r == R_UTF8_OVERLONG) {
+      ret = R_UNICODE_INVALID_CODE_POINT;
       break;
     } else {
       ret = R_UNICODE_INCOMPLETE_CODE_POINT;
@@ -382,6 +410,9 @@ r_utf8_to_utf32 (runichar4 * dst, rsize dstsize, const rchar * src,
       }
       *dstptr++ = (runichar4)uc;
     } else if (r == 0) {
+      break;
+    } else if (r == R_UTF8_OVERLONG) {
+      ret = R_UNICODE_INVALID_CODE_POINT;
       break;
     } else {
       ret = R_UNICODE_INCOMPLETE_CODE_POINT;

--- a/rlib/charset/runicode.c
+++ b/rlib/charset/runicode.c
@@ -720,3 +720,122 @@ r_utf32_to_utf16_dup (const runichar4 * src, rsize srcsize,
     *res = r;
   return ret;
 }
+
+/* ---- Validation entry points ---------------------------------------
+ * Scan-only counterparts to the conversion functions. The byte- /
+ * code-unit-level scan is the same in either case; the converters
+ * have an extra "encode into destination" step that the validators
+ * skip. Implemented standalone here (rather than calling the
+ * conversion functions with a sink destination) to avoid the
+ * destination-buffer threading and to make the streaming srcendptr
+ * semantics explicit. */
+
+RUnicodeResult
+r_utf8_validate (const rchar * src, rssize size, rchar ** endptr)
+{
+  RUnicodeResult ret = R_UNICODE_OK;
+  rssize i, r;
+  runichar uc;
+
+  if (R_UNLIKELY (src == NULL))
+    return R_UNICODE_INVAL;
+  if (size < 0)
+    size = r_strlen (src);
+
+  /* Strip a leading UTF-8 BOM (matches r_utf8_to_utf16's behaviour). */
+  if (size >= 3 &&
+      (ruint8) src[0] == 0xef &&
+      (ruint8) src[1] == 0xbb &&
+      (ruint8) src[2] == 0xbf) {
+    src += 3;
+    size -= 3;
+  }
+
+  for (i = 0; i < size && src[i] != 0; i += r) {
+    r = r_utf8_to_unichar (&src[i], size - i, &uc);
+    if (r > 0) {
+      if ((uc >= 0xd800 && uc < 0xe000) || uc >= 0x110000) {
+        ret = R_UNICODE_INVALID_CODE_POINT;
+        break;
+      }
+    } else if (r == 0) {
+      break;
+    } else if (r == R_UTF8_OVERLONG) {
+      ret = R_UNICODE_INVALID_CODE_POINT;
+      break;
+    } else {
+      ret = R_UNICODE_INCOMPLETE_CODE_POINT;
+      break;
+    }
+  }
+
+  if (endptr != NULL)
+    *endptr = (rchar *)&src[i];
+  return ret;
+}
+
+RUnicodeResult
+r_utf16_validate (const runichar2 * src, rsize size, runichar2 ** endptr)
+{
+  RUnicodeResult ret = R_UNICODE_OK;
+  rsize i = 0;
+
+  if (R_UNLIKELY (src == NULL))
+    return R_UNICODE_INVAL;
+
+  if (size > 0) {
+    if (src[0] == R_UTF16_BOM_SWAP)
+      return R_UNICODE_INVAL;
+    if (src[0] == R_UTF16_BOM) {
+      src++;
+      size--;
+    }
+  }
+
+  while (i < size && src[i] != 0) {
+    if (src[i] < 0xd800 || src[i] >= 0xe000) {
+      i++;
+    } else if (src[i] < 0xdc00) {
+      if (i + 1 < size && src[i + 1] >= 0xdc00 && src[i + 1] < 0xe000) {
+        i += 2;
+      } else {
+        ret = R_UNICODE_INCOMPLETE_CODE_POINT;
+        break;
+      }
+    } else {
+      ret = R_UNICODE_INVALID_CODE_POINT;
+      break;
+    }
+  }
+
+  if (endptr != NULL)
+    *endptr = (runichar2 *)&src[i];
+  return ret;
+}
+
+RUnicodeResult
+r_utf32_validate (const runichar4 * src, rsize size, runichar4 ** endptr)
+{
+  RUnicodeResult ret = R_UNICODE_OK;
+  rsize i = 0;
+
+  if (R_UNLIKELY (src == NULL))
+    return R_UNICODE_INVAL;
+
+  /* UTF-32 BOM is a single 0xFEFF code unit at the start. */
+  if (size > 0 && src[0] == R_UTF16_BOM) {
+    src++;
+    size--;
+  }
+
+  for (; i < size && src[i] != 0; i++) {
+    if (src[i] >= 0x110000 || (src[i] >= 0xd800 && src[i] < 0xe000)) {
+      ret = R_UNICODE_INVALID_CODE_POINT;
+      break;
+    }
+  }
+
+  if (endptr != NULL)
+    *endptr = (runichar4 *)&src[i];
+  return ret;
+}

--- a/rlib/charset/runicode.c
+++ b/rlib/charset/runicode.c
@@ -271,11 +271,15 @@ r_utf16_to_utf8 (rchar * dst, rsize dstsize, const runichar2 * src, rsize srcsiz
     if (src[i] < 0xd800) {
       r = r_unichar_to_utf8 ((runichar)src[i], dstptr, dstend - dstptr);
     } else if (src[i] < 0xdc00) {
-      runichar2 hc = src[i] - 0xd800;
-
-      if (++i < srcsize && src[i] >= 0xdc00 && src[i] < 0xe000) {
-        runichar uc = (runichar)src[i] - 0xdc00 + 0x10000 + (hc << 10);
+      /* High surrogate. Peek at the next unit without consuming - if
+       * the pair is incomplete we want srcendptr to point at this
+       * high surrogate so the caller can resume from here once more
+       * UTF-16 units arrive. */
+      if (i + 1 < srcsize && src[i + 1] >= 0xdc00 && src[i + 1] < 0xe000) {
+        runichar2 hc = src[i] - 0xd800;
+        runichar uc = (runichar)src[i + 1] - 0xdc00 + 0x10000 + (hc << 10);
         r = r_unichar_to_utf8 (uc, dstptr, dstend - dstptr);
+        i++;            /* consume the low surrogate; outer loop bumps for the high */
       } else {
         ret = R_UNICODE_INCOMPLETE_CODE_POINT;
         break;

--- a/rlib/charset/runicode.c
+++ b/rlib/charset/runicode.c
@@ -33,6 +33,11 @@
 #define R_UTF16_BOM       0xFEFFu
 #define R_UTF16_BOM_SWAP  0xFFFEu
 
+/* RFC 3629 caps Unicode codepoints at U+10FFFF, which encodes in
+ * at most 4 UTF-8 bytes. All callers in this file pass codepoints
+ * they have already validated against that bound; an out-of-range
+ * value here returns -1 rather than falling back to pre-RFC-3629
+ * 5- or 6-byte encodings. */
 static inline rssize
 r_unichar_to_utf8 (runichar c, rchar * str, rsize size)
 {
@@ -54,7 +59,7 @@ r_unichar_to_utf8 (runichar c, rchar * str, rsize size)
     str[1] = ((c >>  6) & 0x3f) | 0x80;
     str[0] = ((c >> 12)         | 0xe0);
     return 3;
-  } else if (c < 0x200000) {
+  } else if (c < 0x110000) {
     if (size < 4)
       return -1;
     str[3] = ((c      ) & 0x3f) | 0x80;
@@ -62,26 +67,9 @@ r_unichar_to_utf8 (runichar c, rchar * str, rsize size)
     str[1] = ((c >> 12) & 0x3f) | 0x80;
     str[0] = ((c >> 18)         | 0xf0);
     return 4;
-  } else if (c < 0x4000000) {
-    if (size < 5)
-      return -1;
-    str[4] = ((c      ) & 0x3f) | 0x80;
-    str[3] = ((c >>  6) & 0x3f) | 0x80;
-    str[2] = ((c >> 12) & 0x3f) | 0x80;
-    str[1] = ((c >> 18) & 0x3f) | 0x80;
-    str[0] = ((c >> 24)         | 0xf8);
-    return 5;
   }
 
-  if (size < 6)
-    return -1;
-  str[5] = ((c      ) & 0x3f) | 0x80;
-  str[4] = ((c >>  6) & 0x3f) | 0x80;
-  str[3] = ((c >> 12) & 0x3f) | 0x80;
-  str[2] = ((c >> 18) & 0x3f) | 0x80;
-  str[1] = ((c >> 24) & 0x3f) | 0x80;
-  str[0] = ((c >> 30)         | 0xfc);
-  return 6;
+  return -1;
 }
 
 /* Sentinel returned by r_utf8_to_unichar for sequences that decode
@@ -131,38 +119,13 @@ r_utf8_to_unichar (const rchar * utf8, rsize size, runichar * uc)
     if (*uc < 0x10000)
       return R_UTF8_OVERLONG;
     return 4;
-  } else if ((utf8[0] & 0xfc) == 0xf8) {
-    if (size < 5 || (utf8[1] & 0xc0) != 0x80 || (utf8[2] & 0xc0) != 0x80 ||
-        (utf8[3] & 0xc0) != 0x80 || (utf8[4] & 0xc0) != 0x80)
-      return -1;
-    *uc  = (utf8[0] & 0x03) << 24;
-    *uc |= (utf8[1] & 0x3f) << 18;
-    *uc |= (utf8[2] & 0x3f) << 12;
-    *uc |= (utf8[3] & 0x3f) <<  6;
-    *uc |= (utf8[4] & 0x3f);
-    if (*uc < 0x200000)
-      return R_UTF8_OVERLONG;
-    return 5;
   }
 
-  /* Pre-RFC-3629 legacy 6-byte sequence. RFC 3629 forbids these,
-   * but the rest of the decoder accepts them and lets the caller
-   * reject via the canonical >= 0x110000 check. Stay backwards-
-   * compatible here; the overlong-vs-canonical distinction still
-   * applies. */
-  if (size < 6 || (utf8[1] & 0xc0) != 0x80 || (utf8[2] & 0xc0) != 0x80 ||
-      (utf8[3] & 0xc0) != 0x80 || (utf8[4] & 0xc0) != 0x80 ||
-      (utf8[5] & 0xc0) != 0x80)
-    return -1;
-  *uc  = (utf8[0] & 0x01) << 30;
-  *uc |= (utf8[1] & 0x3f) << 24;
-  *uc |= (utf8[2] & 0x3f) << 18;
-  *uc |= (utf8[3] & 0x3f) << 12;
-  *uc |= (utf8[4] & 0x3f) <<  6;
-  *uc |= (utf8[5] & 0x3f);
-  if (*uc < 0x4000000)
-    return R_UTF8_OVERLONG;
-  return 6;
+  /* Lead bytes 0xF8..0xFF are forbidden by RFC 3629 §3: 5- and
+   * 6-byte sequences only existed in pre-3629 UTF-8 and can only
+   * encode codepoints >= U+200000, well outside the Unicode range.
+   * Reject up-front. */
+  return -1;
 }
 
 

--- a/test/rasn1der.c
+++ b/test/rasn1der.c
@@ -611,6 +611,48 @@ RTEST (rasn1der, parse_string, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rasn1der, parse_string_rejects_malformed_utf8, RTEST_FAST)
+{
+  /* UTF8String with a 2-byte lead byte followed by no continuation -
+   * malformed UTF-8 per RFC 3629 §3. X.680 requires UTF8String values
+   * to be valid UTF-8; parse_string surfaces the rejection via
+   * R_ASN1_DECODER_PARSE_ERROR. */
+  static const ruint8 utf8_bad_incomplete[] = { 0x0c, 0x01, 0xc2 };
+  /* UTF8String containing an overlong "/" (\xC0\xAF) - RFC 3629 §3. */
+  static const ruint8 utf8_bad_overlong[]   = { 0x0c, 0x02, 0xc0, 0xaf };
+  /* UTF8String containing a 3-byte UTF-8 sequence that decodes to
+   * U+D800 - bit-valid but a surrogate codepoint, RFC 3629 §3. */
+  static const ruint8 utf8_bad_surrogate[]  = { 0x0c, 0x03, 0xed, 0xa0, 0x80 };
+  RAsn1BinDecoder * dec;
+  RAsn1BinTLV tlv;
+  rchar * str;
+
+  tlv = (RAsn1BinTLV)R_ASN1_BIN_TLV_INIT;
+  r_assert_cmpptr ((dec = r_asn1_bin_decoder_new (R_ASN1_DER,
+        utf8_bad_incomplete, sizeof (utf8_bad_incomplete))), !=, NULL);
+  r_assert_cmpint (r_asn1_bin_decoder_next (dec, &tlv), ==, R_ASN1_DECODER_OK);
+  r_assert_cmpint (r_asn1_bin_tlv_parse_string (&tlv, &str),
+      ==, R_ASN1_DECODER_PARSE_ERROR);
+  r_asn1_bin_decoder_unref (dec);
+
+  tlv = (RAsn1BinTLV)R_ASN1_BIN_TLV_INIT;
+  r_assert_cmpptr ((dec = r_asn1_bin_decoder_new (R_ASN1_DER,
+        utf8_bad_overlong, sizeof (utf8_bad_overlong))), !=, NULL);
+  r_assert_cmpint (r_asn1_bin_decoder_next (dec, &tlv), ==, R_ASN1_DECODER_OK);
+  r_assert_cmpint (r_asn1_bin_tlv_parse_string (&tlv, &str),
+      ==, R_ASN1_DECODER_PARSE_ERROR);
+  r_asn1_bin_decoder_unref (dec);
+
+  tlv = (RAsn1BinTLV)R_ASN1_BIN_TLV_INIT;
+  r_assert_cmpptr ((dec = r_asn1_bin_decoder_new (R_ASN1_DER,
+        utf8_bad_surrogate, sizeof (utf8_bad_surrogate))), !=, NULL);
+  r_assert_cmpint (r_asn1_bin_decoder_next (dec, &tlv), ==, R_ASN1_DECODER_OK);
+  r_assert_cmpint (r_asn1_bin_tlv_parse_string (&tlv, &str),
+      ==, R_ASN1_DECODER_PARSE_ERROR);
+  r_asn1_bin_decoder_unref (dec);
+}
+RTEST_END;
+
 RTEST (rasn1der, parse_string_bmp_universal, RTEST_FAST)
 {
   /* BMPString is UTF-16BE.  "hello" + U+00E5 ('å'): ASCII chars expand

--- a/test/runicode.c
+++ b/test/runicode.c
@@ -828,6 +828,13 @@ static const RUnicodeBadUtf8 malformed_utf8_vectors[] = {
   /* Kuhn §3.5: impossible bytes (RFC 3629 forbids 0xFE / 0xFF). */
   { "impossible byte 0xFE", { 0xfe }, 1 },
   { "impossible byte 0xFF", { 0xff }, 1 },
+  /* Pre-RFC-3629 5-byte and 6-byte lead bytes (0xF8..0xFD). These
+   * could only encode codepoints >= U+200000, never assignable;
+   * RFC 3629 §3 forbids them outright. */
+  { "5-byte lead 0xF8", { 0xf8, 0x88, 0x80, 0x80, 0x80 }, 5 },
+  { "5-byte lead 0xFB", { 0xfb, 0xbf, 0xbf, 0xbf, 0xbf }, 5 },
+  { "6-byte lead 0xFC", { 0xfc, 0x84, 0x80, 0x80, 0x80, 0x80 }, 6 },
+  { "6-byte lead 0xFD", { 0xfd, 0xbf, 0xbf, 0xbf, 0xbf, 0xbf }, 6 },
 };
 
 RTEST_LOOP (runicode, malformed_utf8_rejected_to_utf16, RTEST_FAST,

--- a/test/runicode.c
+++ b/test/runicode.c
@@ -532,3 +532,363 @@ RTEST (runicode, utf16_to_utf32_dup_roundtrip, RTEST_FAST)
   r_free (back);
 }
 RTEST_END;
+
+/* ========================================================================
+ * Canonical Unicode-conversion stress vectors.
+ *
+ * Sourced from:
+ *  - Unicode Standard Table 3-7 (well-formed UTF-8 byte sequences).
+ *  - Markus Kuhn's "UTF-8 decoder capability and stress test"
+ *    (https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt) -
+ *    the de-facto Unicode-encoding conformance suite.
+ *  - RFC 3629 §3 (forbidden UTF-8 sequences).
+ *
+ * Layout: a single positive table of boundary codepoints round-tripped
+ * across all four conversion pairs, plus per-direction negative tests
+ * exercising each rejection path the spec defines.
+ * ======================================================================= */
+
+typedef struct {
+  const rchar * name;
+  runichar4 codepoint;
+  /* UTF-8 canonical encoding. */
+  const ruint8 * utf8;
+  rsize utf8_len;
+  /* UTF-16 canonical encoding (1 unit for BMP, 2 for supplementary). */
+  runichar2 utf16_a;
+  runichar2 utf16_b;        /* 0 when single-unit. */
+} RUnicodeBoundary;
+
+#define BOUNDARY_U8(...) ((const ruint8 []){__VA_ARGS__})
+#define BOUNDARY_U8_LEN(...) (sizeof ((const ruint8 []){__VA_ARGS__}))
+
+/* Note: U+0000 is excluded - the in-buffer functions stop the loop on
+ * `src[i] != 0`, so an embedded NUL terminates input early. The
+ * Unicode Standard considers U+0000 valid; the rlib API simply
+ * treats it as the C string terminator. */
+static const RUnicodeBoundary boundaries[] = {
+  /* Unicode Standard §3.9 boundary codepoints (Kuhn §2.1 / §2.3). */
+  { "U+007F (max 1-byte)",   0x007F,
+      BOUNDARY_U8 (0x7f), 1,
+      0x007F, 0 },
+  { "U+0080 (min 2-byte)",   0x0080,
+      BOUNDARY_U8 (0xc2, 0x80), 2,
+      0x0080, 0 },
+  { "U+07FF (max 2-byte)",   0x07FF,
+      BOUNDARY_U8 (0xdf, 0xbf), 2,
+      0x07FF, 0 },
+  { "U+0800 (min 3-byte)",   0x0800,
+      BOUNDARY_U8 (0xe0, 0xa0, 0x80), 3,
+      0x0800, 0 },
+  { "U+D7FF (last before surrogates)", 0xD7FF,
+      BOUNDARY_U8 (0xed, 0x9f, 0xbf), 3,
+      0xD7FF, 0 },
+  { "U+E000 (first after surrogates)", 0xE000,
+      BOUNDARY_U8 (0xee, 0x80, 0x80), 3,
+      0xE000, 0 },
+  { "U+FFFD (replacement char)", 0xFFFD,
+      BOUNDARY_U8 (0xef, 0xbf, 0xbd), 3,
+      0xFFFD, 0 },
+  { "U+FFFF (max 3-byte / max BMP)", 0xFFFF,
+      BOUNDARY_U8 (0xef, 0xbf, 0xbf), 3,
+      0xFFFF, 0 },
+  { "U+10000 (min 4-byte / first supplementary)", 0x10000,
+      BOUNDARY_U8 (0xf0, 0x90, 0x80, 0x80), 4,
+      0xD800, 0xDC00 },
+  { "U+10FFFF (max Unicode)", 0x10FFFF,
+      BOUNDARY_U8 (0xf4, 0x8f, 0xbf, 0xbf), 4,
+      0xDBFF, 0xDFFF },
+};
+
+RTEST_LOOP (runicode, boundary_utf8_to_utf16, RTEST_FAST,
+    0, R_N_ELEMENTS (boundaries))
+{
+  const RUnicodeBoundary * b = &boundaries[__i];
+  runichar2 dst[8];
+  rchar * endptr;
+  rsize n;
+  rsize expected_units = (b->utf16_b != 0) ? 2 : 1;
+
+  r_assert_cmpint (r_utf8_to_utf16 (dst, R_N_ELEMENTS (dst),
+        (const rchar *)b->utf8, b->utf8_len, &n, &endptr),
+      ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, expected_units);
+  r_assert_cmpuint (dst[0], ==, b->utf16_a);
+  if (b->utf16_b != 0)
+    r_assert_cmpuint (dst[1], ==, b->utf16_b);
+}
+RTEST_END;
+
+RTEST_LOOP (runicode, boundary_utf16_to_utf8, RTEST_FAST,
+    0, R_N_ELEMENTS (boundaries))
+{
+  const RUnicodeBoundary * b = &boundaries[__i];
+  runichar2 src[2];
+  runichar2 * endptr;
+  rchar dst[8];
+  rsize n;
+  rsize srclen = (b->utf16_b != 0) ? 2 : 1;
+
+  src[0] = b->utf16_a;
+  src[1] = b->utf16_b;
+  r_assert_cmpint (r_utf16_to_utf8 (dst, sizeof (dst), src, srclen,
+        &n, &endptr), ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, b->utf8_len);
+  r_assert_cmpmem (dst, ==, b->utf8, b->utf8_len);
+}
+RTEST_END;
+
+RTEST_LOOP (runicode, boundary_utf8_to_utf32, RTEST_FAST,
+    0, R_N_ELEMENTS (boundaries))
+{
+  const RUnicodeBoundary * b = &boundaries[__i];
+  runichar4 dst[4];
+  rchar * endptr;
+  rsize n;
+
+  r_assert_cmpint (r_utf8_to_utf32 (dst, R_N_ELEMENTS (dst),
+        (const rchar *)b->utf8, b->utf8_len, &n, &endptr),
+      ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 1);
+  r_assert_cmpuint (dst[0], ==, b->codepoint);
+}
+RTEST_END;
+
+RTEST_LOOP (runicode, boundary_utf32_to_utf8, RTEST_FAST,
+    0, R_N_ELEMENTS (boundaries))
+{
+  const RUnicodeBoundary * b = &boundaries[__i];
+  runichar4 src[1];
+  runichar4 * endptr;
+  rchar dst[8];
+  rsize n;
+
+  src[0] = b->codepoint;
+  r_assert_cmpint (r_utf32_to_utf8 (dst, sizeof (dst), src, 1, &n, &endptr),
+      ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, b->utf8_len);
+  r_assert_cmpmem (dst, ==, b->utf8, b->utf8_len);
+}
+RTEST_END;
+
+RTEST_LOOP (runicode, boundary_utf16_to_utf32, RTEST_FAST,
+    0, R_N_ELEMENTS (boundaries))
+{
+  const RUnicodeBoundary * b = &boundaries[__i];
+  runichar2 src[2];
+  runichar2 * endptr;
+  runichar4 dst[4];
+  rsize n;
+  rsize srclen = (b->utf16_b != 0) ? 2 : 1;
+
+  src[0] = b->utf16_a;
+  src[1] = b->utf16_b;
+  r_assert_cmpint (r_utf16_to_utf32 (dst, R_N_ELEMENTS (dst), src, srclen,
+        &n, &endptr), ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 1);
+  r_assert_cmpuint (dst[0], ==, b->codepoint);
+}
+RTEST_END;
+
+RTEST_LOOP (runicode, boundary_utf32_to_utf16, RTEST_FAST,
+    0, R_N_ELEMENTS (boundaries))
+{
+  const RUnicodeBoundary * b = &boundaries[__i];
+  runichar4 src[1];
+  runichar4 * endptr;
+  runichar2 dst[4];
+  rsize n;
+  rsize expected_units = (b->utf16_b != 0) ? 2 : 1;
+
+  src[0] = b->codepoint;
+  r_assert_cmpint (r_utf32_to_utf16 (dst, R_N_ELEMENTS (dst), src, 1,
+        &n, &endptr), ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, expected_units);
+  r_assert_cmpuint (dst[0], ==, b->utf16_a);
+  if (b->utf16_b != 0)
+    r_assert_cmpuint (dst[1], ==, b->utf16_b);
+}
+RTEST_END;
+
+/* ---- Kuhn §4: overlong UTF-8 sequences -------------------------------
+ * RFC 3629 §3 forbids encoding a codepoint in more bytes than the
+ * canonical form requires. r_utf8_to_unichar flags these with the
+ * internal R_UTF8_OVERLONG sentinel; both the UTF-16 and UTF-32
+ * paths surface them as R_UNICODE_INVALID_CODE_POINT. */
+
+typedef struct {
+  const rchar * name;
+  const ruint8 bytes[8];
+  rsize len;
+} RUnicodeBadUtf8;
+
+static const RUnicodeBadUtf8 overlong_vectors[] = {
+  /* Kuhn §4.1 - overlong "/". */
+  { "overlong 2B '/'", { 0xc0, 0xaf }, 2 },
+  { "overlong 3B '/'", { 0xe0, 0x80, 0xaf }, 3 },
+  { "overlong 4B '/'", { 0xf0, 0x80, 0x80, 0xaf }, 4 },
+  /* Kuhn §4.2 - maximum overlong at each length. */
+  { "max overlong 2B (U+007F as 2B)", { 0xc1, 0xbf }, 2 },
+  { "max overlong 3B (U+07FF as 3B)", { 0xe0, 0x9f, 0xbf }, 3 },
+  { "max overlong 4B (U+FFFF as 4B)", { 0xf0, 0x8f, 0xbf, 0xbf }, 4 },
+  /* Kuhn §4.3 - overlong NUL. */
+  { "overlong 2B NUL", { 0xc0, 0x80 }, 2 },
+  { "overlong 3B NUL", { 0xe0, 0x80, 0x80 }, 3 },
+  { "overlong 4B NUL", { 0xf0, 0x80, 0x80, 0x80 }, 4 },
+};
+
+RTEST_LOOP (runicode, overlong_utf8_rejected_to_utf16, RTEST_FAST,
+    0, R_N_ELEMENTS (overlong_vectors))
+{
+  const RUnicodeBadUtf8 * v = &overlong_vectors[__i];
+  runichar2 dst[8];
+  rchar * endptr;
+  rsize n;
+
+  r_assert_cmpint (r_utf8_to_utf16 (dst, R_N_ELEMENTS (dst),
+        (const rchar *)v->bytes, v->len, &n, &endptr),
+      ==, R_UNICODE_INVALID_CODE_POINT);
+  r_assert_cmpuint (n, ==, 0);
+}
+RTEST_END;
+
+RTEST_LOOP (runicode, overlong_utf8_rejected_to_utf32, RTEST_FAST,
+    0, R_N_ELEMENTS (overlong_vectors))
+{
+  const RUnicodeBadUtf8 * v = &overlong_vectors[__i];
+  runichar4 dst[8];
+  rchar * endptr;
+  rsize n;
+
+  r_assert_cmpint (r_utf8_to_utf32 (dst, R_N_ELEMENTS (dst),
+        (const rchar *)v->bytes, v->len, &n, &endptr),
+      ==, R_UNICODE_INVALID_CODE_POINT);
+  r_assert_cmpuint (n, ==, 0);
+}
+RTEST_END;
+
+/* ---- Kuhn §5.1 / §5.2: surrogate codepoints in UTF-8 ------------------
+ * The byte pattern is bit-valid 3-byte UTF-8 but the decoded value is
+ * a surrogate half (U+D800..U+DFFF). RFC 3629 §3 requires rejection. */
+static const RUnicodeBadUtf8 surrogate_in_utf8_vectors[] = {
+  { "U+D800 as UTF-8 (high surrogate)", { 0xed, 0xa0, 0x80 }, 3 },
+  { "U+DBFF as UTF-8 (last high surrogate)", { 0xed, 0xaf, 0xbf }, 3 },
+  { "U+DC00 as UTF-8 (low surrogate)", { 0xed, 0xb0, 0x80 }, 3 },
+  { "U+DFFF as UTF-8 (last low surrogate)", { 0xed, 0xbf, 0xbf }, 3 },
+  /* Kuhn §5.2 - paired surrogates encoded as two 3-byte sequences. */
+  { "paired surrogates as UTF-8",
+      { 0xed, 0xa0, 0x80, 0xed, 0xb0, 0x80 }, 6 },
+};
+
+RTEST_LOOP (runicode, surrogate_in_utf8_rejected_to_utf16, RTEST_FAST,
+    0, R_N_ELEMENTS (surrogate_in_utf8_vectors))
+{
+  const RUnicodeBadUtf8 * v = &surrogate_in_utf8_vectors[__i];
+  runichar2 dst[8];
+  rchar * endptr;
+  rsize n;
+
+  r_assert_cmpint (r_utf8_to_utf16 (dst, R_N_ELEMENTS (dst),
+        (const rchar *)v->bytes, v->len, &n, &endptr),
+      ==, R_UNICODE_INVALID_CODE_POINT);
+  r_assert_cmpuint (n, ==, 0);
+}
+RTEST_END;
+
+RTEST_LOOP (runicode, surrogate_in_utf8_rejected_to_utf32, RTEST_FAST,
+    0, R_N_ELEMENTS (surrogate_in_utf8_vectors))
+{
+  const RUnicodeBadUtf8 * v = &surrogate_in_utf8_vectors[__i];
+  runichar4 dst[8];
+  rchar * endptr;
+  rsize n;
+
+  r_assert_cmpint (r_utf8_to_utf32 (dst, R_N_ELEMENTS (dst),
+        (const rchar *)v->bytes, v->len, &n, &endptr),
+      ==, R_UNICODE_INVALID_CODE_POINT);
+  r_assert_cmpuint (n, ==, 0);
+}
+RTEST_END;
+
+/* ---- Kuhn §3: malformed UTF-8 ----------------------------------------
+ * Sequences that don't even form a valid bit pattern - lone
+ * continuation bytes, impossible 0xFE / 0xFF, and truncated
+ * multi-byte sequences. */
+static const RUnicodeBadUtf8 malformed_utf8_vectors[] = {
+  /* Kuhn §3.1: lone continuation bytes. */
+  { "lone 0x80", { 0x80 }, 1 },
+  { "lone 0xBF", { 0xbf }, 1 },
+  /* Kuhn §3.3: missing continuation. */
+  { "2-byte start missing continuation", { 0xc2 }, 1 },
+  { "3-byte start missing 1 of 2 continuations", { 0xe0, 0xa0 }, 2 },
+  { "4-byte start missing 1 of 3 continuations",
+      { 0xf0, 0x90, 0x80 }, 3 },
+  /* Kuhn §3.5: impossible bytes (RFC 3629 forbids 0xFE / 0xFF). */
+  { "impossible byte 0xFE", { 0xfe }, 1 },
+  { "impossible byte 0xFF", { 0xff }, 1 },
+};
+
+RTEST_LOOP (runicode, malformed_utf8_rejected_to_utf16, RTEST_FAST,
+    0, R_N_ELEMENTS (malformed_utf8_vectors))
+{
+  const RUnicodeBadUtf8 * v = &malformed_utf8_vectors[__i];
+  runichar2 dst[8];
+  rchar * endptr;
+  rsize n;
+  RUnicodeResult r;
+
+  r = r_utf8_to_utf16 (dst, R_N_ELEMENTS (dst),
+      (const rchar *)v->bytes, v->len, &n, &endptr);
+  r_assert (r == R_UNICODE_INCOMPLETE_CODE_POINT ||
+            r == R_UNICODE_INVALID_CODE_POINT);
+  r_assert_cmpuint (n, ==, 0);
+}
+RTEST_END;
+
+RTEST_LOOP (runicode, malformed_utf8_rejected_to_utf32, RTEST_FAST,
+    0, R_N_ELEMENTS (malformed_utf8_vectors))
+{
+  const RUnicodeBadUtf8 * v = &malformed_utf8_vectors[__i];
+  runichar4 dst[8];
+  rchar * endptr;
+  rsize n;
+  RUnicodeResult r;
+
+  r = r_utf8_to_utf32 (dst, R_N_ELEMENTS (dst),
+      (const rchar *)v->bytes, v->len, &n, &endptr);
+  r_assert (r == R_UNICODE_INCOMPLETE_CODE_POINT ||
+            r == R_UNICODE_INVALID_CODE_POINT);
+  r_assert_cmpuint (n, ==, 0);
+}
+RTEST_END;
+
+/* ---- UTF-8 codepoint out of Unicode range ----------------------------
+ * Bit pattern is valid 4-byte UTF-8 but decodes to a codepoint
+ * > U+10FFFF (RFC 3629 §3). */
+RTEST (runicode, utf8_codepoint_out_of_range_to_utf16, RTEST_FAST)
+{
+  static const ruint8 src[4] = { 0xf4, 0x90, 0x80, 0x80 };  /* U+110000 */
+  runichar2 dst[8];
+  rchar * endptr;
+  rsize n;
+
+  r_assert_cmpint (r_utf8_to_utf16 (dst, R_N_ELEMENTS (dst),
+        (const rchar *)src, 4, &n, &endptr),
+      ==, R_UNICODE_INVALID_CODE_POINT);
+  r_assert_cmpuint (n, ==, 0);
+}
+RTEST_END;
+
+RTEST (runicode, utf8_codepoint_out_of_range_to_utf32, RTEST_FAST)
+{
+  static const ruint8 src[4] = { 0xf4, 0x90, 0x80, 0x80 };  /* U+110000 */
+  runichar4 dst[8];
+  rchar * endptr;
+  rsize n;
+
+  r_assert_cmpint (r_utf8_to_utf32 (dst, R_N_ELEMENTS (dst),
+        (const rchar *)src, 4, &n, &endptr),
+      ==, R_UNICODE_INVALID_CODE_POINT);
+  r_assert_cmpuint (n, ==, 0);
+}
+RTEST_END;

--- a/test/runicode.c
+++ b/test/runicode.c
@@ -1158,3 +1158,191 @@ RTEST (runicode, null_out_params_utf32_to_utf16, RTEST_FAST)
   r_assert_cmpuint (dst[0], ==, 'a');
 }
 RTEST_END;
+
+/* ---- Encoding-validation entry points ------------------------------
+ * Scan-only counterparts to the conversion functions. Each validator
+ * applies the same rejection rules as its conversion sibling but
+ * allocates no destination buffer. */
+
+RTEST (runicode, utf8_validate_ok, RTEST_FAST)
+{
+  rchar * endptr;
+  r_assert_cmpint (r_utf8_validate ("abc", 3, &endptr), ==, R_UNICODE_OK);
+  r_assert_cmpptr (endptr, ==, (rchar *)"abc" + 3);
+
+  r_assert_cmpint (r_utf8_validate ("\xCE\xB1\xCE\xB2", 4, NULL),
+      ==, R_UNICODE_OK);
+
+  /* Length via r_strlen. */
+  r_assert_cmpint (r_utf8_validate ("abc", -1, NULL), ==, R_UNICODE_OK);
+}
+RTEST_END;
+
+RTEST_LOOP (runicode, utf8_validate_rejects_overlong, RTEST_FAST,
+    0, R_N_ELEMENTS (overlong_vectors))
+{
+  const RUnicodeBadUtf8 * v = &overlong_vectors[__i];
+  r_assert_cmpint (r_utf8_validate ((const rchar *)v->bytes, v->len, NULL),
+      ==, R_UNICODE_INVALID_CODE_POINT);
+}
+RTEST_END;
+
+RTEST_LOOP (runicode, utf8_validate_rejects_surrogate_in_utf8, RTEST_FAST,
+    0, R_N_ELEMENTS (surrogate_in_utf8_vectors))
+{
+  const RUnicodeBadUtf8 * v = &surrogate_in_utf8_vectors[__i];
+  r_assert_cmpint (r_utf8_validate ((const rchar *)v->bytes, v->len, NULL),
+      ==, R_UNICODE_INVALID_CODE_POINT);
+}
+RTEST_END;
+
+RTEST_LOOP (runicode, utf8_validate_rejects_malformed, RTEST_FAST,
+    0, R_N_ELEMENTS (malformed_utf8_vectors))
+{
+  const RUnicodeBadUtf8 * v = &malformed_utf8_vectors[__i];
+  RUnicodeResult r = r_utf8_validate ((const rchar *)v->bytes, v->len, NULL);
+  r_assert (r == R_UNICODE_INVALID_CODE_POINT ||
+            r == R_UNICODE_INCOMPLETE_CODE_POINT);
+}
+RTEST_END;
+
+RTEST (runicode, utf8_validate_endptr_on_failure, RTEST_FAST)
+{
+  /* "ab" + overlong "/" (\xC0\xAF). endptr should point at the start
+   * of the overlong sequence. */
+  static const ruint8 src[4] = { 'a', 'b', 0xc0, 0xaf };
+  rchar * endptr;
+
+  r_assert_cmpint (r_utf8_validate ((const rchar *)src, sizeof (src),
+        &endptr), ==, R_UNICODE_INVALID_CODE_POINT);
+  r_assert_cmpptr (endptr, ==, (rchar *)src + 2);
+}
+RTEST_END;
+
+RTEST (runicode, utf8_validate_endptr_on_incomplete, RTEST_FAST)
+{
+  /* Resumable position: "a" + half of α. */
+  static const ruint8 src[2] = { 'a', 0xce };
+  rchar * endptr;
+
+  r_assert_cmpint (r_utf8_validate ((const rchar *)src, sizeof (src),
+        &endptr), ==, R_UNICODE_INCOMPLETE_CODE_POINT);
+  r_assert_cmpptr (endptr, ==, (rchar *)src + 1);
+}
+RTEST_END;
+
+RTEST (runicode, utf8_validate_strips_bom, RTEST_FAST)
+{
+  static const ruint8 src[6] = { 0xef, 0xbb, 0xbf, 'a', 'b', 'c' };
+  r_assert_cmpint (r_utf8_validate ((const rchar *)src, sizeof (src), NULL),
+      ==, R_UNICODE_OK);
+}
+RTEST_END;
+
+RTEST (runicode, utf8_validate_null_src, RTEST_FAST)
+{
+  r_assert_cmpint (r_utf8_validate (NULL, 0, NULL), ==, R_UNICODE_INVAL);
+}
+RTEST_END;
+
+RTEST (runicode, utf16_validate_ok, RTEST_FAST)
+{
+  runichar2 src[] = { 'a', 'b', 'c' };
+  runichar2 * endptr;
+
+  r_assert_cmpint (r_utf16_validate (src, 3, &endptr), ==, R_UNICODE_OK);
+  r_assert_cmpptr (endptr, ==, src + 3);
+}
+RTEST_END;
+
+RTEST (runicode, utf16_validate_surrogate_pair, RTEST_FAST)
+{
+  runichar2 src[] = { 'a', 0xD800, 0xDC00, 'z' };
+  r_assert_cmpint (r_utf16_validate (src, 4, NULL), ==, R_UNICODE_OK);
+}
+RTEST_END;
+
+RTEST (runicode, utf16_validate_incomplete, RTEST_FAST)
+{
+  runichar2 src[] = { 'a', 0xD800 };
+  runichar2 * endptr;
+
+  r_assert_cmpint (r_utf16_validate (src, 2, &endptr),
+      ==, R_UNICODE_INCOMPLETE_CODE_POINT);
+  r_assert_cmpptr (endptr, ==, src + 1);
+}
+RTEST_END;
+
+RTEST (runicode, utf16_validate_invalid_lone_low, RTEST_FAST)
+{
+  runichar2 src[] = { 'a', 0xDC00, 'z' };
+  runichar2 * endptr;
+
+  r_assert_cmpint (r_utf16_validate (src, 3, &endptr),
+      ==, R_UNICODE_INVALID_CODE_POINT);
+  r_assert_cmpptr (endptr, ==, src + 1);
+}
+RTEST_END;
+
+RTEST (runicode, utf16_validate_strips_bom_rejects_swap, RTEST_FAST)
+{
+  runichar2 with_bom[] = { 0xFEFF, 'a', 'b' };
+  runichar2 with_swap[] = { 0xFFFE, 'a', 'b' };
+
+  r_assert_cmpint (r_utf16_validate (with_bom, 3, NULL), ==, R_UNICODE_OK);
+  r_assert_cmpint (r_utf16_validate (with_swap, 3, NULL),
+      ==, R_UNICODE_INVAL);
+}
+RTEST_END;
+
+RTEST (runicode, utf16_validate_null_src, RTEST_FAST)
+{
+  r_assert_cmpint (r_utf16_validate (NULL, 0, NULL), ==, R_UNICODE_INVAL);
+}
+RTEST_END;
+
+RTEST (runicode, utf32_validate_ok, RTEST_FAST)
+{
+  runichar4 src[] = { 'a', 0x10FFFF, 'z' };
+  runichar4 * endptr;
+
+  r_assert_cmpint (r_utf32_validate (src, 3, &endptr), ==, R_UNICODE_OK);
+  r_assert_cmpptr (endptr, ==, src + 3);
+}
+RTEST_END;
+
+RTEST (runicode, utf32_validate_rejects_out_of_range, RTEST_FAST)
+{
+  runichar4 src[] = { 'a', 0x110000, 'z' };
+  runichar4 * endptr;
+
+  r_assert_cmpint (r_utf32_validate (src, 3, &endptr),
+      ==, R_UNICODE_INVALID_CODE_POINT);
+  r_assert_cmpptr (endptr, ==, src + 1);
+}
+RTEST_END;
+
+RTEST (runicode, utf32_validate_rejects_surrogate, RTEST_FAST)
+{
+  runichar4 src_high[] = { 'a', 0xD800 };
+  runichar4 src_low[] = { 'a', 0xDFFF };
+
+  r_assert_cmpint (r_utf32_validate (src_high, 2, NULL),
+      ==, R_UNICODE_INVALID_CODE_POINT);
+  r_assert_cmpint (r_utf32_validate (src_low, 2, NULL),
+      ==, R_UNICODE_INVALID_CODE_POINT);
+}
+RTEST_END;
+
+RTEST (runicode, utf32_validate_strips_bom, RTEST_FAST)
+{
+  runichar4 src[] = { 0xFEFF, 'a', 'b' };
+  r_assert_cmpint (r_utf32_validate (src, 3, NULL), ==, R_UNICODE_OK);
+}
+RTEST_END;
+
+RTEST (runicode, utf32_validate_null_src, RTEST_FAST)
+{
+  r_assert_cmpint (r_utf32_validate (NULL, 0, NULL), ==, R_UNICODE_INVAL);
+}
+RTEST_END;

--- a/test/runicode.c
+++ b/test/runicode.c
@@ -35,12 +35,14 @@ RTEST (runicode, utf16_to_utf8, RTEST_FAST)
   r_assert_cmpptr (utf16end, ==, utf16 + 2);
   r_free (utf8);
 
-  /* Partial UTF-16, missing low surrogate */
+  /* Partial UTF-16, missing low surrogate. srcendptr points AT the
+   * unconsumed high surrogate so the caller can resume from there
+   * once more units arrive. */
   utf16[0] = 0x78; utf16[1] = 0x79; utf16[2] = 0xd801; utf16[3] = 0;
   r_assert_cmpptr ((utf8 = r_utf16_to_utf8_dup (utf16, 3, &res, &u8len, &utf16end)), ==, NULL);
   r_assert_cmpint (res, ==, R_UNICODE_INCOMPLETE_CODE_POINT);
   r_assert_cmpuint (u8len, ==, 2);
-  r_assert_cmpptr (utf16end, ==, utf16 + 3);
+  r_assert_cmpptr (utf16end, ==, utf16 + 2);
 
   /* Invalid UTF-16, missing high surrogate */
   utf16[0] = 0x79; utf16[1] = 0x7A; utf16[2] = 0xdc01; utf16[3] = 0;
@@ -890,5 +892,269 @@ RTEST (runicode, utf8_codepoint_out_of_range_to_utf32, RTEST_FAST)
         (const rchar *)src, 4, &n, &endptr),
       ==, R_UNICODE_INVALID_CODE_POINT);
   r_assert_cmpuint (n, ==, 0);
+}
+RTEST_END;
+
+/* ---- UTF-32 BOM stripping ------------------------------------------
+ * UTF-8 ↔ UTF-16 BOM behaviour is covered by the legacy
+ * `utf*_bom` tests above. The new UTF-32 paths strip a leading
+ * 0xFEFF code point from any input where it could occur. */
+
+RTEST (runicode, utf8_bom_to_utf32, RTEST_FAST)
+{
+  static const ruint8 src[] = { 0xef, 0xbb, 0xbf, 'a', 'b', 'c' };
+  runichar4 dst[8];
+  rchar * endptr;
+  rsize n;
+
+  r_assert_cmpint (r_utf8_to_utf32 (dst, R_N_ELEMENTS (dst),
+        (const rchar *)src, sizeof (src), &n, &endptr),
+      ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 3);
+  r_assert_cmpuint (dst[0], ==, 'a');
+}
+RTEST_END;
+
+RTEST (runicode, utf16_bom_to_utf32, RTEST_FAST)
+{
+  runichar2 src[] = { 0xFEFF, 'a', 'b', 'c' };
+  runichar4 dst[8];
+  runichar2 * endptr;
+  rsize n;
+
+  r_assert_cmpint (r_utf16_to_utf32 (dst, R_N_ELEMENTS (dst),
+        src, R_N_ELEMENTS (src), &n, &endptr),
+      ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 3);
+  r_assert_cmpuint (dst[0], ==, 'a');
+}
+RTEST_END;
+
+RTEST (runicode, utf32_bom_to_utf8, RTEST_FAST)
+{
+  runichar4 src[] = { 0xFEFF, 'a', 'b', 'c' };
+  runichar4 * endptr;
+  rchar dst[16];
+  rsize n;
+
+  r_assert_cmpint (r_utf32_to_utf8 (dst, sizeof (dst),
+        src, R_N_ELEMENTS (src), &n, &endptr),
+      ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 3);
+  r_assert_cmpstr (dst, ==, "abc");
+}
+RTEST_END;
+
+RTEST (runicode, utf32_bom_to_utf16, RTEST_FAST)
+{
+  runichar4 src[] = { 0xFEFF, 'a', 'b', 'c' };
+  runichar4 * endptr;
+  runichar2 dst[8];
+  rsize n;
+
+  r_assert_cmpint (r_utf32_to_utf16 (dst, R_N_ELEMENTS (dst),
+        src, R_N_ELEMENTS (src), &n, &endptr),
+      ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 3);
+  r_assert_cmpuint (dst[0], ==, 'a');
+}
+RTEST_END;
+
+/* ---- Streaming resume via srcendptr --------------------------------
+ * `R_UNICODE_INCOMPLETE_CODE_POINT` is the explicit signal that the
+ * source ended mid-codepoint and the caller should resume from
+ * `srcendptr` once more bytes arrive. Verify that a concatenated
+ * (first-chunk-truncated, then-rest) pass produces the same result
+ * as a single-shot conversion. */
+
+RTEST (runicode, utf8_streaming_resume_to_utf16, RTEST_FAST)
+{
+  /* "α" = U+03B1 = 0xCE 0xB1 (2-byte UTF-8). Feed just 0xCE first. */
+  static const ruint8 chunk1[] = { 'a', 0xce };           /* 'a' + half α */
+  static const ruint8 chunk2[] = { 0xb1, 'b' };            /* tail of α + 'b' */
+  runichar2 dst[8];
+  rchar * endptr;
+  rsize n;
+
+  r_assert_cmpint (r_utf8_to_utf16 (dst, R_N_ELEMENTS (dst),
+        (const rchar *)chunk1, sizeof (chunk1), &n, &endptr),
+      ==, R_UNICODE_INCOMPLETE_CODE_POINT);
+  r_assert_cmpuint (n, ==, 1);
+  r_assert_cmpuint (dst[0], ==, 'a');
+  /* srcendptr points at the start of the incomplete sequence (0xCE). */
+  r_assert_cmpptr (endptr, ==, (rchar *)chunk1 + 1);
+
+  /* Concatenate the unconsumed tail with chunk2 and convert again. */
+  {
+    ruint8 joined[8];
+    runichar2 dst2[8];
+    rchar * endptr2;
+    rsize joined_len = sizeof (chunk1) - (rsize)(endptr - (rchar *)chunk1);
+
+    r_memcpy (joined, endptr, joined_len);
+    r_memcpy (joined + joined_len, chunk2, sizeof (chunk2));
+    r_assert_cmpint (r_utf8_to_utf16 (dst2, R_N_ELEMENTS (dst2),
+          (const rchar *)joined, joined_len + sizeof (chunk2),
+          &n, &endptr2), ==, R_UNICODE_OK);
+    r_assert_cmpuint (n, ==, 2);
+    r_assert_cmpuint (dst2[0], ==, 0x3B1);
+    r_assert_cmpuint (dst2[1], ==, 'b');
+  }
+}
+RTEST_END;
+
+RTEST (runicode, utf8_streaming_resume_to_utf32, RTEST_FAST)
+{
+  /* "𐀀" = U+10000 = F0 90 80 80 (4-byte UTF-8). Truncate after 2. */
+  static const ruint8 chunk1[] = { 'x', 0xf0, 0x90 };
+  static const ruint8 chunk2[] = { 0x80, 0x80, 'y' };
+  runichar4 dst[8];
+  rchar * endptr;
+  rsize n;
+  ruint8 joined[8];
+  runichar4 dst2[8];
+  rchar * endptr2;
+  rsize joined_len;
+
+  r_assert_cmpint (r_utf8_to_utf32 (dst, R_N_ELEMENTS (dst),
+        (const rchar *)chunk1, sizeof (chunk1), &n, &endptr),
+      ==, R_UNICODE_INCOMPLETE_CODE_POINT);
+  r_assert_cmpuint (n, ==, 1);
+  r_assert_cmpuint (dst[0], ==, 'x');
+  r_assert_cmpptr (endptr, ==, (rchar *)chunk1 + 1);
+
+  joined_len = sizeof (chunk1) - (rsize)(endptr - (rchar *)chunk1);
+  r_memcpy (joined, endptr, joined_len);
+  r_memcpy (joined + joined_len, chunk2, sizeof (chunk2));
+  r_assert_cmpint (r_utf8_to_utf32 (dst2, R_N_ELEMENTS (dst2),
+        (const rchar *)joined, joined_len + sizeof (chunk2),
+        &n, &endptr2), ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 2);
+  r_assert_cmpuint (dst2[0], ==, 0x10000);
+  r_assert_cmpuint (dst2[1], ==, 'y');
+}
+RTEST_END;
+
+RTEST (runicode, utf16_streaming_resume_to_utf8, RTEST_FAST)
+{
+  /* Surrogate pair for U+10000 split across chunks. */
+  runichar2 chunk1[] = { 'x', 0xD800 };
+  runichar2 chunk2[] = { 0xDC00, 'y' };
+  rchar dst[16];
+  runichar2 * endptr;
+  rsize n;
+  runichar2 joined[8];
+  rchar dst2[16];
+  runichar2 * endptr2;
+  rsize joined_len;
+
+  r_assert_cmpint (r_utf16_to_utf8 (dst, sizeof (dst),
+        chunk1, R_N_ELEMENTS (chunk1), &n, &endptr),
+      ==, R_UNICODE_INCOMPLETE_CODE_POINT);
+  r_assert_cmpuint (n, ==, 1);
+  r_assert_cmpuint ((ruint8)dst[0], ==, 'x');
+
+  joined_len = R_N_ELEMENTS (chunk1) - (rsize)(endptr - chunk1);
+  r_memcpy (joined, endptr, joined_len * sizeof (runichar2));
+  r_memcpy (joined + joined_len, chunk2, sizeof (chunk2));
+  r_assert_cmpint (r_utf16_to_utf8 (dst2, sizeof (dst2),
+        joined, joined_len + R_N_ELEMENTS (chunk2), &n, &endptr2),
+      ==, R_UNICODE_OK);
+  /* "𐀀" + "y" = 4 + 1 UTF-8 bytes. */
+  r_assert_cmpuint (n, ==, 5);
+  r_assert_cmpmem (dst2, ==, "\xF0\x90\x80\x80y", 5);
+}
+RTEST_END;
+
+RTEST (runicode, utf16_streaming_resume_to_utf32, RTEST_FAST)
+{
+  runichar2 chunk1[] = { 'x', 0xD800 };
+  runichar2 chunk2[] = { 0xDC00, 'y' };
+  runichar4 dst[8];
+  runichar2 * endptr;
+  rsize n;
+  runichar2 joined[8];
+  runichar4 dst2[8];
+  runichar2 * endptr2;
+  rsize joined_len;
+
+  r_assert_cmpint (r_utf16_to_utf32 (dst, R_N_ELEMENTS (dst),
+        chunk1, R_N_ELEMENTS (chunk1), &n, &endptr),
+      ==, R_UNICODE_INCOMPLETE_CODE_POINT);
+  r_assert_cmpuint (n, ==, 1);
+  r_assert_cmpuint (dst[0], ==, 'x');
+
+  joined_len = R_N_ELEMENTS (chunk1) - (rsize)(endptr - chunk1);
+  r_memcpy (joined, endptr, joined_len * sizeof (runichar2));
+  r_memcpy (joined + joined_len, chunk2, sizeof (chunk2));
+  r_assert_cmpint (r_utf16_to_utf32 (dst2, R_N_ELEMENTS (dst2),
+        joined, joined_len + R_N_ELEMENTS (chunk2), &n, &endptr2),
+      ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 2);
+  r_assert_cmpuint (dst2[0], ==, 0x10000);
+  r_assert_cmpuint (dst2[1], ==, 'y');
+}
+RTEST_END;
+
+/* ---- NULL out-pointer robustness -----------------------------------
+ * The impl docstrings say `dstoutsize` and `srcendptr` are optional.
+ * Confirm that passing NULL for either works and the conversion
+ * still produces correct output. */
+
+RTEST (runicode, null_out_params_utf8_to_utf16, RTEST_FAST)
+{
+  runichar2 dst[8];
+  r_assert_cmpint (r_utf8_to_utf16 (dst, R_N_ELEMENTS (dst), "abc", 3,
+        NULL, NULL), ==, R_UNICODE_OK);
+  r_assert_cmpuint (dst[0], ==, 'a');
+}
+RTEST_END;
+
+RTEST (runicode, null_out_params_utf16_to_utf8, RTEST_FAST)
+{
+  runichar2 src[] = { 'a', 'b', 'c' };
+  rchar dst[8];
+  r_assert_cmpint (r_utf16_to_utf8 (dst, sizeof (dst), src, 3,
+        NULL, NULL), ==, R_UNICODE_OK);
+  r_assert_cmpstr (dst, ==, "abc");
+}
+RTEST_END;
+
+RTEST (runicode, null_out_params_utf8_to_utf32, RTEST_FAST)
+{
+  runichar4 dst[8];
+  r_assert_cmpint (r_utf8_to_utf32 (dst, R_N_ELEMENTS (dst), "abc", 3,
+        NULL, NULL), ==, R_UNICODE_OK);
+  r_assert_cmpuint (dst[0], ==, 'a');
+}
+RTEST_END;
+
+RTEST (runicode, null_out_params_utf32_to_utf8, RTEST_FAST)
+{
+  runichar4 src[] = { 'a', 'b', 'c' };
+  rchar dst[8];
+  r_assert_cmpint (r_utf32_to_utf8 (dst, sizeof (dst), src, 3,
+        NULL, NULL), ==, R_UNICODE_OK);
+  r_assert_cmpstr (dst, ==, "abc");
+}
+RTEST_END;
+
+RTEST (runicode, null_out_params_utf16_to_utf32, RTEST_FAST)
+{
+  runichar2 src[] = { 'a', 'b', 'c' };
+  runichar4 dst[8];
+  r_assert_cmpint (r_utf16_to_utf32 (dst, R_N_ELEMENTS (dst), src, 3,
+        NULL, NULL), ==, R_UNICODE_OK);
+  r_assert_cmpuint (dst[0], ==, 'a');
+}
+RTEST_END;
+
+RTEST (runicode, null_out_params_utf32_to_utf16, RTEST_FAST)
+{
+  runichar4 src[] = { 'a', 'b', 'c' };
+  runichar2 dst[8];
+  r_assert_cmpint (r_utf32_to_utf16 (dst, R_N_ELEMENTS (dst), src, 3,
+        NULL, NULL), ==, R_UNICODE_OK);
+  r_assert_cmpuint (dst[0], ==, 'a');
 }
 RTEST_END;

--- a/test/runicode.c
+++ b/test/runicode.c
@@ -165,3 +165,370 @@ RTEST (runicode, utf8_to_utf16_bom, RTEST_FAST)
   r_free (ptr);
 }
 RTEST_END;
+
+/* ---- UTF-32 conversions ------------------------------------------ */
+
+RTEST (runicode, utf8_to_utf32, RTEST_FAST)
+{
+  runichar4 utf32[16];
+  rchar * utf8end;
+  rsize n;
+  RUnicodeResult res;
+
+  /* ASCII round-trip. */
+  res = r_utf8_to_utf32 (utf32, R_N_ELEMENTS (utf32), "abc123!\"#", 9,
+      &n, &utf8end);
+  r_assert_cmpint (res, ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 9);
+  r_assert_cmpuint (utf32[0], ==, 'a');
+  r_assert_cmpuint (utf32[8], ==, '#');
+  r_assert_cmpuint (utf32[9], ==, 0);
+  r_assert_cmpptr (utf8end, ==, (rchar *)"abc123!\"#" + 9);
+
+  /* 2-byte UTF-8: U+03B1, U+03B2, U+03B3. */
+  res = r_utf8_to_utf32 (utf32, R_N_ELEMENTS (utf32),
+      "\xCE\xB1\xCE\xB2\xCE\xB3", 6, &n, &utf8end);
+  r_assert_cmpint (res, ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 3);
+  r_assert_cmpuint (utf32[0], ==, 0x3b1);
+  r_assert_cmpuint (utf32[1], ==, 0x3b2);
+  r_assert_cmpuint (utf32[2], ==, 0x3b3);
+
+  /* 4-byte UTF-8: U+10FFFF (max codepoint). */
+  res = r_utf8_to_utf32 (utf32, R_N_ELEMENTS (utf32),
+      "\xF4\x8F\xBF\xBF", 4, &n, &utf8end);
+  r_assert_cmpint (res, ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 1);
+  r_assert_cmpuint (utf32[0], ==, 0x10FFFF);
+}
+RTEST_END;
+
+RTEST (runicode, utf8_to_utf32_overflow, RTEST_FAST)
+{
+  runichar4 utf32[4];   /* Capacity 3 + NUL. */
+  rchar * utf8end;
+  rsize n;
+  RUnicodeResult res;
+
+  res = r_utf8_to_utf32 (utf32, R_N_ELEMENTS (utf32), "abcdef", 6,
+      &n, &utf8end);
+  r_assert_cmpint (res, ==, R_UNICODE_OVERFLOW);
+  r_assert_cmpuint (n, ==, 3);
+}
+RTEST_END;
+
+RTEST (runicode, utf8_to_utf32_incomplete, RTEST_FAST)
+{
+  runichar4 utf32[8];
+  rchar * utf8end;
+  rsize n;
+  RUnicodeResult res;
+
+  /* "ab" + truncated 2-byte sequence (0xCE without continuation). */
+  res = r_utf8_to_utf32 (utf32, R_N_ELEMENTS (utf32), "ab\xCE", 3,
+      &n, &utf8end);
+  r_assert_cmpint (res, ==, R_UNICODE_INCOMPLETE_CODE_POINT);
+  r_assert_cmpuint (n, ==, 2);
+  r_assert_cmpuint (utf32[0], ==, 'a');
+  r_assert_cmpuint (utf32[1], ==, 'b');
+}
+RTEST_END;
+
+RTEST (runicode, utf8_to_utf32_invalid, RTEST_FAST)
+{
+  runichar4 utf32[8];
+  rchar * utf8end;
+  rsize n;
+  RUnicodeResult res;
+
+  /* UTF-8 encoding of U+D800 (high surrogate) - valid bit pattern
+   * but the codepoint is invalid. */
+  res = r_utf8_to_utf32 (utf32, R_N_ELEMENTS (utf32), "a\xED\xA0\x80", 4,
+      &n, &utf8end);
+  r_assert_cmpint (res, ==, R_UNICODE_INVALID_CODE_POINT);
+  r_assert_cmpuint (n, ==, 1);
+  r_assert_cmpuint (utf32[0], ==, 'a');
+}
+RTEST_END;
+
+RTEST (runicode, utf32_to_utf8, RTEST_FAST)
+{
+  runichar4 utf32[16];
+  runichar4 * utf32end;
+  rchar utf8[64];
+  rsize n;
+  RUnicodeResult res;
+
+  utf32[0] = 'a'; utf32[1] = 'b'; utf32[2] = 'c'; utf32[3] = 0;
+  res = r_utf32_to_utf8 (utf8, sizeof (utf8), utf32, 3, &n, &utf32end);
+  r_assert_cmpint (res, ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 3);
+  r_assert_cmpstr (utf8, ==, "abc");
+
+  /* 2-byte UTF-8 outputs. */
+  utf32[0] = 0x3b1; utf32[1] = 0x3b2; utf32[2] = 0x3b3; utf32[3] = 0;
+  res = r_utf32_to_utf8 (utf8, sizeof (utf8), utf32, 3, &n, &utf32end);
+  r_assert_cmpint (res, ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 6);
+  r_assert_cmpmem (utf8, ==, "\xCE\xB1\xCE\xB2\xCE\xB3", 6);
+
+  /* Max codepoint -> 4-byte UTF-8. */
+  utf32[0] = 0x10FFFF; utf32[1] = 0;
+  res = r_utf32_to_utf8 (utf8, sizeof (utf8), utf32, 1, &n, &utf32end);
+  r_assert_cmpint (res, ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 4);
+  r_assert_cmpmem (utf8, ==, "\xF4\x8F\xBF\xBF", 4);
+}
+RTEST_END;
+
+RTEST (runicode, utf32_to_utf8_overflow, RTEST_FAST)
+{
+  runichar4 utf32[4];
+  runichar4 * utf32end;
+  rchar utf8[4];   /* Capacity 3 + NUL; "abcdef" needs 6 + 1. */
+  rsize n;
+  RUnicodeResult res;
+
+  utf32[0] = 'a'; utf32[1] = 'b'; utf32[2] = 'c'; utf32[3] = 'd';
+  res = r_utf32_to_utf8 (utf8, sizeof (utf8), utf32, 4, &n, &utf32end);
+  r_assert_cmpint (res, ==, R_UNICODE_OVERFLOW);
+  r_assert_cmpuint (n, ==, 3);
+}
+RTEST_END;
+
+RTEST (runicode, utf32_to_utf8_invalid, RTEST_FAST)
+{
+  runichar4 utf32[4];
+  runichar4 * utf32end;
+  rchar utf8[16];
+  rsize n;
+  RUnicodeResult res;
+
+  /* Out-of-range codepoint. */
+  utf32[0] = 'a'; utf32[1] = 0x110000;
+  res = r_utf32_to_utf8 (utf8, sizeof (utf8), utf32, 2, &n, &utf32end);
+  r_assert_cmpint (res, ==, R_UNICODE_INVALID_CODE_POINT);
+  r_assert_cmpuint (n, ==, 1);
+
+  /* Surrogate-half codepoint. */
+  utf32[0] = 'a'; utf32[1] = 0xd800;
+  res = r_utf32_to_utf8 (utf8, sizeof (utf8), utf32, 2, &n, &utf32end);
+  r_assert_cmpint (res, ==, R_UNICODE_INVALID_CODE_POINT);
+  r_assert_cmpuint (n, ==, 1);
+}
+RTEST_END;
+
+RTEST (runicode, utf16_to_utf32, RTEST_FAST)
+{
+  runichar4 utf32[16];
+  runichar2 utf16[16];
+  runichar2 * utf16end;
+  rsize n;
+  RUnicodeResult res;
+
+  utf16[0] = 'a'; utf16[1] = 'b'; utf16[2] = 'c'; utf16[3] = 0;
+  res = r_utf16_to_utf32 (utf32, R_N_ELEMENTS (utf32), utf16, 3,
+      &n, &utf16end);
+  r_assert_cmpint (res, ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 3);
+  r_assert_cmpuint (utf32[0], ==, 'a');
+
+  /* Surrogate pair: U+10000. */
+  utf16[0] = 0xD800; utf16[1] = 0xDC00;
+  res = r_utf16_to_utf32 (utf32, R_N_ELEMENTS (utf32), utf16, 2,
+      &n, &utf16end);
+  r_assert_cmpint (res, ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 1);
+  r_assert_cmpuint (utf32[0], ==, 0x10000);
+
+  /* Surrogate pair: U+10FFFF. */
+  utf16[0] = 0xDBFF; utf16[1] = 0xDFFF;
+  res = r_utf16_to_utf32 (utf32, R_N_ELEMENTS (utf32), utf16, 2,
+      &n, &utf16end);
+  r_assert_cmpint (res, ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 1);
+  r_assert_cmpuint (utf32[0], ==, 0x10FFFF);
+}
+RTEST_END;
+
+RTEST (runicode, utf16_to_utf32_overflow, RTEST_FAST)
+{
+  runichar4 utf32[4];
+  runichar2 utf16[8];
+  runichar2 * utf16end;
+  rsize n;
+  RUnicodeResult res;
+
+  utf16[0] = 'a'; utf16[1] = 'b'; utf16[2] = 'c';
+  utf16[3] = 'd'; utf16[4] = 'e'; utf16[5] = 'f';
+  res = r_utf16_to_utf32 (utf32, R_N_ELEMENTS (utf32), utf16, 6,
+      &n, &utf16end);
+  r_assert_cmpint (res, ==, R_UNICODE_OVERFLOW);
+  r_assert_cmpuint (n, ==, 3);
+}
+RTEST_END;
+
+RTEST (runicode, utf16_to_utf32_incomplete, RTEST_FAST)
+{
+  runichar4 utf32[8];
+  runichar2 utf16[4];
+  runichar2 * utf16end;
+  rsize n;
+  RUnicodeResult res;
+
+  /* High surrogate with no following low surrogate. */
+  utf16[0] = 'x'; utf16[1] = 'y'; utf16[2] = 0xD801;
+  res = r_utf16_to_utf32 (utf32, R_N_ELEMENTS (utf32), utf16, 3,
+      &n, &utf16end);
+  r_assert_cmpint (res, ==, R_UNICODE_INCOMPLETE_CODE_POINT);
+  r_assert_cmpuint (n, ==, 2);
+}
+RTEST_END;
+
+RTEST (runicode, utf16_to_utf32_invalid, RTEST_FAST)
+{
+  runichar4 utf32[8];
+  runichar2 utf16[4];
+  runichar2 * utf16end;
+  rsize n;
+  RUnicodeResult res;
+
+  /* Low surrogate with no preceding high surrogate. */
+  utf16[0] = 'y'; utf16[1] = 'z'; utf16[2] = 0xDC01;
+  res = r_utf16_to_utf32 (utf32, R_N_ELEMENTS (utf32), utf16, 3,
+      &n, &utf16end);
+  r_assert_cmpint (res, ==, R_UNICODE_INVALID_CODE_POINT);
+  r_assert_cmpuint (n, ==, 2);
+}
+RTEST_END;
+
+RTEST (runicode, utf32_to_utf16, RTEST_FAST)
+{
+  runichar4 utf32[16];
+  runichar4 * utf32end;
+  runichar2 utf16[16];
+  rsize n;
+  RUnicodeResult res;
+
+  utf32[0] = 'a'; utf32[1] = 'b'; utf32[2] = 'c';
+  res = r_utf32_to_utf16 (utf16, R_N_ELEMENTS (utf16), utf32, 3,
+      &n, &utf32end);
+  r_assert_cmpint (res, ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 3);
+  r_assert_cmpuint (utf16[0], ==, 'a');
+
+  /* Beyond-BMP codepoint emits surrogate pair. */
+  utf32[0] = 0x10000;
+  res = r_utf32_to_utf16 (utf16, R_N_ELEMENTS (utf16), utf32, 1,
+      &n, &utf32end);
+  r_assert_cmpint (res, ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 2);
+  r_assert_cmpuint (utf16[0], ==, 0xD800);
+  r_assert_cmpuint (utf16[1], ==, 0xDC00);
+
+  utf32[0] = 0x10FFFF;
+  res = r_utf32_to_utf16 (utf16, R_N_ELEMENTS (utf16), utf32, 1,
+      &n, &utf32end);
+  r_assert_cmpint (res, ==, R_UNICODE_OK);
+  r_assert_cmpuint (n, ==, 2);
+  r_assert_cmpuint (utf16[0], ==, 0xDBFF);
+  r_assert_cmpuint (utf16[1], ==, 0xDFFF);
+}
+RTEST_END;
+
+RTEST (runicode, utf32_to_utf16_overflow, RTEST_FAST)
+{
+  runichar4 utf32[4];
+  runichar4 * utf32end;
+  runichar2 utf16[3];   /* Capacity 2 + NUL. */
+  rsize n;
+  RUnicodeResult res;
+
+  utf32[0] = 'a'; utf32[1] = 'b'; utf32[2] = 'c';
+  res = r_utf32_to_utf16 (utf16, R_N_ELEMENTS (utf16), utf32, 3,
+      &n, &utf32end);
+  r_assert_cmpint (res, ==, R_UNICODE_OVERFLOW);
+  r_assert_cmpuint (n, ==, 2);
+}
+RTEST_END;
+
+RTEST (runicode, utf32_to_utf16_invalid, RTEST_FAST)
+{
+  runichar4 utf32[4];
+  runichar4 * utf32end;
+  runichar2 utf16[16];
+  rsize n;
+  RUnicodeResult res;
+
+  /* Out-of-range. */
+  utf32[0] = 'a'; utf32[1] = 0x110000;
+  res = r_utf32_to_utf16 (utf16, R_N_ELEMENTS (utf16), utf32, 2,
+      &n, &utf32end);
+  r_assert_cmpint (res, ==, R_UNICODE_INVALID_CODE_POINT);
+  r_assert_cmpuint (n, ==, 1);
+
+  /* Surrogate-half. */
+  utf32[0] = 'a'; utf32[1] = 0xDC00;
+  res = r_utf32_to_utf16 (utf16, R_N_ELEMENTS (utf16), utf32, 2,
+      &n, &utf32end);
+  r_assert_cmpint (res, ==, R_UNICODE_INVALID_CODE_POINT);
+  r_assert_cmpuint (n, ==, 1);
+}
+RTEST_END;
+
+RTEST (runicode, utf8_to_utf32_dup_roundtrip, RTEST_FAST)
+{
+  const rchar * input = "abc\xCE\xB1\xCE\xB2\xCE\xB3\xF4\x8F\xBF\xBF";
+  runichar4 * utf32;
+  rchar * back;
+  rchar * end;
+  runichar4 * end32;
+  RUnicodeResult res;
+  rsize len;
+
+  utf32 = r_utf8_to_utf32_dup (input, -1, &res, &len, &end);
+  r_assert_cmpptr (utf32, !=, NULL);
+  r_assert_cmpint (res, ==, R_UNICODE_OK);
+  r_assert_cmpuint (len, ==, 7);  /* 3 ASCII + 3 Greek + 1 supplementary */
+
+  back = r_utf32_to_utf8_dup (utf32, len, &res, &len, &end32);
+  r_assert_cmpptr (back, !=, NULL);
+  r_assert_cmpint (res, ==, R_UNICODE_OK);
+  r_assert_cmpstr (back, ==, input);
+
+  r_free (utf32);
+  r_free (back);
+}
+RTEST_END;
+
+RTEST (runicode, utf16_to_utf32_dup_roundtrip, RTEST_FAST)
+{
+  runichar2 utf16[6];
+  runichar4 * utf32;
+  runichar2 * back;
+  runichar2 * end16;
+  runichar4 * end32;
+  RUnicodeResult res;
+  rsize len;
+
+  utf16[0] = 'a'; utf16[1] = 'b'; utf16[2] = 0x3B1;
+  utf16[3] = 0xD800; utf16[4] = 0xDC00;     /* U+10000 surrogate pair */
+  utf16[5] = 'z';
+
+  utf32 = r_utf16_to_utf32_dup (utf16, 6, &res, &len, &end16);
+  r_assert_cmpptr (utf32, !=, NULL);
+  r_assert_cmpint (res, ==, R_UNICODE_OK);
+  r_assert_cmpuint (len, ==, 5);
+  r_assert_cmpuint (utf32[3], ==, 0x10000);
+
+  back = r_utf32_to_utf16_dup (utf32, len, &res, &len, &end32);
+  r_assert_cmpptr (back, !=, NULL);
+  r_assert_cmpint (res, ==, R_UNICODE_OK);
+  r_assert_cmpuint (len, ==, 6);
+  r_assert_cmpuint (back[3], ==, 0xD800);
+  r_assert_cmpuint (back[4], ==, 0xDC00);
+
+  r_free (utf32);
+  r_free (back);
+}
+RTEST_END;


### PR DESCRIPTION
## Summary

Started as the UTF-32 conversion routines #147 asked for. Two follow-up audits along the way (test coverage vs canonical stress vectors, then audit-the-callers) grew the scope into a full pass over the Unicode-conversion module. Seven commits, totaling ~3.7k lines of which most is tests and Doxygen.

### What's in here

**UTF-32 conversions (the original #147)**

Fills in the four UTF-32 conversion routines that were sketched (with an `uft` typo) in an `#if 0` block at the bottom of `runicode.h`, plus matching allocating `_dup` siblings. Eight new entry points:

```
r_utf8_to_utf32 / r_utf32_to_utf8     (in-buffer)
r_utf16_to_utf32 / r_utf32_to_utf16   (in-buffer)
..._dup variants                       (allocating)
```

**RFC 3629 conformance fixes in the existing UTF-8 / UTF-16 paths**

Surfaced by running canonical stress vectors (Markus Kuhn's UTF-8 decoder capability + stress test, Unicode Standard Table 3-7, RFC 3629 §3):

- **Overlong UTF-8 rejection.** The decoder was accepting `\xC0\xAF` as `U+002F` and similar — classic filter-evasion vector. `r_utf8_to_unichar` now returns an internal `R_UTF8_OVERLONG` sentinel for sub-canonical encodings; the converters and validator surface it as `R_UNICODE_INVALID_CODE_POINT`.
- **UTF-8-encoded surrogate rejection in the UTF-16 path.** The new UTF-32 path caught these by accident (it explicitly rejects `0xD800..0xDFFF`); the older UTF-8 → UTF-16 path passed them through verbatim, producing WTF-8-style malformed UTF-16 output. Now rejected.
- **`r_utf16_to_utf8` srcendptr bug** (caught by the streaming-resume test). When an incomplete surrogate pair was detected, the function advanced past the high surrogate so `srcendptr` no longer pointed at the resumable position. Restructured to peek without consuming, matching the shape of `r_utf16_to_utf32`.
- **Drop pre-RFC-3629 5- and 6-byte UTF-8 paths.** Codepoints `>= U+200000` were never assignable; RFC 3629 §3 forbids these lead bytes. ~50 lines of effectively-dead code removed; lead bytes `0xF8..0xFF` now reject at decode time.

**Validation API**

```
r_utf8_validate  (src, size, *endptr)
r_utf16_validate (src, size, *endptr)
r_utf32_validate (src, size, *endptr)
```

Scan-only counterparts to the conversion functions — same rejection rules, but allocate nothing. Useful when bytes are already in the target encoding and only well-formedness needs confirming.

**ASN.1 UTF8String caller migration**

X.680 §41 requires `UTF8String` values to be valid UTF-8. The ASN.1 decoder was `strdup`'ing the bytes verbatim — malformed UTF-8 ended up in returned C strings without complaint, propagating to consumers (X.509 subjects, CMS / PKCS#7 identifiers). Now goes through `r_utf8_validate` and surfaces failures as `R_ASN1_DECODER_PARSE_ERROR`.

**Doc + ergonomic fixes**

- File-level Doxygen documents the embedded-NUL behaviour (in-buffer converters stop at `\0` / `U+0000` to match the C-string contract).
- UTF-32 BOM (0xFEFF) stripping wired into the new paths to match the existing UTF-8 / UTF-16 behaviour.
- NULL out-pointer (`dstoutsize` / `srcendptr`) robustness covered explicitly in tests; the impl already supported it.

## Test plan

- [x] Full ASAN suite: **1810 / 1810** passing (was 1543 pre-PR).
- [x] `/runicode/*` — **200 individual cases** including:
  - 6 new conversion-direction matrices (UTF-32-side: round-trip + overflow + incomplete + invalid; tests fanned across all six pairs).
  - 60 boundary-codepoint round-trips across all 6 directions (Unicode Table 3-7 / Kuhn §2).
  - 18 overlong UTF-8 rejection cases (Kuhn §4).
  - 10 UTF-8-encoded-surrogate rejection cases (Kuhn §5.1 / §5.2).
  - 14 malformed-byte rejection cases (Kuhn §3: lone continuations, truncated multi-byte, impossible 0xFE / 0xFF, 5- and 6-byte lead bytes).
  - 19 validation-API cases (positive, negative, BOM, NULL src).
  - 14 BOM / streaming-resume / NULL-out-pointer cases.
- [x] `/rasn1der/parse_string*` — pre-existing 18 string-decode cases pass, plus 3 new `parse_string_rejects_malformed_utf8` cases.
- [x] `doxygen docs/Doxyfile` — clean on every touched header.
- [ ] CI green on aarch64 + Windows.

Closes #147.

Follow-up unicode work tracked separately:
- #184 — UCD-backed character properties + simple case mapping
- #185 — Unicode normalization (NFC / NFD / NFKC / NFKD)
- #186 — the unicode-helpers stack on top of this PR (codepoint API, BE/LE wire decoders, ASCII classification, WTF-8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)