### PR TITLE
docs: document structural headers (types/, ruri, file/)

### DIFF
--- a/docs/topics-order.dox
+++ b/docs/topics-order.dox
@@ -47,6 +47,7 @@
 /** @defgroup r_format       File formats */
 /** @defgroup r_base64       Base64 (RFC 4648) */
 /** @defgroup r_crc          CRC32 */
+/** @defgroup r_uri          URIs */
 /** @defgroup r_crypto       Cryptography */
 /** @defgroup r_binfmt       Binary executable formats */
 /** @defgroup r_argparse     Command-line argument parsing */

--- a/docs/topics-order.dox
+++ b/docs/topics-order.dox
@@ -41,6 +41,7 @@
 /** @defgroup r_cpufeatures  CPU feature detection */
 /** @defgroup r_concurrency  Concurrency */
 /** @defgroup r_io           Generic I/O */
+/** @defgroup r_file         Files and filesystem */
 /** @defgroup r_ev           Event loop and async I/O */
 /** @defgroup r_net          Networking */
 /** @defgroup r_rtc          Real-Time Communications (WebRTC) */

--- a/include/rlib/file/rfile.h
+++ b/include/rlib/file/rfile.h
@@ -22,6 +22,33 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @defgroup r_file Files and filesystem
+ *
+ * @brief Buffered file objects, filesystem path / metadata helpers,
+ * and low-level file I/O over @c RIOHandle.
+ *
+ * Three layers, plus shared types:
+ *
+ *   - @c RFile (rfile.h) — a refcounted buffered file handle (a thin
+ *     layer over @c FILE) with whole-file read/write convenience
+ *     helpers.
+ *   - @c r_fs_* (rfs.h) — path manipulation (basename / dirname /
+ *     build / join), temp-name generation, and filesystem metadata /
+ *     existence tests.
+ *   - @c r_io_*_file (file/rio.h) — open / seek / truncate / size on
+ *     a bare @c RIOHandle, taking the @ref RFileOpenMode /
+ *     @ref RFileAccess / @ref RFileFlags enums from rfiletypes.h.
+ *
+ * @{
+ */
+
+/**
+ * @file rlib/file/rfile.h
+ * @brief Refcounted buffered file object (@c RFile) and whole-file
+ * read/write convenience helpers.
+ */
+
 #include <rlib/file/rfiletypes.h>
 #include <rlib/rref.h>
 #include <stdarg.h>
@@ -29,40 +56,71 @@
 
 R_BEGIN_DECLS
 
-/* Thin wrapper over fopen that picks fopen_s on MSVC */
+/** @brief Thin wrapper over @c fopen that selects @c fopen_s on MSVC. */
 R_API FILE * r_fopen (const rchar * path, const rchar * mode);
 
-/* Convenience API for whole file */
+/** @name Whole-file convenience
+ *  @{ */
+/** @brief Read an entire file into a freshly-allocated buffer. */
 R_API rboolean r_file_read_all (const rchar * filename, ruint8 ** data, rsize * size);
+/** @brief Write @p size bytes to @p filename, replacing its contents. */
 R_API rboolean r_file_write_all (const rchar * filename, rconstpointer data, rsize size);
+/** @brief Read an unsigned integer from a file, returning @p def on failure. */
 R_API ruint r_file_read_uint (const rchar * filename, ruint def);
+/** @brief Read a signed integer from a file, returning @p def on failure. */
 R_API int   r_file_read_int (const rchar * filename, int def);
+/** @} */
 
+/** @brief Opaque, refcounted buffered file handle. */
 typedef struct RFile RFile;
 
+/** @brief Open @p file with an @c fopen-style @p mode string. */
 R_API RFile * r_file_open (const rchar * file, const rchar * mode);
+/** @brief Create a temp file with default @c "w" mode; see @ref r_file_new_tmp_full. */
 #define r_file_new_tmp(dir, pre, path) r_file_new_tmp_full (dir, pre, "w", path)
+/**
+ * @brief Create a uniquely-named temp file.
+ * @param dir  Target directory, or @c NULL for the system temp dir.
+ * @param pre  Filename prefix.
+ * @param mode @c fopen-style mode string.
+ * @param path Optional out-pointer receiving the allocated final path.
+ */
 R_API RFile * r_file_new_tmp_full (const rchar * dir, const rchar * pre,
     const rchar * mode, rchar ** path);
+/** @brief Take a reference (alias for @ref r_ref_ref). */
 #define r_file_ref r_ref_ref
+/** @brief Drop a reference (alias for @ref r_ref_unref). */
 #define r_file_unref r_ref_unref
 
+/** @brief Return the underlying file descriptor. */
 R_API int r_file_get_fd (RFile * file);
 
+/** @brief Read up to @p size bytes; @p actual receives the count read. */
 R_API RIOError r_file_read (RFile * file, rpointer data, rsize size, rsize * actual);
+/** @brief Read a single line (up to @p maxsize bytes, including the NUL). */
 R_API RIOError r_file_read_line (RFile * file, rchar * data, rsize maxsize);
+/** @brief Write @p size bytes; @p actual receives the count written. */
 R_API RIOError r_file_write (RFile * file, rconstpointer data, rsize size, rsize * actual);
+/** @brief @c scanf-style formatted read; @p actual receives items matched. */
 R_API RIOError r_file_scanf (RFile * file, const rchar * fmt, rsize * actual, ...) R_ATTR_SCANF (2, 4);
+/** @brief @c va_list variant of @ref r_file_scanf. */
 R_API RIOError r_file_vscanf (RFile * file, const rchar * fmt, rsize * actual, va_list args) R_ATTR_SCANF (2, 0);
+/** @brief Reposition the file offset relative to @p mode. */
 R_API roffset  r_file_seek (RFile * file, roffset offset, RSeekMode mode);
+/** @brief Return the current file offset. */
 R_API roffset  r_file_tell (RFile * file);
 
+/** @brief @c TRUE if the end-of-file indicator is set. */
 R_API rboolean r_file_is_eof (RFile * file);
+/** @brief @c TRUE if the error indicator is set. */
 R_API rboolean r_file_has_error (RFile * file);
 
+/** @brief Flush buffered writes to the OS. */
 R_API rboolean r_file_flush (RFile * file);
 
 R_END_DECLS
+
+/** @} */ /* r_file */
 
 #endif /* __R_FILE_H__ */
 

--- a/include/rlib/file/rfiletypes.h
+++ b/include/rlib/file/rfiletypes.h
@@ -22,63 +22,80 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @file rlib/file/rfiletypes.h
+ * @brief Enums and flags shared across the file / filesystem / file-IO
+ * APIs (access, open mode, share mode, flags, seek, error).
+ */
+
 #include <rlib/rtypes.h>
 #include <stdio.h>
 
+/** @addtogroup r_file
+ *  @{ */
+
+/** @brief File access rights (bitmask). */
 typedef enum {
-  R_FILE_ACCESS_NONE  = 0x00,
-  R_FILE_EXECUTE      = 0x01,
-  R_FILE_WRITE        = 0x02,
-  R_FILE_READ         = 0x04,
-  R_FILE_RDWR         = (R_FILE_READ | R_FILE_WRITE),
-  R_FILE_ACCESS_ALL   = (R_FILE_EXECUTE | R_FILE_RDWR),
+  R_FILE_ACCESS_NONE  = 0x00,                       /**< No access. */
+  R_FILE_EXECUTE      = 0x01,                        /**< Execute permission. */
+  R_FILE_WRITE        = 0x02,                        /**< Write permission. */
+  R_FILE_READ         = 0x04,                        /**< Read permission. */
+  R_FILE_RDWR         = (R_FILE_READ | R_FILE_WRITE),/**< Read + write. */
+  R_FILE_ACCESS_ALL   = (R_FILE_EXECUTE | R_FILE_RDWR), /**< Read + write + execute. */
 } RFileAccess;
 
+/** @brief Unix-style permission triple (others / group / user). */
 typedef struct {
-  RFileAccess others;
-  RFileAccess group;
-  RFileAccess user;
+  RFileAccess others;   /**< Access for other users. */
+  RFileAccess group;    /**< Access for the owning group. */
+  RFileAccess user;     /**< Access for the owning user. */
 } RFilePermission;
 
+/** @brief Disposition for opening a file (create / open / truncate). */
 typedef enum {
-  R_FILE_CREATE_NEW         = 1,
-  R_FILE_CREATE_ALWAYS      = 2,
-  R_FILE_OPEN_EXISTING      = 3,
-  R_FILE_OPEN_ALWAYS        = 4,
-  R_FILE_TRUNCATE_EXISTING  = 5,
+  R_FILE_CREATE_NEW         = 1,  /**< Create; fail if it already exists. */
+  R_FILE_CREATE_ALWAYS      = 2,  /**< Create, truncating any existing file. */
+  R_FILE_OPEN_EXISTING      = 3,  /**< Open; fail if it does not exist. */
+  R_FILE_OPEN_ALWAYS        = 4,  /**< Open, creating it if absent. */
+  R_FILE_TRUNCATE_EXISTING  = 5,  /**< Open and truncate; fail if absent. */
 } RFileOpenMode;
 
+/** @brief Auxiliary flags for file open (bitmask). */
 typedef enum {
-  R_FILE_FLAG_NONE          = 0x00,
-  R_FILE_FLAG_NONBLOCK      = 0x01,
-  R_FILE_FLAG_CLOEXEC       = 0x02,
-  R_FILE_FLAG_TEMPORARY     = 0x04,
-  R_FILE_FLAG_DIRECTORY     = 0x08,
-  R_FILE_FLAG_NO_CACHE      = 0x10,
+  R_FILE_FLAG_NONE          = 0x00, /**< No flags. */
+  R_FILE_FLAG_NONBLOCK      = 0x01, /**< Non-blocking I/O. */
+  R_FILE_FLAG_CLOEXEC       = 0x02, /**< Close on @c exec. */
+  R_FILE_FLAG_TEMPORARY     = 0x04, /**< Delete when the last handle closes. */
+  R_FILE_FLAG_DIRECTORY     = 0x08, /**< Open a directory rather than a file. */
+  R_FILE_FLAG_NO_CACHE      = 0x10, /**< Bypass the OS page cache. */
 } RFileFlags;
 
+/** @brief Sharing mode controlling concurrent access by others (bitmask). */
 typedef enum {
-  R_FILE_SHARE_EXCLUSIVE  = 0,
-  R_FILE_SHARE_READ       = 1,
-  R_FILE_SHARE_WRITE      = 2,
-  R_FILE_SHARE_DELETE     = 4,
-  R_FILE_SHARE_ALL        = (R_FILE_SHARE_READ | R_FILE_SHARE_WRITE | R_FILE_SHARE_DELETE),
+  R_FILE_SHARE_EXCLUSIVE  = 0,  /**< No sharing. */
+  R_FILE_SHARE_READ       = 1,  /**< Allow concurrent readers. */
+  R_FILE_SHARE_WRITE      = 2,  /**< Allow concurrent writers. */
+  R_FILE_SHARE_DELETE     = 4,  /**< Allow concurrent delete / rename. */
+  R_FILE_SHARE_ALL        = (R_FILE_SHARE_READ | R_FILE_SHARE_WRITE | R_FILE_SHARE_DELETE), /**< Allow all of the above. */
 } RFileShareMode;
 
+/** @brief Reference point for a seek operation. */
 typedef enum {
-  R_SEEK_MODE_SET,
-  R_SEEK_MODE_CUR,
-  R_SEEK_MODE_END
+  R_SEEK_MODE_SET,  /**< From the start of the file. */
+  R_SEEK_MODE_CUR,  /**< From the current position. */
+  R_SEEK_MODE_END   /**< From the end of the file. */
 } RSeekMode;
 
+/** @brief Result code for file / IO operations. */
 typedef enum {
-  R_FILE_ERROR_OK,
-  R_FILE_ERROR_AGAIN,
-  R_FILE_ERROR_INVAL,
-  R_FILE_ERROR_BAD_FILE,
-  R_FILE_ERROR_ERROR
+  R_FILE_ERROR_OK,        /**< Success. */
+  R_FILE_ERROR_AGAIN,     /**< Would block; retry later. */
+  R_FILE_ERROR_INVAL,     /**< Invalid argument. */
+  R_FILE_ERROR_BAD_FILE,  /**< Invalid or closed file handle. */
+  R_FILE_ERROR_ERROR      /**< Generic / unmapped error. */
 } RIOError;
 
+/** @} */
 
 #endif /* __R_FILE_TYPES_H__ */
 

--- a/include/rlib/file/rfs.h
+++ b/include/rlib/file/rfs.h
@@ -22,20 +22,39 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @file rlib/file/rfs.h
+ * @brief Filesystem path manipulation, temp-name generation and
+ * path metadata / existence tests.
+ */
+
 #include <rlib/rtypes.h>
 #include <stdarg.h>
 
+/** @addtogroup r_file
+ *  @{ */
+
+/** @brief Unix directory separator character (@c '/'). */
 #define R_DIR_SEP_UNIX      '/'
+/** @brief Unix directory separator as a string. */
 #define R_DIR_SEP_UNIX_STR  "/"
+/** @brief Windows directory separator character (@c '\\'). */
 #define R_DIR_SEP_WIN32     '\\'
+/** @brief Windows directory separator as a string. */
 #define R_DIR_SEP_WIN32_STR "\\"
 
 #ifdef R_OS_WIN32
+/** @brief Native directory separator character for the target OS. */
 #define R_DIR_SEP         R_DIR_SEP_WIN32
+/** @brief Native directory separator as a string. */
 #define R_DIR_SEP_STR     R_DIR_SEP_WIN32_STR
+/** @brief @c TRUE if @p c is a directory separator on the target OS. */
 #define R_IS_DIR_SEP(c)   ((c) == R_DIR_SEP_WIN32 || (c) == R_DIR_SEP_UNIX)
+/** @brief @c PATH-style search-list separator character. */
 #define R_SEARCH_SEP      ';'
+/** @brief Search-list separator as a string. */
 #define R_SEARCH_SEP_STR  ";"
+/** @brief Executable filename suffix on the target OS. */
 #define R_EXE_SUFFIX      ".exe"
 #else
 #define R_DIR_SEP         R_DIR_SEP_UNIX
@@ -48,42 +67,73 @@
 
 R_BEGIN_DECLS
 
+/** @brief Return the final path component of @p file (newly allocated). */
 R_API rchar * r_fs_path_basename (const rchar * file) R_ATTR_MALLOC;
+/** @brief Return the directory portion of @p file (newly allocated). */
 R_API rchar * r_fs_path_dirname  (const rchar * file) R_ATTR_MALLOC;
 
+/** @brief Join a @c NULL-terminated list of components with the native separator. */
 R_API rchar * r_fs_path_build      (const rchar * first, ...) R_ATTR_MALLOC;
+/** @brief @c va_list variant of @ref r_fs_path_build. */
 R_API rchar * r_fs_path_buildv     (const rchar * first, va_list ap) R_ATTR_MALLOC;
+/** @brief @c NULL-terminated string-array variant of @ref r_fs_path_build. */
 R_API rchar * r_fs_path_build_strv (rchar * const * strv) R_ATTR_MALLOC;
 
+/** @brief Generate a temp filename in the system temp dir; see @ref r_fs_path_new_tmpname_full. */
 #define r_fs_path_new_tmpfile() r_fs_path_new_tmpname_full (NULL, NULL, NULL)
+/**
+ * @brief Generate a unique temp-file path (does not create the file).
+ * @param dir    Target directory, or @c NULL for the system temp dir.
+ * @param prefix Optional filename prefix.
+ * @param suffix Optional filename suffix.
+ */
 R_API rchar * r_fs_path_new_tmpname_full (const rchar * dir,
     const rchar * prefix, const rchar * suffix) R_ATTR_MALLOC;
 
+/** @brief Return the system temp directory (borrowed pointer). */
 R_API const rchar * r_fs_get_tmp_dir (void);
+/** @brief Return the current working directory (newly allocated). */
 R_API rchar * r_fs_get_cur_dir (void) R_ATTR_MALLOC;
 
+/** @brief Return the size of @p path in bytes, or @c -1 on error. */
 R_API rssize r_fs_get_filesize (const rchar * path);
 
+/** @brief @c TRUE if @p path exists. */
 R_API rboolean r_fs_test_exists (const rchar * path);
 
+/** @brief @c TRUE if @p path is a directory. */
 R_API rboolean r_fs_test_is_directory (const rchar * path);
+/** @brief @c TRUE if @p path is a regular file. */
 R_API rboolean r_fs_test_is_regular (const rchar * path);
+/** @brief @c TRUE if @p path is a device node. */
 R_API rboolean r_fs_test_is_device (const rchar * path);
+/** @brief @c TRUE if @p path is a symbolic link. */
 R_API rboolean r_fs_test_is_symlink (const rchar * path);
 
+/** @brief @c TRUE if the caller can read @p path. */
 R_API rboolean r_fs_test_read_access (const rchar * path);
+/** @brief @c TRUE if the caller can write @p path. */
 R_API rboolean r_fs_test_write_access (const rchar * path);
+/** @brief @c TRUE if the caller can execute @p path. */
 R_API rboolean r_fs_test_exec_access (const rchar * path);
 
+/** @brief Create directory @p path with permission @p mode. */
 R_API rboolean r_fs_mkdir (const rchar * path, int mode);
+/** @brief Create @p path and any missing parent directories (@c mkdir @c -p). */
 R_API rboolean r_fs_mkdir_full (const rchar * path, int mode);
 
-/* TRUE if path starts with a directory separator (Unix) or a drive
- * letter + colon + sep / a UNC \\ prefix (Windows).  NULL / empty
- * paths are not absolute. */
+/**
+ * @brief @c TRUE if @p path is absolute.
+ *
+ * Absolute means a leading separator (Unix) or a drive-letter +
+ * colon + separator or a UNC @c \\ prefix (Windows). @c NULL / empty
+ * paths are not absolute.
+ */
 R_API rboolean r_fs_path_is_absolute (const rchar * path);
 
 R_END_DECLS
+
+/** @} */ /* r_file */
 
 #endif /* __R_FS_H__ */
 

--- a/include/rlib/file/rio.h
+++ b/include/rlib/file/rio.h
@@ -22,27 +22,64 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @file rlib/file/rio.h
+ * @brief File-flavoured operations over @c RIOHandle: open, temp-open,
+ * truncate, seek and size.
+ */
+
 #include <rlib/rio.h>
 #include <rlib/file/rfiletypes.h>
 
+/** @addtogroup r_file
+ *  @{ */
+
 R_BEGIN_DECLS
 
+/**
+ * @brief Open a file as a raw @c RIOHandle.
+ * @param file   Path to open.
+ * @param mode   Create / open / truncate disposition.
+ * @param access Requested access rights.
+ * @param share  Sharing mode for concurrent openers.
+ * @param flags  Auxiliary @ref RFileFlags.
+ * @param perm   Permissions to apply when creating; may be @c NULL.
+ * @return Open handle, or @c R_IO_HANDLE_INVALID on failure.
+ */
 R_API RIOHandle r_io_open_file (const rchar * file, RFileOpenMode mode,
     RFileAccess access, RFileShareMode share, RFileFlags flags, const RFilePermission * perm);
+/**
+ * @brief Create and open a uniquely-named temp file as an @c RIOHandle.
+ *
+ * @param dir        Target directory, or @c NULL for the system temp dir.
+ * @param fileprefix Filename prefix.
+ * @param access     Requested access rights.
+ * @param share      Sharing mode for concurrent openers.
+ * @param flags      Auxiliary @ref RFileFlags.
+ * @param perm       Permissions to apply on create; may be @c NULL.
+ * @param path       Optional out-pointer receiving the allocated final path.
+ */
 R_API RIOHandle r_io_open_tmp_full (const rchar * dir, const rchar * fileprefix,
     RFileAccess access, RFileShareMode share, RFileFlags flags, const RFilePermission * perm, rchar ** path);
+/** @brief Convenience temp-open with write access and exclusive sharing. */
 static inline RIOHandle r_io_open_tmp (const rchar * dir, const rchar * pre, rchar ** path)
 { return r_io_open_tmp_full (dir, pre, R_FILE_WRITE, R_FILE_SHARE_EXCLUSIVE, R_FILE_FLAG_NONE, NULL, path); }
 
+/** @brief Truncate or extend @p handle to @p size bytes. */
 R_API rboolean r_io_truncate (RIOHandle handle, rsize size);
 
+/** @brief Reposition @p handle's offset relative to @p mode. */
 R_API roffset r_io_seek (RIOHandle handle, roffset offset, RSeekMode mode);
+/** @brief Return @p handle's current offset (seek by 0 from current). */
 static inline roffset r_io_tell (RIOHandle handle)
 { return r_io_seek (handle, 0, R_SEEK_MODE_CUR); }
 
+/** @brief Return the total size of the file behind @p handle in bytes. */
 R_API ruint64 r_io_filesize (RIOHandle handle);
 
 R_END_DECLS
+
+/** @} */ /* r_file */
 
 #endif /* __R_FILE_IO_H__ */
 

--- a/include/rlib/ruri.h
+++ b/include/rlib/ruri.h
@@ -22,62 +22,146 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @file rlib/ruri.h
+ * @brief Percent-encoding helpers and a parsed-URI type with
+ * component accessors.
+ */
+
 #include <rlib/rtypes.h>
 
 #include <rlib/rref.h>
 
+/**
+ * @defgroup r_uri URIs
+ *
+ * @brief RFC 3986 percent-encoding helpers plus a refcounted parsed
+ * @ref RUri with accessors for every component.
+ *
+ * The standalone @ref r_uri_escape_str / @ref r_uri_unescape_str
+ * percent-encode and decode strings. @ref RUri parses a full URI and
+ * exposes each component (scheme, authority, userinfo, host, port,
+ * path, query, fragment) two ways:
+ *
+ *   - @c r_uri_get_* — return a freshly-allocated, unescaped copy the
+ *     caller frees.
+ *   - @c r_uri_get_*_ptr — return a borrowed pointer into the URI's
+ *     still-escaped backing store plus its length; no allocation.
+ *
+ * @{
+ */
+
+/** @brief RFC 3986 generic (gen-delims) delimiter set. */
 #define R_URI_GENERIC_DELIMITERS        ":/?#[]@"
+/** @brief RFC 3986 sub-delims delimiter set. */
 #define R_URI_SUBCOMPONENT_DELIMITERS   "!$&'()*+,;="
 
 R_BEGIN_DECLS
 
+/**
+ * @brief Percent-encode @p str, escaping everything outside the
+ * unreserved set.
+ * @param str  Input string.
+ * @param size Length, or @c -1 for @c strlen.
+ * @param out  Optional out-pointer for the result length.
+ * @return Newly-allocated escaped string.
+ */
 R_API rchar * r_uri_escape_str (const rchar * str, rssize size, rsize * out) R_ATTR_MALLOC;
+/**
+ * @brief Decode percent-escapes in @p str.
+ * @param str  Input string.
+ * @param size Length, or @c -1 for @c strlen.
+ * @param out  Optional out-pointer for the result length.
+ * @return Newly-allocated unescaped string.
+ */
 R_API rchar * r_uri_unescape_str (const rchar * str, rssize size, rsize * out) R_ATTR_MALLOC;
 
+/** @brief Opaque, refcounted parsed-URI handle. */
 typedef struct RUri RUri;
+/** @brief Take a reference (alias for @ref r_ref_ref). */
 #define r_uri_ref r_ref_ref
+/** @brief Drop a reference (alias for @ref r_ref_unref). */
 #define r_uri_unref r_ref_unref
 
+/** @brief Parse a URI given as an already-unescaped string (alias @c r_uri_new). */
 #define r_uri_new r_uri_new_unescaped
+/** @brief Parse a URI from an unescaped string; @p size may be @c -1 for @c strlen. */
 R_API RUri * r_uri_new_unescaped (const rchar * uri, rssize size) R_ATTR_MALLOC;
+/** @brief Parse a URI from an already percent-escaped string. */
 R_API RUri * r_uri_new_escaped (const rchar * uri, rssize size) R_ATTR_MALLOC;
+/** @brief Build a URI from scheme, authority and path components. */
 R_API RUri * r_uri_new_simple (const rchar * scheme, const rchar * authority,
     const rchar * path);
+/** @brief Build a URI from all components individually. */
 R_API RUri * r_uri_new_full (const rchar * scheme,
     const rchar * userinfo, const rchar * hostname, ruint16 port,
     const rchar * path, const rchar * query, const rchar * fragment);
+/** @brief Build an @c http URI from a host and request target. */
 #define r_uri_new_http(host, req) r_uri_new_http_sized (host, -1, req, -1)
+/** @brief Sized variant of @ref r_uri_new_http. */
 R_API RUri * r_uri_new_http_sized (const rchar * host, rssize hostsize,
     const rchar * request, rssize reqsize);
 
-/* All will be unescaped */
+/** @name Unescaped component accessors (allocating)
+ *  Each returns a freshly-allocated, percent-decoded copy.
+ *  @{ */
+/** @brief Whole URI, unescaped. */
 R_API rchar * r_uri_get_unescaped (const RUri * uri) R_ATTR_MALLOC;
+/** @brief Scheme component (e.g. @c "https"). */
 R_API rchar * r_uri_get_scheme (const RUri * uri) R_ATTR_MALLOC;
+/** @brief Authority component (userinfo + host + port). */
 R_API rchar * r_uri_get_authority (const RUri * uri) R_ATTR_MALLOC;
+/** @brief Userinfo component. */
 R_API rchar * r_uri_get_userinfo (const RUri * uri) R_ATTR_MALLOC;
+/** @brief Host and port together (e.g. @c "host:443"). */
 R_API rchar * r_uri_get_hostname_port (const RUri * uri) R_ATTR_MALLOC;
+/** @brief Host component only. */
 R_API rchar * r_uri_get_hostname (const RUri * uri) R_ATTR_MALLOC;
+/** @brief Port number, or 0 if absent. */
 R_API ruint16 r_uri_get_port (const RUri * uri);
+/** @brief Path component. */
 R_API rchar * r_uri_get_path (const RUri * uri) R_ATTR_MALLOC;
+/** @brief Query component (without the leading @c '?'). */
 R_API rchar * r_uri_get_query (const RUri * uri) R_ATTR_MALLOC;
+/** @brief Fragment component (without the leading @c '#'). */
 R_API rchar * r_uri_get_fragment (const RUri * uri) R_ATTR_MALLOC;
+/** @brief Path + query + fragment together (the HTTP request target). */
 R_API rchar * r_uri_get_pqf (const RUri * uri) R_ATTR_MALLOC;
+/** @} */
 
-/* All will be escaped */
+/** @name Escaped component accessors (borrowed)
+ *  Each returns a borrowed pointer into the URI's escaped backing
+ *  store plus its length via @p size; do not free.
+ *  @{ */
+/** @brief Whole URI, escaped (allocating). */
 R_API rchar * r_uri_get_escaped (const RUri * uri) R_ATTR_MALLOC;
+/** @brief Borrowed pointer to the whole escaped URI. */
 R_API const rchar * r_uri_get_escaped_ptr (const RUri * uri, rsize * size);
+/** @brief Borrowed pointer to the escaped scheme. */
 R_API const rchar * r_uri_get_scheme_ptr (const RUri * uri, rsize * size);
+/** @brief Borrowed pointer to the escaped authority. */
 R_API const rchar * r_uri_get_authority_ptr (const RUri * uri, rsize * size);
+/** @brief Borrowed pointer to the escaped userinfo. */
 R_API const rchar * r_uri_get_userinfo_ptr (const RUri * uri, rsize * size);
+/** @brief Borrowed pointer to the escaped host:port. */
 R_API const rchar * r_uri_get_hostname_port_ptr (const RUri * uri, rsize * size);
+/** @brief Borrowed pointer to the escaped host. */
 R_API const rchar * r_uri_get_hostname_ptr (const RUri * uri, rsize * size);
+/** @brief Borrowed pointer to the escaped port. */
 R_API const rchar * r_uri_get_port_ptr (const RUri * uri, rsize * size);
+/** @brief Borrowed pointer to the escaped path + query + fragment. */
 R_API const rchar * r_uri_get_pqf_ptr (const RUri * uri, rsize * size);
+/** @brief Borrowed pointer to the escaped path. */
 R_API const rchar * r_uri_get_path_ptr (const RUri * uri, rsize * size);
+/** @brief Borrowed pointer to the escaped query. */
 R_API const rchar * r_uri_get_query_ptr (const RUri * uri, rsize * size);
+/** @brief Borrowed pointer to the escaped fragment. */
 R_API const rchar * r_uri_get_fragment_ptr (const RUri * uri, rsize * size);
+/** @} */
 
 R_END_DECLS
+
+/** @} */ /* r_uri */
 
 #endif /* __R_URI_H__ */
 

--- a/include/rlib/types/rbitops.h
+++ b/include/rlib/types/rbitops.h
@@ -24,6 +24,41 @@
 
 /* This header is included by rtypes.h (@ bottom of file) */
 
+/**
+ * @defgroup r_bitops Bit operations
+ * @ingroup r_types
+ *
+ * @brief Width-specific bit-twiddling macros: count-leading / trailing
+ * zeros, population count, parity, and masked shift / rotate.
+ *
+ * Every macro follows the @c R<WIDTH>_<OP> naming convention, where
+ * @c WIDTH is one of @c UINT8 / @c UINT16 / @c UINT32 / @c UINT64 /
+ * @c SIZE (plus the native-width @c UINT / @c ULONG / @c ULONGLONG
+ * helpers the fixed-width ones are built on), and @c OP is one of:
+ *
+ *   - @c _CLZ — count leading zero bits (width for a zero input).
+ *   - @c _CTZ — count trailing zero bits (width for a zero input).
+ *   - @c _POPCOUNT — number of set bits.
+ *   - @c _PARITY — 1 if an odd number of bits are set, else 0.
+ *   - @c _SHL / @c _SHR — shift left / right, masking the operand to
+ *     its width and the shift count to @c [0, width).
+ *   - @c _ROTL / @c _ROTR — rotate left / right within the width.
+ *
+ * CLZ / CTZ / POPCOUNT / PARITY compile down to the compiler's
+ * intrinsics (GCC/Clang @c __builtin_*, MSVC @c _BitScan* /
+ * @c __popcnt); the rest are plain macros. The @c RUINT32_CLZ
+ * family below is documented as the canonical example — the same
+ * eight operations exist for every listed width.
+ *
+ * @{
+ */
+
+/**
+ * @file rlib/types/rbitops.h
+ * @brief Width-specific count-zeros / popcount / parity / shift /
+ * rotate macros.
+ */
+
 R_BEGIN_DECLS
 
 #if defined(_MSC_VER)
@@ -136,9 +171,13 @@ rboolean __inline RULONGLONG_PARITY (ruint64 x)
 
 
 #if RLIB_SIZEOF_INT == 4
+/** @brief Count leading zero bits of a 32-bit @p x (32 if @p x is 0). */
 #define RUINT32_CLZ(x)          RUINT_CLZ (x)
+/** @brief Count trailing zero bits of a 32-bit @p x (32 if @p x is 0). */
 #define RUINT32_CTZ(x)          RUINT_CTZ (x)
+/** @brief Number of set bits in a 32-bit @p x. */
 #define RUINT32_POPCOUNT(x)     RUINT_POPCOUNT (x)
+/** @brief 1 if a 32-bit @p x has an odd number of set bits, else 0. */
 #define RUINT32_PARITY(x)       RUINT_PARITY (x)
 #elif RLIB_SIZEOF_LONG == 4
 #define RUINT32_CLZ(x)          RULONG_CLZ (x)
@@ -151,9 +190,13 @@ rboolean __inline RULONGLONG_PARITY (ruint64 x)
 #define RUINT32_POPCOUNT(x)     RUINT64_POPCOUNT (x & RUINT32_MAX)
 #define RUINT32_PARITY(x)       RUINT64_PARITY (x & RUINT32_MAX)
 #endif
+/** @brief Shift a 32-bit @p x left by @p n (operand and count masked to width). */
 #define RUINT32_SHL(x, n)       (((x) & RUINT32_MAX) << ((n) & 31))
+/** @brief Shift a 32-bit @p x right by @p n (operand and count masked to width). */
 #define RUINT32_SHR(x, n)       (((x) & RUINT32_MAX) >> ((n) & 31))
+/** @brief Rotate a 32-bit @p x left by @p n bits. */
 #define RUINT32_ROTL(x, n)      (RUINT32_SHL (x, n) | RUINT32_SHR (x, 32-(n)))
+/** @brief Rotate a 32-bit @p x right by @p n bits. */
 #define RUINT32_ROTR(x, n)      (RUINT32_SHR (x, n) | RUINT32_SHL (x, 32-(n)))
 
 #if RLIB_SIZEOF_INT == 2
@@ -216,5 +259,7 @@ rboolean __inline RULONGLONG_PARITY (ruint64 x)
 #endif
 
 R_END_DECLS
+
+/** @} */ /* r_bitops */
 
 #endif /* __R_BITOPS_H__ */

--- a/include/rlib/types/rendianness.h
+++ b/include/rlib/types/rendianness.h
@@ -24,19 +24,53 @@
 
 /* This header is included by rtypes.h (@ bottom of file) */
 
+/**
+ * @defgroup r_endian Endianness
+ * @ingroup r_types
+ *
+ * @brief Byte-order detection, byte-swapping, host/network conversion
+ * and alignment-safe load / store of multi-byte integers.
+ *
+ * @ref R_BYTE_ORDER resolves to @ref R_LITTLE_ENDIAN or
+ * @ref R_BIG_ENDIAN for the target. The conversion macros follow the
+ * @c R<TYPE>_TO_<ORDER> / @c R<TYPE>_FROM_<ORDER> convention (for
+ * each integer type and @c LE / @c BE order) and are no-ops when the
+ * host order already matches, a byte swap otherwise. The @c RUINT16_BSWAP
+ * family below is the unconditional swap the conversions build on.
+ *
+ * For reading or writing integers out of arbitrary (possibly
+ * unaligned) byte pointers — network buffers, packed structs — use
+ * the @ref r_load_be32 / @ref r_store_le32 inline helpers, which go
+ * through @c memcpy to avoid undefined behaviour.
+ *
+ * @{
+ */
+
+/**
+ * @file rlib/types/rendianness.h
+ * @brief Byte-order detection, byte swapping, and host/network
+ * integer conversion.
+ */
+
 R_BEGIN_DECLS
 
+/** @brief @ref R_BYTE_ORDER value for little-endian targets. */
 #define R_LITTLE_ENDIAN         1234
+/** @brief @ref R_BYTE_ORDER value for big-endian targets. */
 #define R_BIG_ENDIAN            4321
 
 #if R_GNUC_PREREQ(4, 2)
 /* Appearantly 16bit byteswap is missing from some versions of GCC on x86?? */
 #if !defined(__clang__) && !R_GNUC_PREREQ(4, 8)
+/** @brief Reverse the bytes of a 16-bit value. */
 #define RUINT16_BSWAP(val) ((ruint16) (((ruint16)(val) >> 8) | ((ruint16)(val) << 8)))
 #else
+/** @brief Reverse the bytes of a 16-bit value. */
 #define RUINT16_BSWAP(val) ((ruint16) __builtin_bswap16 ((rint16) (val)))
 #endif
+/** @brief Reverse the bytes of a 32-bit value. */
 #define RUINT32_BSWAP(val) ((ruint32) __builtin_bswap32 ((rint32) (val)))
+/** @brief Reverse the bytes of a 64-bit value. */
 #define RUINT64_BSWAP(val) ((ruint64) __builtin_bswap64 ((rint64) (val)))
 #elif defined(_MSC_VER)
 #define RUINT16_BSWAP(val) (_byteswap_ushort ((unsigned short)(val)))
@@ -60,6 +94,7 @@ R_BEGIN_DECLS
       (((ruint64)(val) & RUINT64_CONSTANT (0xFF00000000000000)) >> 56)))
 #endif
 
