### PR TITLE
docs: document os/ remainder (rproc, rsignal, rsys)

### DIFF
--- a/include/rlib/os/rproc.h
+++ b/include/rlib/os/rproc.h
@@ -18,17 +18,39 @@
 #ifndef __R_PROC_H__
 #define __R_PROC_H__
 
+/**
+ * @file rlib/os/rproc.h
+ * @brief Current-process introspection: debugger detection, executable
+ * path / name, and process ID.
+ */
+
 #include <rlib/rtypes.h>
+
+/**
+ * @defgroup r_proc Process introspection
+ * @ingroup r_os
+ *
+ * @brief Queries about the running process — whether a debugger is
+ * attached, the executable's path and name, and the process ID.
+ *
+ * @{
+ */
 
 R_BEGIN_DECLS
 
+/** @brief @c TRUE if a debugger is currently attached to this process. */
 R_API rboolean r_proc_is_debugger_attached (void);
+/** @brief Return the absolute path of the running executable (newly allocated). */
 R_API rchar * r_proc_get_exe_path (void) R_ATTR_MALLOC;
+/** @brief Return the filename of the running executable (newly allocated). */
 R_API rchar * r_proc_get_exe_name (void) R_ATTR_MALLOC;
 
+/** @brief Return the current process ID. */
 R_API int r_proc_get_id (void);
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_PROC_H__ */
 

--- a/include/rlib/os/rsignal.h
+++ b/include/rlib/os/rsignal.h
@@ -22,25 +22,58 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @file rlib/os/rsignal.h
+ * @brief @c SIGALRM-based one-shot and interval timers.
+ */
+
 #include <rlib/rtypes.h>
 #include <rlib/rtime.h>
 
+/**
+ * @defgroup r_signal Signal timers
+ * @ingroup r_os
+ *
+ * @brief @c SIGALRM-driven timers that invoke a callback once or on a
+ * recurring interval.
+ *
+ * Each timer arms the process @c SIGALRM and calls the supplied
+ * @ref RSignalFunc from signal context, so the callback must be
+ * async-signal-safe.
+ *
+ * @{
+ */
+
 R_BEGIN_DECLS
 
+/** @brief Signal-handler callback; receives the delivered signal number. */
 typedef void (*RSignalFunc) (int sig);
+/** @brief Opaque @c SIGALRM timer handle. */
 typedef struct RSigAlrmTimer RSigAlrmTimer;
 
+/** @brief Arm a one-shot timer firing once after @p timeout. */
 R_API RSigAlrmTimer * r_sig_alrm_timer_new_oneshot (RClockTime timeout,
     RSignalFunc func);
+/** @brief Arm a recurring timer firing every @p interval. */
 R_API RSigAlrmTimer * r_sig_alrm_timer_new_interval (RClockTime interval,
     RSignalFunc func);
+/**
+ * @brief Arm a recurring timer with an initial delay.
+ * @param timeout  Delay before the first fire.
+ * @param interval Period between subsequent fires.
+ * @param func     Callback invoked on each fire.
+ */
 R_API RSigAlrmTimer * r_sig_alrm_timer_new_interval_delayed (RClockTime timeout,
     RClockTime interval, RSignalFunc func);
 
+/** @brief Stop @p timer without freeing it. */
 R_API void r_sig_alrm_timer_cancel (RSigAlrmTimer * timer);
+/** @brief Cancel and free @p timer. */
 R_API void r_sig_alrm_timer_delete (RSigAlrmTimer * timer);
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_SIGNAL_H__ */
 

--- a/include/rlib/os/rsys.h
+++ b/include/rlib/os/rsys.h
@@ -22,64 +22,144 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @file rlib/os/rsys.h
+ * @brief CPU / NUMA-node counts and sets, plus a refcounted hardware
+ * topology object.
+ */
+
 #include <rlib/rtypes.h>
 #include <rlib/rref.h>
 
 #include <rlib/data/rbitset.h>
 
