### PR TITLE
docs: document the generated rlib/rconfig.h (types, macros, platform config)

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -73,6 +73,10 @@ TOC_INCLUDE_HEADINGS    = 0
 ENABLE_PREPROCESSING    = YES
 MACRO_EXPANSION         = YES
 EXPAND_ONLY_PREDEF      = YES
+# RLIB_DOXYGEN is defined only here, never by a compiler, so headers
+# can expose Doxygen-only declarations for typedefs whose real
+# definitions live in the build-generated rlib/rconfig.h (which is
+# outside INPUT) - e.g. the fixed-width rint8 / ruint8 / ... types.
 PREDEFINED              = R_API= \
                           R_API_HIDDEN= \
                           R_BEGIN_DECLS= \
@@ -82,7 +86,8 @@ PREDEFINED              = R_API= \
                           R_ATTR_PRINTF(x,y)= \
                           R_ATTR_WARN_UNUSED= \
                           R_UNLIKELY(x)=x \
-                          R_LIKELY(x)=x
+                          R_LIKELY(x)=x \
+                          RLIB_DOXYGEN
 
 # Paths shown in the generated docs are stripped of the build-system
 # prefix so file titles and breadcrumbs read as `crypto/rcipher.h`,

--- a/docs/topics-order.dox
+++ b/docs/topics-order.dox
@@ -28,6 +28,7 @@
  */
 
 /** @defgroup r_types        Foundational types */
+/** @defgroup r_config       Build configuration and platform */
 /** @defgroup r_mem          Memory */
 /** @defgroup r_data         Data structures */
 /** @defgroup r_str          Strings */

--- a/include/rlib/net/rsocketaddress.h
+++ b/include/rlib/net/rsocketaddress.h
@@ -75,6 +75,22 @@ R_BEGIN_DECLS
 /** @brief Static initialiser for IPv6 @c in6addr_loopback (::1). */
 #define R_SOCKET_ADDRESS_IPV6_LOOPBACK_INIT   { { { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1 } } }
 
