### PR TITLE
ci: harden Linux jobs against the runner image's Chrome apt mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
+          # Drop the Chrome apt source baked into the GitHub Ubuntu image; its
+          # mirror occasionally desyncs and fails apt-get update (we only need
+          # the stock Ubuntu archive here).
+          sudo rm -f /etc/apt/sources.list.d/*google*.list
           sudo apt-get update
           sudo apt-get install -y meson ninja-build
       - name: Configure
@@ -59,6 +63,10 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
+          # Drop the Chrome apt source baked into the GitHub Ubuntu image; its
+          # mirror occasionally desyncs and fails apt-get update (we only need
+          # the stock Ubuntu archive here).
+          sudo rm -f /etc/apt/sources.list.d/*google*.list
           sudo apt-get update
           sudo apt-get install -y meson ninja-build
       - name: Configure
@@ -174,6 +182,10 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
+          # Drop the Chrome apt source baked into the GitHub Ubuntu image; its
+          # mirror occasionally desyncs and fails apt-get update (we only need
+          # the stock Ubuntu archive here).
+          sudo rm -f /etc/apt/sources.list.d/*google*.list
           sudo apt-get update
           sudo apt-get install -y meson ninja-build clang
       - name: Configure
@@ -204,6 +216,10 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install Doxygen
         run: |
+          # Drop the Chrome apt source baked into the GitHub Ubuntu image; its
+          # mirror occasionally desyncs and fails apt-get update (we only need
+          # the stock Ubuntu archive here).
+          sudo rm -f /etc/apt/sources.list.d/*google*.list
           sudo apt-get update
           sudo apt-get install -y doxygen
       - name: Generate documentation
@@ -268,6 +284,10 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
+          # Drop the Chrome apt source baked into the GitHub Ubuntu image; its
+          # mirror occasionally desyncs and fails apt-get update (we only need
+          # the stock Ubuntu archive here).
+          sudo rm -f /etc/apt/sources.list.d/*google*.list
           sudo apt-get update
           sudo apt-get install -y meson ninja-build
       - name: Configure


### PR DESCRIPTION
## Summary
PR #199's Linux x86 jobs (clang, gcc, ASan+UBSan) failed in the dependency-install step — before any compilation — with:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/.../Packages.gz
   File has unexpected size (1216 != 1218). Mirror sync in progress?
##[error]Process completed with exit code 100
```

### Root cause
This is **not a project dependency** — the GitHub-hosted Ubuntu runner *image* ships Google Chrome and registers its apt repo (`dl.google.com/linux/chrome-stable`). Our Linux jobs only install stock-archive packages (`meson` / `ninja-build` / `clang` / `doxygen`), but `apt-get update` refreshes **every** configured repo, so a transient desync on Google's mirror takes the whole step down with exit 100. It only hit the x86 runners (ARM / macOS / Windows images didn't carry it or didn't hit the bad mirror); re-running the jobs went green, confirming it was transient.

### Fix
Remove the `google*.list` apt sources before each `apt-get update`. `rm -f` is a no-op where the file is absent, so the same line is safe and uniform across all five Linux install steps (build / ARM / clang / doxygen / full-sweep). We stay on the standard hosted VM runners — no container or image change.

Considered and rejected: switching hosted image label (same image family, same Chrome repo) and moving to a `container:` (marginally slower startup, bigger change, only justified for environment-pinning — not for this flake).

## Test plan
- [x] `ci.yml` parses as valid YAML
- [ ] CI green on this PR (the install steps now skip the Chrome repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)