+/**
+ * @defgroup r_sys System and hardware topology
+ * @ingroup r_os
+ *
+ * @brief Query CPU and NUMA-node counts, build @ref RBitset masks of
+ * the available CPUs / nodes, and walk a discovered hardware
+ * topology.
+ *
+ * The stateless @c r_sys_cpu_* / @c r_sys_node_* / @c r_sys_*set_*
+ * calls answer one-off questions ("how many logical CPUs?", "which
+ * CPUs are online?"). For repeated structured access, discover an
+ * @ref RSysTopology once and walk its nodes and CPUs.
+ *
+ * @{
+ */
+
 R_BEGIN_DECLS
 
+/** @name CPU counts
+ *  @{ */
+/** @brief Number of physical CPU packages (sockets). */
 R_API ruint r_sys_cpu_packages (void);
+/** @brief Number of physical cores. */
 R_API ruint r_sys_cpu_physical_count (void);
+/** @brief Number of logical CPUs (hardware threads). */
 R_API ruint r_sys_cpu_logical_count (void);
+/** @brief Number of CPUs this process is allowed to run on. */
 R_API ruint r_sys_cpu_allowed_count (void);
+/** @brief Maximum possible CPU count the system can have. */
 R_API ruint r_sys_cpu_max_count (void);
+/** @} */
 
+/** @name CPU sets
+ *  @{ */
+/** @brief Highest valid CPU index + 1 (sizing hint for a cpuset). */
 R_API ruint r_sys_cpuset_max (void);
+/** @brief Allocate a @ref RBitset sized to hold every possible CPU. */
 R_API RBitset * r_sys_cpuset_new (void) R_ATTR_MALLOC;
+/** @brief Fill @p cpuset with all CPUs the system could ever have. */
 R_API rboolean r_sys_cpuset_possible (RBitset * cpuset);
+/** @brief Fill @p cpuset with the physically-present CPUs. */
 R_API rboolean r_sys_cpuset_present (RBitset * cpuset);
+/** @brief Fill @p cpuset with the currently-online CPUs. */
 R_API rboolean r_sys_cpuset_online (RBitset * cpuset);
+/** @brief Fill @p cpuset with the CPUs this process may run on. */
 R_API rboolean r_sys_cpuset_allowed (RBitset * cpuset);
 
+/** @brief Fill @p cpuset with the CPUs belonging to NUMA @p node. */
 R_API rboolean r_sys_cpuset_for_node (RBitset * cpuset, ruint node);
+/** @} */
 
+/** @name NUMA-node counts
+ *  @{ */
+/** @brief Total number of NUMA nodes. */
 R_API ruint r_sys_node_count (void);
+/** @brief Number of nodes that have at least one online CPU. */
 R_API ruint r_sys_node_count_with_online_cpus (void);
+/** @brief Number of nodes that have at least one allowed CPU. */
 R_API ruint r_sys_node_count_with_allowed_cpus (void);
+/** @} */
 
+/** @name NUMA-node sets
+ *  @{ */
+/** @brief Highest valid node index + 1 (sizing hint for a nodeset). */
 R_API ruint r_sys_nodeset_max (void);
+/** @brief Allocate a @ref RBitset sized to hold every possible node. */
 R_API RBitset * r_sys_nodeset_new (void) R_ATTR_MALLOC;
+/** @brief Fill @p nodeset with all nodes the system could have. */
 R_API rboolean r_sys_nodeset_possible (RBitset * nodeset);
+/** @brief Fill @p nodeset with the currently-online nodes. */
 R_API rboolean r_sys_nodeset_online (RBitset * nodeset);
+/** @brief Fill @p nodeset with nodes that have online CPUs. */
 R_API rboolean r_sys_nodeset_with_online_cpus (RBitset * nodeset);
+/** @brief Fill @p nodeset with nodes that have allowed CPUs. */
 R_API rboolean r_sys_nodeset_with_allowed_cpus (RBitset * nodeset);
 
+/** @brief Fill @p nodeset with the nodes spanned by @p cpuset. */
 R_API rboolean r_sys_nodeset_for_cpuset (RBitset * nodeset, const RBitset * cpuset);
+/** @} */
 
