### PR TITLE
ev: fix REvWakeup ref/unref macro names, expose and test it

### DIFF
--- a/include/rlib/ev/revwakeup.h
+++ b/include/rlib/ev/revwakeup.h
@@ -56,9 +56,9 @@ typedef struct REvWakeup REvWakeup;
 /** @brief Create a wakeup source on @p loop. */
 R_API REvWakeup * r_ev_wakeup_new (REvLoop * loop);
 /** @brief Take a reference (alias for @ref r_ref_ref). */
-#define r_ev_resolve_ref r_ref_ref
+#define r_ev_wakeup_ref r_ref_ref
 /** @brief Drop a reference (alias for @ref r_ref_unref). */
-#define r_ev_resolve_unref r_ref_unref
+#define r_ev_wakeup_unref r_ref_unref
 
 /** @brief Wake the loop from another thread; safe to call concurrently. */
 R_API rboolean r_ev_wakeup_signal (REvWakeup * wakeup);

--- a/include/rlib/rev.h
+++ b/include/rlib/rev.h
@@ -38,6 +38,7 @@
 #include <rlib/ev/revresolve.h>
 #include <rlib/ev/revtcp.h>
 #include <rlib/ev/revudp.h>
+#include <rlib/ev/revwakeup.h>
 
 #endif /* __R_EV_H__ */
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -40,6 +40,7 @@ rlibtest_sources = [
   'revloop.c',
   'revtcp.c',
   'revudp.c',
+  'revwakeup.c',
   'rfile.c',
   'rfileio.c',
   'rfs.c',

--- a/test/revwakeup.c
+++ b/test/revwakeup.c
@@ -1,0 +1,33 @@
+#include <rlib/rev.h>
+
+RTEST (revwakeup, new, RTEST_FAST)
+{
+  REvLoop * loop;
+  REvWakeup * wakeup;
+
+  r_assert_cmpptr ((loop = r_ev_loop_new ()), !=, NULL);
+  r_assert_cmpptr ((wakeup = r_ev_wakeup_new (loop)), !=, NULL);
+
+  /* Exercise the ref/unref aliases (r_ref_ref returns the same pointer). */
+  r_assert_cmpptr (r_ev_wakeup_ref (wakeup), ==, wakeup);
+  r_ev_wakeup_unref (wakeup);
+
+  r_ev_wakeup_unref (wakeup);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+RTEST (revwakeup, signal, RTEST_FAST)
+{
+  REvLoop * loop;
+  REvWakeup * wakeup;
+
+  r_assert_cmpptr ((loop = r_ev_loop_new ()), !=, NULL);
+  r_assert_cmpptr ((wakeup = r_ev_wakeup_new (loop)), !=, NULL);
+
+  r_assert (r_ev_wakeup_signal (wakeup));
+
+  r_ev_wakeup_unref (wakeup);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;


### PR DESCRIPTION
## Summary
Your question — "are we missing a test?" — was exactly right. Fixing the misnamed macros uncovered *why* the typo survived, so this PR addresses the whole chain.

**The bug:** `revwakeup.h` defined its refcount aliases as `r_ev_resolve_ref` / `r_ev_resolve_unref` (copy-pasted from `revresolve.h`). They expanded to the correct `r_ref_ref` / `r_ref_unref`, so nothing broke at build time — but the names were wrong, duplicated `revresolve.h`'s real definitions, and left `REvWakeup` with no correctly-named ref/unref.

**Why nothing caught it:**
- `revwakeup.h` was **never included by the `rev.h` umbrella**, so `REvWakeup`'s public surface wasn't reachable through `<rlib/rev.h>`.
- Consequently it had **no test** — nothing referenced the ref/unref macros under *either* spelling, and an unused macro with a valid definition is not a compile error. So neither the build nor CI could surface it; only a reader could.

**The fix (three parts):**
1. Rename the macros to `r_ev_wakeup_ref` / `r_ev_wakeup_unref`. No call sites existed for the wakeup type under either name, so this purely adds the correct names and drops the misleading duplicates.
2. Add `revwakeup.h` to the `rev.h` umbrella so the type is part of the assembled public API (the real root cause).
3. Add `test/revwakeup.c` exercising `new` / `ref` / `unref` / `signal` — which **compile-checks the macro names**, so this class of typo fails the build going forward.

## Incidental finding (not addressed here)
`rlib/rtc/rrtcrtplistener.c:215` has a pre-existing `ssrcs` set-but-unused variable that trips `-Werror=unused-but-set-variable` in strict local build configs (from commit `1694592`, unrelated to docs/this work). Flagging for a separate fix — left out to keep this PR focused.

## Test plan
- [x] `meson compile -C build-release-noerr` succeeds
- [x] `build-release-noerr/test/rlibtest` passes 1860/1860 (was 1858 + 2 new wakeup tests)
- [x] `build-release-noerr/test/rlibtest -f '/revwakeup/*'` → 2 passed
- [x] `doxygen docs/Doxyfile` produces zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)