### PR TITLE
docs: document the networking protocol stack (net/ + net/proto/)

### DIFF
--- a/include/rlib/net/proto/rhttp.h
+++ b/include/rlib/net/proto/rhttp.h
@@ -22,14 +22,42 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @file rlib/net/proto/rhttp.h
+ * @brief HTTP/1.x message model: requests, responses, headers and
+ * bodies, with buffer encode / decode.
+ */
+
 #include <rlib/rtypes.h>
 
 #include <rlib/rbuffer.h>
 #include <rlib/rref.h>
 #include <rlib/ruri.h>
 
+/**
+ * @defgroup r_http_proto HTTP protocol
+ * @ingroup r_net
+ *
+ * @brief HTTP/1.x wire model — parse and build requests and
+ * responses, manipulate headers, and read / set message bodies.
+ *
+ * @ref RHttpMsg is the shared base for @ref RHttpRequest and
+ * @ref RHttpResponse; the @c r_http_request_* / @c r_http_response_*
+ * header and body accessors are convenience macros that forward to
+ * the @c r_http_msg_* base operations. Construct messages from
+ * components or decode them from an @ref RBuffer (the @c _from_buffer
+ * constructors return any unconsumed bytes via a @c remainder
+ * out-parameter for streaming).
+ *
+ * This is the wire codec; the event-loop-driven server lives in
+ * @ref r_http_server.
+ *
+ * @{
+ */
+
 R_BEGIN_DECLS
 