+/** @brief Target byte order: @ref R_LITTLE_ENDIAN or @ref R_BIG_ENDIAN. */
 #if defined(_MSC_VER)
 #define R_BYTE_ORDER R_LITTLE_ENDIAN
 #elif  __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
@@ -195,85 +230,108 @@ R_BEGIN_DECLS
 #define RSSIZE_FROM_BE(val)   (RSSIZE_TO_BE   (val))
 
 
+/** @name Network/host byte-order aliases (BSD @c ntoh / @c hton names)
+ *  @{ */
+/** @brief Network-to-host, 32-bit (alias for @c RUINT32_FROM_BE). */
 #define r_ntohl(val)          (RUINT32_FROM_BE  (val))
+/** @brief Network-to-host, 16-bit (alias for @c RUINT16_FROM_BE). */
 #define r_ntohs(val)          (RUINT16_FROM_BE  (val))
+/** @brief Host-to-network, 32-bit (alias for @c RUINT32_TO_BE). */
 #define r_htonl(val)          (RUINT32_TO_BE    (val))
+/** @brief Host-to-network, 16-bit (alias for @c RUINT16_TO_BE). */
 #define r_htons(val)          (RUINT16_TO_BE    (val))
+/** @} */
 
-/* Alignment-safe load/store helpers for reading multi-byte integers
- * out of arbitrary byte pointers (network buffers, packed structs).
- * Casting a ruint8 * to ruint{16,32,64} * and dereferencing is UB
- * when the pointer doesn't meet the wider type's alignment, even on
- * architectures where it happens to work; modern compilers fold the
- * memcpy below into the same single load/store on x86/x86-64 and
- * emit safe unaligned access on ARM. */
+/** @name Alignment-safe load / store
+ *
+ * Read or write a multi-byte integer through an arbitrary, possibly
+ * unaligned byte pointer (network buffers, packed structs). Casting
+ * a @c ruint8* to a wider pointer and dereferencing is undefined
+ * behaviour when alignment isn't met; these helpers go through
+ * @c memcpy, which compilers fold into a single (un)aligned access.
+ *  @{ */
+/** @brief Load a big-endian 16-bit integer from @p p. */
 static inline ruint16 r_load_be16 (const void * p)
 {
   ruint16 v;
   memcpy (&v, p, sizeof (v));
   return RUINT16_FROM_BE (v);
 }
