### PR TITLE
Crypto documentation pass + rmsgdigest relocation

### DIFF
--- a/include/rlib/asn1/rasn1.h
+++ b/include/rlib/asn1/rasn1.h
@@ -29,7 +29,7 @@
 #include <rlib/data/rmpint.h>
 
 #include <rlib/rbuffer.h>
-#include <rlib/rmsgdigest.h>
+#include <rlib/crypto/rmsgdigest.h>
 
 R_BEGIN_DECLS
 

--- a/include/rlib/crypto/raes.h
+++ b/include/rlib/crypto/raes.h
@@ -27,6 +27,7 @@
 
 /**
  * @defgroup r_crypto_aes AES (FIPS 197)
+ * @ingroup r_crypto_symmetric
  * @brief AES cipher (128 / 192 / 256-bit keys) across ECB, CBC, CTR,
  * CFB, OFB modes; built on the @c RCryptoCipher base.
  * @{

--- a/include/rlib/crypto/rcert.h
+++ b/include/rlib/crypto/rcert.h
@@ -22,6 +22,32 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @addtogroup r_crypto_cert
+ *
+ * Generic certificate handle @c RCryptoCert and the polymorphic
+ * operations (validity range, public-key extraction, fingerprint,
+ * raw-data access) that work across any certificate type live in
+ * @c rcert.h.
+ *
+ * @c RCryptoCert is the same kind of polymorphic handle that
+ * @ref r_crypto_key is for keys: callers parse a certificate via a
+ * concrete builder (typically @c r_crypto_x509_cert_new from
+ * @ref r_crypto_x509, or @ref r_pem_block_get_cert for PEM input)
+ * and then interact with it through the generic API.
+ *
+ * Concrete certificate kinds are tagged by @ref RCryptoCertType.
+ * X.509 is fully supported; OpenPGP is reserved but not yet
+ * implemented.
+ */
+
+/**
+ * @file rlib/crypto/rcert.h
+ * @brief Generic certificate handle and the operations that work
+ * across any certificate type.
+ * @ingroup r_crypto_cert
+ */
+
 #include <rlib/rtypes.h>
 
 #include <rlib/crypto/rkey.h>
@@ -32,32 +58,137 @@
 
 R_BEGIN_DECLS
 
+/**
+ * @ingroup r_crypto_cert
+ * @brief Concrete certificate kind carried by an @ref RCryptoCert.
+ */
 typedef enum {
-  R_CRYPTO_CERT_X509,
-  R_CRYPTO_CERT_OPENPGP,
+  R_CRYPTO_CERT_X509,    /**< X.509 certificate. */
+  R_CRYPTO_CERT_OPENPGP, /**< OpenPGP certificate (reserved, not implemented). */
 } RCryptoCertType;
 
+/**
+ * @ingroup r_crypto_cert
+ * @brief Opaque, refcounted polymorphic certificate handle.
+ */
 typedef struct RCryptoCert RCryptoCert;
 
+/**
+ * @ingroup r_crypto_cert
+ * @brief Increment the certificate's refcount.
+ */
 #define r_crypto_cert_ref r_ref_ref
+/**
+ * @ingroup r_crypto_cert
+ * @brief Decrement the certificate's refcount; frees when it reaches zero.
+ */
 #define r_crypto_cert_unref r_ref_unref
 
+/**
+ * @ingroup r_crypto_cert
+ * @brief Drop the cached raw byte representation, keeping just the
+ * parsed fields.
+ *
+ * Use when memory is tight and the caller is done re-exporting the
+ * certificate. Subsequent calls to @ref r_crypto_cert_get_data_buffer
+ * / @ref r_crypto_cert_dup_data will return @c NULL.
+ */
 R_API void r_crypto_cert_clear_data (RCryptoCert * cert);
 
+/**
+ * @ingroup r_crypto_cert
+ * @brief Return the concrete kind of @p cert (X.509, OpenPGP, ...).
+ */
 R_API RCryptoCertType r_crypto_cert_get_type (const RCryptoCert * cert);
+/**
+ * @ingroup r_crypto_cert
+ * @brief Return @p cert's kind as a short ASCII string (e.g. @c "X.509").
+ */
 R_API const rchar * r_crypto_cert_get_strtype (const RCryptoCert * cert);
+/**
+ * @ingroup r_crypto_cert
+ * @brief Return @p cert's signature bytes plus metadata.
+ *
+ * @param cert     The certificate.
+ * @param signalgo Out: digest used inside the signature scheme.
+ * @param signbits Out: signature length in bits.
+ * @return Pointer to the signature bytes inside @p cert (not owned).
+ */
 R_API const ruint8 * r_crypto_cert_get_signature (const RCryptoCert * cert,
     RMsgDigestType * signalgo, rsize * signbits);
+/**
+ * @ingroup r_crypto_cert
+ * @brief Return the start of @p cert's validity window as a Unix
+ * timestamp (seconds since 1970-01-01 UTC).
+ */
 R_API ruint64 r_crypto_cert_get_valid_from (const RCryptoCert * cert);
+/**
+ * @ingroup r_crypto_cert
+ * @brief Return the end of @p cert's validity window as a Unix
+ * timestamp.
+ */
 R_API ruint64 r_crypto_cert_get_valid_to (const RCryptoCert * cert);
+/**
+ * @ingroup r_crypto_cert
+ * @brief Return @p cert's subject public key as an @ref RCryptoKey.
+ *
+ * The returned key holds a reference; the caller releases it via
+ * @c r_crypto_key_unref.
+ */
 R_API RCryptoKey * r_crypto_cert_get_public_key (const RCryptoCert * cert);
 
+/**
+ * @ingroup r_crypto_cert
+ * @brief Re-emit @p cert into an ASN.1 BER/DER encoder.
+ */
 R_API RCryptoResult r_crypto_cert_export (const RCryptoCert * cert, RAsn1BinEncoder * enc);
 
+/**
+ * @ingroup r_crypto_cert
+ * @brief Return the cached raw certificate bytes as an @c RBuffer.
+ *
+ * The @c RBuffer is borrowed; do not free it. Returns @c NULL if
+ * @ref r_crypto_cert_clear_data has been called.
+ */
 R_API RBuffer * r_crypto_cert_get_data_buffer (const RCryptoCert * cert);
+/**
+ * @ingroup r_crypto_cert
+ * @brief Return a freshly-allocated copy of the certificate's raw
+ * bytes.
+ *
+ * @param cert  The certificate.
+ * @param size  Out: length of the returned blob.
+ */
 R_API ruint8 * r_crypto_cert_dup_data (const RCryptoCert * cert, rsize * size);
+/**
+ * @ingroup r_crypto_cert
+ * @brief Compute the certificate's fingerprint into a caller-supplied
+ * buffer.
+ *
+ * The fingerprint is the digest @p type computed over the raw DER /
+ * BER bytes of @p cert.
+ *
+ * @param cert  The certificate.
+ * @param buf   Output buffer.
+ * @param size  Capacity of @p buf.
+ * @param type  Digest algorithm (SHA-1, SHA-256, ...).
+ * @param out   Out: number of bytes written.
+ */
 R_API RCryptoResult r_crypto_cert_fingerprint (const RCryptoCert * cert,
     ruint8 * buf, rsize size, RMsgDigestType type, rsize * out);
+/**
+ * @ingroup r_crypto_cert
+ * @brief Format the certificate's fingerprint as a string with
+ * optional dividers (e.g. colon-separated hex).
+ *
+ * @param cert      The certificate.
+ * @param type      Digest algorithm.
+ * @param divider   Separator inserted between hex pairs (e.g. @c ":");
+ *                  pass @c NULL or @c "" for no separator.
+ * @param interval  Hex characters between dividers (typically 2).
+ * @return Newly-allocated NUL-terminated string. Caller frees with
+ *         @c r_free.
+ */
 R_API rchar * r_crypto_cert_fingerprint_str (const RCryptoCert * cert,
     RMsgDigestType type, const rchar * divider, rsize interval) R_ATTR_MALLOC;
 

--- a/include/rlib/crypto/rcert.h
+++ b/include/rlib/crypto/rcert.h
@@ -27,7 +27,7 @@
 #include <rlib/crypto/rkey.h>
 
 #include <rlib/rbuffer.h>
-#include <rlib/rmsgdigest.h>
+#include <rlib/crypto/rmsgdigest.h>
 #include <rlib/rref.h>
 
 R_BEGIN_DECLS

--- a/include/rlib/crypto/rcipher.h
+++ b/include/rlib/crypto/rcipher.h
@@ -27,6 +27,7 @@
 
 /**
  * @defgroup r_crypto_cipher Block / stream cipher base
+ * @ingroup r_crypto_symmetric
  * @brief Algorithm-agnostic block / stream cipher interface; concrete
  * cipher families (AES, ARC4, ...) plug into it via @c RCryptoCipherInfo.
  * @{

--- a/include/rlib/crypto/rdh.h
+++ b/include/rlib/crypto/rdh.h
@@ -22,6 +22,34 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @defgroup r_crypto_dh Diffie-Hellman (finite-field)
+ * @ingroup r_crypto_key
+ *
+ * @brief Classic finite-field Diffie-Hellman key exchange over a
+ * prime-modulus group: keypair construction, the standard named
+ * MODP / FFDHE groups, and the shared-secret derivation.
+ *
+ * The keys here are @ref RCryptoKey handles wrapping @c (p, g, y)
+ * for the public side and @c (p, g, y, x) for the private side.
+ * Most callers want to use the named groups via
+ * @ref r_dh_priv_key_new_gen_named, which pulls @c (p, g) from the
+ * RFC tables; @ref r_dh_priv_key_new_gen takes caller-supplied
+ * domain parameters for nonstandard groups.
+ *
+ * For modern elliptic-curve Diffie-Hellman use @ref r_xdh
+ * (Curve25519 / Curve448); this module covers the finite-field
+ * variant that legacy IKE, SSH and TLS still negotiate.
+ *
+ * @{
+ */
+
+/**
+ * @file rlib/crypto/rdh.h
+ * @brief Finite-field Diffie-Hellman: keypair construction, named
+ * MODP / FFDHE groups and shared-secret derivation.
+ */
+
 #include <rlib/rtypes.h>
 #include <rlib/asn1/rasn1.h>
 #include <rlib/crypto/rkey.h>
@@ -30,66 +58,132 @@
 
 R_BEGIN_DECLS
 
+/** @brief Algorithm-name string used in @c RCryptoKey introspection. */
 #define R_DH_STR     "DH"
 
-/* Standard named DH groups. All use g = 2. The R_DH_GROUP_MODP_* values
- * come from RFC 3526 (general-purpose DH used by IKE/SSH); the
- * R_DH_GROUP_FFDHE_* values come from RFC 7919 (designed for TLS). */
+/**
+ * @brief Named DH groups with standardised @c (p, g) parameters.
+ *
+ * All groups use @c g = 2. The @c MODP_* values come from RFC 3526
+ * (general-purpose DH used by IKE and SSH); the @c FFDHE_* values
+ * come from RFC 7919 (designed for TLS, with primes resistant to
+ * Logjam-style precomputation).
+ */
 typedef enum {
   R_DH_GROUP_UNKNOWN = -1,
-  R_DH_GROUP_MODP_2048 = 0,   /* RFC 3526 group 14 */
-  R_DH_GROUP_MODP_3072,       /* RFC 3526 group 15 */
-  R_DH_GROUP_MODP_4096,       /* RFC 3526 group 16 */
-  R_DH_GROUP_MODP_6144,       /* RFC 3526 group 17 */
-  R_DH_GROUP_MODP_8192,       /* RFC 3526 group 18 */
-  R_DH_GROUP_FFDHE_2048,      /* RFC 7919 */
-  R_DH_GROUP_FFDHE_3072,
-  R_DH_GROUP_FFDHE_4096,
-  R_DH_GROUP_FFDHE_6144,
-  R_DH_GROUP_FFDHE_8192,
+  R_DH_GROUP_MODP_2048 = 0,   /**< RFC 3526 group 14. */
+  R_DH_GROUP_MODP_3072,       /**< RFC 3526 group 15. */
+  R_DH_GROUP_MODP_4096,       /**< RFC 3526 group 16. */
+  R_DH_GROUP_MODP_6144,       /**< RFC 3526 group 17. */
+  R_DH_GROUP_MODP_8192,       /**< RFC 3526 group 18. */
+  R_DH_GROUP_FFDHE_2048,      /**< RFC 7919. */
+  R_DH_GROUP_FFDHE_3072,      /**< RFC 7919. */
+  R_DH_GROUP_FFDHE_4096,      /**< RFC 7919. */
+  R_DH_GROUP_FFDHE_6144,      /**< RFC 7919. */
+  R_DH_GROUP_FFDHE_8192,      /**< RFC 7919. */
   R_DH_GROUP_COUNT
 } RDhNamedGroup;
 
-/* Initialise (p, g) with the parameters of the named group. The caller
- * is responsible for clearing both mpints. */
+/**
+ * @brief Initialise @p p and @p g with the parameters of a named group.
+ *
+ * The caller is responsible for clearing both @c rmpints. Returns
+ * @c FALSE if @p group is @c R_DH_GROUP_UNKNOWN or out of range.
+ */
 R_API rboolean r_dh_named_group_get_params (RDhNamedGroup group,
     rmpint * p, rmpint * g);
 
+/**
+ * @brief Build a DH public key from @c rmpint components @c (p, g, y).
+ */
 R_API RCryptoKey * r_dh_pub_key_new (const rmpint * p, const rmpint * g,
     const rmpint * y) R_ATTR_MALLOC;