+/** @brief Result code from the HTTP encode / decode and accessor APIs. */
 typedef enum {
   R_HTTP_OK = 0,
   R_HTTP_INVAL,
@@ -44,13 +72,15 @@ typedef enum {
   R_HTTP_COMPLETE,
 } RHttpError;
 
+/** @brief How a message body's length is determined when parsing. */
 typedef enum {
-  R_HTTP_BODY_PARSE_CHUNKED,
-  R_HTTP_BODY_PARSE_SIZED,
-  R_HTTP_BODY_PARSE_CLOSE,
-  R_HTTP_BODY_PARSE_TUNNEL,
+  R_HTTP_BODY_PARSE_CHUNKED, /**< Chunked transfer-encoding. */
+  R_HTTP_BODY_PARSE_SIZED,   /**< Fixed length from @c Content-Length. */
+  R_HTTP_BODY_PARSE_CLOSE,   /**< Body runs until the connection closes. */
+  R_HTTP_BODY_PARSE_TUNNEL,  /**< Tunnelled (e.g. after @c CONNECT). */
 } RHttpBodyParseType;
 
+/** @brief HTTP request method. */
 typedef enum {
   R_HTTP_METHOD_UNKNOWN = -1,
   R_HTTP_METHOD_GET = 0,
@@ -63,6 +93,7 @@ typedef enum {
   R_HTTP_METHOD_TRACE,
 } RHttpMethod;
 
+/** @brief HTTP status code (standard RFC values; names are self-describing). */
 typedef enum {
   R_HTTP_STATUS_CONTINUE                              = 100,
   R_HTTP_STATUS_SWITCHING_PROTOCOLS                   = 101,
@@ -132,70 +163,133 @@ typedef enum {
   R_HTTP_STATUS_MAX                                   = 999,
 } RHttpStatus;
 
+/** @brief Opaque base message shared by @ref RHttpRequest and @ref RHttpResponse. */
 typedef struct RHttpMsg RHttpMsg;
+/** @brief Serialise the full message (start line + headers + body) to a buffer. */
 R_API RBuffer * r_http_msg_get_buffer (RHttpMsg * msg) R_ATTR_WARN_UNUSED_RESULT;
+/** @brief Copy the message body into a freshly-allocated buffer; @p size receives its length. */
 R_API rchar * r_http_msg_get_body (RHttpMsg * msg, rsize * size) R_ATTR_MALLOC;
+/** @brief Return the message body as an @ref RBuffer. */
 R_API RBuffer * r_http_msg_get_body_buffer (RHttpMsg * msg) R_ATTR_WARN_UNUSED_RESULT;
+/** @brief Set the message body from an @ref RBuffer. */
 R_API RHttpError r_http_msg_set_body_buffer (RHttpMsg * msg, RBuffer * buf);
+/** @brief @c TRUE if a header named @p field is present (@p size or @c -1). */
 R_API rboolean r_http_msg_has_header (RHttpMsg * msg, const rchar * field, rssize size);
+/** @brief @c TRUE if header @p key is present with value @p val. */
 R_API rboolean r_http_msg_has_header_of_value (RHttpMsg * msg,
     const rchar * key, rssize ksize, const rchar * val, rssize vsize);
+/** @brief Return the value of header @p field (newly allocated), or @c NULL. */
 R_API rchar * r_http_msg_get_header (RHttpMsg * msg, const rchar * field, rssize size);
+/** @brief Append a header @p field : @p value to the message. */
 R_API rboolean r_http_msg_add_header (RHttpMsg * msg,
     const rchar * field, rssize fsize, const rchar * value, rssize vsize);
 
+/** @brief Opaque, refcounted HTTP request (an @ref RHttpMsg). */
 typedef struct RHttpRequest RHttpRequest;
+/** @brief Take a reference (alias for @ref r_ref_ref). */
 #define r_http_request_ref    r_ref_ref
+/** @brief Drop a reference (alias for @ref r_ref_unref). */
 #define r_http_request_unref  r_ref_unref
 
+/** @brief Build a request from a method, target URI string and version. */
 R_API RHttpRequest * r_http_request_new (RHttpMethod method,
     const rchar * uri, const rchar * ver, RHttpError * err) R_ATTR_MALLOC;
+/** @brief Build a request from a method, parsed @ref RUri and version. */
 R_API RHttpRequest * r_http_request_new_with_uri (RHttpMethod method,
     RUri * uri, const rchar * ver, RHttpError * err) R_ATTR_MALLOC;
+/**
+ * @brief Decode a request from @p buf.
+ * @param buf       Input bytes to parse.
+ * @param err       Optional out-pointer for the @ref RHttpError.
+ * @param remainder Out-pointer receiving any bytes past this message.
+ */
 R_API RHttpRequest * r_http_request_new_from_buffer (RBuffer * buf,
     RHttpError * err, RBuffer ** remainder) R_ATTR_MALLOC;
+/** @brief Serialise the request to a buffer (forwards to @ref r_http_msg_get_buffer). */
 #define r_http_request_get_buffer(req) r_http_msg_get_buffer ((RHttpMsg *)req)
+/** @brief Return the request method. */
 R_API RHttpMethod r_http_request_get_method (const RHttpRequest * req);
+/** @brief Return the request target as a parsed @ref RUri. */
 R_API RUri * r_http_request_get_uri (RHttpRequest * req);
+/** @brief @ref r_http_msg_has_header on a request. */
 #define r_http_request_has_header(req, field, size) r_http_msg_has_header ((RHttpMsg *)req, field, size)
+/** @brief @ref r_http_msg_has_header_of_value on a request. */
 #define r_http_request_has_header_of_value(req, key, ksize, val, vsize)       \
   r_http_msg_has_header_of_value ((RHttpMsg *)req, key, ksize, val, vsize)
+/** @brief @ref r_http_msg_get_header on a request. */
 #define r_http_request_get_header(req, field, size) r_http_msg_get_header ((RHttpMsg *)req, field, size)
+/** @brief @ref r_http_msg_add_header on a request. */
 #define r_http_request_add_header(req, field, fsize, value, vsize) r_http_msg_add_header ((RHttpMsg *)req, field, fsize, value, vsize)
+/** @brief @ref r_http_msg_get_body on a request. */
 #define r_http_request_get_body(req, size) r_http_msg_get_body ((RHttpMsg *)req, size)
+/** @brief @ref r_http_msg_get_body_buffer on a request. */
 #define r_http_request_get_body_buffer(req) r_http_msg_get_body_buffer ((RHttpMsg *)req)
+/** @brief @ref r_http_msg_set_body_buffer on a request. */
 #define r_http_request_set_body_buffer(req, buf) r_http_msg_set_body_buffer ((RHttpMsg *)req, buf)
+/** @brief How the request body length is determined (chunked / sized / ...). */
 R_API RHttpBodyParseType r_http_request_get_body_parse_type (RHttpRequest * req);
+/** @brief Compute the request body size; @p type receives the parse type. */
 R_API rssize r_http_request_calc_body_size (RHttpRequest * req, RHttpBodyParseType * type);
 
 
+/** @brief Opaque, refcounted HTTP response (an @ref RHttpMsg). */
 typedef struct RHttpResponse RHttpResponse;
+/** @brief Take a reference (alias for @ref r_ref_ref). */
 #define r_http_response_ref   r_ref_ref
+/** @brief Drop a reference (alias for @ref r_ref_unref). */
 #define r_http_response_unref r_ref_unref
 
+/**
+ * @brief Build a response to @p req with the given status, reason
+ * phrase and version. @p phrase may be @c NULL for the default text.
+ */
 R_API RHttpResponse * r_http_response_new (RHttpRequest * req,
     RHttpStatus status, const rchar * phrase, const rchar * ver,
     RHttpError * err) R_ATTR_MALLOC;
+/** @brief Decode a response from @p buf; @p remainder receives trailing bytes. */
 R_API RHttpResponse * r_http_response_new_from_buffer (RHttpRequest * req,
     RBuffer * buf, RHttpError * err, RBuffer ** remainder) R_ATTR_MALLOC;
+/** @brief Return the response status code. */
 R_API RHttpStatus r_http_response_get_status (const RHttpResponse * res);
+/** @brief Serialise the response to a buffer (forwards to @ref r_http_msg_get_buffer). */
 #define r_http_response_get_buffer(res) r_http_msg_get_buffer ((RHttpMsg *)res)
+/** @brief Return the response reason phrase (newly allocated). */
 R_API rchar * r_http_response_get_phrase (const RHttpResponse * res) R_ATTR_MALLOC;
+/** @brief Return the request this response was built for. */
 R_API RHttpRequest * r_http_response_get_request (RHttpResponse * res);
+/** @brief @ref r_http_msg_has_header on a response. */
 #define r_http_response_has_header(res, field, size) r_http_msg_has_header ((RHttpMsg *)res, field, size)
+/** @brief @ref r_http_msg_has_header_of_value on a response. */
 #define r_http_response_has_header_of_value(res, key, ksize, val, vsize)       \
   r_http_msg_has_header_of_value ((RHttpMsg *)res, key, ksize, val, vsize)
+/** @brief @ref r_http_msg_get_header on a response. */
 #define r_http_response_get_header(res, field, size) r_http_msg_get_header ((RHttpMsg *)res, field, size)
+/** @brief @ref r_http_msg_add_header on a response. */
 #define r_http_response_add_header(res, field, fsize, value, vsize) r_http_msg_add_header ((RHttpMsg *)res, field, fsize, value, vsize)
+/** @brief @ref r_http_msg_get_body on a response. */
 #define r_http_response_get_body(res, size) r_http_msg_get_body ((RHttpMsg *)res, size)
+/** @brief @ref r_http_msg_get_body_buffer on a response. */
 #define r_http_response_get_body_buffer(res) r_http_msg_get_body_buffer ((RHttpMsg *)res)
+/** @brief @ref r_http_msg_set_body_buffer on a response. */
 #define r_http_response_set_body_buffer(res, buf) r_http_msg_set_body_buffer ((RHttpMsg *)res, buf)
+/**
+ * @brief Set the response body and its @c Content-Type in one call.
+ * @param res         Target response.
+ * @param buf         Body bytes.
+ * @param contenttype @c Content-Type value to set.
+ * @param size        Length of @p contenttype, or @c -1 for @c strlen.
+ * @param contentlen  @c TRUE to emit a @c Content-Length header.
+ */
 R_API RHttpError r_http_response_set_body_buffer_full (RHttpResponse * res,
     RBuffer * buf, const rchar * contenttype, rssize size, rboolean contentlen);
+/** @brief How the response body length is determined (chunked / sized / ...). */
 R_API RHttpBodyParseType r_http_response_get_body_parse_type (RHttpResponse * res);
+/** @brief Compute the response body size; @p type receives the parse type. */
 R_API rssize r_http_response_calc_body_size (RHttpResponse * res, RHttpBodyParseType * type);
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_NET_PROTO_HTTP_H__ */
 

--- a/include/rlib/net/proto/rrtp.h
+++ b/include/rlib/net/proto/rrtp.h
@@ -22,24 +22,46 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @file rlib/net/proto/rrtp.h
+ * @brief RTP / RTCP (RFC 3550) packet validation, header access and parsing.
+ */
+
 #include <rlib/rtypes.h>
 
 #include <rlib/rbuffer.h>
 #include <rlib/rref.h>
 
+/**
+ * @defgroup r_rtp RTP
+ * @ingroup r_net
+ *
+ * @brief Read and write RTP packets (RFC 3550) over an @ref RBuffer.
+ *
+ * An @ref RRTPBuffer maps an @ref RBuffer into its header, optional
+ * extension and payload regions with @ref r_rtp_buffer_map; the
+ * @c r_rtp_buffer_get_* / @c r_rtp_buffer_set_* accessors then read and
+ * write header fields in place. New packets are allocated with the
+ * @c r_buffer_new_rtp_buffer_* constructors.
+ *
+ * @{
+ */
+
 R_BEGIN_DECLS
 
-#define R_RTP_VERSION                 0x02
-#define R_RTP_HDR_SIZE                12
-#define R_RTP_SEQ_MEDIAN              0x8000
+#define R_RTP_VERSION                 0x02    /**< @brief RTP protocol version (RFC 3550). */
+#define R_RTP_HDR_SIZE                12      /**< @brief Size of the fixed RTP header in bytes. */
+#define R_RTP_SEQ_MEDIAN              0x8000  /**< @brief Sequence-number midpoint, used for wrap detection. */
 
-#define R_RTP_PT_FMT                  RUINT8_FMT
-#define R_RTP_SSRC_FMT                ".8"RINT32_MODIFIER"x"
-#define R_RTP_SEQ_FMT                 ".4"RINT16_MODIFIER"x"
-#define R_RTP_SEQIDX_FMT              ".12"RINT64_MODIFIER"x"
+#define R_RTP_PT_FMT                  RUINT8_FMT              /**< @brief printf format for an RTP payload type. */
+#define R_RTP_SSRC_FMT                ".8"RINT32_MODIFIER"x"  /**< @brief printf format for an SSRC (8 hex digits). */
+#define R_RTP_SEQ_FMT                 ".4"RINT16_MODIFIER"x"  /**< @brief printf format for a sequence number (4 hex digits). */
+#define R_RTP_SEQIDX_FMT              ".12"RINT64_MODIFIER"x" /**< @brief printf format for an extended sequence index (12 hex digits). */
 
 
+/** @brief @c TRUE if @p buf (@p size bytes) looks like a valid RTP header. */
 R_API rboolean r_rtp_is_valid_hdr (rconstpointer buf, rsize size);
+/** @brief @c TRUE if @p buf (@p size bytes) looks like a valid RTCP header. */
 R_API rboolean r_rtcp_is_valid_hdr (rconstpointer buf, rsize size);
 
 
@@ -47,6 +69,7 @@ R_API rboolean r_rtcp_is_valid_hdr (rconstpointer buf, rsize size);
 /* RTP                                                                        */
 /******************************************************************************/
 /* http://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml#rtp-parameters-1 */
+/** @brief RTP payload type (IANA-registered static values; @c 96..127 are dynamic). */
 typedef enum {
   R_RTP_PT_PCMU             =   0, /*  8000 (mono)    [RFC3551] */
   R_RTP_PT_GSM              =   3, /*  8000 (mono)    [RFC3551] */
@@ -77,60 +100,102 @@ typedef enum {
   R_RTP_PT_DYNAMIC_LAST     = 127, /*                 [RFC3551] */
 } RRTPPayloadType;
 
+/** @brief @c TRUE if payload type @p pt is in the dynamic range (@c 96..127). */
 #define R_RTP_PT_IS_DYNAMIC(pt)  ((pt) >= R_RTP_PT_DYNAMIC_FIRST && (pt) <= R_RTP_PT_DYNAMIC_LAST)
 
+/** @brief An RTP packet mapped from an @ref RBuffer into its sub-regions. */
 typedef struct {
-  RBuffer * buffer;
+  RBuffer * buffer;   /**< @brief The mapped backing buffer. */
 
-  RMemMapInfo hdr;
-  RMemMapInfo ext;
-  RMemMapInfo pay;
+  RMemMapInfo hdr;    /**< @brief Mapping of the fixed header (and CSRC list). */
+  RMemMapInfo ext;    /**< @brief Mapping of the header extension, if present. */
+  RMemMapInfo pay;    /**< @brief Mapping of the payload. */
 } RRTPBuffer;
+/** @brief Static initialiser for an empty @ref RRTPBuffer. */
 #define R_RTP_BUFFER_INIT   { NULL, R_MEM_MAP_INFO_INIT, R_MEM_MAP_INFO_INIT, R_MEM_MAP_INFO_INIT }
 
+/** @brief Flags controlling how an @ref RRTPBuffer is mapped. */
 typedef enum {
-  R_RTP_BUFFER_MAP_FLAG_SKIP_PADDING  = (R_MEM_MAP_FLAG_LAST << 0),
-  R_RTP_BUFFER_MAP_FLAG_LAST          = (R_MEM_MAP_FLAG_LAST << 8)
+  R_RTP_BUFFER_MAP_FLAG_SKIP_PADDING  = (R_MEM_MAP_FLAG_LAST << 0), /**< Exclude trailing padding from the payload mapping. */
+  R_RTP_BUFFER_MAP_FLAG_LAST          = (R_MEM_MAP_FLAG_LAST << 8)  /**< First flag bit free for derived use. */
 } RRTPBufferMapFlags;
 
 
+/** @brief Allocate a new RTP buffer wrapping @p payload, with @p pad bytes padding and @p cc CSRC entries. */
 R_API RBuffer * r_buffer_new_rtp_buffer (RBuffer * payload, ruint8 pad, ruint8 cc);
+/** @brief Allocate a new RTP buffer taking ownership of @p payload (@p size bytes), with @p pad padding and @p cc CSRC entries. */
 R_API RBuffer * r_buffer_new_rtp_buffer_take (rpointer payload, rsize size, ruint8 pad, ruint8 cc);
+/** @brief Allocate a new RTP buffer with a @p payload-byte payload, @p pad padding and @p cc CSRC entries. */
 R_API RBuffer * r_buffer_new_rtp_buffer_alloc (rsize payload, ruint8 pad, ruint8 cc);
 
+/** @brief Map @p buf into @p rtp for header/payload access. */
 R_API rboolean r_rtp_buffer_map (RRTPBuffer * rtp, RBuffer * buf, RMemMapFlags flags);
+/** @brief Unmap @p buf, releasing the regions mapped into @p rtp. */
 R_API rboolean r_rtp_buffer_unmap (RRTPBuffer * rtp, RBuffer * buf);
 
 /* READ / getters */
+/** @brief @c TRUE if the padding bit is set. */
 R_API rboolean r_rtp_buffer_has_padding (const RRTPBuffer * rtp);
+/** @brief @c TRUE if the extension bit is set. */
 R_API rboolean r_rtp_buffer_has_extension (const RRTPBuffer * rtp);
+/** @brief @c TRUE if the marker bit is set. */
 R_API rboolean r_rtp_buffer_has_marker (const RRTPBuffer * rtp);
+/** @brief Return the synchronisation source (SSRC) identifier. */
 R_API ruint32 r_rtp_buffer_get_ssrc (const RRTPBuffer * rtp);
+/** @brief Return the payload type. */
 R_API RRTPPayloadType r_rtp_buffer_get_pt (const RRTPBuffer * rtp);
+/** @brief Return the sequence number. */
 R_API ruint16 r_rtp_buffer_get_seq (const RRTPBuffer * rtp);
+/** @brief Return the RTP timestamp. */
 R_API ruint32 r_rtp_buffer_get_timestamp (const RRTPBuffer * rtp);
+/** @brief Return the number of CSRC entries. */
 R_API ruint8 r_rtp_buffer_get_csrc_count (const RRTPBuffer * rtp);
+/** @brief Return the @p n-th contributing source (CSRC) identifier. */
 R_API ruint32 r_rtp_buffer_get_csrc (const RRTPBuffer * rtp, ruint8 n);
 
 /* WRITE / setters */
+/** @brief Set the marker bit. */
 R_API void r_rtp_buffer_set_marker (RRTPBuffer * rtp, rboolean marker);
+/** @brief Set the synchronisation source (SSRC) identifier. */
 R_API void r_rtp_buffer_set_ssrc (RRTPBuffer * rtp, ruint32 ssrc);
+/** @brief Set the payload type. */
 R_API void r_rtp_buffer_set_pt (RRTPBuffer * rtp, RRTPPayloadType pt);
+/** @brief Set the sequence number. */
 R_API void r_rtp_buffer_set_seq (RRTPBuffer * rtp, ruint16 seq);
+/** @brief Set the RTP timestamp. */
 R_API void r_rtp_buffer_set_timestamp (RRTPBuffer * rtp, ruint32 ts);
+/** @brief Set the @p n-th contributing source (CSRC) identifier. */
 R_API rboolean r_rtp_buffer_set_csrc (RRTPBuffer * rtp, ruint8 n, ruint32 csrc);
 /* TODO: padding */
 /* TODO: extension */
 
 
+/** @brief Extend a 16-bit sequence number @p seq to a 48-bit index, given the current index @p curidx. */
 R_API ruint64 r_rtp_estimate_seq_idx (ruint16 seq, ruint64 curidx);
+/** @brief Extend @p rtp's sequence number to a 48-bit index, given the current index @p curidx. */
 R_API ruint64 r_rtp_buffer_estimate_seq_idx (RRTPBuffer * rtp, ruint64 curidx);
+
+/** @} */
 
 
 /******************************************************************************/
 /* RTCP                                                                       */
 /******************************************************************************/
+/**
+ * @defgroup r_rtcp RTCP / SDES
+ * @ingroup r_net
+ *
+ * @brief Parse RTCP compound packets (RFC 3550) over an @ref RBuffer.
+ *
+ * An @ref RRTCPBuffer maps an @ref RBuffer with @ref r_rtcp_buffer_map and
+ * iterates its packets via @ref r_rtcp_buffer_get_next_packet. Per
+ * packet type, accessors decode Sender/Receiver Reports, Source
+ * Description (SDES) chunks and items, BYE and APP packets.
+ *
+ * @{
+ */
 /* http://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml#rtp-parameters-4 */
+/** @brief RTCP packet type (IANA-registered values). */
 typedef enum {
   /* Reserved 192 (Historic-FIR)  [RFC2032] */
   /* Reserved 193 (Historic-NACK) [RFC2032] */
@@ -152,6 +217,7 @@ typedef enum {
   R_RTCP_PT_SNM             = 213, /* Splicing Notification Message [RFC-ietf-ietf-avtext-splicing-notification-09] */
 } RRTCPPacketType;
 
+/** @brief RTCP SDES item type (RFC 3550). */
 typedef enum {
   R_RTCP_SDES_ZERO     = 0x00,
   R_RTCP_SDES_CNAME    = 0x01,
@@ -166,104 +232,150 @@ typedef enum {
   R_RTCP_SDES_UNKNOWN  = 0xff
 } RRTCPSDESType;
 
+/** @brief Result of parsing an RTCP packet or field. */
 typedef enum {
-  R_RTCP_PARSE_ZERO = -1,
-  R_RTCP_PARSE_OK   =  0,
-  R_RTCP_PARSE_INVAL,
-  R_RTCP_PARSE_WRONG_PT,
-  R_RTCP_PARSE_OVERFLOW,
-  R_RTCP_PARSE_UNEXPECTED,
-  R_RTCP_PARSE_BUF_TOO_SMALL,
+  R_RTCP_PARSE_ZERO = -1,         /**< Sentinel / uninitialised. */
+  R_RTCP_PARSE_OK   =  0,         /**< Parsed successfully. */
+  R_RTCP_PARSE_INVAL,             /**< Invalid argument or malformed data. */
+  R_RTCP_PARSE_WRONG_PT,          /**< Packet is not of the expected type. */
+  R_RTCP_PARSE_OVERFLOW,          /**< Field extends past the packet. */
+  R_RTCP_PARSE_UNEXPECTED,        /**< Unexpected structure encountered. */
+  R_RTCP_PARSE_BUF_TOO_SMALL,     /**< Caller buffer too small for the result. */
 } RRTCPParseResult;
 
 
+/** @brief An RTCP compound packet mapped from an @ref RBuffer. */
 typedef struct {
-  RBuffer * buffer;
-  RMemMapInfo info;
+  RBuffer * buffer;   /**< @brief The mapped backing buffer. */
+  RMemMapInfo info;   /**< @brief Mapping covering the compound packet. */
 } RRTCPBuffer;
+/** @brief Static initialiser for an empty @ref RRTCPBuffer. */
 #define R_RTCP_BUFFER_INIT   { NULL, R_MEM_MAP_INFO_INIT }
 
+/** @brief Opaque cursor over a single packet within an @ref RRTCPBuffer. */
 typedef struct RRTCPPacket RRTCPPacket;
+/** @brief Opaque cursor over a single SDES chunk within an SDES packet. */
 typedef struct RRTCPSDESChunk RRTCPSDESChunk;
 
+/** @brief Decoded Sender Report (SR) sender info block. */
 typedef struct {
-  ruint32 ssrc;
-  ruint32 rtptime;
-  ruint64 ntptime;
-  ruint32 packets;
-  ruint32 bytes;
+  ruint32 ssrc;       /**< @brief Sender's synchronisation source identifier. */
+  ruint32 rtptime;    /**< @brief RTP timestamp corresponding to @c ntptime. */
+  ruint64 ntptime;    /**< @brief NTP wall-clock timestamp. */
+  ruint32 packets;    /**< @brief Sender's cumulative packet count. */
+  ruint32 bytes;      /**< @brief Sender's cumulative octet count. */
 } RRTCPSenderInfo;
 
+/** @brief Decoded reception report block (from an SR or RR). */
 typedef struct {
-  ruint32 ssrc;
-  ruint8 fractionlost;
-  rint32 packetslost;
-  ruint32 exthighestseq;
-  ruint32 jitter;
-  ruint32 lsr;
-  ruint32 dlsr;
+  ruint32 ssrc;           /**< @brief Source this block reports on. */
+  ruint8 fractionlost;    /**< @brief Fraction of packets lost since the last report. */
+  rint32 packetslost;     /**< @brief Cumulative number of packets lost. */
+  ruint32 exthighestseq;  /**< @brief Extended highest sequence number received. */
+  ruint32 jitter;         /**< @brief Interarrival jitter estimate. */
+  ruint32 lsr;            /**< @brief Last SR timestamp (middle 32 bits of NTP). */
+  ruint32 dlsr;           /**< @brief Delay since the last SR. */
 } RRTCPReportBlock;
 
+/** @brief A single decoded SDES item, pointing into the packet buffer. */
 typedef struct {
-  RRTCPSDESType type;
-  ruint8 len;
-  ruint8 * data;
+  RRTCPSDESType type;     /**< @brief Item type (@ref RRTCPSDESType). */
+  ruint8 len;             /**< @brief Length of @c data in bytes. */
+  ruint8 * data;          /**< @brief Pointer to the item value. */
 } RRTCPSDESItem;
+/** @brief Static initialiser for an empty @ref RRTCPSDESItem. */
 #define R_RTCP_SDES_ITEM_INIT     { R_RTCP_SDES_UNKNOWN, 0, NULL }
 
 /* TODO: Add construction/writing of RTCP buffers and packets */
 
+/** @brief Map @p buf into @p rtcp for packet iteration. */
 R_API rboolean r_rtcp_buffer_map (RRTCPBuffer * rtcp, RBuffer * buf, RMemMapFlags flags);
+/** @brief Unmap @p buf, releasing the region mapped into @p rtcp. */
 R_API rboolean r_rtcp_buffer_unmap (RRTCPBuffer * rtcp, RBuffer * buf);
 
+/** @brief Number of packets in the RTCP compound buffer @p rtcp. */
 R_API ruint r_rtcp_buffer_get_packet_count (const RRTCPBuffer * rtcp);
+/** @brief Return the first packet in @p rtcp (or @c NULL if empty). */
 #define r_rtcp_buffer_get_first_packet(rtcp) r_rtcp_buffer_get_next_packet (rtcp, NULL)
+/** @brief Return the packet after @p packet (pass @c NULL for the first). */
 R_API RRTCPPacket * r_rtcp_buffer_get_next_packet (RRTCPBuffer * rtcp, const RRTCPPacket * packet);
 
 /* Packet header */
+/** @brief @c TRUE if @p packet has the padding bit set. */
 R_API rboolean r_rtcp_packet_has_padding (const RRTCPPacket * packet);
+/** @brief Return the type-specific count/subtype field of @p packet. */
 R_API ruint8 r_rtcp_packet_get_count (const RRTCPPacket * packet);
+/** @brief Return the RTCP packet type of @p packet. */
 R_API RRTCPPacketType r_rtcp_packet_get_type (const RRTCPPacket * packet);
+/** @brief Return the length of @p packet in bytes. */
 R_API ruint r_rtcp_packet_get_length (const RRTCPPacket * packet);
+/** @brief Return the SSRC of @p packet. */
 R_API ruint32 r_rtcp_packet_get_ssrc (const RRTCPPacket * packet);
 
 /* Sender Report (SR) */
+/** @brief Decode the sender info of an SR @p packet into @p srinfo. */
 R_API rboolean r_rtcp_packet_sr_get_sender_info (const RRTCPPacket * packet,
     RRTCPSenderInfo * srinfo);
+/** @brief Number of report blocks in an SR packet. */
 #define r_rtcp_packet_sr_get_rb_count       r_rtcp_packet_get_count
+/** @brief Decode report block @p idx of an SR @p packet into @p rb. */
 R_API rboolean r_rtcp_packet_sr_get_report_block (const RRTCPPacket * packet,
     ruint8 idx, RRTCPReportBlock * rb);
 
 /* Receiver Report (RR) */
+/** @brief Return the reporter SSRC of an RR @p packet. */
 R_API ruint32 r_rtcp_packet_rr_get_ssrc (const RRTCPPacket * packet);
+/** @brief Number of report blocks in an RR packet. */
 #define r_rtcp_packet_rr_get_rb_count       r_rtcp_packet_get_count
+/** @brief Decode a report block of an RR packet. */
 #define r_rtcp_packet_rr_get_report_block   r_rtcp_packet_sr_get_report_block
 
 /* Source Description (SDES) */
+/** @brief Number of chunks in an SDES packet. */
 #define r_rtcp_packet_sdes_get_chunk_count  r_rtcp_packet_get_count
+/** @brief Return the first SDES chunk of @p packet (or @c NULL if none). */
 #define r_rtcp_packet_sdes_get_first_chunk(packet) r_rtcp_packet_sdes_get_next_chunk (packet, NULL)
+/** @brief Return the chunk after @p chunk (pass @c NULL for the first). */
 R_API RRTCPSDESChunk * r_rtcp_packet_sdes_get_next_chunk (RRTCPPacket * packet,
     RRTCPSDESChunk * chunk);
+/** @brief Return the SSRC/CSRC of an SDES @p chunk. */
 R_API ruint32 r_rtcp_packet_sdes_chunk_get_ssrc (const RRTCPPacket * packet,
     const RRTCPSDESChunk * chunk);
+/** @brief Decode the next SDES item of @p chunk into @p item. */
 R_API RRTCPParseResult r_rtcp_packet_sdes_chunk_get_next_item (const RRTCPPacket * packet,
     RRTCPSDESChunk * chunk, RRTCPSDESItem * item);
 
 /* BYE */
+/** @brief Number of SSRCs listed in a BYE packet. */
 #define r_rtcp_packet_bye_get_ssrc_count  r_rtcp_packet_get_count
+/** @brief Return SSRC @p idx of a BYE @p packet. */
 R_API ruint32 r_rtcp_packet_bye_get_ssrc (const RRTCPPacket * packet, ruint8 idx);
+/**
+ * @brief Copy the optional reason-for-leaving string from a BYE @p packet.
+ * @param packet The BYE packet.
+ * @param reason Caller buffer receiving the reason string.
+ * @param len Capacity of @p reason in bytes.
+ * @param out Receives the number of bytes written.
+ * @return Parse result.
+ */
 R_API RRTCPParseResult r_rtcp_packet_bye_get_reason (const RRTCPPacket * packet,
     rchar * reason, rsize len, ruint8 * out);
 
 /* APP */
+/** @brief Return the application-defined subtype of an APP packet. */
 #define r_rtcp_packet_app_get_subtype     r_rtcp_packet_get_count
+/** @brief Return the SSRC/CSRC of an APP @p packet. */
 R_API ruint32 r_rtcp_packet_app_get_ssrc (const RRTCPPacket * packet);
+/** @brief Return the 4-octet name of an APP @p packet. */
 R_API const rchar * r_rtcp_packet_app_get_name (const RRTCPPacket * packet);
+/** @brief Return the application-defined data of an APP @p packet; @p size receives its length. */
 R_API const ruint8 * r_rtcp_packet_app_get_data (const RRTCPPacket * packet, ruint16 * size);
 
 /* TODO: Feedback */
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_NET_PROTO_RTP_H__ */
 

--- a/include/rlib/net/proto/rsdp.h
+++ b/include/rlib/net/proto/rsdp.h
@@ -22,6 +22,12 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @file rlib/net/proto/rsdp.h
+ * @brief Session Description Protocol (RFC 4566) message building and
+ * zero-copy parsing.
+ */
+
 #include <rlib/rtypes.h>
 #include <rlib/rref.h>
 
@@ -33,20 +39,41 @@
 
 #include <rlib/net/proto/rrtp.h>
 
+/**
+ * @defgroup r_sdp SDP
+ * @ingroup r_net
+ *
+ * @brief Build and parse Session Description Protocol messages
+ * (RFC 4566), including WebRTC / JSEP and ICE / DTLS conventions.
+ *
+ * Two complementary sides share the @ref RSdpResult status codes. The
+ * builder grows a reference-counted @ref RSdpMsg (and its @ref RSdpMedia
+ * sections) with the @c r_sdp_msg_* / @c r_sdp_media_* setters, then
+ * serialises it with @ref r_sdp_msg_to_buffer. The parser maps an
+ * @c RBuffer of received SDP onto an @ref RSdpBuf with
+ * @ref r_sdp_buffer_map — every field stays in place as an @c RStrChunk
+ * pointing into the mapped buffer, read through the @c r_sdp_buf_*
+ * accessor macros, until released with @ref r_sdp_buffer_unmap.
+ *
+ * @{
+ */
+
 R_BEGIN_DECLS
 
+/** @brief Status code returned by the SDP build and parse API. */
 typedef enum {
-  R_SDP_EOB = -1,
-  R_SDP_OK = 0,
-  R_SDP_INVAL,
-  R_SDP_OOM,
-  R_SDP_MAP_FAILED,
-  R_SDP_MISSING_REQUIRED_LINE,
-  R_SDP_BAD_DATA,
-  R_SDP_NOT_FOUND,
-  R_SDP_MORE_DATA,
+  R_SDP_EOB = -1,                   /**< End of buffer reached during iteration. */
+  R_SDP_OK = 0,                     /**< Success. */
+  R_SDP_INVAL,                      /**< Invalid argument. */
+  R_SDP_OOM,                        /**< Out of memory. */
+  R_SDP_MAP_FAILED,                 /**< Failed to map the source buffer. */
+  R_SDP_MISSING_REQUIRED_LINE,      /**< A required SDP line is absent. */
+  R_SDP_BAD_DATA,                   /**< Malformed SDP content. */
+  R_SDP_NOT_FOUND,                  /**< Requested field or attribute not found. */
+  R_SDP_MORE_DATA,                  /**< More data is needed to complete parsing. */
 } RSdpResult;
 
+/** @brief Media direction ("a=sendrecv" etc.); send / recv bits combine. */
 typedef enum {
   R_SDP_MD_INACTIVE         = 0,
   R_SDP_MD_SENDONLY         = 1,
@@ -54,6 +81,7 @@ typedef enum {
   R_SDP_MD_SENDRECV         = R_SDP_MD_SENDONLY | R_SDP_MD_RECVONLY,
 } RSdpMediaDirection;
 
+/** @brief DTLS connection role ("a=setup"); active / passive bits combine. */
 typedef enum {
   R_SDP_CONN_ROLE_HOLDCONN  = 0,
   R_SDP_CONN_ROLE_ACTIVE    = 1,
@@ -61,118 +89,173 @@ typedef enum {
   R_SDP_CONN_ROLE_ACTPASS   = R_SDP_CONN_ROLE_ACTIVE | R_SDP_CONN_ROLE_PASSIVE,
 } RSdpConnRole;
 
+/** @brief ICE candidate type ("a=candidate ... typ"). */
 typedef enum {
-  R_SDP_ICE_TYPE_HOST         = 0,
-  R_SDP_ICE_TYPE_SRFLX        = 1,
-  R_SDP_ICE_TYPE_PRFLX        = 2,
-  R_SDP_ICE_TYPE_RELAY        = 3,
+  R_SDP_ICE_TYPE_HOST         = 0,  /**< Host candidate. */
+  R_SDP_ICE_TYPE_SRFLX        = 1,  /**< Server-reflexive candidate. */
+  R_SDP_ICE_TYPE_PRFLX        = 2,  /**< Peer-reflexive candidate. */
+  R_SDP_ICE_TYPE_RELAY        = 3,  /**< Relayed (TURN) candidate. */
 } RSdpICEType;
 
-/* Bandwidth ("b=") modifier per RFC 4566 §5.8 and successors.  Values
- * defined in kbps: CT (RFC 4566), AS (RFC 4566), X-prefixed extensions.
- * Values defined in bps: TIAS (RFC 3890), RR / RS (RFC 3556). */
+/**
+ * @brief Bandwidth ("b=") modifier per RFC 4566 §5.8 and successors.
+ *
+ * Values defined in kbps: CT (RFC 4566), AS (RFC 4566), X-prefixed
+ * extensions. Values defined in bps: TIAS (RFC 3890), RR / RS
+ * (RFC 3556).
+ */
 typedef enum {
   R_SDP_BW_MODIFIER_UNKNOWN     = 0,
-  R_SDP_BW_MODIFIER_CT          = 1,  /* Conference total, kbps */
-  R_SDP_BW_MODIFIER_AS          = 2,  /* Application specific, kbps */
-  R_SDP_BW_MODIFIER_TIAS        = 3,  /* Transport-independent app spec, bps */
-  R_SDP_BW_MODIFIER_RR          = 4,  /* RTCP receiver bandwidth, bps */
-  R_SDP_BW_MODIFIER_RS          = 5,  /* RTCP sender bandwidth, bps */
-  R_SDP_BW_MODIFIER_X_PREFIXED  = 6,  /* "X-..." vendor extension, kbps */
+  R_SDP_BW_MODIFIER_CT          = 1,  /**< Conference total, kbps. */
+  R_SDP_BW_MODIFIER_AS          = 2,  /**< Application specific, kbps. */
+  R_SDP_BW_MODIFIER_TIAS        = 3,  /**< Transport-independent app spec, bps. */
+  R_SDP_BW_MODIFIER_RR          = 4,  /**< RTCP receiver bandwidth, bps. */
+  R_SDP_BW_MODIFIER_RS          = 5,  /**< RTCP sender bandwidth, bps. */
+  R_SDP_BW_MODIFIER_X_PREFIXED  = 6,  /**< "X-..." vendor extension, kbps. */
 } RSdpBandwidthModifier;
 
 
+/** @brief Parsed (zero-copy) view of an SDP message; see @ref r_sdp_buffer_map. */
 typedef struct RSdpBuf RSdpBuf; /* Fwd decl because of RSdpMsg API */
 
 /* RSdpMsg API */
+/** @brief Reference-counted, mutable SDP message being built. */
 typedef struct RSdpMsg RSdpMsg;
+/** @brief Reference-counted media ("m=") section of an @ref RSdpMsg. */
 typedef struct RSdpMedia RSdpMedia;
 
+/** @brief Allocate an empty SDP message. */
 R_API RSdpMsg * r_sdp_msg_new (void) R_ATTR_MALLOC;
+/** @brief Allocate an SDP message pre-filled for WebRTC / JSEP with the given session id / version. */
 R_API RSdpMsg * r_sdp_msg_new_jsep (ruint64 sessid, ruint sessver) R_ATTR_MALLOC;
+/** @brief Allocate a mutable SDP message copied from a parsed @ref RSdpBuf. */
 R_API RSdpMsg * r_sdp_msg_new_from_sdp_buffer (const RSdpBuf * buf) R_ATTR_MALLOC;
+/** @brief Increase the reference count of @p msg. */
 #define r_sdp_msg_ref     r_ref_ref
+/** @brief Decrease the reference count of @p msg, freeing it at zero. */
 #define r_sdp_msg_unref   r_ref_unref
 
+/** @brief Serialise @p msg into a newly allocated @c RBuffer. */
 R_API RBuffer * r_sdp_msg_to_buffer (const RSdpMsg * msg);
 
+/** @brief Set the protocol version ("v="). */
 R_API RSdpResult r_sdp_msg_set_version (RSdpMsg * msg,
     const rchar * ver, rssize size);
+/** @brief Set the originator ("o=") line from its component fields. */
 R_API RSdpResult r_sdp_msg_set_originator (RSdpMsg * msg,
     const rchar * username, rssize usize,
     const rchar * sid, rssize sidsize, const rchar * sver, rssize sversize,
     const rchar * nettype, rssize nsize,
     const rchar * addrtype, rssize atsize, const rchar * addr, rssize asize);
+/** @brief Set the session name ("s="). */
 R_API RSdpResult r_sdp_msg_set_session_name (RSdpMsg * msg,
     const rchar * name, rssize size);
+/** @brief Set the session information ("i="). */
 R_API RSdpResult r_sdp_msg_set_session_info (RSdpMsg * msg,
     const rchar * info, rssize size);
+/** @brief Set the session URI ("u="). */
 R_API RSdpResult r_sdp_msg_set_uri (RSdpMsg * msg, RUri * uri);
+/** @brief Append an email contact ("e="). */
 R_API RSdpResult r_sdp_msg_add_email (RSdpMsg * msg,
     const rchar * email, rssize size);
+/** @brief Append a phone contact ("p="). */
 R_API RSdpResult r_sdp_msg_add_phone (RSdpMsg * msg,
     const rchar * phone, rssize size);
+/**
+ * @brief Clear the session-level connection ("c=").
+ * @param msg Target SDP message.
+ * @param def @c TRUE to reset to the default connection rather than removing it.
+ */
 R_API RSdpResult r_sdp_msg_clear_connection (RSdpMsg * msg, rboolean def);
+/** @brief Set a session-level unicast connection ("c=") for @p addr. */
 #define r_sdp_msg_set_connection_unicast(msg, addr)                           \
   r_sdp_msg_set_connection_full (msg, addr, 0, 1)
+/** @brief Set the session-level connection ("c=") from its component fields. */
 R_API RSdpResult r_sdp_msg_set_connection_full (RSdpMsg * msg,
     const rchar * nettype, rssize nsize,
     const rchar * addrtype, rssize atsize, const rchar * addr, rssize asize,
     ruint ttl, ruint addrcount);
+/** @brief Append a session-level bandwidth line ("b=") of @p kbps for modifier @p type. */
 R_API RSdpResult r_sdp_msg_add_bandwidth (RSdpMsg * msg,
     const rchar * type, rssize tsize, ruint kbps);
+/** @brief Append a timing line ("t=") spanning @p start to @p stop. */
 R_API RSdpResult r_sdp_msg_add_time (RSdpMsg * msg, ruint64 start, ruint64 stop);
+/** @brief Append a repeat line ("r=") to the timing entry at @p timeidx. */
 R_API RSdpResult r_sdp_msg_add_time_repeat (RSdpMsg * msg, rsize timeidx,
     const rchar * repeat, rssize size);
+/** @brief Append a time-zone adjustment ("z=") at @p time with @p offset seconds. */
 R_API RSdpResult r_sdp_msg_add_time_zone (RSdpMsg * msg, ruint64 time,
     rint64 offset);
+/** @brief Set the encryption key ("k=") method and data. */
 R_API RSdpResult r_sdp_msg_set_key (RSdpMsg * msg,
     const rchar * method, rssize msize, const rchar * data, rssize size);
+/** @brief Append a session-level attribute ("a=key:value"). */
 R_API RSdpResult r_sdp_msg_add_attribute (RSdpMsg * msg,
     const rchar * key, rssize ksize, const rchar * value, rssize vsize);
+/** @brief Append a media ("m=") section; takes a reference on @p media. */
 R_API RSdpResult r_sdp_msg_add_media (RSdpMsg * msg, RSdpMedia * media);
 
 
+/** @brief Allocate an empty media section. */
 R_API RSdpMedia * r_sdp_media_new (void) R_ATTR_MALLOC;
+/** @brief Allocate a media section pre-filled for WebRTC / JSEP over DTLS with the given mid and direction. */
 R_API RSdpMedia * r_sdp_media_new_jsep_dtls (
     const rchar * type, rssize tsize, const rchar * mid, rssize msize,
     RSdpMediaDirection md) R_ATTR_MALLOC;
+/** @brief Allocate a media section from its "m=" component fields. */
 R_API RSdpMedia * r_sdp_media_new_full (const rchar * type, rssize tsize,
     ruint port, ruint portcount, const rchar * proto, rssize psize) R_ATTR_MALLOC;
+/** @brief Increase the reference count of @p media. */
 #define r_sdp_media_ref     r_ref_ref
+/** @brief Decrease the reference count of @p media, freeing it at zero. */
 #define r_sdp_media_unref   r_ref_unref
 
+/** @brief Add an RTP format ("a=rtpmap") with payload type, encoding, clock rate and params. */
 R_API RSdpResult r_sdp_media_add_rtp_fmt (RSdpMedia * media,
     RRTPPayloadType pt, const rchar * enc, rssize esize,
     ruint rate, ruint params);
+/** @brief Add a static RTP payload type @p pt without an "a=rtpmap" line. */
 #define r_sdp_media_add_rtp_fmt_static(m, pt) r_sdp_media_add_rtp_fmt (m, pt, NULL, 0, 0, 0)
+/** @brief Add a media-level unicast connection ("c=") for @p addr. */
 #define r_sdp_media_add_connection_unicast(media, addr)                         \
   r_sdp_media_add_connection_addr (media, addr, 0, 1)
+/** @brief Add a media-level connection ("c=") from a socket address. */
 R_API RSdpResult r_sdp_media_add_connection_addr (RSdpMedia * media,
     RSocketAddress * addr, ruint ttl, ruint addrcount);
+/** @brief Add a media-level connection ("c=") from its component fields. */
 R_API RSdpResult r_sdp_media_add_connection_full (RSdpMedia * media,
     const rchar * nettype, rssize nsize,
     const rchar * addrtype, rssize atsize, const rchar * addr, rssize asize,
     ruint ttl, ruint addrcount);
+/** @brief Set the media information ("i="). */
 R_API RSdpResult r_sdp_media_set_media_info (RSdpMedia * media,
     const rchar * info, rssize size);
+/** @brief Add a media-level bandwidth line ("b=") of @p kbps for modifier @p type. */
 R_API RSdpResult r_sdp_media_add_bandwidth (RSdpMedia * media,
     const rchar * type, rssize tsize, ruint kbps);
+/** @brief Set the media-level encryption key ("k=") method and data. */
 R_API RSdpResult r_sdp_media_set_key (RSdpMedia * media,
     const rchar * method, rssize msize, const rchar * data, rssize size);
+/** @brief Append a media-level attribute ("a=key:value"). */
 R_API RSdpResult r_sdp_media_add_attribute (RSdpMedia * media,
     const rchar * key, rssize ksize, const rchar * value, rssize vsize);
 
+/** @brief Append an attribute scoped to a single payload type @p pt. */
 R_API RSdpResult r_sdp_media_add_pt_specific_attribute (RSdpMedia * media,
     RRTPPayloadType pt, const rchar * key, rssize ksize, const rchar * value, rssize vsize);
+/** @brief Append a source-specific attribute ("a=ssrc:") for @p ssrc. */
 R_API RSdpResult r_sdp_media_add_source_specific_attribute (RSdpMedia * media,
     ruint32 ssrc, const rchar * key, rssize ksize, const rchar * value, rssize vsize);
+/** @brief Add an "a=ssrc:<ssrc> cname:<cname>" attribute. */
 #define r_sdp_media_add_ssrc_cname(m, ssrc, cname, csize) \
   r_sdp_media_add_source_specific_attribute (m, ssrc, "cname", 5, cname, csize)
+/** @brief Add a JSEP "a=ssrc:<ssrc> msid:" attribute with value and app data. */
 R_API RSdpResult r_sdp_media_add_jsep_msid (RSdpMedia * media, ruint32 ssrc,
     const rchar * msidval, rssize vsize, const rchar * msidappdata, rssize asize);
+/** @brief Add ICE credentials ("a=ice-ufrag" / "a=ice-pwd"). */
 R_API RSdpResult r_sdp_media_add_ice_credentials (RSdpMedia * media,
     const rchar * ufrag, rssize usize, const rchar * pwd, rssize psize);
+/** @brief Add an ICE candidate ("a=candidate") from raw string fields. */
 R_API RSdpResult r_sdp_media_add_ice_candidate_raw (RSdpMedia * media,
     const rchar * foundation, rssize fsize, ruint componentid,
     const rchar * transport, rssize transize, ruint64 pri,
@@ -180,298 +263,502 @@ R_API RSdpResult r_sdp_media_add_ice_candidate_raw (RSdpMedia * media,
     const rchar * type, rssize typesize,
     const rchar * raddr, rssize rasize, ruint16 rport,
     const rchar * extension, rssize esize);
+/** @brief Add an ICE candidate ("a=candidate") from socket addresses and an @ref RSdpICEType. */
 R_API RSdpResult r_sdp_media_add_ice_candidate (RSdpMedia * media,
     const rchar * foundation, rssize fsize, ruint componentid,
     const rchar * transport, rssize tsize, ruint64 pri,
     const RSocketAddress * addr, RSdpICEType type,
     const RSocketAddress * raddr, const rchar * extension, rssize esize);
+/** @brief Add the DTLS setup role ("a=setup") and fingerprint ("a=fingerprint"). */
 R_API RSdpResult r_sdp_media_add_dtls_setup (RSdpMedia * media,
     RSdpConnRole role, RMsgDigestType type, const rchar * fingerprint, rssize fsize);
 
+/** @brief Duplicate the value of media attribute @p key, or @c NULL if absent. */
 R_API rchar * r_sdp_media_get_attribute (const RSdpMedia * media,
     const rchar * key, rssize ksize) R_ATTR_MALLOC;
+/** @brief Duplicate the media identification tag ("a=mid"). */
 #define r_sdp_media_get_mid(m)  r_sdp_media_get_attribute (m, "mid", -1)
 
 
 /* Parsing API */
+/** @brief Parsed originator ("o=") line; fields point into the mapped buffer. */
 typedef struct {
-  RStrChunk username;
-  RStrChunk sess_id;
-  RStrChunk sess_version;
-  RStrChunk nettype;
-  RStrChunk addrtype;
-  RStrChunk addr;
+  RStrChunk username;       /**< @brief Originator user name. */
+  RStrChunk sess_id;        /**< @brief Session identifier. */
+  RStrChunk sess_version;   /**< @brief Session version. */
+  RStrChunk nettype;        /**< @brief Network type (e.g. "IN"). */
+  RStrChunk addrtype;       /**< @brief Address type (e.g. "IP4" / "IP6"). */
+  RStrChunk addr;           /**< @brief Unicast address. */
 } RSdpOriginatorBuf;
+/** @brief Duplicate the originator user name as a string. */
 #define r_sdp_originator_buf_username(orig)         r_str_chunk_dup (&(orig)->username)
+/** @brief Duplicate the session id as a string. */
 #define r_sdp_originator_buf_session_id(orig)       r_str_chunk_dup (&(orig)->sess_id)
+/** @brief Parse the session id as a @c ruint64. */
 #define r_sdp_originator_buf_session_id_u64(orig)   r_str_to_uint64 ((orig)->sess_id.str, NULL, 10, NULL)
+/** @brief Duplicate the session version as a string. */
 #define r_sdp_originator_buf_session_version(orig)  r_str_chunk_dup (&(orig)->sess_version)
+/** @brief Parse the session version as a @c ruint64. */
 #define r_sdp_originator_buf_session_version_u64(orig) r_str_to_uint64 ((orig)->sess_version.str, NULL, 10, NULL)
+/** @brief Duplicate the network type as a string. */
 #define r_sdp_originator_buf_nettype(orig)          r_str_chunk_dup (&(orig)->nettype)
+/** @brief Duplicate the address type as a string. */
 #define r_sdp_originator_buf_addrtype(orig)         r_str_chunk_dup (&(orig)->addrtype)
+/** @brief Duplicate the originator address as a string. */
 #define r_sdp_originator_buf_addr(orig)             r_str_chunk_dup (&(orig)->addr)
 
+/** @brief Parsed connection ("c=") line; fields point into the mapped buffer. */
 typedef struct {
-  RStrChunk nettype;
-  RStrChunk addrtype;
-  RStrChunk addr;
-  ruint ttl;
-  ruint addrcount;
+  RStrChunk nettype;        /**< @brief Network type (e.g. "IN"). */
+  RStrChunk addrtype;       /**< @brief Address type (e.g. "IP4" / "IP6"). */
+  RStrChunk addr;           /**< @brief Connection address. */
+  ruint ttl;                /**< @brief Multicast time-to-live, or 0. */
+  ruint addrcount;          /**< @brief Number of contiguous addresses. */
 } RSdpConnectionBuf;
+/** @brief Duplicate the network type as a string. */
 #define r_sdp_connection_buf_nettype(conn)          r_str_chunk_dup (&(conn)->nettype)
+/** @brief Duplicate the address type as a string. */
 #define r_sdp_connection_buf_addrtype(conn)         r_str_chunk_dup (&(conn)->addrtype)
+/** @brief Duplicate the connection address as a string. */
 #define r_sdp_connection_buf_addr(conn)             r_str_chunk_dup (&(conn)->addr)
+/** @brief Multicast time-to-live of the connection. */
 #define r_sdp_connection_buf_ttl(conn)              (conn)->ttl
+/** @brief Number of contiguous addresses in the connection. */
 #define r_sdp_connection_buf_addrcount(conn)        (conn)->addrcount
+/** @brief Build an @c RSocketAddress from a parsed connection and @p port. */
 R_API RSocketAddress * r_sdp_connection_buf_to_socket_address (const RSdpConnectionBuf * conn, ruint port);
 
+/** @brief Parsed timing ("t=") line with its repeat ("r=") entries. */
 typedef struct {
-  RStrChunk start;
-  RStrChunk stop;
-  rsize rcount;
-  RStrChunk * repeat;
+  RStrChunk start;          /**< @brief Session start time. */
+  RStrChunk stop;           /**< @brief Session stop time. */
+  rsize rcount;             /**< @brief Number of repeat entries. */
+  RStrChunk * repeat;       /**< @brief Array of @c rcount repeat strings. */
 } RSdpTimeBuf;
+/** @brief Duplicate the start time as a string. */
 #define r_sdp_time_buf_start(time)                  r_str_chunk_dup (&(time)->start)
+/** @brief Duplicate the stop time as a string. */
 #define r_sdp_time_buf_stop(time)                   r_str_chunk_dup (&(time)->stop)
+/** @brief Number of repeat entries. */
 #define r_sdp_time_buf_repeat_count(time)           (time)->rcount
+/** @brief Duplicate repeat entry @p idx as a string. */
 #define r_sdp_time_buf_repeat(time, idx)            r_str_chunk_dup (&(time)->repeat[idx])
 
-/* Recognise the bandwidth modifier name in an SDP "b=<modifier>:<value>"
- * line and return the matching RSdpBandwidthModifier enum value.  Names
- * are case-insensitive per RFC 4566 §5.8.  Anything beginning with
- * "X-" / "x-" is classified as R_SDP_BW_MODIFIER_X_PREFIXED; anything
- * else unknown becomes R_SDP_BW_MODIFIER_UNKNOWN. */
+/**
+ * @brief Classify the modifier name of an SDP "b=<modifier>:<value>" line.
+ *
+ * Matches case-insensitively per RFC 4566 §5.8 and returns the matching
+ * @ref RSdpBandwidthModifier. Anything beginning with "X-" / "x-" is
+ * classified as @ref R_SDP_BW_MODIFIER_X_PREFIXED; anything else unknown
+ * becomes @c R_SDP_BW_MODIFIER_UNKNOWN.
+ */
 R_API RSdpBandwidthModifier r_sdp_bandwidth_modifier_from_str (
     const rchar * type, rssize tsize);
 
-/* Convert the raw decimal integer attached to a "b=" line into bits per
- * second, using the modifier's declared unit semantics: CT, AS and X-*
- * are kbps and multiplied by 1000; TIAS, RR and RS are bps and returned
- * as-is; UNKNOWN returns 0 because the unit is not interpretable. */
+/**
+ * @brief Convert a raw "b=" value into bits per second by modifier unit.
+ *
+ * CT, AS and X-* are kbps and multiplied by 1000; TIAS, RR and RS are bps
+ * and returned as-is; @c R_SDP_BW_MODIFIER_UNKNOWN returns 0 because the
+ * unit is not interpretable.
+ */
 R_API ruint64 r_sdp_bandwidth_to_bps (RSdpBandwidthModifier modifier,
     ruint value);
 
+/** @brief @ref R_SDP_OK if attribute @p field is present in @p attrib. */
 R_API RSdpResult r_sdp_attrib_check (const RStrKV * attrib, rsize acount,
     const rchar * field, rssize fsize);
+/**
+ * @brief Find attribute @p field in @p attrib, searching from @p start.
+ * @param attrib Attribute array to search.
+ * @param acount Number of entries in @p attrib.
+ * @param field Attribute field name to find.
+ * @param fsize Size of @p field, or -1 if NUL-terminated.
+ * @param start In/out search cursor (attribute index); may be @c NULL.
+ * @return The matching value chunk, or @c NULL if not found.
+ */
 R_API const RStrChunk * r_sdp_attrib_find (const RStrKV * attrib, rsize acount,
     const rchar * field, rssize fsize, rsize * start);
+/**
+ * @brief Duplicate the value of attribute @p field, searching from @p start.
+ * @param attrib Attribute array to search.
+ * @param acount Number of entries in @p attrib.
+ * @param field Attribute field name to find.
+ * @param fsize Size of @p field, or -1 if NUL-terminated.
+ * @param start In/out search cursor (attribute index); may be @c NULL.
+ * @return Newly allocated value string, or @c NULL if not found.
+ */
 R_API rchar * r_sdp_attrib_dup_value (const RStrKV * attrib, rsize acount,
     const rchar * field, rssize fsize, rsize * start);
 
+/** @brief Parsed media ("m=") section; fields point into the mapped buffer. */
 typedef struct {
-  RStrChunk type;
-  ruint port;
-  ruint portcount;
-  RStrChunk proto;
-  rsize fmtcount;
-  RStrChunk * fmt;
-  RStrChunk info;
-  rsize ccount;
-  RSdpConnectionBuf * conn;
-  rsize bcount;
-  RStrKV * bw;
-  RStrKV key;
-  rsize acount;
-  RStrKV * attrib;
+  RStrChunk type;           /**< @brief Media type (e.g. "audio" / "video"). */
+  ruint port;               /**< @brief Transport port. */
+  ruint portcount;          /**< @brief Number of contiguous ports. */
+  RStrChunk proto;          /**< @brief Transport protocol (e.g. "UDP/TLS/RTP/SAVPF"). */
+  rsize fmtcount;           /**< @brief Number of media formats. */
+  RStrChunk * fmt;          /**< @brief Array of @c fmtcount format tokens. */
+  RStrChunk info;           /**< @brief Media information ("i="). */
+  rsize ccount;             /**< @brief Number of connection lines. */
+  RSdpConnectionBuf * conn; /**< @brief Array of @c ccount connections. */
+  rsize bcount;             /**< @brief Number of bandwidth lines. */
+  RStrKV * bw;              /**< @brief Array of @c bcount bandwidth key/value pairs. */
+  RStrKV key;               /**< @brief Encryption key ("k="). */
+  rsize acount;             /**< @brief Number of attributes. */
+  RStrKV * attrib;          /**< @brief Array of @c acount attribute key/value pairs. */
 } RSdpMediaBuf;
+/** @brief Duplicate the media type as a string. */
 #define r_sdp_media_buf_type(media)                 r_str_chunk_dup (&(media)->type)
+/** @brief Transport port of the media section. */
 #define r_sdp_media_buf_port(media)                 (media)->port
+/** @brief Number of contiguous ports. */
 #define r_sdp_media_buf_portcount(media)            (media)->portcount
+/** @brief Duplicate the transport protocol as a string. */
 #define r_sdp_media_buf_proto(media)                r_str_chunk_dup (&(media)->proto)
+/** @brief Number of media formats. */
 #define r_sdp_media_buf_fmt_count(media)            (media)->fmtcount
+/** @brief Duplicate media format @p idx as a string. */
 #define r_sdp_media_buf_fmt(media, idx)             r_str_chunk_dup (&(media)->fmt[idx])
+/** @brief Parse media format @p idx as an unsigned integer. */
 #define r_sdp_media_buf_fmt_uint(media, idx)        r_str_to_uint ((media)->fmt[idx].str, NULL, 0, NULL)
+/** @brief Index of media format @p fmt, or a negative value if absent. */
 R_API rssize r_sdp_media_buf_find_fmt (const RSdpMediaBuf * media, const rchar * fmt, rssize size);
+/** @brief Duplicate the media information as a string. */
 #define r_sdp_media_buf_info(media)                 r_str_chunk_dup (&(media)->info)
+/** @brief Number of connection lines. */
 #define r_sdp_media_buf_conn_count(media)           (media)->ccount
+/** @brief Duplicate the network type of connection @p idx. */
 #define r_sdp_media_buf_conn_nettype(media, idx)    r_sdp_connection_buf_nettype (&(media)->conn[idx])
+/** @brief Duplicate the address type of connection @p idx. */
 #define r_sdp_media_buf_conn_addrtype(media, idx)   r_sdp_connection_buf_addrtype (&(media)->conn[idx])
+/** @brief Duplicate the address of connection @p idx. */
 #define r_sdp_media_buf_conn_addr(media, idx)       r_sdp_connection_buf_addr (&(media)->conn[idx])
+/** @brief Multicast TTL of connection @p idx. */
 #define r_sdp_media_buf_conn_ttl(media, idx)        r_sdp_connection_buf_ttl (&(media)->conn[idx])
+/** @brief Address count of connection @p idx. */
 #define r_sdp_media_buf_conn_addrcount(media, idx)  r_sdp_connection_buf_addrcount (&(media)->conn[idx])
+/** @brief Build an @c RSocketAddress from connection @p idx using the media port. */
 #define r_sdp_media_buf_conn_to_socket_address(media, idx) r_sdp_connection_buf_to_socket_address (&(media)->conn[idx], (media)->port)
+/** @brief Number of bandwidth lines. */
 #define r_sdp_media_buf_bandwidth_count(media)      (media)->bcount
+/** @brief Duplicate the modifier name of bandwidth line @p idx. */
 #define r_sdp_media_buf_bandwidth_type(media, idx)  r_str_kv_dup_key (&(media)->bw[idx])
+/** @brief Classified @ref RSdpBandwidthModifier of bandwidth line @p idx. */
 #define r_sdp_media_buf_bandwidth_modifier(media, idx) \
   r_sdp_bandwidth_modifier_from_str ((media)->bw[idx].key.str, (rssize) (media)->bw[idx].key.size)
+/** @brief Raw integer value of bandwidth line @p idx. */
 #define r_sdp_media_buf_bandwidth_raw(media, idx)  r_str_to_uint ((media)->bw[idx].val.str, NULL, 10, NULL)
+/** @brief Bandwidth of line @p idx in bits per second. */
 #define r_sdp_media_buf_bandwidth_bps(media, idx) \
   r_sdp_bandwidth_to_bps (r_sdp_media_buf_bandwidth_modifier (media, idx), \
       r_sdp_media_buf_bandwidth_raw (media, idx))
+/** @brief Duplicate the media key method. */
 #define r_sdp_media_buf_key_method(media)           r_str_kv_dup_key (&(media)->key)
+/** @brief Duplicate the media key data. */
 #define r_sdp_media_buf_key_data(media)             r_str_kv_dup_value (&(media)->key)
+/** @brief Number of media attributes. */
 #define r_sdp_media_buf_attrib_count(media)         (media)->acount
+/** @brief @c TRUE if media attribute @p f is present. */
 #define r_sdp_media_buf_has_attrib(media, f, fsize) (r_sdp_attrib_check ((media)->attrib, (media)->acount, f, fsize) == R_SDP_OK)
+/** @brief Find media attribute @p f from cursor @p s; see @ref r_sdp_attrib_find. */
 #define r_sdp_media_buf_attrib_find(media, f, fsize, s) r_sdp_attrib_find ((media)->attrib, (media)->acount, f, fsize, s)
+/** @brief Duplicate the value of media attribute @p f from cursor @p s. */
 #define r_sdp_media_buf_attrib_dup_value(media, f, fsize, s) r_sdp_attrib_dup_value ((media)->attrib, (media)->acount, f, fsize, s)
+/**
+ * @brief Find a format-specific attribute @p field for format @p fmt.
+ * @param media Parsed media section.
+ * @param fmt Format token to match.
+ * @param fmtsize Size of @p fmt, or -1 if NUL-terminated.
+ * @param field Attribute field name to find.
+ * @param fsize Size of @p field, or -1 if NUL-terminated.
+ * @param attrib Out chunk receiving the matched attribute.
+ * @param start In/out search cursor; may be @c NULL.
+ */
 R_API RSdpResult r_sdp_media_buf_fmt_specific_attrib (const RSdpMediaBuf * media,
     const rchar * fmt, rssize fmtsize, const rchar * field, rssize fsize,
     RStrChunk * attrib, rsize * start);
+/**
+ * @brief Find a format-specific attribute @p field for format index @p fmtidx.
+ * @param media Parsed media section.
+ * @param fmtidx Format index to match.
+ * @param field Attribute field name to find.
+ * @param fsize Size of @p field, or -1 if NUL-terminated.
+ * @param attrib Out chunk receiving the matched attribute.
+ * @param start In/out search cursor; may be @c NULL.
+ */
 R_API RSdpResult r_sdp_media_buf_fmtidx_specific_attrib (const RSdpMediaBuf * media,
     rsize fmtidx, const rchar * field, rssize fsize, RStrChunk * attrib, rsize * start);
+/** @brief Find the "rtpmap" attribute for format @p fmt. */
 #define r_sdp_media_buf_rtpmap_for_fmt(media, fmt, fmtsize, attrib)           \
   r_sdp_media_buf_fmt_specific_attrib (media, fmt, fmtsize,                   \
       R_STR_WITH_SIZE_ARGS ("rtpmap"), attrib, NULL)
+/** @brief Find the "rtpmap" attribute for format index @p fmtidx. */
 #define r_sdp_media_buf_rtpmap_for_fmt_idx(media, fmtidx, attrib)             \
   r_sdp_media_buf_fmtidx_specific_attrib (media, fmtidx,                      \
       R_STR_WITH_SIZE_ARGS ("rtpmap"), attrib, NULL)
+/** @brief Find an "rtcp-fb" attribute for format @p fmt from cursor @p start. */
 #define r_sdp_media_buf_rtcpfb_for_fmt(media, fmt, fmtsize, attrib, start)    \
   r_sdp_media_buf_fmt_specific_attrib (media, fmt, fmtsize,                   \
       R_STR_WITH_SIZE_ARGS ("rtcp-fb"), attrib, start)
+/** @brief Find an "rtcp-fb" attribute for format index @p fmtidx from cursor @p start. */
 #define r_sdp_media_buf_rtcpfb_for_fmt_idx(media, fmtidx, attrib, start)      \
   r_sdp_media_buf_fmtidx_specific_attrib (media, fmtidx,                      \
       R_STR_WITH_SIZE_ARGS ("rtcp-fb"), attrib, start)
+/** @brief Find the "fmtp" attribute for format @p fmt. */
 #define r_sdp_media_buf_fmtp_for_fmt(media, fmt, fmtsize, attrib)             \
   r_sdp_media_buf_fmt_specific_attrib (media, fmt, fmtsize,                   \
       R_STR_WITH_SIZE_ARGS ("fmtp"), attrib, NULL)
+/** @brief Find the "fmtp" attribute for format index @p fmtidx. */
 #define r_sdp_media_buf_fmtp_for_fmt_idx(media, fmtidx, attrib)               \
   r_sdp_media_buf_fmtidx_specific_attrib (media, fmtidx,                      \
       R_STR_WITH_SIZE_ARGS ("fmtp"), attrib, NULL)
+/** @brief Allocate an array of the distinct SSRCs referenced by "a=ssrc" attributes. */
 R_API ruint32 * r_sdp_media_buf_source_specific_sources (
     const RSdpMediaBuf * media, rsize * size);
+/** @brief Allocate an array of all "a=ssrc" attributes for @p ssrc. */
 R_API RStrKV * r_sdp_media_buf_source_specific_all_media_attribs (
     const RSdpMediaBuf * media, ruint32 ssrc, rsize * size) R_ATTR_MALLOC;
+/** @brief Find a single "a=ssrc" attribute @p field for @p ssrc into @p attrib. */
 R_API RSdpResult r_sdp_media_buf_source_specific_media_attrib (const RSdpMediaBuf * media,
     ruint32 ssrc, const rchar * field, rssize fsize, RStrChunk * attrib);
+/** @brief Find an "a=ssrc-group" attribute by @p semantics from cursor @p start into @p attrib. */
 R_API RSdpResult r_sdp_media_buf_ssrc_group_attrib (const RSdpMediaBuf * media,
     const rchar * semantics, rssize size, RStrChunk * attrib, rsize * start);
+/**
+ * @brief Find an "a=extmap" attribute from cursor @p start.
+ * @param media Parsed media section.
+ * @param id Out receiving the extension id.
+ * @param attrib Out chunk receiving the matched attribute.
+ * @param start In/out search cursor; may be @c NULL.
+ */
 R_API RSdpResult r_sdp_media_buf_extmap_attrib (const RSdpMediaBuf * media,
     ruint16 * id, RStrChunk * attrib, rsize * start);
 
+/** @brief Parsed (zero-copy) view of an SDP message; populated by @ref r_sdp_buffer_map. */
 struct RSdpBuf {
-  RMemMapInfo info;
+  RMemMapInfo info;             /**< @brief Mapping holding the buffer the chunks point into. */
 
-  RStrChunk ver;
-  RSdpOriginatorBuf orig;
-  RStrChunk session_name;
-  RStrChunk session_info;
-  RStrChunk uri;
-  rsize ecount;
-  RStrChunk * email;
-  rsize pcount;
-  RStrChunk * phone;
-  RSdpConnectionBuf conn;
-  rsize bcount;
-  RStrKV * bw;
-  rsize tcount;
-  RSdpTimeBuf * time;
-  rsize zcount;
-  RStrKV * zone;
-  RStrKV key;
-  rsize acount;
-  RStrKV * attrib;
+  RStrChunk ver;                /**< @brief Protocol version ("v="). */
+  RSdpOriginatorBuf orig;       /**< @brief Originator ("o="). */
+  RStrChunk session_name;       /**< @brief Session name ("s="). */
+  RStrChunk session_info;       /**< @brief Session information ("i="). */
+  RStrChunk uri;                /**< @brief Session URI ("u="). */
+  rsize ecount;                 /**< @brief Number of email lines. */
+  RStrChunk * email;            /**< @brief Array of @c ecount emails ("e="). */
+  rsize pcount;                 /**< @brief Number of phone lines. */
+  RStrChunk * phone;            /**< @brief Array of @c pcount phones ("p="). */
+  RSdpConnectionBuf conn;       /**< @brief Session-level connection ("c="). */
+  rsize bcount;                 /**< @brief Number of bandwidth lines. */
+  RStrKV * bw;                  /**< @brief Array of @c bcount bandwidth pairs ("b="). */
+  rsize tcount;                 /**< @brief Number of timing lines. */
+  RSdpTimeBuf * time;           /**< @brief Array of @c tcount timing entries ("t="). */
+  rsize zcount;                 /**< @brief Number of time-zone adjustments. */
+  RStrKV * zone;                /**< @brief Array of @c zcount time-zone pairs ("z="). */
+  RStrKV key;                   /**< @brief Encryption key ("k="). */
+  rsize acount;                 /**< @brief Number of session attributes. */
+  RStrKV * attrib;              /**< @brief Array of @c acount attribute pairs ("a="). */
 
-  rsize mcount;
-  RSdpMediaBuf * media;
+  rsize mcount;                 /**< @brief Number of media sections. */
+  RSdpMediaBuf * media;         /**< @brief Array of @c mcount media sections ("m="). */
 };
 
+/** @brief Parse @p buf into the zero-copy view @p sdp; release with @ref r_sdp_buffer_unmap. */
 R_API RSdpResult r_sdp_buffer_map (RSdpBuf * sdp, RBuffer * buf);
+/** @brief Release a view previously populated by @ref r_sdp_buffer_map. */
 R_API RSdpResult r_sdp_buffer_unmap (RSdpBuf * sdp, RBuffer * buf);
 
+/** @brief Duplicate the protocol version as a string. */
 #define r_sdp_buf_version(buf)                      r_str_chunk_dup (&(buf)->ver)
+/** @brief Duplicate the session name as a string. */
 #define r_sdp_buf_session_name(buf)                 r_str_chunk_dup (&(buf)->session_name)
+/** @brief Duplicate the session information as a string. */
 #define r_sdp_buf_session_info(buf)                 r_str_chunk_dup (&(buf)->session_info)
+/** @brief Duplicate the session URI as a string. */
 #define r_sdp_buf_uri_str(buf)                      r_str_chunk_dup (&(buf)->uri)
+/** @brief Parse the session URI into a new @c RUri. */
 #define r_sdp_buf_uri(buf)                          r_uri_new_escaped ((buf)->uri.str, (buf)->uri.size)
 
+/** @brief Duplicate the originator user name as a string. */
 #define r_sdp_buf_orig_username(buf)                r_sdp_originator_buf_username (&(buf)->orig)
+/** @brief Duplicate the originator session id as a string. */
 #define r_sdp_buf_orig_session_id(buf)              r_sdp_originator_buf_session_id (&(buf)->orig)
+/** @brief Parse the originator session id as a @c ruint64. */
 #define r_sdp_buf_orig_session_id_u64(buf)          r_sdp_originator_buf_session_id_u64 (&(buf)->orig)
+/** @brief Duplicate the originator session version as a string. */
 #define r_sdp_buf_orig_session_version(buf)         r_sdp_originator_buf_session_version (&(buf)->orig)
+/** @brief Parse the originator session version as a @c ruint64. */
 #define r_sdp_buf_orig_session_version_u64(buf)     r_sdp_originator_buf_session_version_u64 (&(buf)->orig)
+/** @brief Duplicate the originator network type as a string. */
 #define r_sdp_buf_orig_nettype(buf)                 r_sdp_originator_buf_nettype (&(buf)->orig)
+/** @brief Duplicate the originator address type as a string. */
 #define r_sdp_buf_orig_addrtype(buf)                r_sdp_originator_buf_addrtype (&(buf)->orig)
+/** @brief Duplicate the originator address as a string. */
 #define r_sdp_buf_orig_addr(buf)                    r_sdp_originator_buf_addr (&(buf)->orig)
 
+/** @brief Number of email lines. */
 #define r_sdp_buf_email_count(buf)                  (buf)->ecount
+/** @brief Number of phone lines. */
 #define r_sdp_buf_phone_count(buf)                  (buf)->pcount
+/** @brief Number of session-level bandwidth lines. */
 #define r_sdp_buf_bandwidth_count(buf)              (buf)->bcount
+/** @brief Number of timing lines. */
 #define r_sdp_buf_time_count(buf)                   (buf)->tcount
+/** @brief Number of time-zone adjustments. */
 #define r_sdp_buf_time_zone_count(buf)              (buf)->zcount
+/** @brief Number of session-level attributes. */
 #define r_sdp_buf_attrib_count(buf)                 (buf)->acount
+/** @brief Number of media sections. */
 #define r_sdp_buf_media_count(buf)                  (buf)->mcount
 
+/** @brief Duplicate email line @p idx as a string. */
 #define r_sdp_buf_email(buf, idx)                   r_str_chunk_dup (&(buf)->email[idx])
+/** @brief Duplicate phone line @p idx as a string. */
 #define r_sdp_buf_phone(buf, idx)                   r_str_chunk_dup (&(buf)->phone[idx])
 
+/** @brief Duplicate the session connection network type as a string. */
 #define r_sdp_buf_conn_nettype(buf)                 r_sdp_connection_buf_nettype (&(buf)->conn)
+/** @brief Duplicate the session connection address type as a string. */
 #define r_sdp_buf_conn_addrtype(buf)                r_sdp_connection_buf_addrtype (&(buf)->conn)
+/** @brief Duplicate the session connection address as a string. */
 #define r_sdp_buf_conn_addr(buf)                    r_sdp_connection_buf_addr (&(buf)->conn)
+/** @brief Multicast TTL of the session connection. */
 #define r_sdp_buf_conn_ttl(buf)                     r_sdp_connection_buf_ttl (&(buf)->conn)
+/** @brief Address count of the session connection. */
 #define r_sdp_buf_conn_addrcount(buf)               r_sdp_connection_buf_addrcount (&(buf)->conn)
+/** @brief Build an @c RSocketAddress from the session connection and @p port. */
 #define r_sdp_buf_conn_to_socket_address(buf, port) r_sdp_connection_buf_to_socket_address (&(buf)->conn, port)
 
+/** @brief Duplicate the modifier name of session bandwidth line @p idx. */
 #define r_sdp_buf_bandwidth_type(buf, idx)          r_str_kv_dup_key (&(buf)->bw[idx])
+/** @brief Classified @ref RSdpBandwidthModifier of session bandwidth line @p idx. */
 #define r_sdp_buf_bandwidth_modifier(buf, idx) \
   r_sdp_bandwidth_modifier_from_str ((buf)->bw[idx].key.str, (rssize) (buf)->bw[idx].key.size)
+/** @brief Raw integer value of session bandwidth line @p idx. */
 #define r_sdp_buf_bandwidth_raw(buf, idx)           r_str_to_uint ((buf)->bw[idx].val.str, NULL, 10, NULL)
+/** @brief Session bandwidth of line @p idx in bits per second. */
 #define r_sdp_buf_bandwidth_bps(buf, idx) \
   r_sdp_bandwidth_to_bps (r_sdp_buf_bandwidth_modifier (buf, idx), \
       r_sdp_buf_bandwidth_raw (buf, idx))
 
+/** @brief Duplicate the start time of timing line @p idx. */
 #define r_sdp_buf_time_start(buf, idx)              r_sdp_time_buf_start (&(buf)->time[idx])
+/** @brief Duplicate the stop time of timing line @p idx. */
 #define r_sdp_buf_time_stop(buf, idx)               r_sdp_time_buf_stop (&(buf)->time[idx])
+/** @brief Number of repeat entries on timing line @p idx. */
 #define r_sdp_buf_time_repeat_count(buf, idx)       r_sdp_time_buf_repeat_count (&(buf)->time[idx])
+/** @brief Duplicate repeat entry @p ridx of timing line @p idx. */
 #define r_sdp_buf_time_repeat(buf, idx, ridx)       r_sdp_time_buf_repeat (&(buf)->time[idx], ridx)
 
+/** @brief Duplicate the adjustment time of time-zone entry @p idx as a string. */
 #define r_sdp_buf_zone_time_str(buf, idx)           r_str_kv_dup_key (&(buf)->zone[idx])
+/** @brief Parse the adjustment time of time-zone entry @p idx as an unsigned integer. */
 #define r_sdp_buf_zone_time_uint(buf, idx)          r_str_to_uint ((buf)->zone[idx].key.str, NULL, 10, NULL)
+/** @brief Duplicate the offset of time-zone entry @p idx as a string. */
 #define r_sdp_buf_zone_offset_str(buf, idx)         r_str_kv_dup_value (&(buf)->zone[idx])
+/** @brief Parse the offset of time-zone entry @p idx as an unsigned integer. */
 #define r_sdp_buf_zone_offset_uint(buf, idx)        r_str_to_uint ((buf)->zone[idx].val.str, NULL, 10, NULL)
 
+/** @brief Duplicate the session key method. */
 #define r_sdp_buf_key_method(buf)                   r_str_kv_dup_key (&(buf)->key)
+/** @brief Duplicate the session key data. */
 #define r_sdp_buf_key_data(buf)                     r_str_kv_dup_value (&(buf)->key)
 
+/** @brief @c TRUE if session attribute @p f is present. */
 #define r_sdp_buf_has_attrib(buf, f, fsize)         (r_sdp_attrib_check ((buf)->attrib, (buf)->acount, f, fsize) == R_SDP_OK)
+/** @brief Find session attribute @p f from cursor @p s; see @ref r_sdp_attrib_find. */
 #define r_sdp_buf_attrib_find(buf, f, fsize, s)     r_sdp_attrib_find ((buf)->attrib, (buf)->acount, f, fsize, s)
+/** @brief Duplicate the value of session attribute @p f from cursor @p s. */
 #define r_sdp_buf_attrib_dup_value(buf, f, fsize, s) r_sdp_attrib_dup_value ((buf)->attrib, (buf)->acount, f, fsize, s)
 
 /* media lines */
+/** @brief Duplicate the media type of media section @p idx. */
 #define r_sdp_buf_media_type(buf, idx)                  r_sdp_media_buf_type (&(buf)->media[idx])
+/** @brief Transport port of media section @p idx. */
 #define r_sdp_buf_media_port(buf, idx)                  r_sdp_media_buf_port (&(buf)->media[idx])
+/** @brief Port count of media section @p idx. */
 #define r_sdp_buf_media_portcount(buf, idx)             r_sdp_media_buf_portcount (&(buf)->media[idx])
+/** @brief Duplicate the transport protocol of media section @p idx. */
 #define r_sdp_buf_media_proto(buf, idx)                 r_sdp_media_buf_proto (&(buf)->media[idx])
+/** @brief Number of formats in media section @p idx. */
 #define r_sdp_buf_media_fmt_count(buf, idx)             r_sdp_media_buf_fmt_count (&(buf)->media[idx])
+/** @brief Duplicate format @p fidx of media section @p idx. */
 #define r_sdp_buf_media_fmt(buf, idx, fidx)             r_sdp_media_buf_fmt (&(buf)->media[idx], fidx)
+/** @brief Parse format @p fidx of media section @p idx as an unsigned integer. */
 #define r_sdp_buf_media_fmt_uint(buf, idx, fidx)        r_sdp_media_buf_fmt_uint (&(buf)->media[idx], fidx)
+/** @brief Duplicate the media information of media section @p idx. */
 #define r_sdp_buf_media_info(buf, idx)                  r_sdp_media_buf_info (&(buf)->media[idx])
+/** @brief Number of connection lines in media section @p idx. */
 #define r_sdp_buf_media_conn_count(buf, idx)            r_sdp_media_buf_conn_count (&(buf)->media[idx])
+/** @brief Duplicate the network type of connection @p cidx in media section @p idx. */
 #define r_sdp_buf_media_conn_nettype(buf, idx, cidx)    r_sdp_media_buf_conn_nettype (&(buf)->media[idx], cidx)
+/** @brief Duplicate the address type of connection @p cidx in media section @p idx. */
 #define r_sdp_buf_media_conn_addrtype(buf, idx, cidx)   r_sdp_media_buf_conn_addrtype (&(buf)->media[idx], cidx)
+/** @brief Duplicate the address of connection @p cidx in media section @p idx. */
 #define r_sdp_buf_media_conn_addr(buf, idx, cidx)       r_sdp_media_buf_conn_addr (&(buf)->media[idx], cidx)
+/** @brief Multicast TTL of connection @p cidx in media section @p idx. */
 #define r_sdp_buf_media_conn_ttl(buf, idx, cidx)        r_sdp_media_buf_conn_ttl (&(buf)->media[idx], cidx)
+/** @brief Address count of connection @p cidx in media section @p idx. */
 #define r_sdp_buf_media_conn_addrcount(buf, idx, cidx)  r_sdp_media_buf_conn_addrcount (&(buf)->media[idx], cidx)
+/** @brief Build an @c RSocketAddress from connection @p cidx in media section @p idx. */
 #define r_sdp_buf_media_conn_to_socket_address(buf, idx, cidx) r_sdp_media_buf_conn_to_socket_address (&(buf)->media[idx], cidx)
+/** @brief Number of bandwidth lines in media section @p idx. */
 #define r_sdp_buf_media_bandwidth_count(buf, idx)       r_sdp_media_buf_bandwidth_count (&(buf)->media[idx])
+/** @brief Duplicate the modifier name of bandwidth line @p bidx in media section @p idx. */
 #define r_sdp_buf_media_bandwidth_type(buf, idx, bidx)  r_sdp_media_buf_bandwidth_type (&(buf)->media[idx], bidx)
+/** @brief Classified @ref RSdpBandwidthModifier of bandwidth line @p bidx in media section @p idx. */
 #define r_sdp_buf_media_bandwidth_modifier(buf, idx, bidx) \
   r_sdp_media_buf_bandwidth_modifier (&(buf)->media[idx], bidx)
+/** @brief Raw integer value of bandwidth line @p bidx in media section @p idx. */
 #define r_sdp_buf_media_bandwidth_raw(buf, idx, bidx)   r_sdp_media_buf_bandwidth_raw (&(buf)->media[idx], bidx)
+/** @brief Bandwidth of line @p bidx in media section @p idx, in bits per second. */
 #define r_sdp_buf_media_bandwidth_bps(buf, idx, bidx) \
   r_sdp_media_buf_bandwidth_bps (&(buf)->media[idx], bidx)
+/** @brief Duplicate the key method of media section @p idx. */
 #define r_sdp_buf_media_key_method(buf, idx)            r_sdp_media_buf_key_method (&(buf)->media[idx])
+/** @brief Duplicate the key data of media section @p idx. */
 #define r_sdp_buf_media_key_data(buf, idx)              r_sdp_media_buf_key_data (&(buf)->media[idx])
+/** @brief Number of attributes in media section @p idx. */
 #define r_sdp_buf_media_attrib_count(buf, idx)          r_sdp_media_buf_attrib_count (&(buf)->media[idx])
+/** @brief @c TRUE if attribute @p f is present in media section @p idx. */
 #define r_sdp_buf_media_has_attrib(buf, idx, f, fsize)  r_sdp_media_buf_has_attrib (&(buf)->media[idx], f, fsize)
+/** @brief Duplicate the value of attribute @p f from cursor @p s in media section @p idx. */
 #define r_sdp_buf_media_attrib_dup_value(buf, idx, s, f, fsize) \
   r_sdp_media_buf_attrib_dup_value (&(buf)->media[idx], s, f, fsize)
+/** @brief Find the "rtpmap" attribute for format @p fmt in media section @p idx. */
 #define r_sdp_buf_media_rtpmap_for_fmt(buf, idx, fmt, fsize, attrib) \
   r_sdp_media_buf_rtpmap_for_fmt (&(buf)->media[idx], fmt, fsize, attrib)
+/** @brief Find the "rtpmap" attribute for format index @p fmtidx in media section @p idx. */
 #define r_sdp_buf_media_rtpmap_for_fmt_idx(buf, idx, fmtidx, attrib) \
   r_sdp_media_buf_rtpmap_for_fmt_idx (&(buf)->media[idx], fmtidx, attrib)
+/** @brief Find an "rtcp-fb" attribute for format @p fmt in media section @p idx from cursor @p start. */
 #define r_sdp_buf_media_rtcpfb_for_fmt(buf, idx, fmt, fsize, attrib, start) \
   r_sdp_media_buf_rtcpfb_for_fmt (&(buf)->media[idx], fmt, fsize, attrib, start)
+/** @brief Find an "rtcp-fb" attribute for format index @p fmtidx in media section @p idx from cursor @p start. */
 #define r_sdp_buf_media_rtcpfb_for_fmt_idx(buf, idx, fmtidx, attrib, start) \
   r_sdp_media_buf_rtcpfb_for_fmt_idx (&(buf)->media[idx], fmtidx, attrib, start)
+/** @brief Find the "fmtp" attribute for format @p fmt in media section @p idx. */
 #define r_sdp_buf_media_fmtp_for_fmt(buf, idx, fmt, fsize, attrib) \
   r_sdp_media_buf_fmtp_for_fmt (&(buf)->media[idx], fmt, fsize, attrib)
+/** @brief Find the "fmtp" attribute for format index @p fmtidx in media section @p idx. */
 #define r_sdp_buf_media_fmtp_for_fmt_idx(buf, idx, fmtidx, attrib) \
   r_sdp_media_buf_fmtp_for_fmt_idx (&(buf)->media[idx], fmtidx, attrib)
 
+/**
+ * @brief Find a grouping ("a=group") chunk by semantics and member mid.
+ * @param sdp Parsed SDP view.
+ * @param group Out chunk receiving the matched grouping.
+ * @param semantics Grouping semantics (e.g. "BUNDLE").
+ * @param ssize Size of @p semantics, or -1 if NUL-terminated.
+ * @param mid Member media identification tag to match.
+ * @param midsize Size of @p mid, or -1 if NUL-terminated.
+ */
 R_API RSdpResult r_sdp_buf_find_grouping (const RSdpBuf * sdp, RStrChunk * group,
     const rchar * semantics, rssize ssize, const rchar * mid, rssize midsize);
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_NET_PROTO_SDP_H__ */
 

--- a/include/rlib/net/proto/rstun.h
+++ b/include/rlib/net/proto/rstun.h
@@ -22,50 +22,96 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @file rlib/net/proto/rstun.h
+ * @brief STUN / TURN (RFC 5389) message validation, building and
+ * attribute parsing.
+ */
+
 #include <rlib/rtypes.h>
 
 #include <rlib/net/rsocketaddress.h>
 
+/**
+ * @defgroup r_stun STUN / TURN
+ * @ingroup r_net
+ *
+ * @brief Validate, build and parse STUN / TURN messages and their
+ * attributes (RFC 5389 / 5766), used by ICE in @ref r_rtc.
+ *
+ * Parsing is zero-copy over a caller-held buffer: validate with
+ * @ref r_stun_is_valid_msg, read header fields with the
+ * @c r_stun_msg_* accessors, and iterate attributes with
+ * @ref r_stun_attr_tlv_first / @ref r_stun_attr_tlv_next into an
+ * @ref RStunAttrTLV. Building uses an @ref RStunMsgCtx writing into a
+ * caller buffer: @ref r_stun_msg_begin, add attributes, then
+ * @ref r_stun_msg_end (optionally appending a FINGERPRINT).
+ *
+ * @{
+ */
+
 R_BEGIN_DECLS
 
-#define R_STUN_HEADER_SIZE              20
-#define R_STUN_MSGLEN_OFFSET            2
-#define R_STUN_MAGIC_COOKIE_OFFSET      4
-#define R_STUN_TRANSACTION_ID_OFFSET    8
-#define R_STUN_MSGLEN_SIZE              (R_STUN_MAGIC_COOKIE_OFFSET - R_STUN_MSGLEN_OFFSET)
-#define R_STUN_MAGIC_COOKIE_SIZE        (R_STUN_TRANSACTION_ID_OFFSET - R_STUN_MAGIC_COOKIE_OFFSET)
-#define R_STUN_TRANSACTION_ID_SIZE      (R_STUN_HEADER_SIZE - R_STUN_TRANSACTION_ID_OFFSET)
-#define R_STUN_MSG_INTEGRITY_SIZE       20
-#define R_STUN_FINGERPRINT_XOR          0x5354554e
-#define R_STUN_MAGIC_COOKIE             0x2112a442
-#define R_STUN_TYPE_CLASS_MASK          0x0110
-#define R_STUN_TYPE_METHOD_MASK         0x3eef
+/** @name Message header layout
+ *  Byte offsets and sizes within the fixed 20-byte STUN header.
+ *  @{ */
+#define R_STUN_HEADER_SIZE              20  /**< @brief Fixed STUN header size in bytes. */
+#define R_STUN_MSGLEN_OFFSET            2   /**< @brief Offset of the message-length field. */
+#define R_STUN_MAGIC_COOKIE_OFFSET      4   /**< @brief Offset of the magic-cookie field. */
+#define R_STUN_TRANSACTION_ID_OFFSET    8   /**< @brief Offset of the transaction-ID field. */
+#define R_STUN_MSGLEN_SIZE              (R_STUN_MAGIC_COOKIE_OFFSET - R_STUN_MSGLEN_OFFSET) /**< @brief Size of the message-length field. */
+#define R_STUN_MAGIC_COOKIE_SIZE        (R_STUN_TRANSACTION_ID_OFFSET - R_STUN_MAGIC_COOKIE_OFFSET) /**< @brief Size of the magic-cookie field. */
+#define R_STUN_TRANSACTION_ID_SIZE      (R_STUN_HEADER_SIZE - R_STUN_TRANSACTION_ID_OFFSET) /**< @brief Size of the transaction-ID field. */
+#define R_STUN_MSG_INTEGRITY_SIZE       20  /**< @brief Size of a MESSAGE-INTEGRITY value (HMAC-SHA1). */
+#define R_STUN_FINGERPRINT_XOR          0x5354554e /**< @brief XOR constant applied to the CRC-32 FINGERPRINT. */
+#define R_STUN_MAGIC_COOKIE             0x2112a442 /**< @brief The STUN magic cookie value. */
+#define R_STUN_TYPE_CLASS_MASK          0x0110 /**< @brief Mask selecting the class bits of the message type. */
+#define R_STUN_TYPE_METHOD_MASK         0x3eef /**< @brief Mask selecting the method bits of the message type. */
+/** @} */
 
+/** @brief @c TRUE if @p buf (@p size bytes) looks like a valid STUN message. */
 R_API rboolean r_stun_is_valid_msg (rconstpointer buf, rsize size);
 
+/** @brief STUN message class (the two class bits of the type). */
 typedef enum {
-  R_STUN_CLASS_REQUEST                    = 0x0000,
-  R_STUN_CLASS_INDICATION                 = 0x0010,
-  R_STUN_CLASS_SUCCESS_RESPONSE           = 0x0100,
-  R_STUN_CLASS_ERROR_RESPONSE             = 0x0110,
+  R_STUN_CLASS_REQUEST                    = 0x0000, /**< Request. */
+  R_STUN_CLASS_INDICATION                 = 0x0010, /**< Indication (no response expected). */
+  R_STUN_CLASS_SUCCESS_RESPONSE           = 0x0100, /**< Success response. */
+  R_STUN_CLASS_ERROR_RESPONSE             = 0x0110, /**< Error response. */
 } RStunClass;
 
+/** @brief STUN / TURN method (the method bits of the type). */
 typedef enum {
-  R_STUN_METHOD_BINDING                   = 0x0001,
-  R_STUN_METHOD_ALLOCATE                  = 0x0003,
+  R_STUN_METHOD_BINDING                   = 0x0001, /**< STUN Binding. */
+  R_STUN_METHOD_ALLOCATE                  = 0x0003, /**< TURN Allocate. */
 } RStunMethod;
 
+/** @name Header-field accessors
+ *  Read fields straight out of a STUN message buffer.
+ *  @{ */
+/** @brief Return the 16-bit message type from @p buf. */
 static inline ruint16 r_stun_msg_type (rconstpointer buf) { return RUINT16_FROM_BE (*(const ruint16 *)buf); }
+/** @brief Return the message-length field from @p buf. */
 static inline ruint16 r_stun_msg_len  (rconstpointer buf) { return RUINT16_FROM_BE (*(const ruint16 *)&((const ruint8 *)(buf))[R_STUN_MSGLEN_OFFSET]); }
+/** @brief Pointer to the magic-cookie field in @p buf. */
 #define r_stun_msg_magic_cookie(buf)      (*(const ruint32 *)&((const ruint8 *)(buf))[R_STUN_MAGIC_COOKIE_OFFSET])
+/** @brief Pointer to the transaction-ID field in @p buf. */
 #define r_stun_msg_transaction_id(buf)    (&((const ruint8 *)(buf))[R_STUN_TRANSACTION_ID_OFFSET])
+/** @brief @c TRUE if @p buf is a request. */
 #define r_stun_msg_is_request(buf)        ((r_stun_msg_type (buf) & R_STUN_TYPE_CLASS_MASK)  == R_STUN_CLASS_REQUEST)
+/** @brief @c TRUE if @p buf is an indication. */
 #define r_stun_msg_is_indication(buf)     ((r_stun_msg_type (buf) & R_STUN_TYPE_CLASS_MASK)  == R_STUN_CLASS_INDICATION)
+/** @brief @c TRUE if @p buf is a success response. */
 #define r_stun_msg_is_success_resp(buf)   ((r_stun_msg_type (buf) & R_STUN_TYPE_CLASS_MASK)  == R_STUN_CLASS_SUCCESS_RESPONSE)
+/** @brief @c TRUE if @p buf is an error response. */
 #define r_stun_msg_is_err_resp(buf)       ((r_stun_msg_type (buf) & R_STUN_TYPE_CLASS_MASK)  == R_STUN_CLASS_ERROR_RESPONSE)
+/** @brief @c TRUE if @p buf's method is Binding. */
 #define r_stun_msg_method_is_binding(buf) ((r_stun_msg_type (buf) & R_STUN_TYPE_METHOD_MASK) == R_STUN_METHOD_BINDING)
+/** @brief @c TRUE if @p buf's method is Allocate. */
 #define r_stun_msg_method_is_allocate(buf)((r_stun_msg_type (buf) & R_STUN_TYPE_METHOD_MASK) == R_STUN_METHOD_ALLOCATE)
+/** @} */
 
+/** @brief STUN / TURN attribute type (RFC-registered values; @c 0x8000+ are comprehension-optional). */
 typedef enum {
   R_STUN_ATTR_TYPE_RESERVED_0             = 0x0000, /* Reserved */
   R_STUN_ATTR_TYPE_MAPPED_ADDRESS         = 0x0001,
@@ -103,54 +149,95 @@ typedef enum {
   R_STUN_ATTR_TYPE_ICE_CONTROLLING        = 0x802A,
 } RStunAttrType;
 
+/** @brief @c TRUE if attribute @p type is comprehension-optional (@c 0x8000+). */
 #define r_stun_attr_type_is_optional(type)  ((type) & 0x8000)
 
+/** @brief One parsed STUN attribute, pointing into the message buffer. */
 typedef struct RStunAttrTLV {
-  const ruint8 *  start;  /* (first octet of tlv) */
-  ruint16         type;   /* Type (parsed) */
-  ruint16         len;    /* Length (parsed) */
-  const ruint8 *  value;  /* Value  (pointer to first value octet) */
+  const ruint8 *  start;  /**< First octet of the attribute (its type field). */
+  ruint16         type;   /**< Parsed attribute type (@ref RStunAttrType). */
+  ruint16         len;    /**< Parsed value length in bytes. */
+  const ruint8 *  value;  /**< Pointer to the first value octet. */
 } RStunAttrTLV;
+/** @brief Static initialiser for an empty @ref RStunAttrTLV. */
 #define R_STUN_ATTR_TLV_INIT              { NULL, 0, 0, NULL }
+/** @brief Size of an attribute's type+length header, in bytes. */
 #define R_STUN_ATTR_TLV_HEADER_SIZE       4
 
+/** @brief Builder cursor writing a STUN message into a caller buffer. */
 typedef struct {
-  ruint8 * buf;
-  rsize alloc_size;
-  ruint16 used_size;
+  ruint8 * buf;       /**< Destination buffer. */
+  rsize alloc_size;   /**< Capacity of @c buf in bytes. */
+  ruint16 used_size;  /**< Bytes written so far. */
 } RStunMsgCtx;
 
-/* Building stun packets */
+/** @name Building messages
+ *  @{ */
+/**
+ * @brief Begin a STUN message in @p buf with the given class / method.
+ * @param ctx            Builder cursor to initialise.
+ * @param buf            Destination buffer.
+ * @param size           Capacity of @p buf in bytes.
+ * @param cls            Message class.
+ * @param method         Message method.
+ * @param transaction_id 12-byte transaction ID.
+ */
 R_API rboolean r_stun_msg_begin (RStunMsgCtx * ctx, rpointer buf, rsize size,
     RStunClass cls, RStunMethod method,
     const ruint8 transaction_id[R_STUN_TRANSACTION_ID_SIZE]);
+/** @brief Append a pre-built attribute @p tlv. */
 R_API rboolean r_stun_msg_add_attribute (RStunMsgCtx * ctx, const RStunAttrTLV * tlv);
+/** @brief Append an XOR-mapped address attribute of the given @p type. */
 R_API rboolean r_stun_msg_add_xor_address (RStunMsgCtx * ctx,
     RStunAttrType type, const RSocketAddress * addr);
+/** @brief Append a short-term-credential MESSAGE-INTEGRITY attribute keyed by @p key. */
 R_API rboolean r_stun_msg_add_message_integrity_short_cred (RStunMsgCtx * ctx,
     rconstpointer key, rsize keysize);
+/**
+ * @brief Finalise the message, patching the length field.
+ * @param ctx         Builder cursor.
+ * @param fingerprint @c TRUE to append a FINGERPRINT attribute.
+ * @return Total message length in bytes.
+ */
 R_API ruint16 r_stun_msg_end (RStunMsgCtx * ctx, rboolean fingerprint);
+/** @} */
 
-/* For parsing stun packets */
+/** @name Parsing messages
+ *  @{ */
+/** @brief Number of attributes in the STUN message @p buf. */
 R_API ruint r_stun_msg_attribute_count (rconstpointer buf);
+/** @brief Position @p tlv on the first attribute of @p buf. */
 R_API rboolean r_stun_attr_tlv_first (rconstpointer buf, RStunAttrTLV * tlv);
+/** @brief Advance @p tlv to the next attribute; @c FALSE past the last. */
 R_API rboolean r_stun_attr_tlv_next (rconstpointer buf, RStunAttrTLV * tlv);
 
+/** @brief Parse a MAPPED-ADDRESS-style attribute into a socket address. */
 R_API RSocketAddress * r_stun_attr_tlv_parse_address (rconstpointer buf, const RStunAttrTLV * tlv);
+/** @brief Parse an XOR-MAPPED-ADDRESS-style attribute (de-XORing against the header). */
 R_API RSocketAddress * r_stun_attr_tlv_parse_xor_address (rconstpointer buf, const RStunAttrTLV * tlv);
+/** @brief Parse a REQUESTED-TRANSPORT attribute's protocol byte. */
 R_API ruint8 r_stun_attr_tlv_parse_reqested_transport_protocol (rconstpointer buf, const RStunAttrTLV * tlv);
+/** @brief Parse an ERROR-CODE attribute's numeric code. */
 R_API ruint r_stun_attr_tlv_parse_error_code (rconstpointer buf, const RStunAttrTLV * tlv);
+/** @brief Parse a LIFETIME attribute (seconds). */
 #define r_stun_att_tlv_parse_lifetime(buf, tlv) RUINT32_FROM_BE (*(ruint32 *)((tlv)->value))
+/** @brief Parse a PRIORITY attribute (ICE candidate priority). */
 #define r_stun_att_tlv_parse_priority(buf, tlv) RUINT32_FROM_BE (*(ruint32 *)((tlv)->value))
 
+/** @brief Verify a short-term-credential MESSAGE-INTEGRITY against @p key. */
 R_API rboolean r_stun_msg_check_integrity_short_cred (rconstpointer buf,
     const RStunAttrTLV * tlv, rconstpointer key, rsize keysize);
+/** @brief Compute the FINGERPRINT (CRC-32 XOR @ref R_STUN_FINGERPRINT_XOR) over @p buf. */
 R_API ruint32 r_stun_msg_calc_fingerprint (rconstpointer buf,
     const RStunAttrTLV * tlv);
+/** @brief @c TRUE if the FINGERPRINT attribute @p tlv matches the computed value. */
 #define r_stun_msg_check_fingerprint(buf, tlv)                                \
   (r_stun_msg_calc_fingerprint (buf, tlv) == RUINT32_FROM_BE (*(ruint32 *)((tlv)->value)))
+/** @} */
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_NET_PROTO_STUN_H__ */
 

--- a/include/rlib/net/proto/rtls.h
+++ b/include/rlib/net/proto/rtls.h
@@ -22,6 +22,12 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @file rlib/net/proto/rtls.h
+ * @brief TLS / DTLS wire-protocol constants, record / handshake parsing
+ * and message building.
+ */
+
 #include <rlib/rtypes.h>
 
 #include <rlib/rbuffer.h>
@@ -33,16 +39,41 @@
 #include <rlib/crypto/rsrtpciphersuite.h>
 #include <rlib/crypto/rtlsciphersuite.h>
 
+/**
+ * @defgroup r_tls_proto TLS / DTLS protocol
+ * @ingroup r_net
+ *
+ * @brief TLS and DTLS wire-protocol constants (versions, content / handshake
+ * types, alerts, extensions, signature schemes and related IANA-registered
+ * tables), together with the record / handshake structures and the parsing
+ * and building helpers operating directly on the wire bytes.
+ *
+ * Parsing centres on @ref RTLSParser, which walks records out of an
+ * @c RBuffer, optionally decrypts them, and feeds the handshake-message
+ * parsers (@ref RTLSHelloMsg, @ref RTLSCertificate, @ref RTLSCertReq, ...).
+ * Building helpers write records and handshake headers straight into a caller
+ * buffer, with parallel @c r_tls_ / @c r_dtls_ entry points for the stream and
+ * datagram framings. The higher-level server session that drives these
+ * primitives lives in @ref r_tls_server.
+ *
+ * @{
+ */
+
 R_BEGIN_DECLS
 
-#define R_TLS_RECORD_HDR_SIZE             5
-#define R_TLS_RECORD_EXTRA_DTLS_SIZE      8
-#define R_TLS_HS_HDR_SIZE                 4
-#define R_TLS_HS_EXTRA_DTLS_SIZE          8
-#define R_DTLS_RECORD_HDR_SIZE            (R_TLS_RECORD_HDR_SIZE + R_TLS_RECORD_EXTRA_DTLS_SIZE)
-#define R_DTLS_HS_HDR_SIZE                (R_TLS_HS_HDR_SIZE + R_TLS_HS_EXTRA_DTLS_SIZE)
-#define R_TLS_SESSION_TICKET_LIFETIME     7200
+/** @name Record and handshake header layout
+ *  Fixed header sizes for TLS records / handshakes and their extra DTLS bytes.
+ *  @{ */
+#define R_TLS_RECORD_HDR_SIZE             5  /**< @brief TLS record header size in bytes. */
+#define R_TLS_RECORD_EXTRA_DTLS_SIZE      8  /**< @brief Extra DTLS record-header bytes (epoch + sequence number). */
+#define R_TLS_HS_HDR_SIZE                 4  /**< @brief TLS handshake header size in bytes. */
+#define R_TLS_HS_EXTRA_DTLS_SIZE          8  /**< @brief Extra DTLS handshake-header bytes (message seq + fragment offset/length). */
+#define R_DTLS_RECORD_HDR_SIZE            (R_TLS_RECORD_HDR_SIZE + R_TLS_RECORD_EXTRA_DTLS_SIZE) /**< @brief DTLS record header size in bytes. */
+#define R_DTLS_HS_HDR_SIZE                (R_TLS_HS_HDR_SIZE + R_TLS_HS_EXTRA_DTLS_SIZE) /**< @brief DTLS handshake header size in bytes. */
+#define R_TLS_SESSION_TICKET_LIFETIME     7200 /**< @brief Default session-ticket lifetime hint, in seconds. */
+/** @} */
 
+/** @brief TLS / DTLS protocol version (the 16-bit version field; DTLS uses 0xfe**). */
 typedef enum {
   R_TLS_VERSION_UNKNOWN                                 = 0x0000,
   R_TLS_VERSION_SSL_1_0                                 = 0x0100,
@@ -57,6 +88,7 @@ typedef enum {
   R_TLS_VERSION_DTLS_1_3                                = 0xfefc,
 } RTLSVersion;
 
+/** @brief Client certificate type for CertificateRequest (IANA TLS ClientCertificateType). */
 /* http://www.iana.org/assignments/tls-parameters/#tls-parameters-2 */
 typedef enum {
   R_TLS_CLIENT_CERT_TYPE_RSA_SIGN                       = 0x01, /* [RFC5246] */
@@ -72,6 +104,7 @@ typedef enum {
   R_TLS_CLIENT_CERT_TYPE_ECDSA_FIXED_ECDH               = 0x42, /* [RFC4492] */
 } RTLSClientCertificateType;
 
+/** @brief TLS record content type (IANA TLS ContentType). */
 /* http://www.iana.org/assignments/tls-parameters/#tls-parameters-5 */
 typedef enum {
   R_TLS_CONTENT_TYPE_CHANGE_CIPHER_SPEC                 = 0x14, /* [RFC5246] */
@@ -80,15 +113,17 @@ typedef enum {
   R_TLS_CONTENT_TYPE_APPLICATION_DATA                   = 0x17, /* [RFC5246] */
   R_TLS_CONTENT_TYPE_HEARTBEAT                          = 0x18, /* [RFC6520] */
 
-  R_TLS_CONTENT_TYPE_FIRST                              = R_TLS_CONTENT_TYPE_CHANGE_CIPHER_SPEC,
-  R_TLS_CONTENT_TYPE_LAST                               = R_TLS_CONTENT_TYPE_HEARTBEAT
+  R_TLS_CONTENT_TYPE_FIRST                              = R_TLS_CONTENT_TYPE_CHANGE_CIPHER_SPEC, /**< Lowest valid content type. */
+  R_TLS_CONTENT_TYPE_LAST                               = R_TLS_CONTENT_TYPE_HEARTBEAT /**< Highest valid content type. */
 } RTLSContentType;
 
+/** @brief Severity level of a TLS alert. */
 typedef enum {
   R_TLS_ALERT_LEVEL_WARNING                             = 0x01,
   R_TLS_ALERT_LEVEL_FATAL                               = 0x02,
 } RTLSAlertLevel;
 
+/** @brief TLS alert description (IANA TLS Alert registry). */
 /* http://www.iana.org/assignments/tls-parameters/#tls-parameters-6 */
 typedef enum {
   R_TLS_ALERT_TYPE_CLOSE_NOTIFY                         = 0x00, /* [RFC5246] */
@@ -124,6 +159,7 @@ typedef enum {
   R_TLS_ALERT_TYPE_UNKNOWN_PSK_IDENTITY                 = 0x73, /* [RFC4279] */
 } RTLSAlertType;
 
+/** @brief Handshake message type (IANA TLS HandshakeType). */
 /* http://www.iana.org/assignments/tls-parameters/#tls-parameters-7 */
 typedef enum {
   R_TLS_HANDSHAKE_TYPE_HELLO_REQUEST                    = 0x00, /* [RFC5246] */
@@ -143,6 +179,7 @@ typedef enum {
   R_TLS_HANDSHAKE_TYPE_SUPPLEMENTAL_DATA                = 0x17, /* [RFC4680] */
 } RTLSHandshakeType;
 
+/** @brief TLS extension type (IANA TLS ExtensionType). */
 /* http://www.iana.org/assignments/tls-extensiontype-values/ */
 typedef enum {
   R_TLS_EXT_TYPE_SERVER_NAME                            = 0x0000, /* [RFC6066] */
@@ -176,6 +213,7 @@ typedef enum {
   R_TLS_EXT_TYPE_RENEGOTIATION_INFO                     = 0xff01, /* [RFC5746] */
 } RTLSExtensionType;
 
+/** @brief Named group / elliptic curve for key exchange (IANA TLS Supported Groups). */
 /* http://www.iana.org/assignments/tls-parameters/#tls-parameters-8 */
 typedef enum {
   R_TLS_SUPPORTED_GROUP_SECT163K1                       = 0x0001, /* [RFC4492] */
@@ -217,6 +255,7 @@ typedef enum {
   R_TLS_SUPPORTED_GROUP_ARBITRARY_EXPLICIT_CHAR2_CURVES = 0xff02, /* [RFC4492] */
 } RTLSSupportedGroup;
 
+/** @brief Elliptic-curve point format (IANA TLS EC Point Formats). */
 /* http://www.iana.org/assignments/tls-parameters/#tls-parameters-9 */
 typedef enum {
   R_TLS_EC_POINT_FORMAT_UNCOMPRESSED                    = 0x00, /* [RFC4492] */
@@ -224,6 +263,7 @@ typedef enum {
   R_TLS_EC_POINT_FORMAT_ANSIX962_COMPRESSED_CHAR2       = 0x02, /* [RFC4492] */
 } RTLSEcPointFormat;
 
+/** @brief Elliptic-curve description type (IANA TLS EC Curve Type). */
 /* http://www.iana.org/assignments/tls-parameters/#tls-parameters-10 */
 typedef enum {
   R_TLS_EC_TYPE_EXPLICIT_PRIME                          = 0x01, /* [RFC4492] */
@@ -231,6 +271,7 @@ typedef enum {
   R_TLS_EC_TYPE_NAMED_CURVE                             = 0x03, /* [RFC4492] */
 } RTLSEcCurveType;
 
+/** @brief Signature scheme / hash-and-signature algorithm pair (IANA TLS SignatureScheme). */
 /* http://www.iana.org/assignments/tls-parameters/#tls-parameters-16 */
 /* http://www.iana.org/assignments/tls-parameters/#tls-parameters-18 */
 typedef enum {
@@ -259,6 +300,7 @@ typedef enum {
   R_TLS_SIGN_SCHEME_ED448                               = 0x0808, /* [TLS1.3] */
 } RTLSSignatureScheme;
 
+/** @brief Authorization-data format for the supplemental-data extension (IANA TLS Authorization Data Formats). */
 /* http://www.iana.org/assignments/tls-parameters/#authorization-data */
 typedef enum {
   R_TLS_AUTH_DATA_FORMAT_X509_ATTR_CERT                 = 0x00, /* [RFC5878] */
@@ -270,234 +312,428 @@ typedef enum {
   R_TLS_AUTH_DATA_FORMAT_DTCP_AUTHORIZATION             = 0x42, /* [RFC7562] */
 } RTLSAuthorizationDataFormats;
 
+/** @brief Heartbeat message type (IANA TLS Heartbeat Message Types). */
 /* http://www.iana.org/assignments/tls-parameters/#heartbeat-message-types */
 typedef enum {
   R_TLS_HEARTBEAT_MSG_TYPE_REQUEST                      = 0x01, /* [RFC6520] */
   R_TLS_HEARTBEAT_MSG_TYPE_RESPONSE                     = 0x02, /* [RFC6520] */
 } RTLSHeartbeatMessageType;
 
+/** @brief Heartbeat mode negotiated by the heartbeat extension (IANA TLS Heartbeat Modes). */
 /* http://www.iana.org/assignments/tls-parameters/#heartbeat-modes */
 typedef enum {
   R_TLS_HEARTBEAT_MODE_PEER_ALLOWED_TO_SEND             = 0x01, /* [RFC6520] */
   R_TLS_HEARTBEAT_MODE_PEER_NOT_ALLOWED_TO_SEND         = 0x02, /* [RFC6520] */
 } RTLSHeartbeatMode;
 
+/** @brief Result code returned by the TLS / DTLS parsing and building API (negative values are errors). */
 typedef enum {
-  R_TLS_ERROR_NOT_NEEDED                                =  0x02,
-  R_TLS_ERROR_EOB                                       =  0x01,
-  R_TLS_ERROR_OK                                        =  0x00,
-  R_TLS_ERROR_INVAL                                     = -0x01,
-  R_TLS_ERROR_OOM                                       = -0x02,
-  R_TLS_ERROR_INVALID_RECORD                            = -0x03,
-  R_TLS_ERROR_CORRUPT_RECORD                            = -0x04,
-  R_TLS_ERROR_BUF_TOO_SMALL                             = -0x05,
-  R_TLS_ERROR_VERSION                                   = -0x06,
-  R_TLS_ERROR_WRONG_TYPE                                = -0x07,
-  R_TLS_ERROR_NOT_DTLS                                  = -0x08,
-  R_TLS_ERROR_QUEUE_FULL                                = -0x09,
-  R_TLS_ERROR_NO_CERTIFICATE                            = -0x0a,
-  R_TLS_ERROR_CORRUPT_CERTIFICATE                       = -0x0b,
-  R_TLS_ERROR_WRONG_STATE                               = -0x0c,
-  R_TLS_ERROR_HANDSHAKE_FAILURE                         = -0x0d,
-  R_TLS_ERROR_INVALID_MAC                               = -0x0e,
-  R_TLS_ERROR_HS_VERIFICATION_FAILED                    = -0x0f,
-  R_TLS_ERROR_ENCRYPTION_FAILED                         = -0x10,
+  R_TLS_ERROR_NOT_NEEDED                                =  0x02, /**< Operation was a no-op / not required. */
+  R_TLS_ERROR_EOB                                       =  0x01, /**< End of buffer reached. */
+  R_TLS_ERROR_OK                                        =  0x00, /**< Success. */
+  R_TLS_ERROR_INVAL                                     = -0x01, /**< Invalid argument. */
+  R_TLS_ERROR_OOM                                       = -0x02, /**< Out of memory. */
+  R_TLS_ERROR_INVALID_RECORD                            = -0x03, /**< Record failed validation. */
+  R_TLS_ERROR_CORRUPT_RECORD                            = -0x04, /**< Record is malformed / truncated. */
+  R_TLS_ERROR_BUF_TOO_SMALL                             = -0x05, /**< Output buffer too small. */
+  R_TLS_ERROR_VERSION                                   = -0x06, /**< Unexpected or unsupported protocol version. */
+  R_TLS_ERROR_WRONG_TYPE                                = -0x07, /**< Wrong record / handshake type for the operation. */
+  R_TLS_ERROR_NOT_DTLS                                  = -0x08, /**< DTLS-only operation on a non-DTLS parser. */
+  R_TLS_ERROR_QUEUE_FULL                                = -0x09, /**< Reassembly / output queue is full. */
+  R_TLS_ERROR_NO_CERTIFICATE                            = -0x0a, /**< Expected certificate is missing. */
+  R_TLS_ERROR_CORRUPT_CERTIFICATE                       = -0x0b, /**< Certificate is malformed. */
+  R_TLS_ERROR_WRONG_STATE                               = -0x0c, /**< Operation not valid in the current state. */
+  R_TLS_ERROR_HANDSHAKE_FAILURE                         = -0x0d, /**< Generic handshake failure. */
+  R_TLS_ERROR_INVALID_MAC                               = -0x0e, /**< Record MAC verification failed. */
+  R_TLS_ERROR_HS_VERIFICATION_FAILED                    = -0x0f, /**< Handshake verify-data check failed. */
+  R_TLS_ERROR_ENCRYPTION_FAILED                         = -0x10, /**< Record encryption failed. */
 } RTLSError;
 
+/** @brief TLS record compression method (only @c NULL is supported / non-deprecated). */
 typedef enum {
   R_TLS_COMPRESSION_NULL                                =  0,
 } RTLSCompresssionMethod;
 
 
-#define R_TLS_HELLO_RANDOM_BYTES              32
-#define R_TLS_HELLO_EXT_HDR_SIZE              (2 * sizeof (ruint16))
+/** @name Hello message layout
+ *  Sizes used when parsing / building Hello messages.
+ *  @{ */
+#define R_TLS_HELLO_RANDOM_BYTES              32 /**< @brief Size of the Hello @c random field in bytes. */
+#define R_TLS_HELLO_EXT_HDR_SIZE              (2 * sizeof (ruint16)) /**< @brief Size of an extension's type + length header. */
+/** @} */
 
+/** @brief Cursor over a (D)TLS record being parsed out of a buffer. */
 typedef struct {
-  RBuffer * buf;
-  rsize recsize;
+  RBuffer * buf;          /**< @brief Source buffer holding the record(s). */
+  rsize recsize;          /**< @brief Size of the current record's payload. */
 
-  RTLSContentType content;
-  RTLSVersion version;
-  ruint16 epoch;                              /* DTLS only */
-  ruint64 seqno;                              /* DTLS only */
-  rsize offset;
-  RMemMapInfo fragment;
+  RTLSContentType content; /**< @brief Content type of the current record. */
+  RTLSVersion version;     /**< @brief Protocol version of the current record. */
+  ruint16 epoch;           /**< @brief DTLS epoch (DTLS only). */
+  ruint64 seqno;           /**< @brief DTLS record sequence number (DTLS only). */
+  rsize offset;            /**< @brief Read offset within the buffer. */
+  RMemMapInfo fragment;    /**< @brief Mapping of the current record's payload. */
 } RTLSParser;
+/** @brief Static initialiser for an empty @ref RTLSParser. */
 #define R_TLS_PARSER_INIT           { NULL, 0, 0, 0, 0, 0, 0, R_MEM_MAP_INFO_INIT }
 
+/** @brief Parsed ClientHello / ServerHello, pointing into the record buffer. */
 typedef struct {
-  RTLSVersion version;
+  RTLSVersion version;     /**< @brief Advertised / selected protocol version. */
 
-  const ruint8 * random;
+  const ruint8 * random;   /**< @brief The @ref R_TLS_HELLO_RANDOM_BYTES random field. */
 
-  ruint8 sidlen;
-  const ruint8 * sid; /* session id */
-  ruint8 cookielen;
-  const ruint8 * cookie; /* Only for DTLS ClientHello */
-  ruint16 cslen;
-  const ruint8 * cs; /* cipher suites */
-  ruint8 complen;
-  const ruint8 * compression;
-  ruint16 extlen;
-  const ruint8 * ext; /* extensions */
+  ruint8 sidlen;           /**< @brief Session-ID length in bytes. */
+  const ruint8 * sid;      /**< @brief Session ID. */
+  ruint8 cookielen;        /**< @brief Cookie length (DTLS ClientHello only). */
+  const ruint8 * cookie;   /**< @brief DTLS ClientHello cookie. */
+  ruint16 cslen;           /**< @brief Cipher-suites list length in bytes. */
+  const ruint8 * cs;       /**< @brief Cipher-suites list. */
+  ruint8 complen;          /**< @brief Compression-methods list length in bytes. */
+  const ruint8 * compression; /**< @brief Compression-methods list. */
+  ruint16 extlen;          /**< @brief Extensions block length in bytes. */
+  const ruint8 * ext;      /**< @brief Extensions block. */
 } RTLSHelloMsg;
 
+/** @brief One parsed Hello extension, pointing into the Hello buffer. */
 typedef struct {
-  const ruint8 *  start;
-  ruint16         type;
-  ruint16         len;
-  const ruint8 *  data;
+  const ruint8 *  start;   /**< @brief First octet of the extension (its type field). */
+  ruint16         type;    /**< @brief Extension type (@ref RTLSExtensionType). */
+  ruint16         len;     /**< @brief Extension data length in bytes. */
+  const ruint8 *  data;    /**< @brief Pointer to the first data octet. */
 } RTLSHelloExt;
+/** @brief Static initialiser for an empty @ref RTLSHelloExt. */
 #define R_TLS_HELLO_EXT_INIT                { NULL, 0, 0, NULL }
 
+/** @brief One certificate entry from a Certificate handshake message. */
 typedef struct {
-  const ruint8 * start;
-  ruint32 len;
-  const ruint8 * cert;
+  const ruint8 * start;    /**< @brief First octet of the entry (its length field). */
+  ruint32 len;             /**< @brief Certificate length in bytes. */
+  const ruint8 * cert;     /**< @brief Pointer to the DER-encoded certificate. */
 } RTLSCertificate;
+/** @brief Static initialiser for an empty @ref RTLSCertificate. */
 #define R_TLS_CERTIFICATE_INIT              { NULL, 0, NULL }
 
+/** @brief Parsed CertificateRequest message, pointing into the record buffer. */
 typedef struct {
-  ruint8 certtypecount;
-  const ruint8 * certtype;
-  ruint16 signschemecount;
-  const ruint8 * signscheme;
-  ruint16 cacount;
-  const ruint8 * ca;
+  ruint8 certtypecount;       /**< @brief Number of accepted certificate types. */
+  const ruint8 * certtype;    /**< @brief Accepted certificate types (@ref RTLSClientCertificateType). */
+  ruint16 signschemecount;    /**< @brief Number of accepted signature schemes. */
+  const ruint8 * signscheme;  /**< @brief Accepted signature schemes (@ref RTLSSignatureScheme). */
+  ruint16 cacount;            /**< @brief Length of the accepted-CA list in bytes. */
+  const ruint8 * ca;          /**< @brief Distinguished names of accepted CAs. */
 } RTLSCertReq;
 
+/** @brief Peek the protocol version of the record in @p buf without full parsing; @c R_TLS_VERSION_UNKNOWN if not a record. */
 R_API RTLSVersion r_tls_parse_data_shallow (rconstpointer buf, rsize size);
 
+/** @brief Initialise @p parser over a raw @p buf of @p size bytes. */
 R_API RTLSError r_tls_parser_init (RTLSParser * parser, rconstpointer buf, rsize size);
+/** @brief Initialise @p parser over an existing @c RBuffer. */
 R_API RTLSError r_tls_parser_init_buffer (RTLSParser * parser, RBuffer * buf);
+/**
+ * @brief Initialise @p parser on the next record, taking ownership of @p buf.
+ * @param parser Parser to initialise.
+ * @param buf In/out pointer to the buffer to consume; advanced past the record.
+ */
 R_API RTLSError r_tls_parser_init_next (RTLSParser * parser, RBuffer ** buf);
+/** @brief Return the buffer for the next record, advancing past the current one. */
 R_API RBuffer * r_tls_parser_next (RTLSParser * parser);
+/** @brief Release resources held by @p parser. */
 R_API void r_tls_parser_clear (RTLSParser * parser);
 
+/** @brief Decrypt and MAC-verify the current record in place. */
 R_API RTLSError r_tls_parser_decrypt (RTLSParser * parser,
     const RCryptoCipher * cipher, RHmac * mac);
 
+/** @brief @c TRUE if protocol @p version is a DTLS version. */
 #define r_tls_version_is_dtls(version) ((version) > RUINT16_MAX / 2)
+/** @brief @c TRUE if @p parser holds a DTLS record. */
 #define r_tls_parser_is_dtls(parser) r_tls_version_is_dtls ((parser)->version)
+/** @brief @c TRUE if the current DTLS handshake fragment completes its message. */
 R_API rboolean r_tls_parser_dtls_is_complete_handshake_fragment (const RTLSParser * parser);
 
+/** @brief Read the handshake message type without consuming the header. */
 R_API RTLSError r_tls_parser_parse_handshake_peek_type (const RTLSParser * parser,
     RTLSHandshakeType * type);
+/** @brief Parse the handshake header, returning only type and length. */
 #define r_tls_parser_parse_handshake(parser, type, length)                    \
   r_tls_parser_parse_handshake_full (parser, type, length, NULL, NULL, NULL)
+/**
+ * @brief Parse the handshake header, including DTLS reassembly fields.
+ * @param parser Parser positioned on a handshake record.
+ * @param type Out: handshake message type.
+ * @param length Out: total handshake message length.
+ * @param msgseq Out: DTLS message sequence (may be @c NULL).
+ * @param fragoff Out: DTLS fragment offset (may be @c NULL).
+ * @param fraglen Out: DTLS fragment length (may be @c NULL).
+ */
 R_API RTLSError r_tls_parser_parse_handshake_full (const RTLSParser * parser,
     RTLSHandshakeType * type, ruint32 * length, ruint16 * msgseq,
     ruint32 * fragoff, ruint32 * fraglen);
+/** @brief Parse the current record as a ClientHello / ServerHello into @p msg. */
 R_API RTLSError r_tls_parser_parse_hello (const RTLSParser * parser, RTLSHelloMsg * msg);
+/** @brief Parse the next certificate entry of a Certificate message into @p cert. */
 R_API RTLSError r_tls_parser_parse_certificate_next (const RTLSParser * parser, RTLSCertificate * cert);
+/** @brief Parse the current record as a CertificateRequest into @p req. */
 R_API RTLSError r_tls_parser_parse_certificate_request (const RTLSParser * parser, RTLSCertReq * req);
+/**
+ * @brief Parse the current record as a NewSessionTicket.
+ * @param parser Parser positioned on the message.
+ * @param lifetime Out: ticket lifetime hint in seconds.
+ * @param ticket Out: pointer to the ticket bytes.
+ * @param ticketsize Out: ticket length in bytes.
+ */
 R_API RTLSError r_tls_parser_parse_new_session_ticket (const RTLSParser * parser,
     ruint32 * lifetime, const ruint8 ** ticket, ruint16 * ticketsize);
+/**
+ * @brief Parse the current record as a CertificateVerify.
+ * @param parser Parser positioned on the message.
+ * @param sigscheme Out: signature scheme used.
+ * @param sig Out: pointer to the signature bytes.
+ * @param sigsize Out: signature length in bytes.
+ */
 R_API RTLSError r_tls_parser_parse_certificate_verify (const RTLSParser * parser,
     RTLSSignatureScheme * sigscheme, const ruint8 ** sig, ruint16 * sigsize);
+/**
+ * @brief Parse the current record as an RSA ClientKeyExchange.
+ * @param parser Parser positioned on the message.
+ * @param encprems Out: pointer to the encrypted pre-master secret.
+ * @param size Out: length of the encrypted pre-master secret in bytes.
+ */
 R_API RTLSError r_tls_parser_parse_client_key_exchange_rsa (const RTLSParser * parser,
     const ruint8 ** encprems, rsize * size);
+/**
+ * @brief Parse the current record as a Finished message.
+ * @param parser Parser positioned on the message.
+ * @param verify_data Out: pointer to the verify-data bytes.
+ * @param size Out: verify-data length in bytes.
+ */
 R_API RTLSError r_tls_parser_parse_finished (const RTLSParser * parser,
     const ruint8 ** verify_data, rsize * size);
 
+/** @brief Parse the current record as an Alert into @p level and @p type. */
 R_API RTLSError r_tls_parser_parse_alert (const RTLSParser * parser,
     RTLSAlertLevel * level, RTLSAlertType * type);
 
-/* Hello msg */
+/** @name Hello message accessors
+ *  Read fields and lists out of a parsed @ref RTLSHelloMsg.
+ *  @{ */
+/** @brief Number of cipher suites advertised in @p msg. */
 #define r_tls_hello_msg_cipher_suite_count(msg) ((msg)->cslen / sizeof (ruint16))
+/** @brief Number of compression methods advertised in @p msg. */
 #define r_tls_hello_msg_compression_count(msg)  ((msg)->complen / sizeof (ruint8))
+/** @brief Return the @p n th cipher suite in @p msg. */
 static inline RTLSCipherSuite r_tls_hello_msg_cipher_suite (const RTLSHelloMsg * msg, int n)
 { return (RTLSCipherSuite) r_load_be16 (msg->cs + n * sizeof (ruint16)); }
+/** @brief Return the @p n th compression method in @p msg. */
 static inline RTLSCompresssionMethod r_tls_hello_msg_compression_method (const RTLSHelloMsg * msg, int n)
 { return (RTLSCompresssionMethod)msg->compression[n]; }
+/** @brief @c TRUE if @p msg advertises cipher suite @p cs. */
 R_API rboolean r_tls_hello_msg_has_cipher_suite (const RTLSHelloMsg * msg, RTLSCipherSuite cs);
+/** @brief Position @p ext on the first extension of @p msg. */
 R_API RTLSError r_tls_hello_msg_extension_first (const RTLSHelloMsg * msg, RTLSHelloExt * ext);
+/** @brief Advance @p ext to the next extension of @p msg. */
 R_API RTLSError r_tls_hello_msg_extension_next (const RTLSHelloMsg * msg, RTLSHelloExt * ext);
+/** @} */
 
-/* signature_algorithms extension */
+/** @name signature_algorithms extension accessors
+ *  @{ */
+/** @brief Number of signature schemes in the signature_algorithms extension @p ext. */
 static inline ruint16 r_tls_hello_ext_sign_scheme_count (const RTLSHelloExt * ext)
 { return r_load_be16 (ext->data) / sizeof (ruint16); }
+/** @brief Return the @p n th signature scheme in @p ext. */
 static inline RTLSSignatureScheme r_tls_hello_ext_sign_scheme (const RTLSHelloExt * ext, int n)
 { return (RTLSSignatureScheme) r_load_be16 (ext->data + (n + 1) * sizeof (ruint16)); }
+/** @} */
 
-/* ec_point_format extension */
+/** @name ec_point_format extension accessors
+ *  @{ */
+/** @brief Number of point formats in the ec_point_format extension @p ext. */
 static inline ruint16 r_tls_hello_ext_ec_point_format_count (const RTLSHelloExt * ext)
 { return ext->data[0]; }
+/** @brief Return the @p n th EC point format in @p ext. */
 static inline RTLSEcPointFormat r_tls_hello_ext_ec_point_format (const RTLSHelloExt * ext, int n)
 { return (RTLSEcPointFormat)ext->data[n+1]; }
+/** @} */
 
-/* supported_groups/elliptic_curves extension */
+/** @name supported_groups / elliptic_curves extension accessors
+ *  @{ */
+/** @brief Number of named groups in the supported_groups extension @p ext. */
 static inline ruint16 r_tls_hello_ext_supported_groups_count (const RTLSHelloExt * ext)
 { return r_load_be16 (ext->data) / sizeof (ruint16); }
+/** @brief Return the @p n th named group in @p ext. */
 static inline RTLSSupportedGroup r_tls_hello_ext_supported_group (const RTLSHelloExt * ext, int n)
 { return (RTLSSupportedGroup) r_load_be16 (ext->data + (n + 1) * sizeof (ruint16)); }
+/** @} */
 
-/* use_srtp extension */
+/** @name use_srtp extension accessors
+ *  @{ */
+/** @brief Number of SRTP protection profiles in the use_srtp extension @p ext. */
 static inline ruint16 r_tls_hello_ext_use_srtp_profile_count (const RTLSHelloExt * ext)
 { return r_load_be16 (ext->data) / sizeof (ruint16); }
+/** @brief Return the @p n th SRTP protection profile in @p ext. */
 static inline RSRTPCipherSuite r_tls_hello_ext_use_srtp_profile(const RTLSHelloExt * ext, int n)
 { return (RSRTPCipherSuite) r_load_be16 (ext->data + (n + 1) * sizeof (ruint16)); }
+/** @brief Size of the SRTP MKI field in @p ext, in bytes. */
 static inline ruint8 r_tls_hello_ext_use_srtp_mki_size (const RTLSHelloExt * ext)
 { return ext->data[sizeof (ruint16) + r_load_be16 (ext->data)]; }
+/** @brief Pointer to the SRTP MKI field in @p ext. */
 static inline const ruint8 * r_tls_hello_ext_use_srtp_mki (const RTLSHelloExt * ext)
 { return &ext->data[sizeof (ruint16) + r_load_be16 (ext->data) + sizeof (ruint8)]; }
+/** @} */
 
 
-/* Certificate */
+/** @brief Decode the certificate entry @p cert into an @c RCryptoCert (caller owns the result). */
 R_API RCryptoCert * r_tls_certificate_get_cert (const RTLSCertificate * cert);
 
-/* Certificate request */
+/** @name CertificateRequest accessors
+ *  @{ */
+/** @brief Return the @p n th accepted certificate type in @p req. */
 static inline RTLSClientCertificateType r_tls_cert_req_cert_type (const RTLSCertReq * req, int n)
 { return (RTLSClientCertificateType)req->certtype[n]; }
+/** @brief Return the @p n th accepted signature scheme in @p req. */
 static inline RTLSSignatureScheme r_tls_cert_req_sign_scheme (const RTLSCertReq * req, int n)
 { return (RTLSSignatureScheme) r_load_be16 (req->signscheme + n * sizeof (ruint16)); }
+/** @} */
 
+/** @brief TLS pseudo-random function: expand @p secret into @p dst, fed a @c NULL-terminated list of seed chunks. */
 typedef RTLSError (*RTLSPrfFunc) (ruint8 * dst, rsize dsize,
     const ruint8 * secret, rsize secsize, ...);
 
+/** @brief TLS 1.0 / 1.1 PRF (MD5+SHA1) over a @c NULL-terminated seed list. */
 R_API RTLSError r_tls_1_0_prf (ruint8 * dst, rsize dsize,
     const ruint8 * secret, rsize secsize, ...) R_ATTR_NULL_TERMINATED;
+/** @brief TLS 1.2 PRF based on HMAC-SHA-224 over a @c NULL-terminated seed list. */
 R_API RTLSError r_tls_1_2_prf_sha224 (ruint8 * dst, rsize dsize,
     const ruint8 * secret, rsize secsize, ...) R_ATTR_NULL_TERMINATED;
+/** @brief TLS 1.2 PRF based on HMAC-SHA-256 over a @c NULL-terminated seed list. */
 R_API RTLSError r_tls_1_2_prf_sha256 (ruint8 * dst, rsize dsize,
     const ruint8 * secret, rsize secsize, ...) R_ATTR_NULL_TERMINATED;
+/** @brief TLS 1.2 PRF based on HMAC-SHA-384 over a @c NULL-terminated seed list. */
 R_API RTLSError r_tls_1_2_prf_sha384 (ruint8 * dst, rsize dsize,
     const ruint8 * secret, rsize secsize, ...) R_ATTR_NULL_TERMINATED;
+/** @brief TLS 1.2 PRF based on HMAC-SHA-512 over a @c NULL-terminated seed list. */
 R_API RTLSError r_tls_1_2_prf_sha512 (ruint8 * dst, rsize dsize,
     const ruint8 * secret, rsize secsize, ...) R_ATTR_NULL_TERMINATED;
 
 
+/**
+ * @brief Encrypt and MAC a TLS record buffer.
+ * @param buf Plaintext record payload.
+ * @param seqno Record sequence number fed to the MAC.
+ * @param cipher Record-protection cipher.
+ * @param iv Explicit IV, or @c NULL.
+ * @param hmac Record MAC, or @c NULL.
+ * @return New buffer holding the protected record, or @c NULL on failure.
+ */
 R_API RBuffer * r_tls_encrypt_buffer (RBuffer * buf, ruint64 seqno,
     const RCryptoCipher * cipher, const ruint8 * iv, RHmac * hmac);
+/**
+ * @brief Encrypt and MAC a DTLS record buffer (sequence taken from the record).
+ * @param buf Plaintext record payload.
+ * @param cipher Record-protection cipher.
+ * @param iv Explicit IV, or @c NULL.
+ * @param hmac Record MAC, or @c NULL.
+ * @return New buffer holding the protected record, or @c NULL on failure.
+ */
 R_API RBuffer * r_dtls_encrypt_buffer (RBuffer * buf,
     const RCryptoCipher * cipher, const ruint8 * iv, RHmac * hmac);
 
+/**
+ * @brief Write a TLS handshake record header into @p data.
+ * @param data Destination buffer.
+ * @param size Capacity of @p data in bytes.
+ * @param out Out: bytes written.
+ * @param ver Protocol version.
+ * @param type Handshake message type.
+ * @param len Handshake message body length.
+ */
 R_API RTLSError r_tls_write_handshake (rpointer data, rsize size,
     rsize * out, RTLSVersion ver, RTLSHandshakeType type, ruint16 len);
+/**
+ * @brief Write a DTLS handshake record header into @p data.
+ * @param data Destination buffer.
+ * @param size Capacity of @p data in bytes.
+ * @param out Out: bytes written.
+ * @param ver Protocol version.
+ * @param type Handshake message type.
+ * @param len Handshake message body length.
+ * @param epoch DTLS epoch.
+ * @param seqno DTLS record sequence number.
+ * @param msgseq DTLS handshake message sequence.
+ * @param foff Fragment offset.
+ * @param flen Fragment length.
+ */
 R_API RTLSError r_dtls_write_handshake (rpointer data, rsize size,
     rsize * out, RTLSVersion ver, RTLSHandshakeType type, ruint16 len,
     ruint16 epoch, ruint64 seqno, ruint16 msgseq, ruint32 foff, ruint32 flen);
+/** @brief Patch the body length of a previously written TLS handshake header. */
 R_API RTLSError r_tls_update_handshake_len (rpointer data, rsize size, ruint16 len);
+/**
+ * @brief Patch the length / fragment fields of a written DTLS handshake header.
+ * @param data Buffer holding the handshake header.
+ * @param size Size of @p data in bytes.
+ * @param len Handshake message body length.
+ * @param foff Fragment offset.
+ * @param flen Fragment length.
+ */
 R_API RTLSError r_dtls_update_handshake_len (rpointer data, rsize size, ruint16 len,
     ruint32 foff, ruint32 flen);
 
+/** @brief Generate a Hello @c random field using @c RPrng @p prng. */
 R_API RTLSError r_tls_generate_hello_random (ruint8 randrom[R_TLS_HELLO_RANDOM_BYTES], RPrng * prng);
+/**
+ * @brief Write a ServerHello handshake message into @p data.
+ * @param data Destination buffer.
+ * @param size Capacity of @p data in bytes.
+ * @param out Out: bytes written.
+ * @param ver Selected protocol version.
+ * @param srvrand Server random field.
+ * @param sid Session ID, or @c NULL.
+ * @param sidsize Session-ID length in bytes.
+ * @param cs Selected cipher suite.
+ * @param comp Selected compression method.
+ */
 R_API RTLSError r_tls_write_hs_server_hello (rpointer data, rsize size, rsize * out,
     RTLSVersion ver, const ruint8 srvrand[R_TLS_HELLO_RANDOM_BYTES],
     const ruint8 * sid, ruint8 sidsize,
     RTLSCipherSuite cs, RTLSCompresssionMethod comp);
+/** @brief DTLS alias for @ref r_tls_write_hs_server_hello. */
 #define r_dtls_write_hs_server_hello r_tls_write_hs_server_hello
+/**
+ * @brief Write a NewSessionTicket handshake message into @p buf.
+ * @param buf Destination buffer.
+ * @param size Capacity of @p buf in bytes.
+ * @param out Out: bytes written.
+ * @param lifetime Ticket lifetime hint in seconds.
+ * @param ticket Ticket bytes.
+ * @param tsize Ticket length in bytes.
+ */
 R_API RTLSError r_tls_write_hs_new_session_ticket (rpointer buf, rsize size, rsize * out,
     ruint32 lifetime, const ruint8 * ticket, ruint16 tsize);
+/** @brief DTLS alias for @ref r_tls_write_hs_new_session_ticket. */
 #define r_dtls_write_hs_new_session_ticket r_tls_write_hs_new_session_ticket
 
 
+/** @brief Write a TLS ChangeCipherSpec record into @p data. */
 R_API RTLSError r_tls_write_change_cipher (rpointer data, rsize size,
     rsize * out, RTLSVersion ver);
+/**
+ * @brief Write a DTLS ChangeCipherSpec record into @p data.
+ * @param data Destination buffer.
+ * @param size Capacity of @p data in bytes.
+ * @param out Out: bytes written.
+ * @param ver Protocol version.
+ * @param epoch DTLS epoch.
+ * @param seqno DTLS record sequence number.
+ */
 R_API RTLSError r_dtls_write_change_cipher (rpointer data, rsize size,
     rsize * out, RTLSVersion ver, ruint16 epoch, ruint64 seqno);
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_NET_PROTO_TLS_H__ */
 

--- a/include/rlib/net/rhttpserver.h
+++ b/include/rlib/net/rhttpserver.h
@@ -22,6 +22,12 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @file rlib/net/rhttpserver.h
+ * @brief Event-loop-driven HTTP server with pattern-routed request
+ * handlers.
+ */
+
 #include <rlib/rtypes.h>
 #include <rlib/rref.h>
 
@@ -30,33 +36,86 @@
 
 #include <rlib/net/rsocketaddress.h>
 
+/**
+ * @defgroup r_http_server HTTP server
+ * @ingroup r_net
+ *
+ * @brief Refcounted HTTP server that runs on an @c REvLoop and
+ * dispatches requests to pattern-matched handlers.
+ *
+ * Register one or more handlers with @ref r_http_server_set_handler
+ * (each bound to a path pattern), then @ref r_http_server_listen on a
+ * socket address. Each request invokes the matching
+ * @ref RHttpRequestHandler, which returns the @ref RHttpResponse to
+ * send. Requests can also be injected directly via
+ * @ref r_http_server_process_request, bypassing the listener.
+ *
+ * Built on the @ref r_http_proto wire codec.
+ *
+ * @{
+ */
+
 R_BEGIN_DECLS
 
+/** @brief Opaque, refcounted HTTP server. */
 typedef struct RHttpServer RHttpServer;
+/**
+ * @brief Request handler; returns the response to send.
+ * @param data   User pointer registered with the handler.
+ * @param req    The incoming request.
+ * @param addr   Peer address.
+ * @param server The server dispatching the request.
+ */
 typedef RHttpResponse * (*RHttpRequestHandler) (rpointer data,
     RHttpRequest * req, RSocketAddress * addr, RHttpServer * server);
+/** @brief Callback invoked when an injected request's response is ready. */
 typedef void (*RHttpResponseReady) (rpointer data,
     RHttpResponse * res, RHttpServer * server);
+/** @brief Callback invoked once the server has fully stopped. */
 typedef void (*RHttpServerStop) (rpointer data, RHttpServer * server);
 
+/** @brief Create an HTTP server bound to event loop @p loop. */
 R_API RHttpServer * r_http_server_new (REvLoop * loop);
+/** @brief Take a reference (alias for @ref r_ref_ref). */
 #define r_http_server_ref    r_ref_ref
+/** @brief Drop a reference (alias for @ref r_ref_unref). */
 #define r_http_server_unref  r_ref_unref
 
+/**
+ * @brief Route requests whose path matches @p pattern to @p handler.
+ * @param server  Target server.
+ * @param pattern Path pattern to match.
+ * @param size    Length of @p pattern, or @c -1 for @c strlen.
+ * @param handler Handler invoked for matching requests.
+ * @param data    User pointer passed to @p handler.
+ * @param notify  Destructor for @p data; may be @c NULL.
+ */
 R_API rboolean r_http_server_set_handler (RHttpServer * server,
   const rchar * pattern, rssize size, RHttpRequestHandler handler,
   rpointer data, RDestroyNotify notify);
 
+/** @brief Start accepting connections on @p addr. */
 R_API rboolean r_http_server_listen (RHttpServer * server, RSocketAddress * addr);
+/**
+ * @brief Stop the server; @p func fires once shutdown completes.
+ * @return Number of in-flight requests still draining.
+ */
 R_API rsize r_http_server_stop (RHttpServer * server, RHttpServerStop func,
     rpointer data, RDestroyNotify notify);
 
-/* May be used to inject requests into the server without using the listening API. */
+/**
+ * @brief Inject a request directly, bypassing the listening socket.
+ *
+ * Useful for testing or for serving requests received out-of-band;
+ * @p ready fires with the produced response.
+ */
 R_API rboolean r_http_server_process_request (RHttpServer * server,
     RHttpRequest * req, RSocketAddress * addr,
     RHttpResponseReady ready, rpointer data, RDestroyNotify notify);
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_NET_HTTP_SERVER_H__ */
 

--- a/include/rlib/net/rresolve.h
+++ b/include/rlib/net/rresolve.h
@@ -22,54 +22,95 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @file rlib/net/rresolve.h
+ * @brief Hostname / service resolution into a linked list of socket
+ * addresses (synchronous @c getaddrinfo wrapper).
+ */
+
 #include <rlib/rtypes.h>
 
 #include <rlib/net/rsocket.h>
 #include <rlib/net/rsocketaddress.h>
 
+/**
+ * @defgroup r_resolve DNS resolution
+ * @ingroup r_net
+ *
+ * @brief Resolve a host/service name into a linked list of
+ * @ref RResolvedAddr socket addresses.
+ *
+ * @ref r_resolve_sync wraps the platform @c getaddrinfo: pass a host
+ * and/or service string, optional @ref RResolveHints to constrain the
+ * family / type / protocol, and @ref RResolveAddrFlags (mapped to the
+ * @c R_AI_* flags). The result is a caller-owned list freed with
+ * @ref r_resolved_addr_free.
+ *
+ * @{
+ */
+
 R_BEGIN_DECLS
 
+/** @brief Result code from a resolve operation. */
 typedef enum {
-  R_RESOLVE_IN_PROGRESS = -1,
-  R_RESOLVE_OK = 0,
-  R_RESOLVE_INVAL,
-  R_RESOLVE_OOM,
-  R_RESOLVE_BAD_HINTS,
-  R_RESOLVE_BAD_FLAGS,
-  R_RESOLVE_NO_DATA,
-  R_RESOLVE_NOT_SUPPORTED,
-  R_RESOLVE_ERROR,
+  R_RESOLVE_IN_PROGRESS = -1, /**< Async resolution still pending. */
+  R_RESOLVE_OK = 0,           /**< Success. */
+  R_RESOLVE_INVAL,            /**< Invalid argument. */
+  R_RESOLVE_OOM,              /**< Allocation failed. */
+  R_RESOLVE_BAD_HINTS,        /**< Invalid @ref RResolveHints. */
+  R_RESOLVE_BAD_FLAGS,        /**< Invalid @ref RResolveAddrFlags. */
+  R_RESOLVE_NO_DATA,          /**< Name resolved but has no addresses. */
+  R_RESOLVE_NOT_SUPPORTED,    /**< Requested family / operation unsupported. */
+  R_RESOLVE_ERROR,            /**< Generic / unmapped resolver error. */
 } RResolveResult;
 
+/** @brief Resolution flags; mirror the platform @c AI_* hint flags. */
 typedef enum {
-  R_RESOLVE_ADDR_FLAG_PASSIVE     = R_AI_PASSIVE,
-  R_RESOLVE_ADDR_FLAG_CANONNAME   = R_AI_CANONNAME,
-  R_RESOLVE_ADDR_FLAG_NUMERICHOST = R_AI_NUMERICHOST,
-  R_RESOLVE_ADDR_FLAG_V4MAPPED    = R_AI_V4MAPPED,
-  R_RESOLVE_ADDR_FLAG_ALL         = R_AI_ALL,
-  R_RESOLVE_ADDR_FLAG_ADDRCONFIG  = R_AI_ADDRCONFIG,
+  R_RESOLVE_ADDR_FLAG_PASSIVE     = R_AI_PASSIVE,     /**< Address intended for @c bind. */
+  R_RESOLVE_ADDR_FLAG_CANONNAME   = R_AI_CANONNAME,   /**< Request the canonical name. */
+  R_RESOLVE_ADDR_FLAG_NUMERICHOST = R_AI_NUMERICHOST, /**< Host is a numeric address. */
+  R_RESOLVE_ADDR_FLAG_V4MAPPED    = R_AI_V4MAPPED,    /**< Allow IPv4-mapped IPv6. */
+  R_RESOLVE_ADDR_FLAG_ALL         = R_AI_ALL,         /**< Return IPv6 + IPv4-mapped. */
+  R_RESOLVE_ADDR_FLAG_ADDRCONFIG  = R_AI_ADDRCONFIG,  /**< Only host-configured families. */
 } RResolveAddrFlag;
+/** @brief Bitwise-OR of @ref RResolveAddrFlag values. */
 typedef ruint32 RResolveAddrFlags;
 
+/** @brief Constraints narrowing which addresses a resolve returns. */
 typedef struct {
-  RSocketFamily family;
-  RSocketType type;
-  RSocketProtocol protocol;
+  RSocketFamily family;     /**< Desired address family, or @c NONE for any. */
+  RSocketType type;         /**< Desired socket type, or @c NONE for any. */
+  RSocketProtocol protocol; /**< Desired protocol, or @c DEFAULT for any. */
 } RResolveHints;
 
+/** @brief One resolved address; a node in a singly-linked result list. */
 typedef struct RResolvedAddr RResolvedAddr;
 struct RResolvedAddr {
-  RResolveHints hints;
-  RSocketAddress * addr;
-  RResolvedAddr * next;
+  RResolveHints hints;      /**< Family / type / protocol of this address. */
+  RSocketAddress * addr;    /**< The resolved socket address. */
+  RResolvedAddr * next;     /**< Next address, or @c NULL at the end. */
 };
 
+/** @brief Free a resolved-address list returned by @ref r_resolve_sync. */
 R_API void r_resolved_addr_free (RResolvedAddr * addr);
+/**
+ * @brief Synchronously resolve @p host / @p service into addresses.
+ *
+ * @param host    Host name or numeric address; may be @c NULL.
+ * @param service Service name or port string; may be @c NULL.
+ * @param flags   @ref RResolveAddrFlags controlling resolution.
+ * @param hints   Optional constraints; may be @c NULL.
+ * @param res     Optional out-pointer for the @ref RResolveResult.
+ * @return Head of a caller-owned @ref RResolvedAddr list (free with
+ *         @ref r_resolved_addr_free), or @c NULL on failure.
+ */
 R_API RResolvedAddr * r_resolve_sync (const rchar * host, const rchar * service,
     RResolveAddrFlags flags, const RResolveHints * hints, RResolveResult * res);
 
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_RESOLVE_H__ */
 

--- a/include/rlib/net/rsrtp.h
+++ b/include/rlib/net/rsrtp.h
@@ -22,6 +22,11 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @file rlib/net/rsrtp.h
+ * @brief SRTP / SRTCP encryption and decryption keyed per SSRC.
+ */
+
 #include <rlib/rtypes.h>
 
 #include <rlib/crypto/rsrtpciphersuite.h>
@@ -31,43 +36,74 @@
 #include <rlib/rref.h>
 
 
+/** @brief Wildcard SSRC filter matching any stream (see @ref r_srtp_add_crypto_context_with_filter). */
 #define R_SRTP_FILTER_ANY         RUINT32_MAX
+
+/**
+ * @defgroup r_srtp SRTP / SRTCP
+ * @ingroup r_net
+ *
+ * @brief Encrypt and authenticate RTP / RTCP packets (RFC 3711) using
+ * per-SSRC crypto contexts.
+ *
+ * Create an @ref RSRTPCtx, register a cipher suite + key per SSRC
+ * (@ref r_srtp_add_crypto_context_for_ssrc) or for a filter pattern
+ * (@ref r_srtp_add_crypto_context_with_filter, e.g.
+ * @ref R_SRTP_FILTER_ANY), then transform packets with the
+ * encrypt / decrypt entry points. Keys typically come from a
+ * DTLS-SRTP handshake (see @ref r_tls_server).
+ *
+ * @{
+ */
 
 R_BEGIN_DECLS
 
+/** @brief Result code from an SRTP operation. */
 typedef enum {
-  R_SRTP_ERROR_OK,
-  R_SRTP_ERROR_OOM,
-  R_SRTP_ERROR_INVAL,
-  R_SRTP_ERROR_INTERNAL,
-  R_SRTP_ERROR_NO_CRYPTO_CTX,
-  R_SRTP_ERROR_CRYPTO_CTX_EXISTS,
-  R_SRTP_ERROR_WRONG_DIRECTION,
-  R_SRTP_ERROR_BAD_RTP_HDR,
-  R_SRTP_ERROR_BAD_RTCP_HDR,
-  R_SRTP_ERROR_REPLAYED,
-  R_SRTP_ERROR_REPLAY_TOO_OLD,
-  R_SRTP_ERROR_AUTH,
-  R_SRTP_ERROR_E_BIT_MISMATCH,
+  R_SRTP_ERROR_OK,                /**< Success. */
+  R_SRTP_ERROR_OOM,               /**< Allocation failed. */
+  R_SRTP_ERROR_INVAL,             /**< Invalid argument. */
+  R_SRTP_ERROR_INTERNAL,          /**< Internal error. */
+  R_SRTP_ERROR_NO_CRYPTO_CTX,     /**< No crypto context for the packet's SSRC. */
+  R_SRTP_ERROR_CRYPTO_CTX_EXISTS, /**< A context already exists for that SSRC. */
+  R_SRTP_ERROR_WRONG_DIRECTION,   /**< Context used for the wrong direction. */
+  R_SRTP_ERROR_BAD_RTP_HDR,       /**< Malformed RTP header. */
+  R_SRTP_ERROR_BAD_RTCP_HDR,      /**< Malformed RTCP header. */
+  R_SRTP_ERROR_REPLAYED,          /**< Packet rejected as a replay. */
+  R_SRTP_ERROR_REPLAY_TOO_OLD,    /**< Packet older than the replay window. */
+  R_SRTP_ERROR_AUTH,              /**< Authentication-tag check failed. */
+  R_SRTP_ERROR_E_BIT_MISMATCH,    /**< SRTCP E-bit / encryption-flag mismatch. */
 } RSRTPError;
 
+/** @brief Opaque, refcounted SRTP session context (a set of per-SSRC keys). */
 typedef struct RSRTPCtx RSRTPCtx;
 
+/** @brief Create an empty SRTP context. */
 R_API RSRTPCtx * r_srtp_ctx_new (void) R_ATTR_MALLOC;
+/** @brief Take a reference (alias for @ref r_ref_ref). */
 #define r_srtp_ctx_ref      r_ref_ref
+/** @brief Drop a reference (alias for @ref r_ref_unref). */
 #define r_srtp_ctx_unref    r_ref_unref
 
+/** @brief Install a cipher suite + key for a specific @p ssrc. */
 R_API RSRTPError r_srtp_add_crypto_context_for_ssrc (RSRTPCtx * ctx,
     ruint32 ssrc, RSRTPCipherSuite cs, const ruint8 * key);
+/** @brief Install a cipher suite + key for an SSRC @p filter (e.g. @ref R_SRTP_FILTER_ANY). */
 R_API RSRTPError r_srtp_add_crypto_context_with_filter (RSRTPCtx * ctx,
     ruint32 filter, RSRTPCipherSuite cs, const ruint8 * key);
 
+/** @brief Encrypt an RTP packet into a new SRTP buffer. */
 R_API RBuffer * r_srtp_encrypt_rtp (RSRTPCtx * ctx, RBuffer * packet, RSRTPError * err) R_ATTR_WARN_UNUSED_RESULT;
+/** @brief Decrypt and verify an SRTP packet into a new RTP buffer. */
 R_API RBuffer * r_srtp_decrypt_rtp (RSRTPCtx * ctx, RBuffer * packet, RSRTPError * err) R_ATTR_WARN_UNUSED_RESULT;
+/** @brief Encrypt an RTCP packet into a new SRTCP buffer. */
 R_API RBuffer * r_srtp_encrypt_rtcp (RSRTPCtx * ctx, RBuffer * packet, RSRTPError * err) R_ATTR_WARN_UNUSED_RESULT;
+/** @brief Decrypt and verify an SRTCP packet into a new RTCP buffer. */
 R_API RBuffer * r_srtp_decrypt_rtcp (RSRTPCtx * ctx, RBuffer * packet, RSRTPError * err) R_ATTR_WARN_UNUSED_RESULT;
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_NET_SRTP_H__ */
 

--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -22,6 +22,12 @@
 #error "#include <rlib.h> only pelase."
 #endif
 
+/**
+ * @file rlib/net/rtlsserver.h
+ * @brief Server-side TLS / DTLS session: handshake, record I/O, key
+ * export and DTLS-SRTP negotiation.
+ */
+
 #include <rlib/rtypes.h>
 
 #include <rlib/crypto/rtlsciphersuite.h>
@@ -32,47 +38,86 @@
 #include <rlib/rbuffer.h>
 #include <rlib/rref.h>
 
+/**
+ * @defgroup r_tls_server TLS / DTLS server
+ * @ingroup r_net
+ *
+ * @brief Server-side TLS / DTLS endpoint driving a handshake and
+ * encrypting / decrypting record traffic via callbacks.
+ *
+ * The transport is callback-based rather than owning a socket: feed
+ * received bytes in with @ref r_tls_server_incoming_data, and the
+ * @ref RTLSCallbacks deliver outgoing records (@c out) and decrypted
+ * application data (@c appdata). Configure a certificate / key with
+ * @ref r_tls_server_set_cert, then @ref r_tls_server_start.
+ *
+ * Also exposes DTLS-SRTP negotiation (@ref r_tls_server_get_dtls_srtp_profile)
+ * for @ref r_srtp keying, and RFC 5705 keying-material export.
+ *
+ * @{
+ */
+
 R_BEGIN_DECLS
 
+/** @brief Opaque, refcounted TLS / DTLS server session. */
 typedef struct RTLSServer RTLSServer;
 
+/** @brief Callback delivering a buffer (outgoing record or app data). */
 typedef rboolean (*RTLSServerBufferCb) (rpointer ctx, RBuffer * buf, RTLSServer * server);
+/** @brief Callback fired when the handshake completes. */
 typedef void (*RTLSServerHandshakeDoneCb) (rpointer ctx, RTLSServer * server);
+/** @brief Callback selecting the preferred cipher suites for a TLS version. */
 typedef rboolean (*RTLSPreferredCipherSuitesCb) (rpointer ctx, RTLSVersion ver, RTLSCipherSuite * cs, rsize * count);
 
+/** @brief Callback bundle wiring a session to its transport and policy. */
 typedef struct {
-  RTLSPreferredCipherSuitesCb   preferred_cipher_suites;
-  RTLSServerHandshakeDoneCb     handshake_done;
-  RTLSServerBufferCb            out;
-  RTLSServerBufferCb            appdata;
+  RTLSPreferredCipherSuitesCb   preferred_cipher_suites; /**< Choose cipher suites; may be @c NULL for defaults. */
+  RTLSServerHandshakeDoneCb     handshake_done;          /**< Fired once the handshake finishes. */
+  RTLSServerBufferCb            out;                     /**< Sink for outgoing encrypted records. */
+  RTLSServerBufferCb            appdata;                 /**< Sink for decrypted application data. */
 } RTLSCallbacks;
 
+/** @brief Create a TLS server with the given callbacks and user context. */
 R_API RTLSServer * r_tls_server_new (const RTLSCallbacks * cb,
     rpointer userdata, RDestroyNotify notify) R_ATTR_MALLOC;
+/** @brief Take a reference (alias for @ref r_ref_ref). */
 #define r_tls_server_ref    r_ref_ref
+/** @brief Drop a reference (alias for @ref r_ref_unref). */
 #define r_tls_server_unref  r_ref_unref
 
+/** @brief Set the server certificate and its private key. */
 R_API RTLSError r_tls_server_set_cert (RTLSServer * server,
     RCryptoCert * cert, RCryptoKey * privkey);
+/** @brief Override the server-random (testing / determinism). */
 R_API RTLSError r_tls_server_set_random (RTLSServer * server,
     const ruint8 servrandom[R_TLS_HELLO_RANDOM_BYTES]);
+/** @brief Start the session on @p loop, drawing randomness from @p prng. */
 R_API RTLSError r_tls_server_start (RTLSServer * server, REvLoop * loop,
     RPrng * prng) R_ATTR_WARN_UNUSED_RESULT;
 
+/** @brief Feed received ciphertext bytes into the session. */
 R_API rboolean r_tls_server_incoming_data (RTLSServer * server, RBuffer * buffer);
+/** @brief Encrypt and send application data through the session. */
 R_API rboolean r_tls_server_send_appdata (RTLSServer * server, RBuffer * buffer);
 
+/** @brief Export RFC 5705 keying material for an application label / context. */
 R_API RTLSError r_tls_server_export_keying_matierial (const RTLSServer * server,
     ruint8 * material, rsize size, const rchar * label, rsize len,
     const ruint8 * ctx, rsize ctxsize);
 
 
+/** @brief Negotiated TLS / DTLS version. */
 R_API RTLSVersion r_tls_server_get_version (const RTLSServer * server);
+/** @brief Negotiated cipher suite, or @c NULL before the handshake completes. */
 R_API const RTLSCipherSuiteInfo * r_tls_server_get_cipher_suite (const RTLSServer * server);
+/** @brief Negotiated DTLS-SRTP protection profile (for @ref r_srtp). */
 R_API RSRTPCipherSuite r_tls_server_get_dtls_srtp_profile (const RTLSServer * server);
+/** @brief Negotiated DTLS-SRTP MKI; @p size receives its byte length. */
 R_API const ruint8 * r_tls_server_get_dtls_srtp_mki (const RTLSServer * server, ruint8 * size);
 
 R_END_DECLS
+
+/** @} */
 
 #endif /* __R_NET_TLS_SERVER_H__ */
 


### PR DESCRIPTION
## Summary
Documents the nine previously-orphaned networking headers, each as a sub-group under the existing **Networking** (`r_net`) Topic — completing the layers its umbrella brief already named.

**`net/` higher-level objects**
- `r_resolve` — `getaddrinfo`-based hostname / service resolution into an `RResolvedAddr` list
- `r_http_server` — event-loop HTTP server with pattern-routed request handlers
- `r_tls_server` — server-side TLS / DTLS session, callback transport, key export, DTLS-SRTP negotiation
- `r_srtp` — SRTP / SRTCP encrypt / decrypt with per-SSRC crypto contexts

**`net/proto/` wire codecs**
- `r_http_proto` — HTTP/1.x request / response message model (headers, bodies, buffer encode/decode)
- `r_stun` — STUN / TURN message validation, zero-copy attribute parsing, and message building
- `r_rtp` / `r_rtcp` — RTP and RTCP (RFC 3550) packet access and compound-packet parsing
- `r_sdp` — SDP (RFC 4566) reference-counted builder and zero-copy parser
- `r_tls_proto` — TLS / DTLS wire constants, record/handshake structures and parsing

Per-function `@brief`/`@param`/`@return` on every `R_API`, type and struct-member briefs, and `@name`-grouped header-layout constants. Large standard-constant enum tables (HTTP status codes, STUN attribute types, TLS IANA registries) use type-level briefs instead of redundant per-value text. This also fills the opaque-handle brief gaps flagged in the earlier audit (`RHttpMsg`, `RResolvedAddr`, `RSRTPCtx`, `RTLSServer`, `RHttpServer`, the RTP/RTCP/SDP handles, …).

Comment-only — no API or behaviour change. The three largest proto headers (`rrtp`, `rsdp`, `rtls`) were drafted in parallel and reconciled into the shared conventions.

## Remaining orphan subsystems (future passes)
`ev/` and `rtc/`.

## Test plan
- [x] `meson compile -C build-release-noerr` succeeds
- [x] `build-release-noerr/test/rlibtest` passes 1858/1858
- [x] `doxygen docs/Doxyfile` produces zero warnings
- [x] All ten `r_net` child groups render under the Networking Topic

🤖 Generated with [Claude Code](https://claude.com/claude-code)