+/** @brief Load a big-endian 32-bit integer from @p p. */
 static inline ruint32 r_load_be32 (const void * p)
 {
   ruint32 v;
   memcpy (&v, p, sizeof (v));
   return RUINT32_FROM_BE (v);
 }
+/** @brief Load a big-endian 64-bit integer from @p p. */
 static inline ruint64 r_load_be64 (const void * p)
 {
   ruint64 v;
   memcpy (&v, p, sizeof (v));
   return RUINT64_FROM_BE (v);
 }
+/** @brief Load a little-endian 16-bit integer from @p p. */
 static inline ruint16 r_load_le16 (const void * p)
 {
   ruint16 v;
   memcpy (&v, p, sizeof (v));
   return RUINT16_FROM_LE (v);
 }
+/** @brief Load a little-endian 32-bit integer from @p p. */
 static inline ruint32 r_load_le32 (const void * p)
 {
   ruint32 v;
   memcpy (&v, p, sizeof (v));
   return RUINT32_FROM_LE (v);
 }
+/** @brief Load a little-endian 64-bit integer from @p p. */
 static inline ruint64 r_load_le64 (const void * p)
 {
   ruint64 v;
   memcpy (&v, p, sizeof (v));
   return RUINT64_FROM_LE (v);
 }
+/** @brief Store @p v as a big-endian 16-bit integer at @p p. */
 static inline void r_store_be16 (void * p, ruint16 v)
 {
   ruint16 be = RUINT16_TO_BE (v);
   memcpy (p, &be, sizeof (be));
 }