+/** @name Address-family constants
+ *
+ * Platform @c AF_* values mapped in @c rlib/rconfig.h. Used to seed
+ * @ref RSocketFamily; prefer the @c R_SOCKET_FAMILY_* enumerators in
+ * application code.
+ *  @{ */
+#ifdef RLIB_DOXYGEN
+/* Doxygen-only mirror; real values are host-resolved in rconfig.h. */
+#define R_AF_UNIX       1  /**< @brief Unix-domain address family (@c AF_UNIX). */
+#define R_AF_INET       2  /**< @brief IPv4 address family (@c AF_INET). */
+#define R_AF_INET6     10  /**< @brief IPv6 address family (@c AF_INET6). */
+#define R_AF_IRDA      23  /**< @brief IrDA address family (@c AF_IRDA). */
+#define R_AF_BLUETOOTH 31  /**< @brief Bluetooth address family (@c AF_BLUETOOTH). */
+#endif
+/** @} */
+
 /** @brief Address family discriminator. */
 typedef enum {
   R_SOCKET_FAMILY_NONE = 0,                       /**< Uninitialised / unknown. */

--- a/include/rlib/rpoll.h
+++ b/include/rlib/rpoll.h
@@ -52,10 +52,27 @@
 
 R_BEGIN_DECLS
 
+/** @name Poll event flags
+ *
+ * Bits for @ref RPoll::events (requested) and @ref RPoll::revents
+ * (returned). Platform-mapped onto the host's @c POLL* constants in
+ * @c rlib/rconfig.h.
+ *  @{ */
+#ifdef RLIB_DOXYGEN
+/* Doxygen-only mirror; real values are host-resolved in rconfig.h. */
+#define R_IO_IN   0x001 /**< @brief Data available to read. */
+#define R_IO_OUT  0x004 /**< @brief Writable without blocking. */
+#define R_IO_PRI  0x002 /**< @brief Urgent / priority data available. */
+#define R_IO_ERR  0x008 /**< @brief Error condition (output only). */
+#define R_IO_HUP  0x010 /**< @brief Hang-up / peer closed (output only). */
+#define R_IO_NVAL 0x020 /**< @brief Invalid handle (output only). */
+#endif
+/** @} */
+
 /** @brief Single poll descriptor; mirrors @c struct @c pollfd. */
 typedef struct {
   RIOHandle handle;   /**< Handle to poll. */
-  rushort events;     /**< Requested events bitmask (@c POLL* constants). */
+  rushort events;     /**< Requested events bitmask (@c R_IO_* flags). */
   rushort revents;    /**< Returned events, filled by @ref r_poll. */
 } RPoll;
 

--- a/include/rlib/rtypes.h
+++ b/include/rlib/rtypes.h
@@ -170,12 +170,38 @@ typedef unsigned int            ruint;
 /** @} */
 
 /**
+ * @name Fixed-width integer types
+ *
+ * Exact-width signed and unsigned integers. The typedefs themselves
+ * are emitted into the build-generated @c rlib/rconfig.h (the host's
+ * @c short / @c int / @c long widths are probed at configure time so
+ * the sizes are guaranteed); they are documented here, where every
+ * caller already includes them via @c rlib/rtypes.h.
+ * @{
+ */
+#ifdef RLIB_DOXYGEN
+/* Doxygen-only mirror of the typedefs emitted into rlib/rconfig.h.
+ * Never compiled (RLIB_DOXYGEN is defined only by the Doxyfile). */
+typedef signed char    rint8;    /**< @brief Signed 8-bit integer. */
+typedef signed short   rint16;   /**< @brief Signed 16-bit integer. */
+typedef signed int     rint32;   /**< @brief Signed 32-bit integer. */
+typedef signed long    rint64;   /**< @brief Signed 64-bit integer. */
+typedef signed long    rintmax;  /**< @brief Widest signed integer the host supports. */
+typedef unsigned char  ruint8;   /**< @brief Unsigned 8-bit integer. */
+typedef unsigned short ruint16;  /**< @brief Unsigned 16-bit integer. */
+typedef unsigned int   ruint32;  /**< @brief Unsigned 32-bit integer. */
+typedef unsigned long  ruint64;  /**< @brief Unsigned 64-bit integer. */
+typedef unsigned long  ruintmax; /**< @brief Widest unsigned integer the host supports. */
+#endif
+/** @} */
+
+/**
  * @name Fixed-width integer limits
  *
- * The actual @c rint8 / @c ruint8 / ... typedefs live in
- * @c rlib/rconfig.h (chosen per host so the sizes are guaranteed);
- * the @c MIN / @c MAX constants live here so a single include of
- * @c rlib/rtypes.h covers both.
+ * The @c MIN / @c MAX constants for the @ref rint8 / @ref ruint8 /
+ * ... types. The typedefs live in @c rlib/rconfig.h (chosen per host
+ * so the sizes are guaranteed); the constants live here so a single
+ * include of @c rlib/rtypes.h covers both.
  * @{
  */
 /** @brief Minimum value of @c rint8. */
@@ -213,6 +239,10 @@ typedef unsigned int            ruint;
  * past the 32-bit boundary on platforms that need it.
  * @{
  */
+#ifdef RLIB_DOXYGEN
+typedef unsigned long           rsize;  /**< @brief Unsigned pointer-sized size type (like @c size_t). */
+typedef signed long             rssize; /**< @brief Signed pointer-sized size type (like @c ssize_t). */
+#endif
 /** @brief 64-bit signed file / stream offset. */
 typedef rint64                  roffset;
 /** @brief Minimum value of @c roffset. */
@@ -236,8 +266,16 @@ typedef rint64                  roffset;
  * @c ruintptr / @c rsize to silence pedantic warnings about
  * pointer / integer conversions on platforms where the widths
  * happen to mismatch.
+ *
+ * @c rintptr / @c ruintptr (signed / unsigned integers wide enough
+ * to hold a pointer, like @c intptr_t / @c uintptr_t) are typedef'd
+ * in @c rlib/rconfig.h.
  * @{
  */
+#ifdef RLIB_DOXYGEN
+typedef signed long             rintptr;  /**< @brief Signed integer wide enough to hold a pointer (like @c intptr_t). */
+typedef unsigned long           ruintptr; /**< @brief Unsigned integer wide enough to hold a pointer (like @c uintptr_t). */
+#endif
 /** @brief Generic pointer (alias for @c void @c *). */
 typedef void*                   rpointer;
 /** @brief Generic const pointer (alias for @c const @c void @c *). */

--- a/include/rlib/rtypes.h
+++ b/include/rlib/rtypes.h
@@ -231,6 +231,53 @@ typedef unsigned long  ruintmax; /**< @brief Widest unsigned integer the host su
 /** @} */
 
 /**
+ * @name Fixed-width integer printf macros and constants
+ *
+ * @c printf / @c scanf length modifiers and conversion specifiers for
+ * each width, plus literal-suffix helpers and the wide-type limits.
+ * These are emitted into @c rlib/rconfig.h with the host-correct
+ * spellings; use them as @c printf ("value=%" RINT64_FMT "\n", v).
+ * The values shown here are illustrative — the real ones are resolved
+ * per host at configure time.
+ * @{
+ */
+#ifdef RLIB_DOXYGEN
+/* Doxygen-only mirror; real definitions are host-resolved in rconfig.h. */
+#define RINT8_MODIFIER   "hh" /**< @brief @c printf length modifier for @ref rint8 / @ref ruint8. */
+#define RINT8_FMT        "hhi" /**< @brief @c printf conversion for @ref rint8. */
+#define RUINT8_FMT       "hhu" /**< @brief @c printf conversion for @ref ruint8. */
+#define RINT16_MODIFIER  "h"  /**< @brief @c printf length modifier for @ref rint16 / @ref ruint16. */
+#define RINT16_FMT       "hi" /**< @brief @c printf conversion for @ref rint16. */
+#define RUINT16_FMT      "hu" /**< @brief @c printf conversion for @ref ruint16. */
+#define RINT32_MODIFIER  ""   /**< @brief @c printf length modifier for @ref rint32 / @ref ruint32. */
+#define RINT32_FMT       "i"  /**< @brief @c printf conversion for @ref rint32. */
+#define RUINT32_FMT      "u"  /**< @brief @c printf conversion for @ref ruint32. */
+#define RINT64_MODIFIER  "ll" /**< @brief @c printf length modifier for @ref rint64 / @ref ruint64. */
+#define RINT64_FMT       "lli" /**< @brief @c printf conversion for @ref rint64. */
+#define RUINT64_FMT      "llu" /**< @brief @c printf conversion for @ref ruint64. */
+#define RINTMAX_MODIFIER "j"  /**< @brief @c printf length modifier for @ref rintmax / @ref ruintmax. */
+#define RINTMAX_FMT      "ji" /**< @brief @c printf conversion for @ref rintmax. */
+#define RUINTMAX_FMT     "ju" /**< @brief @c printf conversion for @ref ruintmax. */
+#define RSIZE_MODIFIER   "z"  /**< @brief @c printf length modifier for @ref rsize. */
+#define RSSIZE_MODIFIER  "z"  /**< @brief @c printf length modifier for @ref rssize. */
+#define RSIZE_FMT        "zu" /**< @brief @c printf conversion for @ref rsize. */
+#define RSSIZE_FMT       "zi" /**< @brief @c printf conversion for @ref rssize. */
+#define RINTPTR_MODIFIER "t"  /**< @brief @c printf length modifier for @ref rintptr / @ref ruintptr. */
+#define RINTPTR_FMT      "ti" /**< @brief @c printf conversion for @ref rintptr. */
+#define RUINTPTR_FMT     "tu" /**< @brief @c printf conversion for @ref ruintptr. */
+
+#define RINT64_CONSTANT(val)  val          /**< @brief Suffix an integer literal as a 64-bit signed (@ref rint64) constant. */
+#define RUINT64_CONSTANT(val) val          /**< @brief Suffix an integer literal as a 64-bit unsigned (@ref ruint64) constant. */
+#define RUINTMAX_MAX  ((ruintmax) -1)      /**< @brief Maximum value of @ref ruintmax. */
+#define RINTMAX_MIN   (-RINTMAX_MAX - 1)   /**< @brief Minimum value of @ref rintmax. */
+#define RINTMAX_MAX   ((rintmax) (RUINTMAX_MAX >> 1)) /**< @brief Maximum value of @ref rintmax. */
+#define RSIZE_MAX     ((rsize) -1)         /**< @brief Maximum value of @ref rsize. */
+#define RSSIZE_MIN    (-RSSIZE_MAX - 1)    /**< @brief Minimum value of @ref rssize. */
+#define RSSIZE_MAX    ((rssize) (RSIZE_MAX >> 1)) /**< @brief Maximum value of @ref rssize. */
+#endif
+/** @} */
+
+/**
  * @name Size and file-offset types
  *
  * @c rsize / @c rssize (unsigned and signed pointer-sized) are
@@ -385,6 +432,85 @@ typedef rpointer (*RFuncUniversalReturn) ();
 R_END_DECLS
 
 /** @} */ /* r_types group */
+
+/**
+ * @defgroup r_config Build configuration and platform
+ *
+ * @brief Compile-time feature, architecture, OS and ABI macros
+ * resolved at configure time and emitted into the build-generated
+ * @c rlib/rconfig.h.
+ *
+ * The @c R_OS_* / @c R_ARCH_* macros are defined only for the target
+ * being built (test with @c \#ifdef); the @c RLIB_HAVE_* flags report
+ * which optional subsystems were compiled in; the @c RLIB_SIZEOF_*
+ * macros give the host's type widths in bytes; and the @c R_AI_*
+ * macros mirror the platform's @c getaddrinfo hint flags.
+ *
+ * @{
+ */
+#ifdef RLIB_DOXYGEN
+/* Doxygen-only mirror; the real macros are host-resolved in rconfig.h.
+ * R_OS_* / R_ARCH_* are #mesondefine'd (present only for the target);
+ * shown here as plain defines so they appear in the docs. */
+
+/** @name Optional subsystems
+ *  Defined when the corresponding subsystem was compiled in.
+ *  @{ */
+#define RLIB_HAVE_THREADS  /**< @brief Threads, mutexes and TLS are available. */
+#define RLIB_HAVE_MODULES  /**< @brief Dynamic module loading is available. */
+#define RLIB_HAVE_SIGNALS  /**< @brief Signal timers are available. */
+#define RLIB_HAVE_FILES    /**< @brief File and filesystem APIs are available. */
+#define RLIB_HAVE_SOCKETS  /**< @brief Socket and networking APIs are available. */
+#define RLIB_HAVE_ALLOCA_H /**< @brief @c <alloca.h> is present on the host. */
+/** @} */
+
+/** @name Target architecture
+ *  Exactly one is defined, for the architecture being built.
+ *  @{ */
+#define R_ARCH_X86      /**< @brief Targeting 32-bit x86. */
+#define R_ARCH_X86_64   /**< @brief Targeting 64-bit x86-64. */
+#define R_ARCH_IA64     /**< @brief Targeting Itanium (IA-64). */
+#define R_ARCH_ARM      /**< @brief Targeting 32-bit ARM. */
+#define R_ARCH_THUMB    /**< @brief Targeting ARM Thumb. */
+#define R_ARCH_AARCH64  /**< @brief Targeting 64-bit ARM (AArch64). */
+#define R_ARCH_SPARC    /**< @brief Targeting SPARC. */
+#define R_ARCH_XTENSA   /**< @brief Targeting Xtensa. */
+/** @} */
+
+/** @name Target operating system
+ *  Defined for the OS being built; @c R_OS_UNIX also covers the
+ *  Unix-like family (Linux / BSD / Darwin).
+ *  @{ */
+#define R_OS_BARE_METAL /**< @brief Targeting a bare-metal / no-OS environment. */
+#define R_OS_WIN32      /**< @brief Targeting Windows. */
+#define R_OS_UNIX       /**< @brief Targeting a Unix-like OS. */
+#define R_OS_LINUX      /**< @brief Targeting Linux. */
+#define R_OS_BSD        /**< @brief Targeting a BSD. */
+#define R_OS_DARWIN     /**< @brief Targeting macOS / Darwin. */
+#define R_OS_RTEMS      /**< @brief Targeting RTEMS. */
+/** @} */
+
+/** @name Type sizes (bytes)
+ *  @{ */
+#define RLIB_SIZEOF_VOID_P 8 /**< @brief @c sizeof(void*) on the host. */
+#define RLIB_SIZEOF_INT    4 /**< @brief @c sizeof(int) on the host. */
+#define RLIB_SIZEOF_LONG   8 /**< @brief @c sizeof(long) on the host. */
+#define RLIB_SIZEOF_INTMAX 8 /**< @brief @c sizeof(rintmax) on the host. */
+#define RLIB_SIZEOF_SIZE_T 8 /**< @brief @c sizeof(rsize) on the host. */
+/** @} */
+
+/** @name getaddrinfo hint flags
+ *  Mirror the platform's @c AI_* constants for DNS resolution.
+ *  @{ */
+#define R_AI_PASSIVE      /**< @brief Address is intended for @c bind (passive socket). */
+#define R_AI_CANONNAME    /**< @brief Request the canonical host name. */
+#define R_AI_NUMERICHOST  /**< @brief Treat the host string as a numeric address only. */
+#define R_AI_V4MAPPED     /**< @brief Return IPv4-mapped IPv6 addresses if no IPv6 found. */
+#define R_AI_ALL          /**< @brief Return both IPv6 and IPv4-mapped addresses. */
+#define R_AI_ADDRCONFIG   /**< @brief Only return families configured on the host. */
+/** @} */
+#endif /* RLIB_DOXYGEN */
+/** @} */ /* r_config group */
 
 #include <rlib/types/rmemops.h>
 #include <rlib/types/rendianness.h>


### PR DESCRIPTION
## Summary
The build-generated `rlib/rconfig.h` (public, installed; sizes/flags probed per host at configure time) was entirely undocumented because it lives outside Doxygen's `INPUT`. This PR documents all of its public surface using an `#ifdef RLIB_DOXYGEN` mirror block — `RLIB_DOXYGEN` is defined only in the Doxyfile `PREDEFINED` list, never by a compiler, so the docs see real declarations while the build is untouched.

**Foundational types (`r_types`)**
- The 14 fixed-width / pointer-sized typedefs: `rint8`…`ruintmax`, `rsize`, `rssize`, `rintptr`, `ruintptr`.
- Their `printf` length-modifiers / conversion specifiers (`RINT64_FMT`, `RUINT32_MODIFIER`, …), the `RINT64_CONSTANT` / `RUINT64_CONSTANT` literal-suffix helpers, and the wide-type limits (`RINTMAX`/`RUINTMAX`/`RSIZE`/`RSSIZE` `MIN`/`MAX`).

**New `r_config` Topic — "Build configuration and platform"**
- `R_OS_*` / `R_ARCH_*` target macros, `RLIB_HAVE_*` subsystem feature flags, `RLIB_SIZEOF_*` ABI widths, and `R_AI_*` getaddrinfo hint flags.

**Placed with their consumers**
- `R_IO_*` poll-event flags under `r_poll` (the only way to set `RPoll::events`; previously had no documented home).
- `R_AF_*` address-family constants under `r_socketaddress` (noting callers should prefer the `RSocketFamily` enumerators).

`config.h.meson` (the internal `HAVE_*` build-probe header) is **not** public/installed and is intentionally left alone.

## Test plan
- [x] `meson compile -C build-release-noerr` succeeds (every `RLIB_DOXYGEN` block is excluded from compilation)
- [x] `build-release-noerr/test/rlibtest` passes 1858/1858
- [x] `doxygen docs/Doxyfile` produces zero warnings
- [x] New `r_config` Topic and all migrated symbols render; integer macros appear on Foundational types, `R_IO_*` on Polling, `R_AF_*` on Socket addresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)