-/* Topology API */
+/** @name Topology objects
+ *
+ * @ref RSysTopology / @ref RSysNode / @ref RSysCpu are refcounted;
+ * use the @c _ref / @c _unref aliases. Nodes and CPUs are owned by
+ * their parent topology.
+ *  @{ */
+/** @brief Opaque, refcounted hardware-topology snapshot. */
 typedef struct RSysTopology  RSysTopology;
+/** @brief Opaque, refcounted NUMA node within a topology. */
 typedef struct RSysNode      RSysNode;
+/** @brief Opaque, refcounted CPU within a topology node. */
 typedef struct RSysCpu       RSysCpu;
 
+/** @brief Discover the current hardware topology. */
 R_API RSysTopology * r_sys_topology_discover (void);
 
+/** @brief Number of NUMA nodes in @p topo. */
 R_API rsize r_sys_topology_node_count (const RSysTopology * topo);
+/** @brief Return the @p idx-th node of @p topo (borrowed). */
 R_API RSysNode * r_sys_topology_node (RSysTopology * topo, rsize idx);
 
+/** @brief Fill @p cpuset with the CPUs belonging to @p node. */
 R_API rboolean r_sys_topology_node_cpuset (const RSysNode * node, RBitset * cpuset);
+/** @brief Number of CPUs in @p node. */
 R_API rsize r_sys_topology_node_cpu_count (const RSysNode * node);
+/** @brief Return the @p idx-th CPU of @p node (borrowed). */
 R_API RSysCpu * r_sys_topology_node_cpu (RSysNode * node, rsize idx);
+/** @brief Bytes of memory local to @p node. */
 R_API rsize r_sys_topology_node_available_memory (const RSysNode * node);
 
+/** @brief Take a reference on a topology (alias for @ref r_ref_ref). */
 #define r_sys_topology_ref    r_ref_ref
+/** @brief Drop a reference on a topology (alias for @ref r_ref_unref). */
 #define r_sys_topology_unref  r_ref_unref
+/** @brief Take a reference on a node (alias for @ref r_ref_ref). */
 #define r_sys_node_ref        r_ref_ref
+/** @brief Drop a reference on a node (alias for @ref r_ref_unref). */
 #define r_sys_node_unref      r_ref_unref
+/** @brief Take a reference on a CPU (alias for @ref r_ref_ref). */
 #define r_sys_cpu_ref         r_ref_ref
+/** @brief Drop a reference on a CPU (alias for @ref r_ref_unref). */
 #define r_sys_cpu_unref       r_ref_unref
+/** @} */
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_SYS_H__ */
 


### PR DESCRIPTION
## Summary
Completes the **Operating system** Topic by documenting the three `os/` headers that previously had no `@defgroup`/`@ingroup` and so were absent from the Topic tree.

- **`r_proc`** — current-process introspection: debugger detection, executable path/name, PID.
- **`r_signal`** — `SIGALRM`-driven one-shot / interval timers, with the `RSigAlrmTimer` handle and an async-signal-safety note on the callback.
- **`r_sys`** — CPU and NUMA-node counts, `RBitset` cpuset/nodeset masks, and the refcounted `RSysTopology` / `RSysNode` / `RSysCpu` topology objects (split into counts / sets / topology subsections).

This also fills the `@brief` gaps on the `RSigAlrmTimer`, `RSysTopology`, `RSysNode`, and `RSysCpu` opaque handles flagged in the recent opaque-handle audit (the os/ portion). Comment-only; no API or behaviour change.

`r_os` now has all six children: r_env, r_module, r_tty, r_proc, r_signal, r_sys.

## Remaining orphan subsystems (future passes)
`ev/`, `rtc/`, and the higher-level `net/` + `net/proto/` headers.

## Test plan
- [x] `meson compile -C build-release-noerr` succeeds
- [x] `build-release-noerr/test/rlibtest` passes 1858/1858
- [x] `doxygen docs/Doxyfile` produces zero warnings
- [x] r_proc / r_signal / r_sys render under the Operating system Topic; the four opaque handles now carry briefs

🤖 Generated with [Claude Code](https://claude.com/claude-code)