+/** @brief Store @p v as a big-endian 32-bit integer at @p p. */
 static inline void r_store_be32 (void * p, ruint32 v)
 {
   ruint32 be = RUINT32_TO_BE (v);
   memcpy (p, &be, sizeof (be));
 }
+/** @brief Store @p v as a big-endian 64-bit integer at @p p. */
 static inline void r_store_be64 (void * p, ruint64 v)
 {
   ruint64 be = RUINT64_TO_BE (v);
   memcpy (p, &be, sizeof (be));
 }
+/** @brief Store @p v as a little-endian 16-bit integer at @p p. */
 static inline void r_store_le16 (void * p, ruint16 v)
 {
   ruint16 le = RUINT16_TO_LE (v);
   memcpy (p, &le, sizeof (le));
 }
+/** @brief Store @p v as a little-endian 32-bit integer at @p p. */
 static inline void r_store_le32 (void * p, ruint32 v)
 {
   ruint32 le = RUINT32_TO_LE (v);
   memcpy (p, &le, sizeof (le));
 }
+/** @brief Store @p v as a little-endian 64-bit integer at @p p. */
 static inline void r_store_le64 (void * p, ruint64 v)
 {
   ruint64 le = RUINT64_TO_LE (v);
   memcpy (p, &le, sizeof (le));
 }
