### PR TITLE
rtc: drop unused ssrcs counter in rtp listener update

### DIFF
--- a/rlib/rtc/rrtcrtplistener.c
+++ b/rlib/rtc/rrtcrtplistener.c
@@ -212,7 +212,7 @@ RRtcError
 r_rtc_rtp_listener_update_receiver (RRtcRtpListener * l,
     RRtcRtpReceiver * r, RRtcRtpParameters * params)
 {
-  rsize i, c, ssrcs = 0;
+  rsize i, c;
 
   if (R_UNLIKELY (r == NULL)) return R_RTC_INVAL;
   if (R_UNLIKELY (params == NULL)) return R_RTC_INVAL;
@@ -224,11 +224,11 @@ r_rtc_rtp_listener_update_receiver (RRtcRtpListener * l,
   for (i = 0, c = r_ptr_array_size (&params->encodings); i < c; i++) {
     RRtcRtpEncodingParameters * encp = r_ptr_array_get (&params->encodings, i);
     if (encp->ssrc != 0)
-      r_hash_table_insert (l->recv_ssrcmap, RSIZE_TO_POINTER (encp->ssrc), r), ssrcs++;
+      r_hash_table_insert (l->recv_ssrcmap, RSIZE_TO_POINTER (encp->ssrc), r);
     if (encp->rtx.ssrc != 0)
-      r_hash_table_insert (l->recv_ssrcmap, RSIZE_TO_POINTER (encp->rtx.ssrc), r), ssrcs++;
+      r_hash_table_insert (l->recv_ssrcmap, RSIZE_TO_POINTER (encp->rtx.ssrc), r);
     if (encp->fec.ssrc != 0)
-      r_hash_table_insert (l->recv_ssrcmap, RSIZE_TO_POINTER (encp->fec.ssrc), r), ssrcs++;
+      r_hash_table_insert (l->recv_ssrcmap, RSIZE_TO_POINTER (encp->fec.ssrc), r);
   }
   /* FIXME: update mid against mux table */
   for (i = 0, c = r_ptr_array_size (&params->codecs); i < c; i++) {


### PR DESCRIPTION
## Summary
`r_rtc_rtp_listener_update_receiver` declared a local `ssrcs` counter, incremented it three times via comma operators while inserting SSRC map entries, and never read it. That trips `-Werror=unused-but-set-variable` under strict build configs (surfaced locally while building `build-debug-test`); the project's `-noerr` CI configs let it pass, which is why it had gone unnoticed.

The count had no observer, so this removes the variable and the trailing `, ssrcs++` increments rather than papering over it with a `(void)` suppression. The hash-table inserts are unchanged, so behaviour is identical.

Found incidentally while addressing the `REvWakeup` fix (#202); split out as its own PR since it's unrelated.

## Test plan
- [x] `meson compile -C build-debug-test` (the strict `-Werror` config that flagged it) now builds cleanly
- [x] `build-debug-test/test/rlibtest` passes 1858/1858

🤖 Generated with [Claude Code](https://claude.com/claude-code)