+
+/**
+ * @brief Build a DH public key from raw big-endian byte buffers.
+ *
+ * Convenience wrapper around @ref r_dh_pub_key_new.
+ */
 R_API RCryptoKey * r_dh_pub_key_new_binary (rconstpointer p, rsize psize,
     rconstpointer g, rsize gsize,
     rconstpointer y, rsize ysize) R_ATTR_MALLOC;
 
+/**
+ * @brief Build a DH private key from @c rmpint components @c (p, g, y, x).
+ */
 R_API RCryptoKey * r_dh_priv_key_new (const rmpint * p, const rmpint * g,
     const rmpint * y, const rmpint * x) R_ATTR_MALLOC;
+
+/**
+ * @brief Build a DH private key from raw big-endian byte buffers.
+ *
+ * Convenience wrapper around @ref r_dh_priv_key_new.
+ */
 R_API RCryptoKey * r_dh_priv_key_new_binary (rconstpointer p, rsize psize,
     rconstpointer g, rsize gsize,
     rconstpointer y, rsize ysize,
     rconstpointer x, rsize xsize) R_ATTR_MALLOC;
+
+/**
+ * @brief Decode a DH private key from an ASN.1 PKCS#3 / PKCS#8 TLV.
+ *
+ * Used by the PEM and X.509 import paths to materialise an
+ * @ref RCryptoKey from a DER blob.
+ */
 R_API RCryptoKey * r_dh_priv_key_new_from_asn1 (RAsn1BinDecoder * dec,
     RAsn1BinTLV * tlv) R_ATTR_MALLOC;
 
-/* Pick a random x in [2, p-2] and derive y = g^x mod p. Caller owns the
- * returned key. */
+/**
+ * @brief Generate a fresh DH keypair in a caller-supplied group.
+ *
+ * Picks a random @c x in @c [2, p-2] and derives @c y = g^x mod p.
+ *
+ * @param p     Prime modulus.
+ * @param g     Generator.
+ * @param prng  Randomness source for sampling @c x.
+ */
 R_API RCryptoKey * r_dh_priv_key_new_gen (const rmpint * p, const rmpint * g,
     RPrng * prng) R_ATTR_MALLOC;
+
+/**
+ * @brief Generate a fresh DH keypair in a standard named group.
+ *
+ * Convenience wrapper that loads @c (p, g) for @p group from the
+ * RFC tables before calling @ref r_dh_priv_key_new_gen.
+ */
 R_API RCryptoKey * r_dh_priv_key_new_gen_named (RDhNamedGroup group,
     RPrng * prng) R_ATTR_MALLOC;
 
+/** @brief Copy the prime modulus @c p into @p p. */
 R_API rboolean r_dh_pub_key_get_p (const RCryptoKey * key, rmpint * p);
+/** @brief Copy the generator @c g into @p g. */
 R_API rboolean r_dh_pub_key_get_g (const RCryptoKey * key, rmpint * g);
+/** @brief Copy the public value @c y = g^x mod p into @p y. */
 R_API rboolean r_dh_pub_key_get_y (const RCryptoKey * key, rmpint * y);
+/** @brief Copy the private value @c x into @p x. */
 R_API rboolean r_dh_priv_key_get_x (const RCryptoKey * key, rmpint * x);
 
-/* Compute the shared secret peer_pub.y ^ priv.x mod priv.p and write it
- * to out as a left-zero-padded big-endian byte string sized to match p.
- * The two keys must share the same (p, g) group; the peer's y is also
- * range-checked to be in (1, p-1). On entry *outsize is the capacity of
- * out; on success it is updated to the number of bytes written. */
+/**
+ * @brief Compute the shared DH secret.
+ *
+ * Computes @c peer_pub.y ^ priv.x mod priv.p and writes it to @p out
+ * as a left-zero-padded big-endian byte string sized to match @c p.
+ *
+ * The two keys must share the same @c (p, g) group; the peer's @c y
+ * is range-checked to be in @c (1, p-1) before the exponentiation
+ * so that small-subgroup attacks fail with @c R_CRYPTO_INVAL.
+ *
+ * @param priv      Local private key.
+ * @param peer_pub  Peer's public key.
+ * @param out       Output buffer.
+ * @param outsize   On entry, capacity of @p out; on success, updated
+ *                  to the number of bytes written.
+ */
 R_API RCryptoResult r_dh_compute_shared (const RCryptoKey * priv,
     const RCryptoKey * peer_pub, ruint8 * out, rsize * outsize);
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_CRYPTO_DH_H__ */