+/** @} */
 
 R_END_DECLS
+
+/** @} */ /* r_endian */
 
 #endif /* __R_ENDIANNESS_H__ */

--- a/include/rlib/types/rmacros.h
+++ b/include/rlib/types/rmacros.h
@@ -22,12 +22,35 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @defgroup r_macros Portability macros
+ * @ingroup r_types
+ *
+ * @brief Compiler-portability shims and small utility macros used
+ * throughout rlib.
+ *
+ * Everything here resolves to a compiler-specific spelling (GCC /
+ * Clang attributes, MSVC @c __declspec, or an empty fallback) so the
+ * rest of the codebase can use one name regardless of toolchain:
+ * symbol-visibility decoration (@ref R_API), function / variable
+ * attributes (the @c R_ATTR_* family), branch hints, constructors,
+ * and the usual @c MIN / @c MAX / stringify helpers.
+ *
+ * @{
+ */
+
+/**
+ * @file rlib/types/rmacros.h
+ * @brief Compiler-portability macros and small utility macros.
+ */
+
 #if defined(__GNUC__) && __GNUC__ < 4
 #error Please use a modern GNU compatible compiler
 #endif
 
 #include <stddef.h>
 
+/** @brief @c TRUE if compiling with GCC @p x.@p y or newer (@c 0 elsewhere). */
 #ifdef __GNUC__
 #define R_GNUC_PREREQ(x, y) \
   ((__GNUC__ == (x) && __GNUC_MINOR__ >= (y)) || (__GNUC__ > (x)))
@@ -35,9 +58,14 @@
 #define R_GNUC_PREREQ(x, y) 0
 #endif
 
+/** @name Symbol visibility
+ *  @{ */
 #if defined(_WIN32) || defined(__CYGWIN__)
+/** @brief Mark a symbol as exported from the shared library. */
 #define R_API_EXPORT __declspec(dllexport)
+/** @brief Mark a symbol as imported from the shared library. */
 #define R_API_IMPORT __declspec(dllimport)
+/** @brief Mark a symbol as hidden (not exported). */
 #define R_API_HIDDEN
 #elif defined(__GNUC__)
 #define R_API_EXPORT __attribute__ ((visibility ("default")))
@@ -49,12 +77,20 @@
 #define R_API_HIDDEN
 #endif
 
+/**
+ * @brief Public-API decoration: resolves to @c R_API_EXPORT while
+ * building rlib and @c R_API_IMPORT for consumers.
+ */
 #if defined(RLIB_COMPILATION)
 #define R_API R_API_EXPORT
 #else
 #define R_API R_API_IMPORT
 #endif
+/** @} */
 
+/** @name Common constants
+ *  @{ */
+/** @brief Null pointer constant (defined only if absent). */
 #ifndef NULL
 #ifdef __cplusplus
 #define NULL  (0L)
@@ -63,31 +99,53 @@
 #endif
 #endif
 
+/** @brief Boolean false (@c 0). */
 #ifndef FALSE
 #define FALSE (0)
 #endif
+/** @brief Boolean true (@c !FALSE). */
 #ifndef TRUE
 #define TRUE  (!FALSE)
 #endif
+/** @} */
 
 #undef  MAX
 #undef  MIN
 #undef  ABS
 #undef  CLAMP
 
+/** @name Arithmetic helpers
+ *
+ * Argument-evaluating macros (no type checking) — beware passing
+ * expressions with side effects.
+ *  @{ */
+/** @brief Larger of @p a and @p b. */
 #define MAX(a, b)       (((a) > (b)) ? (a) : (b))
+/** @brief Smaller of @p a and @p b. */
 #define MIN(a, b)       (((a) < (b)) ? (a) : (b))
+/** @brief Absolute value of @p a. */
 #define ABS(a)          (((a) < 0) ? -(a) : (a))
+/** @brief Clamp @p x to the inclusive range [@p l, @p h]. */
 #define CLAMP(x, l, h)  (((x) > (h)) ? (h) : (((x) < (l)) ? (l) : (x)))
 
+/** @brief Number of elements in a fixed-size array @p a. */
 #define R_N_ELEMENTS(a)               (sizeof (a) / sizeof ((a)[0]))
+/** @} */
 
+/** @name Token manipulation
+ *  @{ */
+/** @brief Stringify @p str without macro expansion. */
 #define R_STRINGIFY_ARG(str)          #str
+/** @brief Stringify @p str after macro expansion. */
 #define R_STRINGIFY(str)              R_STRINGIFY_ARG (str)
+/** @brief Token-paste @p a1 and @p a2 without macro expansion. */
 #define R_PASTE_ARGS(a1, a2)          a1 ## a2
+/** @brief Token-paste @p a1 and @p a2 after macro expansion. */
 #define R_PASTE(a1, a2)               R_PASTE_ARGS (a1, a2)
 
+/** @brief Source location string @c "file:line". */
 #define R_STRLOC        __FILE__ ":" R_STRINGIFY (__LINE__)
+/** @brief Current function name as a string (compiler-specific spelling). */
 #if defined (__GNUC__) && defined (__cplusplus)
 #define R_STRFUNC     ((const char*) (__PRETTY_FUNCTION__))
 #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
@@ -97,16 +155,23 @@
 #else
 #define R_STRFUNC     ((const char*) ("???"))
 #endif
+/** @} */
 
+/** @name Declaration and statement wrappers
+ *  @{ */
+/** @brief Open an @c extern @c "C" block under C++ (no-op in C). */
 #ifdef  __cplusplus
 #define R_BEGIN_DECLS  extern "C" {
+/** @brief Close an @ref R_BEGIN_DECLS block. */
 #define R_END_DECLS    }
 #else
 #define R_BEGIN_DECLS
 #define R_END_DECLS
 #endif
 
+/** @brief Start a brace-free multi-statement macro body; pair with @ref R_STMT_END. */
 #define R_STMT_START  do
+/** @brief End an @ref R_STMT_START body (suppresses MSVC C4127 on the @c while(0)). */
 #ifndef _MSC_VER
 #define R_STMT_END    while (0)
 #else
@@ -116,9 +181,14 @@
     while(0) \
     __pragma(warning(pop))
 #endif
+/** @} */
 
+/** @name Initializers and branch hints
+ *  @{ */
 #if defined(__GNUC__)
+/** @brief Declare a function @p f that runs before @c main (static constructor). */
 #define R_INITIALIZER(f)   static void __attribute__((constructor)) f (void)
+/** @brief Declare a function @p f that runs at process exit (static destructor). */
 #define R_DEINITIALIZER(f) static void __attribute__((destructor))  f (void)
 #elif defined(_MSC_VER)
 #define R_INITIALIZER(f)                                                    \
@@ -136,18 +206,28 @@
 #error Your compiler does not support initializers/deinitializers
 #endif
 
+/** @brief Hint that @p expr is likely true (branch-prediction). */
 #if defined(__GNUC__) && defined(__OPTIMIZE__)
 #define R_LIKELY(expr)      __builtin_expect(!!(expr), 1)
+/** @brief Hint that @p expr is likely false (branch-prediction). */
 #define R_UNLIKELY(expr)    __builtin_expect(!!(expr), 0)
 #else
 #define R_LIKELY(expr)      (expr)
 #define R_UNLIKELY(expr)    (expr)
 #endif
+/** @} */
 
+/** @name Section, function, and variable attributes
+ *
+ * Each resolves to the GCC/Clang attribute, the MSVC equivalent, or
+ * nothing on toolchains that lack it.
+ *  @{ */
 #if defined(__GNUC__)
 #if __MACH__
-#define R_ATTR_DATA_SECTION(sec)   __attribute__((section("__DATA,"sec)))
-#define R_ATTR_CODE_SECTION(sec)   __attribute__((section("__TEXT,"sec)))
+/** @brief Place a variable in the named writable data @p sec(tion). */
+#define R_ATTR_DATA_SECTION(sec)   __attribute__((section("__DATA," sec)))
+/** @brief Place a function in the named code/text @p sec(tion). */
+#define R_ATTR_CODE_SECTION(sec)   __attribute__((section("__TEXT," sec)))
 #else
 #define R_ATTR_DATA_SECTION(sec)   __attribute__((section(sec)))
 #define R_ATTR_CODE_SECTION(sec)   __attribute__((section(sec)))
@@ -161,6 +241,7 @@
 #error Your compiler does not support data/code/text section attributes
 #endif
 
+/** @brief Warn if a function's return value is ignored. */
 #if defined(__GNUC__)
 #define R_ATTR_WARN_UNUSED_RESULT     __attribute__((warn_unused_result))
 #elif defined(_MSC_VER) && (_MSC_VER >= 1700)
@@ -169,9 +250,12 @@
 #define R_ATTR_WARN_UNUSED_RESULT
 #endif
 
+/** @brief Mark a function as never returning. */
 #if defined(__GNUC__)
 #define R_ATTR_NORETURN               __attribute__((__noreturn__))
+/** @brief Allow duplicate definitions to be merged (weak symbol). */
 #define R_ATTR_WEAK                   __attribute__((weak))
+/** @brief Align a variable / type to @p a bytes. */
 #define R_ATTR_ALIGN(a)               __attribute__((aligned(a)))
 #elif defined(_MSC_VER)
 #define R_ATTR_NORETURN               __declspec(noreturn)
@@ -183,21 +267,30 @@
 #define R_ATTR_ALIGN(a)
 #endif
 
+/** @brief Mark an intentional @c switch fall-through. */
 #if defined(__clang__) || R_GNUC_PREREQ(7, 0)
 #define R_ATTR_FALLTHROUGH            __attribute__((fallthrough))
 #else
 #define R_ATTR_FALLTHROUGH            ((void)0)
 #endif
 
+/** @brief Mark a variadic function as requiring a @c NULL sentinel. */
 #if defined(__GNUC__)
 #define R_ATTR_NULL_TERMINATED        __attribute__((__sentinel__))
+/** @brief Suppress unused-symbol warnings. */
 #define R_ATTR_UNUSED                 __attribute__((__unused__))
+/** @brief Mark a function as pure with no memory reads (@c const). */
 #define R_ATTR_CONST                  __attribute__((__const__))
+/** @brief Mark a function as side-effect-free (@c pure). */
 #define R_ATTR_PURE                   __attribute__((__pure__))
+/** @brief Mark a function as returning newly-allocated memory. */
 #define R_ATTR_MALLOC                 __attribute__((__malloc__))
+/** @brief Mark parameter @p arg_idx as a format string passed through verbatim. */
 #define R_ATTR_FORMAT_ARG(arg_idx)    __attribute__((__format_arg__ (arg_idx)))
+/** @brief Enable @c printf-style format checking (@p fmt_idx, @p arg_idx are 1-based). */
 #define R_ATTR_PRINTF(fmt_idx, arg_idx) \
   __attribute__((__format__ (__printf__, fmt_idx, arg_idx)))
+/** @brief Enable @c scanf-style format checking. */
 #define R_ATTR_SCANF(fmt_idx, arg_idx)  \
   __attribute__((__format__ (__scanf__, fmt_idx, arg_idx)))
 #else
@@ -211,6 +304,7 @@
 #define R_ATTR_SCANF(fmt_idx, arg_idx)
 #endif
 
+/** @brief Pointer-aliasing hint (@c restrict) in the compiler's spelling. */
 #if defined(__clang__)
 #define R_ATTR_RESTRICT __restrict__
 #elif defined(__GNUC__)
@@ -220,7 +314,11 @@
 #else
 #define R_ATTR_RESTRICT
 #endif
+/** @} */
 
+/** @name Feature-test fallbacks
+ *  Define the Clang feature-test builtins as @c 0 on compilers that lack them.
+ *  @{ */
 #ifndef __has_feature
 #define __has_feature(x) 0
 #endif
@@ -233,11 +331,16 @@
 
 #if  (defined(__clang__) && __has_feature(__alloc_size__)) || \
     (!defined(__clang__) && R_GNUC_PREREQ(4, 3))
+/** @brief Mark parameter @p x as the allocation size (single-argument form). */
 #define R_ATTR_ALLOC_SIZE_ARG(x)    __attribute__((__alloc_size__(x)))
+/** @brief Mark parameters @p x, @p y as the allocation size (count × size form). */
 #define R_ATTR_ALLOC_SIZE_ARGS(x,y) __attribute__((__alloc_size__(x,y)))
 #else
 #define R_ATTR_ALLOC_SIZE_ARG(x)
 #define R_ATTR_ALLOC_SIZE_ARGS(x,y)
 #endif
+/** @} */
+
+/** @} */ /* r_macros */
 
 #endif /* __R_MACROS_H__ */


### PR DESCRIPTION
## Summary
Continues the per-subsystem Doxygen pass, clearing the small/structural headers that previously had no `@defgroup`/`@ingroup` and so were absent from the Topic index.

- **`types/` (under `r_types`)**: `r_macros` (portability + utility macros), `r_bitops` (width-specific count-zeros / popcount / parity / shift / rotate), `r_endian` (byte-order detection, byteswap, host/network conversion, alignment-safe load/store). The uniform `R<WIDTH>_<OP>` macro families document a canonical width as the worked example with the convention spelled out in the group brief.
- **`r_uri`** (new top-level Topic): percent-encoding helpers and the parsed `RUri` component accessors.
- **`file/`** (new top-level `r_file` "Files and filesystem"): `RFile` buffered handles + whole-file helpers (rfile.h), the shared access/open/share/flags/seek/error enums (rfiletypes.h), filesystem path / metadata helpers (rfs.h), and `RIOHandle`-based file open/seek/truncate/size (file/rio.h).
- **Topic ordering**: `r_file` slots after `r_io`; `r_uri` next to the other encoding utilities — both added to `docs/topics-order.dox`.

Comment-only changes plus one cosmetic whitespace fix in the macOS-only `__DATA,`/`__TEXT,` section macros (identical token sequence in C; silences a C++11 reserved-literal-suffix warning).

## Remaining orphan subsystems (future passes)
`os/` remainder (rproc / rsignal / rsys), `ev/`, `rtc/`, and the higher-level `net/` + `net/proto/` headers.

## Test plan
- [x] `meson compile -C build-release-noerr` succeeds
- [x] `build-release-noerr/test/rlibtest` passes 1858/1858
- [x] `doxygen docs/Doxyfile` produces zero warnings
- [x] New Topics (`r_macros`, `r_bitops`, `r_endian`, `r_uri`, `r_file`) render in the expected tree positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)