--- a/include/rlib/crypto/rdsa.h
+++ b/include/rlib/crypto/rdsa.h
@@ -22,55 +22,165 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @defgroup r_crypto_dsa DSA (FIPS 186-4)
+ * @ingroup r_crypto_key
+ *
+ * @brief Digital Signature Algorithm: keypair construction and the
+ * sign / verify operations parameterised by an @ref RMsgDigestType.
+ *
+ * DSA is a finite-field signature scheme defined by FIPS 186-4. Like
+ * @ref r_crypto_rsa, DSA keys are surfaced as @ref RCryptoKey
+ * handles; the constructors here build that handle from already
+ * parsed @c rmpint components, raw big-endian byte buffers, or an
+ * ASN.1 TLV. @ref r_dsa_priv_key_new_gen generates a fresh keypair
+ * at one of the FIPS-approved (L, N) sizes.
+ *
+ * For new protocols prefer @ref r_ed25519 / @ref r_ed448 EdDSA over
+ * DSA: EdDSA is deterministic, side-channel friendly and does not
+ * depend on per-signature randomness. DSA is documented here for
+ * interop with existing systems that mandate it.
+ *
+ * @{
+ */
+
+/**
+ * @file rlib/crypto/rdsa.h
+ * @brief DSA (FIPS 186-4) key construction, signature and
+ * verification.
+ */
+
 #include <rlib/rtypes.h>
 #include <rlib/crypto/rkey.h>
 #include <rlib/data/rmpint.h>
 
 R_BEGIN_DECLS
 
+/** @brief Algorithm-name string used in @c RCryptoKey introspection. */
 #define R_DSA_STR     "DSA"
 
+/**
+ * @brief Build a DSA public key from just the public value @c y;
+ * domain parameters @c (p, q, g) are left unset.
+ *
+ * Convenience for parsers that pull @c (p, q, g) from a separate
+ * source (e.g. a certificate's AlgorithmIdentifier) and want to
+ * attach them afterwards.
+ */
 #define r_dsa_pub_key_new(y)  r_dsa_pub_key_new_full (NULL, NULL, NULL, y)
+
+/**
+ * @brief Build a DSA public key from already-parsed @c rmpint
+ * components @c (p, q, g, y).
+ */
 R_API RCryptoKey * r_dsa_pub_key_new_full (const rmpint * p, const rmpint * q,
     const rmpint * g, const rmpint * y) R_ATTR_MALLOC;
+
+/**
+ * @brief Build a DSA public key from raw big-endian byte buffers.
+ *
+ * Convenience wrapper that parses each component into an @c rmpint
+ * before calling @ref r_dsa_pub_key_new_full.
+ */
 R_API RCryptoKey * r_dsa_pub_key_new_binary (rconstpointer p, rsize psize,
     rconstpointer q, rsize qsize, rconstpointer g, rsize gsize,
     rconstpointer y, rsize ysize) R_ATTR_MALLOC;
 
+/**
+ * @brief Build a DSA private key from already-parsed @c rmpint
+ * components @c (p, q, g, y, x).
+ */
 R_API RCryptoKey * r_dsa_priv_key_new (const rmpint * p, const rmpint * q,
     const rmpint * g, const rmpint * y, const rmpint * x) R_ATTR_MALLOC;
+
+/**
+ * @brief Build a DSA private key from raw big-endian byte buffers.
+ *
+ * Convenience wrapper around @ref r_dsa_priv_key_new.
+ */
 R_API RCryptoKey * r_dsa_priv_key_new_binary (rconstpointer p, rsize psize,
     rconstpointer q, rsize qsize, rconstpointer g, rsize gsize,
     rconstpointer y, rsize ysize, rconstpointer x, rsize xsize) R_ATTR_MALLOC;
+
+/**
+ * @brief Decode a DSA private key from an ASN.1 PKCS#8 TLV.
+ *
+ * Used by the PEM and X.509 import paths (see @c rpem.h and
+ * @c rx509.h) to materialise an @ref RCryptoKey from a DER blob.
+ */
 R_API RCryptoKey * r_dsa_priv_key_new_from_asn1 (RAsn1BinDecoder * dec, RAsn1BinTLV * tlv) R_ATTR_MALLOC;
 
-/* Generate a fresh DSA keypair following FIPS 186-4 §A.1.1.2 (probable
- * primes p and q), §A.2.1 (generator g), and §B.1.2 (private value x,
- * public value y). The (L, N) pair must be one of the FIPS-approved
- * size combinations: (1024, 160), (2048, 224), (2048, 256), (3072, 256). */
+/**
+ * @brief Generate a fresh DSA keypair.
+ *
+ * Follows FIPS 186-4 §A.1.1.2 (probable primes @c p and @c q),
+ * §A.2.1 (generator @c g) and §B.1.2 (private @c x, public @c y).
+ *
+ * @param L     Modulus size in bits.
+ * @param N     Subgroup-order size in bits.
+ * @param prng  Randomness source.
+ *
+ * @c (L, N) must be one of the FIPS-approved size combinations:
+ * @c (1024, 160), @c (2048, 224), @c (2048, 256) or @c (3072, 256).
+ */
 R_API RCryptoKey * r_dsa_priv_key_new_gen (rsize L, rsize N,
     RPrng * prng) R_ATTR_MALLOC;
 
+/** @brief Copy the prime modulus @c p into @p p. */
 R_API rboolean r_dsa_pub_key_get_p (const RCryptoKey * key, rmpint * p);
+/** @brief Copy the subgroup order @c q into @p q. */
 R_API rboolean r_dsa_pub_key_get_q (const RCryptoKey * key, rmpint * q);
+/** @brief Copy the generator @c g into @p g. */
 R_API rboolean r_dsa_pub_key_get_g (const RCryptoKey * key, rmpint * g);
+/** @brief Copy the public value @c y = g^x mod p into @p y. */
 R_API rboolean r_dsa_pub_key_get_y (const RCryptoKey * key, rmpint * y);
+/** @brief Copy the private value @c x into @p x. */
 R_API rboolean r_dsa_priv_key_get_x (const RCryptoKey * key, rmpint * x);
 
+/**
+ * @brief DSA sign over message bytes.
+ *
+ * Hashes @p msg with @p mdtype, then signs the resulting digest per
+ * FIPS 186-4 §4.6. The signature is encoded as an ASN.1 DER
+ * SEQUENCE OF @c (r, s) integers.
+ */
 R_API RCryptoResult r_dsa_sign_msg (const RCryptoKey * key, RPrng * prng,
     RMsgDigestType mdtype, rconstpointer msg, rsize msgsize,
     rpointer sig, rsize * sigsize);
+
+/**
+ * @brief DSA sign over a precomputed digest.
+ *
+ * Same as @ref r_dsa_sign_msg but the caller supplies the
+ * already-hashed value; @p mdtype identifies which digest produced
+ * @p hash so its length matches @c N / 8.
+ */
 R_API RCryptoResult r_dsa_sign_msg_hash (const RCryptoKey * key, RPrng * prng,
     RMsgDigestType mdtype, rconstpointer hash, rsize hashsize,
     rpointer sig, rsize * sigsize);
+
+/**
+ * @brief DSA verify over message bytes.
+ *
+ * Hashes @p msg with @p mdtype, then checks the @c (r, s) signature
+ * per FIPS 186-4 §4.7.
+ */
 R_API RCryptoResult r_dsa_verify_msg (const RCryptoKey * key,
     RMsgDigestType mdtype, rconstpointer msg, rsize msgsize,
     rconstpointer sig, rsize sigsize);
+
+/**
+ * @brief DSA verify over a precomputed digest.
+ *
+ * Counterpart to @ref r_dsa_sign_msg_hash.
+ */
 R_API RCryptoResult r_dsa_verify_msg_with_hash (const RCryptoKey * key,
     RMsgDigestType mdtype, rconstpointer hash, rsize hashsize,
     rconstpointer sig, rsize sigsize);
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_CRYPTO_DSA_H__ */
 

--- a/include/rlib/crypto/recc.h
+++ b/include/rlib/crypto/recc.h
@@ -22,6 +22,35 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @defgroup r_crypto_ecc ECDSA / ECDH keys
+ * @ingroup r_crypto_ec
+ *
+ * @brief @ref RCryptoKey wrappers for the short-Weierstrass curves
+ * exposed by @ref r_ecurve - ECDSA signing keys plus ECDH
+ * key-agreement keys.
+ *
+ * The curve math itself (named curves, point arithmetic, scalar
+ * multiplication) lives in @ref r_ecurve. This header binds those
+ * primitives to the polymorphic @ref RCryptoKey handle: callers
+ * build an ECDSA or ECDH key, then either pass it to the generic
+ * @c r_crypto_key_sign / @c _verify dispatch or use the explicit
+ * @ref r_ecdh_compute_shared entry point.
+ *
+ * For Curve25519 / Curve448 use @ref r_xdh instead; for the EdDSA
+ * signature variants use @ref r_ed25519 / @ref r_ed448. The keys
+ * in this header cover the short-Weierstrass family
+ * (secp256r1 / secp384r1 / secp521r1 / ...).
+ *
+ * @{
+ */
+
+/**
+ * @file rlib/crypto/recc.h
+ * @brief ECDSA and ECDH key construction over the short-Weierstrass
+ * curves in @ref r_ecurve, plus the shared-secret computation.
+ */
+
 #include <rlib/rtypes.h>
 #include <rlib/crypto/recurve.h>
 #include <rlib/crypto/rkey.h>
@@ -29,45 +58,115 @@
 
 R_BEGIN_DECLS
 
+/** @brief Algorithm-name string used in @c RCryptoKey introspection. */
 #define R_ECDSA_STR     "ECDSA"
+/** @brief Algorithm-name string used in @c RCryptoKey introspection. */
 #define R_ECDH_STR      "ECDH"
 
+/**
+ * @brief Build an ECDSA public key from a named curve and an encoded
+ * affine point @c Q.
+ *
+ * @param curve    The short-Weierstrass curve (@ref REcurveID).
+ * @param ecp      Encoded point (typically SEC 1 uncompressed
+ *                 @c 0x04 || X || Y).
+ * @param ecpsize  Length of @p ecp.
+ */
 R_API RCryptoKey * r_ecdsa_pub_key_new (REcurveID curve,
     rconstpointer ecp, rsize ecpsize) R_ATTR_MALLOC;
+
+/**
+ * @brief Build an ECDH public key from a named curve and an encoded
+ * affine point @c Q.
+ *
+ * @param curve    The short-Weierstrass curve (@ref REcurveID).
+ * @param ecp      Encoded point (SEC 1 uncompressed).
+ * @param ecpsize  Length of @p ecp.
+ */
 R_API RCryptoKey * r_ecdh_pub_key_new (REcurveID curve,
     rconstpointer ecp, rsize ecpsize) R_ATTR_MALLOC;
+
+/**
+ * @brief Build an ECDSA private key from a named curve, public point
+ * and private scalar.
+ *
+ * @param curve       The short-Weierstrass curve.
+ * @param ecp         Encoded public point @c Q.
+ * @param ecpsize     Length of @p ecp.
+ * @param scalar      Big-endian private scalar @c d.
+ * @param scalarsize  Length of @p scalar.
+ */
 R_API RCryptoKey * r_ecdsa_priv_key_new (REcurveID curve,
     rconstpointer ecp, rsize ecpsize,
     rconstpointer scalar, rsize scalarsize) R_ATTR_MALLOC;
+
+/**
+ * @brief Build an ECDH private key from a named curve, public point
+ * and private scalar.
+ */
 R_API RCryptoKey * r_ecdh_priv_key_new (REcurveID curve,
     rconstpointer ecp, rsize ecpsize,
     rconstpointer scalar, rsize scalarsize) R_ATTR_MALLOC;
+
+/**
+ * @brief Return the named curve @p key is parameterised on.
+ */
 R_API REcurveID r_ecc_key_get_curve (const RCryptoKey * key);
+
+/**
+ * @brief Return the raw private scalar bytes for an ECDSA or ECDH
+ * private key.
+ *
+ * The pointer is owned by @p key (do not free). Returns @c FALSE for
+ * public keys or if the scalar was never set.
+ */
 R_API rboolean r_ecc_priv_key_get_scalar (const RCryptoKey * key,
     const ruint8 ** scalar, rsize * scalarsize);
 
-/* Pick a random d in [1, n-1] for `curve` and produce a private ECDH
- * key whose public point is Q = d * G. Caller owns the returned key.
- * If `prng` is NULL a fresh system PRNG is used. */
+/**
+ * @brief Generate a fresh ECDH keypair on a named curve.
+ *
+ * Picks a random @c d in @c [1, n-1] and derives @c Q = d * G.
+ *
+ * @param curve  The curve.
+ * @param prng   Randomness source. Pass @c NULL to use a fresh
+ *               system PRNG.
+ */
 R_API RCryptoKey * r_ecdh_priv_key_new_gen (REcurveID curve,
     RPrng * prng) R_ATTR_MALLOC;
 
-/* Retrieve the affine public point Q for an ECDSA or ECDH key. Returns
- * FALSE if `key` doesn't carry a parsed point (e.g. an ECDSA key built
- * from an encoding the math layer can't yet decode). */
+/**
+ * @brief Retrieve the affine public point @c Q for an ECDSA or ECDH key.
+ *
+ * @return @c FALSE if @p key doesn't carry a parsed point (e.g. an
+ * ECDSA key built from an encoding the math layer can't yet decode).
+ */
 R_API rboolean r_ecc_key_get_q (const RCryptoKey * key, REcurveAffinePoint * q);
 
-/* Compute the ECDH shared secret X-coordinate (peer_pub.Q * priv.d).x
- * and write it as a left-zero-padded big-endian byte string sized to
- * the curve's coord_bytes. The two keys must use the same named curve;
- * the peer's point is on-curve checked (it was validated at key
- * construction, but private-key paths that derived Q internally also
- * need to refuse the identity). On entry *outsize is the capacity of
- * out; on success it is updated to the number of bytes written. */
+/**
+ * @brief Compute the ECDH shared-secret X-coordinate.
+ *
+ * Computes @c (peer_pub.Q * priv.d).x and writes it as a
+ * left-zero-padded big-endian byte string sized to the curve's
+ * coord_bytes.
+ *
+ * The two keys must use the same named curve; the peer's point is
+ * on-curve checked at this layer (it was validated at construction,
+ * but private-key paths that derived @c Q internally also need to
+ * refuse the identity).
+ *
+ * @param priv      Local private key.
+ * @param peer_pub  Peer's public key.
+ * @param out       Output buffer.
+ * @param outsize   On entry, capacity of @p out; on success, updated
+ *                  to the number of bytes written.
+ */
 R_API RCryptoResult r_ecdh_compute_shared (const RCryptoKey * priv,
     const RCryptoKey * peer_pub, ruint8 * out, rsize * outsize);
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_CRYPTO_ECC_H__ */
 

--- a/include/rlib/crypto/recurve-edwards.h
+++ b/include/rlib/crypto/recurve-edwards.h
@@ -28,6 +28,7 @@
 
 /**
  * @defgroup r_ecurve_edwards Twisted Edwards curves (edwards25519 / edwards448)
+ * @ingroup r_crypto_ec
  * @brief Twisted Edwards point arithmetic on the curves underlying
  * the RFC 8032 EdDSA signature schemes.
  * @{

--- a/include/rlib/crypto/recurve-montgomery.h
+++ b/include/rlib/crypto/recurve-montgomery.h
@@ -28,6 +28,7 @@
 
 /**
  * @defgroup r_ecurve_montgomery Montgomery curves (Curve25519 / Curve448)
+ * @ingroup r_crypto_ec
  * @brief u-coordinate Montgomery ladder for the RFC 7748 curves.
  * @{
  */

--- a/include/rlib/crypto/recurve.h
+++ b/include/rlib/crypto/recurve.h
@@ -27,6 +27,7 @@
 
 /**
  * @defgroup r_ecurve Short-Weierstrass elliptic curves
+ * @ingroup r_crypto_ec
  * @brief Named prime curves and affine point arithmetic for the
  * short-Weierstrass form y^2 = x^3 + ax + b over GF(p).
  * @{

--- a/include/rlib/crypto/red25519.h
+++ b/include/rlib/crypto/red25519.h
@@ -28,6 +28,7 @@
 
 /**
  * @defgroup r_ed25519 Ed25519 EdDSA
+ * @ingroup r_crypto_ec
  * @brief Ed25519 sign / verify per RFC 8032 §5.1.
  * @{
  */

--- a/include/rlib/crypto/red448.h
+++ b/include/rlib/crypto/red448.h
@@ -28,6 +28,7 @@
 
 /**
  * @defgroup r_ed448 Ed448 EdDSA
+ * @ingroup r_crypto_ec
  * @brief Ed448 sign / verify per RFC 8032 §5.2.
  * @{
  */

--- a/include/rlib/crypto/rhmac.h
+++ b/include/rlib/crypto/rhmac.h
@@ -22,32 +22,141 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @defgroup r_crypto_hmac HMAC (RFC 2104)
+ * @ingroup r_crypto_hash
+ *
+ * @brief Keyed-Hash Message Authentication Code built on top of any
+ * @ref r_msg_digest hash function.
+ *
+ * HMAC turns an unkeyed hash @c H into a keyed authenticator that
+ * lets two parties sharing a secret detect tampering of an arbitrary
+ * byte stream. The construction is:
+ *
+ *     HMAC(K, m) = H( (K' XOR opad) || H( (K' XOR ipad) || m ) )
+ *
+ * with @c K' the secret key padded / hashed to the underlying
+ * digest's block size. rlib accepts any @ref RMsgDigestType for @c H
+ * (SHA-1, the SHA-2 family, ...); the cost of HMAC is roughly two
+ * digest computations on top of the input length.
+ *
+ * Typical use mirrors @ref r_msg_digest's absorb / squeeze cycle:
+ *
+ * @code
+ * RHmac * h = r_hmac_new (R_MSG_DIGEST_TYPE_SHA256, key, keysize);
+ * r_hmac_update (h, msg, msgsize);
+ * ruint8 tag[32];
+ * r_hmac_get_data (h, tag, sizeof (tag), NULL);
+ * r_hmac_free (h);
+ * @endcode
+ *
+ * The receiver side uses @ref r_hmac_verify, which finalises and
+ * compares against a known tag in constant time:
+ *
+ * @code
+ * RHmac * h = r_hmac_new (R_MSG_DIGEST_TYPE_SHA256, key, keysize);
+ * r_hmac_update (h, msg, msgsize);
+ * if (!r_hmac_verify (h, expected_tag, sizeof (expected_tag)))
+ *   reject ();
+ * r_hmac_free (h);
+ * @endcode
+ *
+ * @{
+ */
+
+/**
+ * @file rlib/crypto/rhmac.h
+ * @brief HMAC (RFC 2104) keyed message-authentication code built on
+ * top of @ref r_msg_digest hash functions.
+ */
+
 #include <rlib/rtypes.h>
 #include <rlib/crypto/rmsgdigest.h>
 
 R_BEGIN_DECLS
 
+/** @brief Opaque HMAC computation state. */
 typedef struct RHmac       RHmac;
 
+/**
+ * @brief Create a new HMAC state keyed by @p key.
+ *
+ * @param type     Underlying hash function (any @ref RMsgDigestType).
+ * @param key      Secret key bytes.
+ * @param keysize  Length of @p key in bytes; may be larger or smaller
+ *                 than the hash block size (RFC 2104 prescribes how
+ *                 each case is handled).
+ * @return New @c RHmac on success, or @c NULL if @p type is
+ *         unsupported or allocation failed. Free with
+ *         @ref r_hmac_free.
+ */
 R_API RHmac * r_hmac_new (RMsgDigestType type, rconstpointer key, rsize keysize) R_ATTR_MALLOC;
+
+/** @brief Release an @c RHmac and zero its key material. */
 R_API void r_hmac_free (RHmac * hmac);
 
+/**
+ * @brief Output tag size in bytes (matches the underlying digest size).
+ */
 R_API rsize r_hmac_size (const RHmac * hmac);
+
+/**
+ * @brief Reset the state so a fresh message can be authenticated with
+ * the same key, without reallocating.
+ */
 R_API void r_hmac_reset (RHmac * hmac);
 
+/**
+ * @brief Absorb @p size bytes of message data into the HMAC.
+ *
+ * May be called repeatedly between @ref r_hmac_new / @ref r_hmac_reset
+ * and the finalisation step. Returns @c FALSE if the HMAC has already
+ * been finalised.
+ */
 R_API rboolean r_hmac_update (RHmac * hmac, rconstpointer data, rsize size);
+
+/**
+ * @brief Finalise and copy the HMAC tag into @p data.
+ *
+ * @param hmac  Computation state.
+ * @param data  Output buffer.
+ * @param size  Capacity of @p data; must be >= @ref r_hmac_size.
+ * @param out   Optional out-parameter receiving the number of bytes
+ *              written. Pass @c NULL to ignore.
+ * @return @c TRUE on success. The state becomes finalised; further
+ *         @ref r_hmac_update calls fail until @ref r_hmac_reset.
+ */
 R_API rboolean r_hmac_get_data (RHmac * hmac, ruint8 * data, rsize size, rsize * out);
+
+/**
+ * @brief Finalise and return the HMAC tag as a lowercase hex string.
+ *
+ * The string is allocated with @c r_malloc; the caller frees it with
+ * @c r_free.
+ */
 R_API rchar * r_hmac_get_hex (RHmac * hmac);
-/* Finalise the HMAC and compare its first `tag_size` bytes against
- * `expected_tag` in constant time. Returns TRUE iff the tag matches.
- * `tag_size` may be shorter than r_hmac_size for truncated-MAC
- * profiles (SRTP-80, SRTP-32, etc.) but must not exceed it. The
- * compare uses r_memcmp_ct, so the timing leaks neither which byte
- * (if any) differed nor whether the verify failed early. */
+
+/**
+ * @brief Finalise and compare the HMAC tag against an expected value
+ * in constant time.
+ *
+ * @param hmac          Computation state.
+ * @param expected_tag  Tag to compare against.
+ * @param tag_size      Number of bytes to compare. May be shorter
+ *                      than @ref r_hmac_size for truncated-MAC
+ *                      profiles (SRTP-80, SRTP-32, ...) but must not
+ *                      exceed it.
+ * @return @c TRUE iff the first @p tag_size bytes match.
+ *
+ * The compare uses @c r_memcmp_ct, so its timing reveals neither
+ * which byte (if any) differed nor whether the verify failed early.
+ */
 R_API rboolean r_hmac_verify (RHmac * hmac,
     rconstpointer expected_tag, rsize tag_size);
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_CRYPTO_MAC_H__ */
 

--- a/include/rlib/crypto/rhmac.h
+++ b/include/rlib/crypto/rhmac.h
@@ -23,7 +23,7 @@
 #endif
 
 #include <rlib/rtypes.h>
-#include <rlib/rmsgdigest.h>
+#include <rlib/crypto/rmsgdigest.h>
 
 R_BEGIN_DECLS
 

--- a/include/rlib/crypto/rkey.h
+++ b/include/rlib/crypto/rkey.h
@@ -31,6 +31,7 @@
 
 /**
  * @defgroup r_crypto_key Asymmetric cryptographic keys
+ * @ingroup r_crypto
  * @brief Generic @c RCryptoKey handle plus the metadata enums it
  * carries (key type, algorithm, error code) and the dispatched
  * encrypt / decrypt / sign / verify / export entry points.

--- a/include/rlib/crypto/rkey.h
+++ b/include/rlib/crypto/rkey.h
@@ -25,7 +25,7 @@
 #include <rlib/rtypes.h>
 
 #include <rlib/asn1/rasn1.h>
-#include <rlib/rmsgdigest.h>
+#include <rlib/crypto/rmsgdigest.h>
 #include <rlib/rrand.h>
 #include <rlib/rref.h>
 

--- a/include/rlib/crypto/rmsgdigest.h
+++ b/include/rlib/crypto/rmsgdigest.h
@@ -33,7 +33,7 @@
  */
 
 /**
- * @file rlib/rmsgdigest.h
+ * @file rlib/crypto/rmsgdigest.h
  * @brief Cryptographic message digests with a uniform absorb /
  * finalise / extract interface.
  *

--- a/include/rlib/crypto/rpem.h
+++ b/include/rlib/crypto/rpem.h
@@ -22,6 +22,43 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @defgroup r_crypto_pem PEM (RFC 7468)
+ * @ingroup r_crypto_encoding
+ *
+ * @brief Textual container framing for keys, certificates and the
+ * other ASN.1-shaped objects that ride a base64 + BEGIN/END envelope.
+ *
+ * PEM (Privacy-Enhanced Mail) is the ubiquitous "@c -----BEGIN X-----"
+ * encoding for binary cryptographic objects on disk and in transport:
+ * X.509 certificates, RSA / DSA private keys, certificate signing
+ * requests, CRLs, etc. The format is base64-wrapped DER with a label
+ * line and a CRC-ish ending that names the object class.
+ *
+ * Two layers are exposed:
+ *
+ *   - A convenience API (@ref r_pem_parse_key_from_data,
+ *     @ref r_pem_parse_cert_from_data) that returns a parsed
+ *     @ref RCryptoKey / @c RCryptoCert directly when the input
+ *     contains a single object.
+ *   - A streaming parser (@ref r_pem_parser_new and the
+ *     @ref r_pem_parser_next_block iteration) that walks a file or
+ *     buffer containing any number of PEM blocks, hands back each
+ *     as an @ref RPemBlock, and lets the caller introspect its type
+ *     or pull out the embedded key / certificate.
+ *
+ * Writing is the symmetric `r_pem_write_*` family which serialises
+ * a key or cert back into PEM text.
+ *
+ * @{
+ */
+
+/**
+ * @file rlib/crypto/rpem.h
+ * @brief PEM (RFC 7468) container parsing and emission for keys and
+ * certificates.
+ */
+
 #include <rlib/rtypes.h>
 
 #include <rlib/rmemfile.h>
@@ -32,71 +69,181 @@
 
 R_BEGIN_DECLS
 
+/** @brief Opaque streaming PEM parser. Refcounted. */
 typedef struct RPemParser RPemParser;
+/** @brief Opaque PEM block (one BEGIN/END pair). Refcounted. */
 typedef struct RPemBlock RPemBlock;
 
-/* Convenience API */
+/**
+ * @brief Parse a private key out of a single-block PEM buffer.
+ *
+ * @param data        PEM-formatted bytes.
+ * @param size        Length of @p data, or @c -1 if NUL-terminated.
+ * @param passphrase  Optional passphrase for encrypted private keys
+ *                    (PKCS#8 EncryptedPrivateKeyInfo). Pass @c NULL
+ *                    for unencrypted blocks.
+ * @param ppsize      Length of @p passphrase.
+ * @return Parsed @ref RCryptoKey, or @c NULL if the buffer does not
+ *         contain a key block or the passphrase is wrong.
+ */
 R_API RCryptoKey * r_pem_parse_key_from_data (const rchar * data, rssize size,
     const rchar * passphrase, rsize ppsize);
+
+/**
+ * @brief Parse a certificate out of a single-block PEM buffer.
+ *
+ * @param data  PEM-formatted bytes.
+ * @param size  Length of @p data, or @c -1 if NUL-terminated.
+ * @return Parsed @c RCryptoCert, or @c NULL.
+ */
 R_API RCryptoCert * r_pem_parse_cert_from_data (const rchar * data, rssize size);
 
+/**
+ * @brief Object kind carried by a PEM block.
+ *
+ * Driven by the BEGIN-label string. Use @ref r_pem_block_is_key /
+ * @ref r_pem_block_is_encrypted as shorthand for category checks.
+ */
 typedef enum {
   R_PEM_TYPE_UNKNOWN                  = -1,
-  R_PEM_TYPE_CERTIFICATE              =  0, /* X.509 */
-  R_PEM_TYPE_CERTIFICATE_LIST             , /* X.509 CRL */
-  R_PEM_TYPE_CERTIFICATE_REQUEST          , /* PKCS#10 */
-  R_PEM_TYPE_PUBLIC_KEY                   , /* PubKey inside a X.509 */
-  R_PEM_TYPE_RSA_PRIVATE_KEY              , /* PKCS#1 */
-  R_PEM_TYPE_DSA_PRIVATE_KEY              ,
-  R_PEM_TYPE_PRIVATE_KEY                  , /* PKCS#8 */
-  R_PEM_TYPE_ENCRYPTED_PRIVATE_KEY        , /* PKCS#8 */
+  R_PEM_TYPE_CERTIFICATE              =  0, /**< X.509 certificate. */
+  R_PEM_TYPE_CERTIFICATE_LIST             , /**< X.509 certificate revocation list. */
+  R_PEM_TYPE_CERTIFICATE_REQUEST          , /**< PKCS#10 CSR. */
+  R_PEM_TYPE_PUBLIC_KEY                   , /**< SubjectPublicKeyInfo (typically from an X.509). */
+  R_PEM_TYPE_RSA_PRIVATE_KEY              , /**< PKCS#1 RSAPrivateKey. */
+  R_PEM_TYPE_DSA_PRIVATE_KEY              , /**< Legacy SEC1-style DSA private key. */
+  R_PEM_TYPE_PRIVATE_KEY                  , /**< PKCS#8 PrivateKeyInfo. */
+  R_PEM_TYPE_ENCRYPTED_PRIVATE_KEY        , /**< PKCS#8 EncryptedPrivateKeyInfo. */
   R_PEM_TYPE_COUNT,
   R_PEM_TYPE_KEY_START = R_PEM_TYPE_PUBLIC_KEY,
   R_PEM_TYPE_KEY_END   = R_PEM_TYPE_ENCRYPTED_PRIVATE_KEY
 } RPemType;
 
+/** @brief Open a PEM parser reading from a file path. */
 R_API RPemParser * r_pem_parser_new_from_file (const rchar * filename) R_ATTR_MALLOC;
+/** @brief Open a PEM parser reading from a memory-mapped file. */
 R_API RPemParser * r_pem_parser_new_from_memfile (RMemFile * file) R_ATTR_MALLOC;
+/**
+ * @brief Open a PEM parser reading from an in-memory buffer.
+ *
+ * @param data  Buffer holding PEM-encoded blocks.
+ * @param size  Length of @p data, or @c -1 if NUL-terminated.
+ */
 R_API RPemParser * r_pem_parser_new (const rchar * data, rssize size) R_ATTR_MALLOC;
+/** @brief Increment the parser's refcount. */
 #define r_pem_parser_ref r_ref_ref
+/** @brief Decrement the parser's refcount; frees when it reaches zero. */
 #define r_pem_parser_unref r_ref_unref
 
+/**
+ * @brief Rewind the parser so the next @ref r_pem_parser_next_block
+ * call starts from the first block of the input.
+ */
 R_API void r_pem_parser_reset (RPemParser * parser);
 
 
+/**
+ * @brief Return the next PEM block in the input, or @c NULL at EOF.
+ *
+ * The block is refcounted; the caller owns one reference and must
+ * @ref r_pem_block_unref it.
+ */
 R_API RPemBlock * r_pem_parser_next_block (RPemParser * parser) R_ATTR_MALLOC;
+/** @brief Increment the block's refcount. */
 #define r_pem_block_ref r_ref_ref
+/** @brief Decrement the block's refcount; frees when it reaches zero. */
 #define r_pem_block_unref r_ref_unref
 
+/** @brief Return the @ref RPemType encoded in the block's BEGIN label. */
 R_API RPemType r_pem_block_get_type (RPemBlock * block);
+/**
+ * @brief True if the block holds an encrypted private key (PKCS#8
+ * EncryptedPrivateKeyInfo); @ref r_pem_block_get_key needs a
+ * passphrase to materialise it.
+ */
 R_API rboolean r_pem_block_is_encrypted (RPemBlock * block);
+/**
+ * @brief True if the block holds any key kind (public or private,
+ * encrypted or not).
+ */
 R_API rboolean r_pem_block_is_key (RPemBlock * block);
 
+/** @brief Byte length of the decoded (binary) blob. */
 R_API rsize r_pem_block_get_blob_size (RPemBlock * block);
+/** @brief Byte length of the base64 payload between BEGIN and END. */
 R_API rsize r_pem_block_get_base64_size (RPemBlock * block);
+/**
+ * @brief Return the base64 payload as a freshly-allocated string.
+ * @param block  The PEM block.
+ * @param size   Out: length of the returned string (excluding NUL).
+ */
 R_API rchar * r_pem_block_get_base64 (RPemBlock * block, rsize * size) R_ATTR_MALLOC;
+/**
+ * @brief Decode the block's base64 payload and return the binary blob.
+ * @param block  The PEM block.
+ * @param size   Out: length of the returned blob in bytes.
+ */
 R_API ruint8 * r_pem_block_decode_base64 (RPemBlock * block, rsize * size) R_ATTR_MALLOC;
+/**
+ * @brief Return an ASN.1 BER/DER decoder over the block's binary
+ * payload, for callers that want to walk the structure directly
+ * rather than going through the key / cert builders.
+ */
 R_API RAsn1BinDecoder * r_pem_block_get_asn1_decoder (RPemBlock * block);
 
+/**
+ * @brief Materialise a key block as an @ref RCryptoKey.
+ *
+ * @param block       The PEM block. Must satisfy @ref r_pem_block_is_key.
+ * @param passphrase  Required for encrypted PKCS#8 blocks; ignored
+ *                    otherwise. Pass @c NULL when not applicable.
+ * @param ppsize      Length of @p passphrase.
+ */
 R_API RCryptoKey * r_pem_block_get_key (RPemBlock * block,
     const rchar * passphrase, rsize ppsize);
+/** @brief Materialise a certificate block as an @c RCryptoCert. */
 R_API RCryptoCert * r_pem_block_get_cert (RPemBlock * block);
 
 
+/**
+ * @brief Emit @p key as a public-key PEM block into a freshly
+ * allocated string.
+ *
+ * @param key       Key to emit (only the public side is written).
+ * @param linesize  Base64 line wrap width (RFC 7468 prescribes 64).
+ * @param out       Out: length of the returned string.
+ */
 R_API rchar * r_pem_write_public_key_dup (const RCryptoKey * key,
     rsize linesize, rsize * out);
+/**
+ * @brief Emit @p key as a public-key PEM block into @p data.
+ * @param key       Key to emit (only the public side is written).
+ * @param data      Destination buffer.
+ * @param size      Capacity of @p data.
+ * @param linesize  Base64 line wrap width (RFC 7468 prescribes 64).
+ * @param out       Out: number of bytes written.
+ */
 R_API rboolean r_pem_write_public_key (const RCryptoKey * key,
     rpointer data, rsize size, rsize linesize, rsize * out);
+/**
+ * @brief Emit @p key as a private-key PEM block (PKCS#8 PrivateKeyInfo)
+ * into a freshly allocated string.
+ */
 R_API rchar * r_pem_write_private_key_dup (const RCryptoKey * key,
     rsize linesize, rsize * out);
+/** @brief Emit @p key as a private-key PEM block into @p data. */
 R_API rboolean r_pem_write_private_key (const RCryptoKey * key,
     rpointer data, rsize size, rsize linesize, rsize * out);
+/** @brief Emit @p cert as a CERTIFICATE PEM block into a fresh string. */
 R_API rchar * r_pem_write_cert_dup (const RCryptoCert * cert,
     rsize linesize, rsize * out);
+/** @brief Emit @p cert as a CERTIFICATE PEM block into @p data. */
 R_API rboolean r_pem_write_cert (const RCryptoCert * cert,
     rpointer data, rsize size, rsize linesize, rsize * out);
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_CRYPTO_PEM_H__ */
 

--- a/include/rlib/crypto/rrsa.h
+++ b/include/rlib/crypto/rrsa.h
@@ -22,6 +22,43 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @defgroup r_crypto_rsa RSA
+ * @ingroup r_crypto_key
+ *
+ * @brief RSA key construction, RSAES (encrypt/decrypt) and RSASSA
+ * (sign/verify) under raw, OAEP and PKCS#1 v1.5 padding.
+ *
+ * RSA keys are surfaced as the generic @ref RCryptoKey handle from
+ * @ref r_crypto_key. The @c r_rsa_pub_key_new / @c r_rsa_priv_key_new
+ * family construct one from already-parsed @c rmpint components or
+ * raw big-endian byte buffers; @c r_rsa_priv_key_new_gen generates a
+ * fresh keypair via a caller-supplied PRNG. Once you have an
+ * @ref RCryptoKey, encrypt / decrypt / sign / verify go through the
+ * polymorphic @c r_crypto_key_* dispatch, or directly through the
+ * scheme-specific entry points below.
+ *
+ * Three padding modes are supported:
+ *
+ *   - @c R_RSA_PADDING_PKCS1_V15 — RSAES-PKCS1-v1_5 (encrypt) and
+ *     RSASSA-PKCS1-v1_5 (sign). Legacy compatibility; see security
+ *     caveats on @ref r_rsa_pkcs1v1_5_decrypt below.
+ *   - @c R_RSA_PADDING_PKCS1_V21 — RSAES-OAEP and RSASSA-PSS.
+ *     Modern, preferred for new protocols.
+ *   - Raw RSA — @ref r_rsa_raw_encrypt / @ref r_rsa_raw_decrypt
+ *     expose textbook RSA. Do not use without your own padding;
+ *     it is provided for protocol-level work that does its own
+ *     framing (e.g. building TLS internals).
+ *
+ * @{
+ */
+
+/**
+ * @file rlib/crypto/rrsa.h
+ * @brief RSA key construction plus RSAES / RSASSA primitives under
+ * raw, OAEP and PKCS#1 v1.5 padding.
+ */
+
 #include <rlib/rtypes.h>
 #include <rlib/crypto/rkey.h>
 
@@ -31,112 +68,299 @@
 
 R_BEGIN_DECLS
 
+/** @brief Algorithm-name string used in @c RCryptoKey introspection. */
 #define R_RSA_STR     "RSA"
 
+/**
+ * @brief RSA padding mode selector.
+ *
+ * Stored on the @ref RCryptoKey and consulted by the polymorphic
+ * @c r_crypto_key_encrypt / @c r_crypto_key_sign dispatch. The
+ * scheme-specific @c r_rsa_*_encrypt / @c _sign / @c _verify entry
+ * points ignore this field and use whichever padding their name
+ * indicates.
+ */
 typedef enum {
   R_RSA_PADDING_UNKNOWN       = -1,
-  R_RSA_PADDING_PKCS1_V15     = 0, /* RSAES-PKCS1-v1_5 and RSASSA-PKCS1-v1_5 */
-  R_RSA_PADDING_PKCS1_V21     = 1, /* RSAES-OAEP and RSASSA-PSS */
+  R_RSA_PADDING_PKCS1_V15     = 0, /**< RSAES-PKCS1-v1_5 + RSASSA-PKCS1-v1_5. */
+  R_RSA_PADDING_PKCS1_V21     = 1, /**< RSAES-OAEP + RSASSA-PSS. */
 } RRsaPadding;
 
+/**
+ * @brief Build an RSA public key from already-parsed @c rmpint
+ * components @c (n, e).
+ */
 R_API RCryptoKey * r_rsa_pub_key_new (const rmpint * n, const rmpint * e) R_ATTR_MALLOC;
+
+/**
+ * @brief Build an RSA public key from raw big-endian byte buffers.
+ *
+ * Convenience wrapper that parses @p n and @p e into @c rmpints
+ * before calling @ref r_rsa_pub_key_new.
+ */
 R_API RCryptoKey * r_rsa_pub_key_new_binary (rconstpointer n, rsize nsize,
     rconstpointer e, rsize esize) R_ATTR_MALLOC;
 
+/**
+ * @brief Build an RSA private key from @c (n, e, d).
+ *
+ * The CRT components (@c p, @c q, @c dp, @c dq, @c qp) are left
+ * unset; private operations will use the slower @c (n, d) path.
+ * For CRT-accelerated keys use @ref r_rsa_priv_key_new_full.
+ */
 R_API RCryptoKey * r_rsa_priv_key_new (const rmpint * n, const rmpint * e,
     const rmpint * d) R_ATTR_MALLOC;
+
+/**
+ * @brief Build an RSA private key with the full CRT representation.
+ *
+ * @param ver  PKCS#1 version tag (typically 0).
+ * @param n    Modulus.
+ * @param e    Public exponent.
+ * @param d    Private exponent.
+ * @param p,q  Prime factors of @p n.
+ * @param dp   @c d mod (p-1).
+ * @param dq   @c d mod (q-1).
+ * @param qp   @c q^-1 mod p (CRT coefficient).
+ *
+ * Components @c dp / @c dq / @c qp accelerate private operations via
+ * the Chinese Remainder Theorem.
+ */
 R_API RCryptoKey * r_rsa_priv_key_new_full (rint32 ver,
     const rmpint * n, const rmpint * e, /* public part */
     const rmpint * d, const rmpint * p, const rmpint * q,
     const rmpint * dp, const rmpint * dq, const rmpint * qp) R_ATTR_MALLOC;
+
+/**
+ * @brief Build an RSA private key from raw big-endian @c (n, e, d) buffers.
+ *
+ * Convenience wrapper around @ref r_rsa_priv_key_new.
+ */
 R_API RCryptoKey * r_rsa_priv_key_new_binary (rconstpointer n, rsize nsize,
     rconstpointer e, rsize esize, rconstpointer d, rsize dsize) R_ATTR_MALLOC;
+
+/**
+ * @brief Decode an RSA private key from an ASN.1 RSAPrivateKey TLV
+ * (PKCS#1 §A.1.2).
+ *
+ * Used by the PEM and X.509 import paths (see @c rpem.h and
+ * @c rx509.h) to materialise an @ref RCryptoKey from a DER blob.
+ */
 R_API RCryptoKey * r_rsa_priv_key_new_from_asn1 (RAsn1BinDecoder * dec, RAsn1BinTLV * tlv) R_ATTR_MALLOC;
 
+/**
+ * @brief Generate a fresh RSA keypair.
+ *
+ * @param bits  Modulus size in bits.
+ * @param e     Public exponent (typically 65537).
+ * @param prng  Randomness source used for prime sampling.
+ * @return New @ref RCryptoKey carrying the full CRT representation,
+ *         or @c NULL on failure.
+ */
 R_API RCryptoKey * r_rsa_priv_key_new_gen (rsize bits, ruint64 e,
     RPrng * prng) R_ATTR_MALLOC;
 
 
+/** @brief Alias for @ref r_rsa_pub_key_get_padding; same field. */
 #define r_rsa_priv_key_get_padding r_rsa_pub_key_get_padding
+/** @brief Alias for @ref r_rsa_pub_key_set_padding; same field. */
 #define r_rsa_priv_key_set_padding r_rsa_pub_key_set_padding
+
+/**
+ * @brief Set the @ref RRsaPadding selector that the polymorphic
+ * dispatch (@c r_crypto_key_encrypt / @c _sign) uses for this key.
+ */
 R_API rboolean r_rsa_pub_key_set_padding (RCryptoKey * key, RRsaPadding padding);
+
+/**
+ * @brief Read back the @ref RRsaPadding selector previously stored
+ * with @ref r_rsa_pub_key_set_padding.
+ */
 R_API RRsaPadding r_rsa_pub_key_get_padding (const RCryptoKey * key);
 
+/** @brief Alias for @ref r_rsa_pub_key_get_e (public field). */
 #define r_rsa_priv_key_get_e r_rsa_pub_key_get_e
+
+/** @brief Copy the public exponent @c e into @p e. */
 R_API rboolean r_rsa_pub_key_get_e (const RCryptoKey * key, rmpint * e);
+/** @brief Copy the modulus @c n into @p n. */
 R_API rboolean r_rsa_pub_key_get_n (const RCryptoKey * key, rmpint * n);
+/** @brief Copy the private exponent @c d into @p d. */
 R_API rboolean r_rsa_priv_key_get_d (const RCryptoKey * key, rmpint * d);
+/** @brief Copy the prime factor @c p into @p p (CRT-representation keys). */
 R_API rboolean r_rsa_priv_key_get_p (const RCryptoKey * key, rmpint * p);
+/** @brief Copy the prime factor @c q into @p q (CRT-representation keys). */
 R_API rboolean r_rsa_priv_key_get_q (const RCryptoKey * key, rmpint * q);
+/** @brief Copy the CRT exponent @c dp = d mod (p-1) into @p dp. */
 R_API rboolean r_rsa_priv_key_get_dp (const RCryptoKey * key, rmpint * dp);
+/** @brief Copy the CRT exponent @c dq = d mod (q-1) into @p dq. */
 R_API rboolean r_rsa_priv_key_get_dq (const RCryptoKey * key, rmpint * dq);
+/** @brief Copy the CRT coefficient @c qp = q^-1 mod p into @p qp. */
 R_API rboolean r_rsa_priv_key_get_qp (const RCryptoKey * key, rmpint * qp);
 
 
+/**
+ * @brief Textbook RSA encryption: @c out = m^e mod n.
+ *
+ * @warning No padding. Direct use is insecure for almost every
+ * protocol - the same plaintext always encrypts to the same
+ * ciphertext, and small messages can be recovered by cube-root.
+ * Use OAEP (@ref r_rsa_oaep_encrypt) or PKCS#1 v1.5
+ * (@ref r_rsa_pkcs1v1_5_encrypt) unless you're building padding
+ * yourself.
+ */
 R_API RCryptoResult r_rsa_raw_encrypt (const RCryptoKey * key, RPrng * prng,
     rconstpointer data, rsize size, ruint8 * out, rsize * outsize);
+
+/**
+ * @brief Textbook RSA decryption: @c out = c^d mod n.
+ *
+ * @warning No padding-check. See the warning on @ref r_rsa_raw_encrypt.
+ */
 R_API RCryptoResult r_rsa_raw_decrypt (const RCryptoKey * key,
     rconstpointer data, rsize size, ruint8 * out, rsize * outsize);
 
+/**
+ * @brief RSAES-OAEP encryption (PKCS#1 v2.x).
+ *
+ * Authenticated, randomised padding. Preferred over PKCS#1 v1.5 for
+ * any new protocol that needs RSA-based encryption.
+ */
 R_API RCryptoResult r_rsa_oaep_encrypt (const RCryptoKey * key, RPrng * prng,
     rconstpointer data, rsize size, ruint8 * out, rsize * outsize);
+
+/**
+ * @brief RSAES-OAEP decryption (PKCS#1 v2.x).
+ */
 R_API RCryptoResult r_rsa_oaep_decrypt (const RCryptoKey * key,
     rconstpointer data, rsize size, ruint8 * out, rsize * outsize);
 
+/**
+ * @brief RSAES-PKCS1-v1_5 encryption.
+ *
+ * Legacy. New protocols should prefer OAEP. Encryption is fine; the
+ * danger is on the decrypt side - see the security note on
+ * @ref r_rsa_pkcs1v1_5_decrypt.
+ */
 R_API RCryptoResult r_rsa_pkcs1v1_5_encrypt (const RCryptoKey * key, RPrng * prng,
     rconstpointer data, rsize size, ruint8 * out, rsize * outsize);
-/* Variable-length PKCS#1 v1.5 decrypt that returns distinct error
- * codes for each padding-validation failure mode and walks the PS
- * field via an early-out loop. Both of those signals are
- * attacker-observable - the function is a Bleichenbacher oracle
- * when exposed to chosen-ciphertext input. SAFE only for
- * trusted-source ciphertexts (e.g. blob decryption where you
- * encrypted the data yourself and just need to recover it).
+
+/**
+ * @brief Variable-length PKCS#1 v1.5 decrypt.
  *
- * For network-facing decrypt - TLS-RSA premaster, JWE RSA1_5,
- * S/MIME, anything else where an attacker can submit ciphertexts
- * and observe accept / reject - use r_rsa_pkcs1v1_5_decrypt_implicit
- * below, which collapses every failure mode into a constant-time
- * synthetic message of caller-supplied length. */
+ * Returns distinct error codes for each padding-validation failure
+ * mode and walks the PS field via an early-out loop. Both of those
+ * signals are attacker-observable - the function is a Bleichenbacher
+ * oracle when exposed to chosen-ciphertext input.
+ *
+ * @warning SAFE only for trusted-source ciphertexts (e.g. blob
+ * decryption where you encrypted the data yourself and just need to
+ * recover it).
+ *
+ * For network-facing decrypt (TLS-RSA premaster, JWE RSA1_5, S/MIME,
+ * anything else where an attacker can submit ciphertexts and observe
+ * accept / reject), use @ref r_rsa_pkcs1v1_5_decrypt_implicit, which
+ * collapses every failure mode into a constant-time synthetic
+ * message of caller-supplied length.
+ */
 R_API RCryptoResult r_rsa_pkcs1v1_5_decrypt (const RCryptoKey * key,
     rconstpointer data, rsize size, ruint8 * out, rsize * outsize);
-/* RSAES-PKCS1-v1_5 decrypt with implicit rejection - the standard
- * Bleichenbacher / ROBOT / Marvin mitigation. Always writes out_size
- * bytes to `out` and returns R_CRYPTO_OK on any well-formed raw
- * decrypt: the real plaintext when padding is valid and the
- * recovered message length matches out_size, or a deterministic
- * synthetic message derived from the private key + ciphertext
- * otherwise. The padding check and the length scan are constant-
- * time across every byte of the recovered block, and success /
- * failure share the same return code and output length, so a
- * network attacker can't distinguish them.
+
+/**
+ * @brief RSAES-PKCS1-v1_5 decrypt with implicit rejection - the
+ * standard Bleichenbacher / ROBOT / Marvin mitigation.
+ *
+ * Always writes @p out_size bytes to @p out and returns
+ * @c R_CRYPTO_OK on any well-formed raw decrypt: the real plaintext
+ * when padding is valid and the recovered message length matches
+ * @p out_size, or a deterministic synthetic message derived from
+ * the private key + ciphertext otherwise. The padding check and
+ * the length scan are constant-time across every byte of the
+ * recovered block, and success / failure share the same return
+ * code and output length, so a network attacker can't distinguish
+ * them.
  *
  * Callers that need to detect "ciphertext doesn't decrypt to what
  * the protocol expected" must do so at a higher layer (e.g. the
  * TLS Finished transcript check), never through return-code
- * inspection on this primitive. out_size must be in (0, k - 11]
- * where k is the modulus byte length, matching the RSAES-PKCS1-v1_5
- * maximum-message bound; out_size = 0 or larger out_size returns
- * R_CRYPTO_WRONG_SIZE. */
+ * inspection on this primitive.
+ *
+ * @param key       Private RSA key.
+ * @param data      Ciphertext bytes.
+ * @param size      Length of @p data, must equal the modulus byte length.
+ * @param out       Destination for the recovered (or synthetic) message;
+ *                  exactly @p out_size bytes are always written.
+ * @param out_size  Must be in @c (0, k-11] where @c k is the modulus
+ *                  byte length (the RSAES-PKCS1-v1_5 maximum-message
+ *                  bound). Zero or larger values return
+ *                  @c R_CRYPTO_WRONG_SIZE.
+ */
 R_API RCryptoResult r_rsa_pkcs1v1_5_decrypt_implicit (const RCryptoKey * key,
     rconstpointer data, rsize size, ruint8 * out, rsize out_size);
+
+/**
+ * @brief RSASSA-PKCS1-v1_5 sign over message bytes.
+ *
+ * Hashes @p msg with @p mdtype, then signs the resulting digest.
+ */
 R_API RCryptoResult r_rsa_pkcs1v1_5_sign_msg (const RCryptoKey * key, RPrng * prng,
     RMsgDigestType mdtype, rconstpointer msg, rsize msgsize,
     rpointer sig, rsize * sigsize);
+
+/**
+ * @brief RSASSA-PKCS1-v1_5 sign over a precomputed digest.
+ *
+ * Same as @ref r_rsa_pkcs1v1_5_sign_msg but the caller supplies the
+ * already-hashed value; @p mdtype is still required so the PKCS#1
+ * v1.5 DigestInfo prefix can be selected.
+ */
 R_API RCryptoResult r_rsa_pkcs1v1_5_sign_msg_hash (const RCryptoKey * key, RPrng * prng,
     RMsgDigestType mdtype, rconstpointer hash, rsize hashsize,
     rpointer sig, rsize * sigsize);
+
+/**
+ * @brief RSASSA-PKCS1-v1_5 sign over a precomputed digest without a
+ * DigestInfo prefix.
+ *
+ * The signed payload is the raw hash bytes. Used by protocols that
+ * frame DigestInfo at a higher layer (e.g. some TLS 1.0 / 1.1
+ * profiles).
+ */
 R_API RCryptoResult r_rsa_pkcs1v1_5_sign_hash (const RCryptoKey * key, RPrng * prng,
     rconstpointer hash, rsize hashsize, rpointer sig, rsize * sigsize);
+
+/**
+ * @brief RSASSA-PKCS1-v1_5 verify over message bytes.
+ *
+ * Hashes @p msg using whichever digest is encoded in the signature's
+ * DigestInfo, then compares.
+ */
 R_API RCryptoResult r_rsa_pkcs1v1_5_verify_msg (const RCryptoKey * key,
     rconstpointer msg, rsize msgsize, rconstpointer sig, rsize sigsize);
+
+/**
+ * @brief RSASSA-PKCS1-v1_5 verify with a caller-specified digest type
+ * over a precomputed hash.
+ *
+ * Used when the caller already hashed the message and knows which
+ * @ref RMsgDigestType produced @p hash.
+ */
 R_API RCryptoResult r_rsa_pkcs1v1_5_verify_msg_with_hash (const RCryptoKey * key,
     RMsgDigestType mdtype, rconstpointer hash, rsize hashsize,
     rconstpointer sig, rsize sigsize);
+
+/**
+ * @brief RSASSA-PKCS1-v1_5 verify of a raw-hash signature (no
+ * DigestInfo).
+ *
+ * Counterpart to @ref r_rsa_pkcs1v1_5_sign_hash.
+ */
 R_API RCryptoResult r_rsa_pkcs1v1_5_verify_hash (const RCryptoKey * key,
     rconstpointer hash, rsize hashsize, rconstpointer sig, rsize sigsize);
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_CRYPTO_RSA_H__ */
 

--- a/include/rlib/crypto/rsrtpciphersuite.h
+++ b/include/rlib/crypto/rsrtpciphersuite.h
@@ -22,6 +22,36 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @defgroup r_crypto_srtp_ciphersuite SRTP ciphersuites
+ * @ingroup r_crypto_ciphersuite
+ *
+ * @brief Lookup table mapping IANA SRTP / SDP-security-descriptions
+ * ciphersuite identifiers to the concrete cipher / MAC / KDF
+ * parameters needed to instantiate the protection profile.
+ *
+ * Each suite is named by its IANA identifier (`R_SRTP_CS_*`) and
+ * carries an @ref RSRTPCipherSuiteInfo entry describing:
+ *
+ *   - the cipher to use on RTP / RTCP payload (`cipher`, `saltbits`),
+ *   - the authentication MAC (`auth`, `authprefixlen`) and the SRTP /
+ *     SRTCP tag lengths,
+ *   - the key-derivation PRF.
+ *
+ * The full IANA list is at
+ * <https://www.iana.org/assignments/srtp-protection/srtp-protection.xhtml>
+ * (SRTP protection profiles) and
+ * <https://www.iana.org/assignments/sdp-security-descriptions/sdp-security-descriptions.xhtml>
+ * (SDP `crypto:` descriptions).
+ *
+ * @{
+ */
+
+/**
+ * @file rlib/crypto/rsrtpciphersuite.h
+ * @brief SRTP ciphersuite enumeration and parameter-table lookup.
+ */
+
 #include <rlib/rtypes.h>
 
 #include <rlib/crypto/rcipher.h>
@@ -29,52 +59,84 @@
 
 R_BEGIN_DECLS
 
-/* https://www.iana.org/assignments/sdp-security-descriptions/sdp-security-descriptions.xhtml#sdp-security-descriptions-3 */
-/* https://www.iana.org/assignments/srtp-protection/srtp-protection.xhtml#srtp-protection-1 */
+/**
+ * @brief IANA-registered SRTP ciphersuites.
+ *
+ * Values are the 16-bit IANA identifiers. @c R_SRTP_CS_NONE is the
+ * sentinel returned by negotiation helpers when no suite matches.
+ */
 typedef enum {
   R_SRTP_CS_NONE                                      = -1,
   R_SRTP_CS_NULL_NULL                                 = 0x0000,
-  R_SRTP_CS_AES_128_CM_HMAC_SHA1_80                   = 0x0001, /* [RFC4568], [RFC5764] */
-  R_SRTP_CS_AES_128_CM_HMAC_SHA1_32                   = 0x0002, /* [RFC4568], [RFC5764] */
-  R_SRTP_CS_F8_128_HMAC_SHA1_80                       = 0x0003, /* [RFC4568] */
+  R_SRTP_CS_AES_128_CM_HMAC_SHA1_80                   = 0x0001, /**< RFC 4568, RFC 5764. */
+  R_SRTP_CS_AES_128_CM_HMAC_SHA1_32                   = 0x0002, /**< RFC 4568, RFC 5764. */
+  R_SRTP_CS_F8_128_HMAC_SHA1_80                       = 0x0003, /**< RFC 4568. */
 
-  R_SRTP_CS_NULL_HMAC_SHA1_80                         = 0x0005, /* [RFC5764] */
-  R_SRTP_CS_NULL_HMAC_SHA1_32                         = 0x0006, /* [RFC5764] */
-  R_SRTP_CS_AEAD_AES_128_GCM                          = 0x0007, /* [RFC7714] */
-  R_SRTP_CS_AEAD_AES_256_GCM                          = 0x0008, /* [RFC7714] */
+  R_SRTP_CS_NULL_HMAC_SHA1_80                         = 0x0005, /**< RFC 5764. */
+  R_SRTP_CS_NULL_HMAC_SHA1_32                         = 0x0006, /**< RFC 5764. */
+  R_SRTP_CS_AEAD_AES_128_GCM                          = 0x0007, /**< RFC 7714. */
+  R_SRTP_CS_AEAD_AES_256_GCM                          = 0x0008, /**< RFC 7714. */
 
-  R_SRTP_CS_SEED_CTR_128_HMAC_SHA1_80                 = 0x0011, /* [RFC5669] */
-  R_SRTP_CS_SEED_128_CCM_80                           = 0x0012, /* [RFC5669] */
-  R_SRTP_CS_SEED_128_GCM_96                           = 0x0013, /* [RFC5669] */
-  R_SRTP_CS_AES_192_CM_HMAC_SHA1_80                   = 0x0021, /* [RFC6188] */
-  R_SRTP_CS_AES_192_CM_HMAC_SHA1_32                   = 0x0022, /* [RFC6188] */
-  R_SRTP_CS_AES_256_CM_HMAC_SHA1_80                   = 0x0023, /* [RFC6188] */
-  R_SRTP_CS_AES_256_CM_HMAC_SHA1_32                   = 0x0024, /* [RFC6188] */
+  R_SRTP_CS_SEED_CTR_128_HMAC_SHA1_80                 = 0x0011, /**< RFC 5669. */
+  R_SRTP_CS_SEED_128_CCM_80                           = 0x0012, /**< RFC 5669. */
+  R_SRTP_CS_SEED_128_GCM_96                           = 0x0013, /**< RFC 5669. */
+  R_SRTP_CS_AES_192_CM_HMAC_SHA1_80                   = 0x0021, /**< RFC 6188. */
+  R_SRTP_CS_AES_192_CM_HMAC_SHA1_32                   = 0x0022, /**< RFC 6188. */
+  R_SRTP_CS_AES_256_CM_HMAC_SHA1_80                   = 0x0023, /**< RFC 6188. */
+  R_SRTP_CS_AES_256_CM_HMAC_SHA1_32                   = 0x0024, /**< RFC 6188. */
 } RSRTPCipherSuite;
 
+/**
+ * @brief Parameter table for one SRTP ciphersuite.
+ *
+ * Returned by @ref r_srtp_cipher_suite_get_info; describes how to
+ * wire the protection profile into the SRTP / SRTCP framing.
+ */
 typedef struct {
-  RSRTPCipherSuite suite;
-  const rchar * str;
+  RSRTPCipherSuite suite;             /**< IANA identifier. */
+  const rchar * str;                  /**< Short ASCII name (matches SDP). */
 
-  const RCryptoCipherInfo * cipher;
-  rsize saltbits;
+  const RCryptoCipherInfo * cipher;   /**< Payload cipher. */
+  rsize saltbits;                     /**< Session-salt size in bits. */
 
-  RMsgDigestType auth;
-  rsize authprefixlen;
-  rsize srtp_tagbits;
-  rsize srtcp_tagbits;
+  RMsgDigestType auth;                /**< Authentication MAC. */
+  rsize authprefixlen;                /**< Length of authenticated prefix. */
+  rsize srtp_tagbits;                 /**< Tag length on RTP packets, bits. */
+  rsize srtcp_tagbits;                /**< Tag length on RTCP packets, bits. */
 
-  const RCryptoCipherInfo * kdprf;
+  const RCryptoCipherInfo * kdprf;    /**< Key-derivation pseudorandom function. */
 } RSRTPCipherSuiteInfo;
 
+/** @brief True iff rlib has an implementation for @p suite. */
 R_API rboolean r_srtp_cipher_suite_is_supported (RSRTPCipherSuite suite);
+
+/**
+ * @brief Pick the most-preferred suite in @p preferred that also
+ * appears in @p incoming.
+ *
+ * Used by SDP-style negotiation to select a common suite. Returns
+ * @c R_SRTP_CS_NONE if the intersection is empty.
+ *
+ * @param incoming   Peer-offered suites in their order.
+ * @param ilen       Length of @p incoming.
+ * @param preferred  Local preference order (most preferred first).
+ * @param plen       Length of @p preferred.
+ */
 R_API RSRTPCipherSuite r_srtp_cipher_suite_filter (
     const RSRTPCipherSuite * incoming, ruint ilen,
     const RSRTPCipherSuite * preferred, ruint plen);
+
+/** @brief Look up the parameter table for @p suite, or @c NULL. */
 R_API const RSRTPCipherSuiteInfo * r_srtp_cipher_suite_get_info (RSRTPCipherSuite suite);
+/**
+ * @brief Look up the parameter table by short ASCII name (e.g.
+ * @c "AES_CM_128_HMAC_SHA1_80"), or @c NULL.
+ */
 R_API const RSRTPCipherSuiteInfo * r_srtp_cipher_suite_get_info_from_str (const rchar * str);
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_CRYPTO_SRTP_CIPHER_SUITE_H__ */
 

--- a/include/rlib/crypto/rsrtpciphersuite.h
+++ b/include/rlib/crypto/rsrtpciphersuite.h
@@ -25,7 +25,7 @@
 #include <rlib/rtypes.h>
 
 #include <rlib/crypto/rcipher.h>
-#include <rlib/rmsgdigest.h>
+#include <rlib/crypto/rmsgdigest.h>
 
 R_BEGIN_DECLS
 

--- a/include/rlib/crypto/rtlsciphersuite.h
+++ b/include/rlib/crypto/rtlsciphersuite.h
@@ -25,7 +25,7 @@
 #include <rlib/rtypes.h>
 
 #include <rlib/crypto/rcipher.h>
-#include <rlib/rmsgdigest.h>
+#include <rlib/crypto/rmsgdigest.h>
 
 R_BEGIN_DECLS
 

--- a/include/rlib/crypto/rtlsciphersuite.h
+++ b/include/rlib/crypto/rtlsciphersuite.h
@@ -22,6 +22,34 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @defgroup r_crypto_tls_ciphersuite TLS / DTLS ciphersuites
+ * @ingroup r_crypto_ciphersuite
+ *
+ * @brief Lookup table mapping IANA TLS ciphersuite identifiers to
+ * the concrete key-exchange / cipher / MAC parameters needed to
+ * negotiate and instantiate the suite.
+ *
+ * Each suite is named by its 16-bit IANA identifier (`R_TLS_CS_*`)
+ * and carries an @ref RTLSCipherSuiteInfo entry with:
+ *
+ *   - the key-exchange family (@ref RKeyExchangeType),
+ *   - the payload cipher,
+ *   - the record-MAC digest.
+ *
+ * The full IANA registry, including which suites apply to TLS only
+ * vs. TLS + DTLS, lives at
+ * <https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4>.
+ *
+ * @{
+ */
+
+/**
+ * @file rlib/crypto/rtlsciphersuite.h
+ * @brief TLS / DTLS ciphersuite enumeration and parameter-table
+ * lookup.
+ */
+
 #include <rlib/rtypes.h>
 
 #include <rlib/crypto/rcipher.h>
@@ -29,7 +57,14 @@
 
 R_BEGIN_DECLS
 
-/* http://www.iana.org/assignments/tls-parameters/#tls-parameters-4 */
+/**
+ * @brief IANA-registered TLS / DTLS ciphersuites.
+ *
+ * Values are the 16-bit IANA identifiers. Comments after each
+ * value note the applicable transport (TLS only vs. TLS + DTLS)
+ * and the defining RFC. @c R_TLS_CS_NONE is the sentinel returned
+ * by negotiation helpers when no suite matches.
+ */
 typedef enum {
   R_TLS_CS_NONE                                           = -1,
   R_TLS_CS_NULL_WITH_NULL_NULL                            = 0x0000, /* TLS & DTLS [RFC5247] */
@@ -362,6 +397,9 @@ typedef enum {
   R_TLS_CS_RSA_PSK_WITH_CHACHA20_POLY1305_SHA256          = 0xccae, /* TLS & DTLS [RFC7905] */
 } RTLSCipherSuite;
 
+/**
+ * @brief TLS key-exchange family used by a ciphersuite.
+ */
 typedef enum {
   R_KEY_EXCHANGE_NULL = 0,
   R_KEY_EXCHANGE_RSA,
@@ -384,24 +422,46 @@ typedef enum {
   R_KEY_EXCHANGE_KRB5,
 } RKeyExchangeType;
 
+/**
+ * @brief Parameter table for one TLS ciphersuite.
+ *
+ * Returned by @ref r_tls_cipher_suite_get_info.
+ */
 typedef struct {
-  RTLSCipherSuite suite;
-  const rchar * str;
+  RTLSCipherSuite suite;              /**< IANA identifier. */
+  const rchar * str;                  /**< Short ASCII name. */
 
-  RKeyExchangeType key_exchange;
-  const RCryptoCipherInfo * cipher;
-  RMsgDigestType mac;
+  RKeyExchangeType key_exchange;      /**< Key-exchange family. */
+  const RCryptoCipherInfo * cipher;   /**< Payload cipher. */
+  RMsgDigestType mac;                 /**< Record-MAC digest. */
 } RTLSCipherSuiteInfo;
 
+/** @brief True iff rlib has an implementation for @p suite. */
 R_API rboolean r_tls_cipher_suite_is_supported (RTLSCipherSuite suite);
+/**
+ * @brief Pick the most-preferred suite in @p preferred that also
+ * appears in @p incoming.
+ *
+ * Used by ServerHello-style negotiation. Returns @c R_TLS_CS_NONE
+ * if the intersection is empty.
+ *
+ * @param incoming   Peer-offered suites in their order.
+ * @param ilen       Length of @p incoming.
+ * @param preferred  Local preference order (most preferred first).
+ * @param plen       Length of @p preferred.
+ */
 R_API RTLSCipherSuite r_tls_cipher_suite_filter (
     const RTLSCipherSuite * incoming, ruint ilen,
     const RTLSCipherSuite * preferred, ruint plen);
 
+/** @brief Look up the parameter table for @p suite, or @c NULL. */
 R_API const RTLSCipherSuiteInfo * r_tls_cipher_suite_get_info (RTLSCipherSuite suite);
+/** @brief Look up the parameter table by short ASCII name, or @c NULL. */
 R_API const RTLSCipherSuiteInfo * r_tls_cipher_suite_get_info_from_str (const rchar * str);
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_CRYPTO_CIPHER_SUITE_H__ */
 

--- a/include/rlib/crypto/rx509.h
+++ b/include/rlib/crypto/rx509.h
@@ -22,6 +22,34 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @defgroup r_crypto_x509 X.509 certificates (RFC 5280)
+ * @ingroup r_crypto_cert
+ *
+ * @brief X.509 builders for @ref RCryptoCert plus the accessors and
+ * predicates that only make sense for the X.509 certificate kind.
+ *
+ * Use @ref r_crypto_x509_cert_new to parse a DER-encoded
+ * certificate; the result is an @ref RCryptoCert that the generic
+ * @c r_crypto_cert_* accessors in @ref r_crypto_cert can introspect.
+ * The X.509-specific accessors here expose fields that don't have a
+ * cross-format meaning: version, issuer / subject DNs, serial
+ * number, key-usage bitmasks, the CA flag, etc.
+ *
+ * Certificate validation is split between the X.509-specific
+ * @ref r_crypto_x509_cert_verify_signature (single hop, given a
+ * parent) and the chain-building logic that belongs in callers; no
+ * built-in path-building or revocation checking is provided.
+ *
+ * @{
+ */
+
+/**
+ * @file rlib/crypto/rx509.h
+ * @brief X.509 certificate parsing, field accessors and
+ * single-hop signature verification.
+ */
+
 #include <rlib/rtypes.h>
 
 #include <rlib/asn1/rasn1.h>
@@ -29,62 +57,150 @@
 
 R_BEGIN_DECLS
 
+/** @brief X.509 version field. */
 typedef enum {
   R_X509_VERSION_UNKNOWN  = -1,
-  R_X509_VERSION_V1       = 0,
-  R_X509_VERSION_V2       = 1,
-  R_X509_VERSION_V3       = 2,
+  R_X509_VERSION_V1       = 0,  /**< RFC 5280 v1. */
+  R_X509_VERSION_V2       = 1,  /**< RFC 5280 v2 (unique IDs). */
+  R_X509_VERSION_V3       = 2,  /**< RFC 5280 v3 (extensions). */
 } RX509Version;
+/** @brief Highest X.509 version this implementation parses. */
 #define R_X509_VERSION_SUPPORTED R_X509_VERSION_V3
 
+/**
+ * @brief X.509 @c KeyUsage bitmask (RFC 5280 §4.2.1.3).
+ *
+ * Bit positions match the on-wire BIT STRING. Multiple bits may be
+ * set; the returned value is the union of the certificate's
+ * declared usages.
+ */
 typedef enum {
   R_X509_KEY_USAGE_NONE                         = 0,
-  R_X509_KEY_USAGE_DIGITAL_SIGNATURE            = (1 << 0), /* bit 0 */
-  R_X509_KEY_USAGE_NON_REPUDIATION              = (1 << 1), /* bit 1 */
-  R_X509_KEY_USAGE_KEY_ENCIPHERMENT             = (1 << 2), /* bit 2 */
-  R_X509_KEY_USAGE_DATA_ENCIPHERMENT            = (1 << 3), /* bit 3 */
-  R_X509_KEY_USAGE_KEY_AGREEMENT                = (1 << 4), /* bit 4 */
-  R_X509_KEY_USAGE_KEY_CERT_SIGN                = (1 << 5), /* bit 5 */
-  R_X509_KEY_USAGE_CRL_SIGN                     = (1 << 6), /* bit 6 */
-  R_X509_KEY_USAGE_ENCIPHER_ONLY                = (1 << 7), /* bit 7 */
-  R_X509_KEY_USAGE_DECIPHER_ONLY                = (1 << 8), /* bit 8 */
+  R_X509_KEY_USAGE_DIGITAL_SIGNATURE            = (1 << 0), /**< bit 0 */
+  R_X509_KEY_USAGE_NON_REPUDIATION              = (1 << 1), /**< bit 1 */
+  R_X509_KEY_USAGE_KEY_ENCIPHERMENT             = (1 << 2), /**< bit 2 */
+  R_X509_KEY_USAGE_DATA_ENCIPHERMENT            = (1 << 3), /**< bit 3 */
+  R_X509_KEY_USAGE_KEY_AGREEMENT                = (1 << 4), /**< bit 4 */
+  R_X509_KEY_USAGE_KEY_CERT_SIGN                = (1 << 5), /**< bit 5 */
+  R_X509_KEY_USAGE_CRL_SIGN                     = (1 << 6), /**< bit 6 */
+  R_X509_KEY_USAGE_ENCIPHER_ONLY                = (1 << 7), /**< bit 7 */
+  R_X509_KEY_USAGE_DECIPHER_ONLY                = (1 << 8), /**< bit 8 */
 } RX509KeyUsage;
 
+/**
+ * @brief X.509 @c ExtendedKeyUsage bitmask (RFC 5280 §4.2.1.12).
+ *
+ * Each bit maps to one of the well-known EKU OIDs.
+ */
 typedef enum {
   R_X509_EXT_KEY_USAGE_NONE                     = 0,
-  R_X509_EXT_KEY_USAGE_ANY                      = (1 << 0),
-  R_X509_EXT_KEY_USAGE_SERVER_AUTH              = (1 << 1),
-  R_X509_EXT_KEY_USAGE_CLIENT_AUTH              = (1 << 2),
-  R_X509_EXT_KEY_USAGE_CODE_SIGNING             = (1 << 3),
-  R_X509_EXT_KEY_USAGE_EMAIL_PROTECTION         = (1 << 4),
-  R_X509_EXT_KEY_USAGE_TIME_STAMPING            = (1 << 5),
-  R_X509_EXT_KEY_USAGE_OCSP_SIGNING             = (1 << 6),
+  R_X509_EXT_KEY_USAGE_ANY                      = (1 << 0), /**< @c anyExtendedKeyUsage. */
+  R_X509_EXT_KEY_USAGE_SERVER_AUTH              = (1 << 1), /**< TLS server. */
+  R_X509_EXT_KEY_USAGE_CLIENT_AUTH              = (1 << 2), /**< TLS client. */
+  R_X509_EXT_KEY_USAGE_CODE_SIGNING             = (1 << 3), /**< Code signing. */
+  R_X509_EXT_KEY_USAGE_EMAIL_PROTECTION         = (1 << 4), /**< S/MIME. */
+  R_X509_EXT_KEY_USAGE_TIME_STAMPING            = (1 << 5), /**< RFC 3161. */
+  R_X509_EXT_KEY_USAGE_OCSP_SIGNING             = (1 << 6), /**< OCSP responder. */
 } RX509ExtKeyUsage;
 
+/**
+ * @brief Parse a DER-encoded X.509 certificate, copying the bytes.
+ *
+ * @param data  Pointer to the certificate's DER bytes.
+ * @param size  Length of @p data.
+ * @return Parsed @ref RCryptoCert, or @c NULL on malformed input.
+ */
 R_API RCryptoCert * r_crypto_x509_cert_new (rconstpointer data, rsize size) R_ATTR_MALLOC;
+
+/**
+ * @brief Parse a DER-encoded X.509 certificate, taking ownership of
+ * the buffer.
+ *
+ * @p data must have been allocated with @c r_malloc; on success the
+ * certificate frees it with @c r_free when its refcount drops.
+ */
 R_API RCryptoCert * r_crypto_x509_cert_new_take (rpointer data, rsize size) R_ATTR_MALLOC;
+
+/**
+ * @brief Parse a DER-encoded X.509 certificate from an @c RBuffer.
+ *
+ * Shares the buffer's storage; the certificate keeps a reference on
+ * @p buf for as long as it lives.
+ */
 R_API RCryptoCert * r_crypto_x509_cert_new_from_buffer (RBuffer * buf) R_ATTR_MALLOC;
 
+/** @brief Return the @c version field (v1 / v2 / v3). */
 R_API RX509Version r_crypto_x509_cert_version (const RCryptoCert * cert);
+/** @brief Return the @c serialNumber as a 64-bit integer. */
 R_API ruint64 r_crypto_x509_cert_serial_number (const RCryptoCert * cert);
+/** @brief Return the issuer Distinguished Name as a string. */
 R_API const rchar * r_crypto_x509_cert_issuer (const RCryptoCert * cert);
+/** @brief Return the subject Distinguished Name as a string. */
 R_API const rchar * r_crypto_x509_cert_subject (const RCryptoCert * cert);
+/**
+ * @brief Return the v2 @c issuerUniqueID, or @c NULL if absent.
+ * @param cert  The certificate.
+ * @param size  Out: length of the returned blob.
+ */
 R_API const ruint8 * r_crypto_x509_cert_issuer_unique_id (const RCryptoCert * cert, rsize * size);
+/**
+ * @brief Return the v2 @c subjectUniqueID, or @c NULL if absent.
+ * @param cert  The certificate.
+ * @param size  Out: length of the returned blob.
+ */
 R_API const ruint8 * r_crypto_x509_cert_subject_unique_id (const RCryptoCert * cert, rsize * size);
+/**
+ * @brief Return the v3 @c SubjectKeyIdentifier extension, or @c NULL
+ * if absent.
+ * @param cert  The certificate.
+ * @param size  Out: length of the returned key identifier.
+ */
 R_API const ruint8 * r_crypto_x509_cert_subject_key_id (const RCryptoCert * cert, rsize * size);
+/**
+ * @brief Return the v3 @c AuthorityKeyIdentifier extension, or
+ * @c NULL if absent.
+ * @param cert  The certificate.
+ * @param size  Out: length of the returned key identifier.
+ */
 R_API const ruint8 * r_crypto_x509_cert_authority_key_id (const RCryptoCert * cert, rsize * size);
+/** @brief Return the @c KeyUsage bitmask. */
 R_API RX509KeyUsage r_crypto_x509_cert_key_usage (const RCryptoCert * cert);
+/** @brief Return the @c ExtendedKeyUsage bitmask. */
 R_API RX509ExtKeyUsage r_crypto_x509_cert_ext_key_usage (const RCryptoCert * cert);
+/**
+ * @brief True iff @p cert's @c certificatePolicies extension contains
+ * the OID dotted string @p policy.
+ */
 R_API rboolean r_crypto_x509_cert_has_policy (const RCryptoCert * cert, const rchar * policy);
 
+/**
+ * @brief True iff @p cert is a CA: the @c BasicConstraints @c CA flag
+ * is set.
+ */
 R_API rboolean r_crypto_x509_cert_is_ca (const RCryptoCert * cert);
+/** @brief True iff issuer DN equals subject DN. */
 R_API rboolean r_crypto_x509_cert_is_self_issued (const RCryptoCert * cert);
+/**
+ * @brief True iff @p cert is self-signed: self-issued AND the
+ * signature verifies under @p cert's own public key.
+ */
 R_API rboolean r_crypto_x509_cert_is_self_signed (const RCryptoCert * cert);
 
+/**
+ * @brief Verify @p cert's signature against @p parent's public key.
+ *
+ * Single-hop check only. Chain construction (path building, AIA
+ * fetching, name constraints), validity-window checking and
+ * revocation (CRL, OCSP) are the caller's responsibility.
+ *
+ * @return @c R_CRYPTO_OK iff the signature is valid.
+ */
 R_API RCryptoResult r_crypto_x509_cert_verify_signature (const RCryptoCert * cert,
     const RCryptoCert * parent);
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_CRYPTO_X509_H__ */
 

--- a/include/rlib/crypto/rxdh.h
+++ b/include/rlib/crypto/rxdh.h
@@ -30,6 +30,7 @@
 
 /**
  * @defgroup r_xdh X25519 / X448 key exchange
+ * @ingroup r_crypto_ec
  * @brief Diffie-Hellman key exchange over the Montgomery curves
  * Curve25519 and Curve448 (RFC 7748).
  * @{

--- a/include/rlib/net/proto/rsdp.h
+++ b/include/rlib/net/proto/rsdp.h
@@ -26,7 +26,7 @@
 #include <rlib/rref.h>
 
 #include <rlib/rbuffer.h>
-#include <rlib/rmsgdigest.h>
+#include <rlib/crypto/rmsgdigest.h>
 #include <rlib/rsocketaddress.h>
 #include <rlib/rstr.h>
 #include <rlib/ruri.h>

--- a/include/rlib/rcrypto.h
+++ b/include/rlib/rcrypto.h
@@ -18,6 +18,80 @@
 #ifndef __R_CRYPTO_H__
 #define __R_CRYPTO_H__
 
+/**
+ * @defgroup r_crypto Cryptography
+ *
+ * @brief Symmetric and asymmetric primitives, message digests, MACs,
+ * elliptic curves, certificates and the wire-format encodings (PEM,
+ * ASN.1) that surround them.
+ *
+ * The crypto API breaks into the following sub-areas:
+ *
+ *   - @ref r_crypto_symmetric — block / stream cipher base and AES.
+ *   - @ref r_crypto_hash — message digests and HMAC.
+ *   - @ref r_crypto_key — polymorphic asymmetric-key handle plus the
+ *     concrete key kinds (RSA, DSA, DH) that plug into it.
+ *   - @ref r_crypto_ec — elliptic-curve arithmetic and the EdDSA /
+ *     X25519 / X448 primitives layered on top.
+ *   - @ref r_crypto_cert — generic certificate handle plus X.509.
+ *   - @ref r_crypto_encoding — PEM container framing (BER / DER lives
+ *     alongside the other binary-format parsers under
+ *     @c include/rlib/asn1).
+ *   - @ref r_crypto_ciphersuite — SRTP and TLS ciphersuite tables.
+ */
+
+/**
+ * @defgroup r_crypto_symmetric Symmetric ciphers
+ * @ingroup r_crypto
+ *
+ * @brief Block / stream cipher base interface and the concrete
+ * algorithm implementations that plug into it.
+ */
+
+/**
+ * @defgroup r_crypto_hash Message digests and MACs
+ * @ingroup r_crypto
+ *
+ * @brief Cryptographic hash functions plus the HMAC construction
+ * that turns them into keyed message-authentication codes.
+ */
+
+/**
+ * @defgroup r_crypto_ec Elliptic curves
+ * @ingroup r_crypto
+ *
+ * @brief Curve arithmetic over GF(p) for the three families rlib
+ * carries (short-Weierstrass, twisted Edwards, Montgomery) plus the
+ * signature (Ed25519 / Ed448) and key-exchange (X25519 / X448)
+ * primitives layered on top.
+ */
+
+/**
+ * @defgroup r_crypto_encoding Wire-format encodings
+ * @ingroup r_crypto
+ *
+ * @brief PEM container parsing / emission. ASN.1 BER and DER live
+ * alongside the other binary-format parsers under @c include/rlib/asn1,
+ * but the crypto headers consume them heavily so they are listed here
+ * as adjacent reading.
+ */
+
+/**
+ * @defgroup r_crypto_cert Certificates
+ * @ingroup r_crypto
+ *
+ * @brief Generic certificate handle (@c RCryptoCert) plus the X.509
+ * concrete instantiation.
+ */
+
+/**
+ * @defgroup r_crypto_ciphersuite Ciphersuite tables
+ * @ingroup r_crypto
+ *
+ * @brief Lookup tables describing the parameters of SRTP and TLS
+ * ciphersuites by their IANA / RFC identifier.
+ */
+
 #include <rlib/rlib.h>
 
 #include <rlib/crypto/raes.h>

--- a/include/rlib/rcrypto.h
+++ b/include/rlib/rcrypto.h
@@ -107,6 +107,7 @@
 #include <rlib/crypto/recurve-montgomery.h>
 #include <rlib/crypto/rhmac.h>
 #include <rlib/crypto/rkey.h>
+#include <rlib/crypto/rmsgdigest.h>
 #include <rlib/crypto/rpem.h>
 #include <rlib/crypto/rrsa.h>
 #include <rlib/crypto/rxdh.h>

--- a/include/rlib/rlib.h
+++ b/include/rlib/rlib.h
@@ -44,7 +44,7 @@
 #include <rlib/rmemallocator.h>
 #include <rlib/rmemfile.h>
 #include <rlib/rmodule.h>
-#include <rlib/rmsgdigest.h>
+#include <rlib/crypto/rmsgdigest.h>
 #include <rlib/rpoll.h>
 #include <rlib/rrand.h>
 #include <rlib/rref.h>

--- a/include/rlib/rmsgdigest.h
+++ b/include/rlib/rmsgdigest.h
@@ -26,6 +26,7 @@
 
 /**
  * @defgroup r_msg_digest Cryptographic message digests
+ * @ingroup r_crypto_hash
  * @brief MD2 / MD4 / MD5 / SHA-1 / SHA-2 family hashes plus the
  * SHAKE256 extendable-output function (XOF).
  * @{

--- a/include/rlib/rtc/rrtcsessiondescription.h
+++ b/include/rlib/rtc/rrtcsessiondescription.h
@@ -27,7 +27,7 @@
 #include <rlib/rref.h>
 
 #include <rlib/rbuffer.h>
-#include <rlib/rmsgdigest.h>
+#include <rlib/crypto/rmsgdigest.h>
 #include <rlib/rrand.h>
 #include <rlib/rsocketaddress.h>
 

--- a/rlib/crypto/red25519.c
+++ b/rlib/crypto/red25519.c
@@ -23,7 +23,7 @@
 
 #include <rlib/crypto/recurve-edwards.h>
 #include <rlib/rmem.h>
-#include <rlib/rmsgdigest.h>
+#include <rlib/crypto/rmsgdigest.h>
 #include <rlib/rrand.h>
 
 /* L (the prime-order subgroup of edwards25519) as BE bytes for use

--- a/rlib/crypto/red448.c
+++ b/rlib/crypto/red448.c
@@ -23,7 +23,7 @@
 
 #include <rlib/crypto/recurve-edwards.h>
 #include <rlib/rmem.h>
-#include <rlib/rmsgdigest.h>
+#include <rlib/crypto/rmsgdigest.h>
 #include <rlib/rrand.h>
 
 /* L (the prime-order subgroup of edwards448) as BE bytes for use

--- a/rlib/crypto/rmsgdigest.c
+++ b/rlib/crypto/rmsgdigest.c
@@ -17,7 +17,7 @@
  */
 
 #include "config.h"
-#include <rlib/rmsgdigest.h>
+#include <rlib/crypto/rmsgdigest.h>
 
 #include <rlib/rmem.h>
 #include <rlib/rstr.h>

--- a/rlib/crypto/rpem.c
+++ b/rlib/crypto/rpem.c
@@ -31,7 +31,7 @@
 #include <rlib/charset/rascii.h>
 
 #include <rlib/rmem.h>
-#include <rlib/rmsgdigest.h>
+#include <rlib/crypto/rmsgdigest.h>
 #include <rlib/rstr.h>
 #include <rlib/rbase64.h>
 

--- a/rlib/meson.build
+++ b/rlib/meson.build
@@ -21,7 +21,7 @@ rlib_sources = [
   'rmemfile.c',
   'rmemscan.c',
   'rmodule.c',
-  'rmsgdigest.c',
+  'crypto/rmsgdigest.c',
   'rpoll.c',
   'rprng-kiss.c',
   'rprng-mt.c',


### PR DESCRIPTION
## Summary

Bring the crypto subtree up to documentation parity and group every crypto module under a single **Cryptography** topic with sub-organizers.

**Restructure** — introduces `r_crypto` as the top-level Topics entry and six organizer sub-groups (Symmetric, Hash, Asymmetric keys [via `r_crypto_key`], Elliptic curves, Encoding, Cert, Ciphersuite). The ten existing crypto `@defgroups` keep their names and gain an `@ingroup` line so they nest under the right organizer; no group renames, no breaking changes.

**File move** — `include/rlib/rmsgdigest.h` → `include/rlib/crypto/rmsgdigest.h` and `rlib/rmsgdigest.c` → `rlib/crypto/rmsgdigest.c`. Digests are a crypto primitive and now live alongside the rest. All `#include` paths updated; `rlib.h` keeps the include so `<rlib.h>` consumers stay source-compatible.

**Per-header docs** — adds `@defgroup`, `@file` and per-function `@brief`/`@param`/`@return` to every previously-undocumented crypto header:

| Header | Group | R_APIs documented |
|---|---|---|
| `rhmac.h` | `r_crypto_hmac` | 8 |
| `rrsa.h` | `r_crypto_rsa` | 30 |
| `rdsa.h` | `r_crypto_dsa` | 15 |
| `rdh.h` | `r_crypto_dh` | 13 |
| `rpem.h` | `r_crypto_pem` | 23 |
| `rcert.h` | `r_crypto_cert` | 12 |
| `rx509.h` | `r_crypto_x509` | 18 |
| `rsrtpciphersuite.h` | `r_crypto_srtp_ciphersuite` | 4 |
| `rtlsciphersuite.h` | `r_crypto_tls_ciphersuite` | 4 |
| `recc.h` | `r_crypto_ecc` | 9 |

Existing security-critical `/* */` prose (RSA Bleichenbacher / implicit-rejection caveats; DH small-subgroup range check) graduates to Doxygen so the warnings surface on the rendered API page rather than only in the source.

## Test plan
- [x] `meson compile -C build-release-noerr` builds clean
- [x] `build-release-noerr/test/rlibtest` → 1858 passed, 0 failed
- [x] `doxygen docs/Doxyfile` → 0 warnings
- [x] Topics page: `Cryptography` parent with all seven sub-organizers; every previously-orphan header now resolves to the right one
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)