### PR TITLE
crypto: audit fixes — defects, hardening, docs

### DIFF
--- a/include/rlib/crypto/rcert.h
+++ b/include/rlib/crypto/rcert.h
@@ -91,7 +91,8 @@ typedef struct RCryptoCert RCryptoCert;
  *
  * Use when memory is tight and the caller is done re-exporting the
  * certificate. Subsequent calls to @ref r_crypto_cert_get_data_buffer
- * / @ref r_crypto_cert_dup_data will return @c NULL.
+ * / @ref r_crypto_cert_dup_data re-encode the certificate from its
+ * parsed fields instead of returning the cached bytes.
  */
 R_API void r_crypto_cert_clear_data (RCryptoCert * cert);
 

--- a/include/rlib/crypto/rdh.h
+++ b/include/rlib/crypto/rdh.h
@@ -125,7 +125,8 @@ R_API RCryptoKey * r_dh_priv_key_new_binary (rconstpointer p, rsize psize,
     rconstpointer x, rsize xsize) R_ATTR_MALLOC;
 
 /**
- * @brief Decode a DH private key from an ASN.1 PKCS#3 / PKCS#8 TLV.
+ * @brief Decode a DH private key from an ASN.1 @c SEQUENCE
+ * (version, p, g, x).
  *
  * Used by the PEM and X.509 import paths to materialise an
  * @ref RCryptoKey from a DER blob.

--- a/include/rlib/crypto/rdsa.h
+++ b/include/rlib/crypto/rdsa.h
@@ -103,7 +103,8 @@ R_API RCryptoKey * r_dsa_priv_key_new_binary (rconstpointer p, rsize psize,
     rconstpointer y, rsize ysize, rconstpointer x, rsize xsize) R_ATTR_MALLOC;
 
 /**
- * @brief Decode a DSA private key from an ASN.1 PKCS#8 TLV.
+ * @brief Decode a DSA private key from a traditional DSAPrivateKey
+ * ASN.1 @c SEQUENCE (version, p, q, g, y, x).
  *
  * Used by the PEM and X.509 import paths (see @c rpem.h and
  * @c rx509.h) to materialise an @ref RCryptoKey from a DER blob.

--- a/include/rlib/crypto/red25519.h
+++ b/include/rlib/crypto/red25519.h
@@ -53,9 +53,8 @@
  * rejected when it is not in the canonical range @c [0, L); the
  * public key is rejected on a non-canonical encoding.
  *
- * Ed448 sign / verify lives under a separate module (when SHAKE256
- * lands - see issue #179); the shared twisted-Edwards math is in
- * @c rlib/crypto/recurve-edwards.h.
+ * Ed448 sign / verify lives in @c rlib/crypto/red448.h; the shared
+ * twisted-Edwards math is in @c rlib/crypto/recurve-edwards.h.
  */
 
 R_BEGIN_DECLS

--- a/include/rlib/crypto/rpem.h
+++ b/include/rlib/crypto/rpem.h
@@ -79,9 +79,10 @@ typedef struct RPemBlock RPemBlock;
  *
  * @param data        PEM-formatted bytes.
  * @param size        Length of @p data, or @c -1 if NUL-terminated.
- * @param passphrase  Optional passphrase for encrypted private keys
- *                    (PKCS#8 EncryptedPrivateKeyInfo). Pass @c NULL
- *                    for unencrypted blocks.
+ * @param passphrase  Optional passphrase for legacy RFC 1421
+ *                    (Proc-Type / DEK-Info) encrypted keys. Pass
+ *                    @c NULL for unencrypted blocks. PKCS#8
+ *                    EncryptedPrivateKeyInfo is not yet supported.
  * @param ppsize      Length of @p passphrase.
  * @return Parsed @ref RCryptoKey, or @c NULL if the buffer does not
  *         contain a key block or the passphrase is wrong.
@@ -195,8 +196,10 @@ R_API RAsn1BinDecoder * r_pem_block_get_asn1_decoder (RPemBlock * block);
  * @brief Materialise a key block as an @ref RCryptoKey.
  *
  * @param block       The PEM block. Must satisfy @ref r_pem_block_is_key.
- * @param passphrase  Required for encrypted PKCS#8 blocks; ignored
- *                    otherwise. Pass @c NULL when not applicable.
+ * @param passphrase  Required for legacy RFC 1421 (Proc-Type /
+ *                    DEK-Info) encrypted keys; ignored otherwise. Pass
+ *                    @c NULL when not applicable. PKCS#8
+ *                    EncryptedPrivateKeyInfo is not yet supported.
  * @param ppsize      Length of @p passphrase.
  */
 R_API RCryptoKey * r_pem_block_get_key (RPemBlock * block,

--- a/include/rlib/crypto/rsrtpciphersuite.h
+++ b/include/rlib/crypto/rsrtpciphersuite.h
@@ -130,7 +130,7 @@ R_API RSRTPCipherSuite r_srtp_cipher_suite_filter (
 R_API const RSRTPCipherSuiteInfo * r_srtp_cipher_suite_get_info (RSRTPCipherSuite suite);
 /**
  * @brief Look up the parameter table by short ASCII name (e.g.
- * @c "AES_CM_128_HMAC_SHA1_80"), or @c NULL.
+ * @c "SRTP-AES-128-CM-HMAC-SHA1-80"), or @c NULL.
  */
 R_API const RSRTPCipherSuiteInfo * r_srtp_cipher_suite_get_info_from_str (const rchar * str);
 

--- a/include/rlib/crypto/rx509.h
+++ b/include/rlib/crypto/rx509.h
@@ -181,8 +181,13 @@ R_API rboolean r_crypto_x509_cert_is_ca (const RCryptoCert * cert);
 /** @brief True iff issuer DN equals subject DN. */
 R_API rboolean r_crypto_x509_cert_is_self_issued (const RCryptoCert * cert);
 /**
- * @brief True iff @p cert is self-signed: self-issued AND the
- * signature verifies under @p cert's own public key.
+ * @brief Heuristic self-signed check based on key identifiers: returns
+ * @c TRUE when the AuthorityKeyIdentifier is absent, or when it matches
+ * the SubjectKeyIdentifier.
+ *
+ * This does @b not verify the signature or compare issuer/subject DNs;
+ * use @ref r_crypto_x509_cert_verify_signature and
+ * @ref r_crypto_x509_cert_is_self_issued for those.
  */
 R_API rboolean r_crypto_x509_cert_is_self_signed (const RCryptoCert * cert);
 

--- a/rlib/crypto/raes.c
+++ b/rlib/crypto/raes.c
@@ -524,7 +524,7 @@ r_cipher_aes_new_with_info (const RCryptoCipherInfo * info, const ruint8 * key)
   /* GCM-specific setup: derive H = E_K(0^128) and pick a GHASH kernel.
    * Done once per cipher so the per-op fast path is just a function-
    * pointer dispatch. */
-  if (info->mode == R_CRYPTO_CIPHER_MODE_GCM) {
+  if (ret != NULL && info->mode == R_CRYPTO_CIPHER_MODE_GCM) {
     ruint8 zero[R_AES_BLOCK_BYTES] = { 0 };
     ret->encrypt_block (ret, ret->ghash_h, zero);
     ret->ghash_mul = NULL;
@@ -2295,6 +2295,12 @@ r_gcm_compute_tag (const RAesCipher * aes,
   aes->encrypt_block (aes, ek, j0);
   for (i = 0; i < R_AES_BLOCK_BYTES; i++)
     tag[i] = ek[i] ^ y[i];
+
+  /* ek is the tag-encryption mask and y the GHASH accumulator; wipe
+   * both, matching the secret-scrubbing the mode ops do. */
+  r_memclear_secure (ek, sizeof (ek));
+  r_memclear_secure (y, sizeof (y));
+  r_memclear_secure (lenblock, sizeof (lenblock));
 }
 
 /* Shared encrypt/decrypt body. @p generate_tag controls whether the

--- a/rlib/crypto/rdsa.c
+++ b/rlib/crypto/rdsa.c
@@ -717,10 +717,12 @@ r_dsa_priv_key_new_gen (rsize L, rsize N, RPrng * prng)
   r_mpint_init (&ret->pub.y);
   r_mpint_init_secure (&ret->x);
 
-  if (prng != NULL)
+  if (prng != NULL) {
     r_prng_ref (prng);
-  else
-    prng = r_rand_prng_new ();
+  } else if ((prng = r_rand_prng_new ()) == NULL) {
+    r_crypto_key_unref ((RCryptoKey *) ret);
+    return NULL;
+  }
 
   /* gen_prime uses the lenient small-witness sieve only; re-test with
    * random witnesses to catch the rare crafted-or-unlucky composite. */
@@ -791,7 +793,7 @@ r_dsa_priv_key_new_from_asn1 (RAsn1BinDecoder * dec, RAsn1BinTLV * tlv)
     r_mpint_init (&ret->pub.q);
     r_mpint_init (&ret->pub.g);
     r_mpint_init (&ret->pub.y);
-    r_mpint_init (&ret->x);
+    r_mpint_init_secure (&ret->x);
 
     if (r_asn1_bin_decoder_into (dec, tlv) != R_ASN1_DECODER_OK ||
         r_asn1_bin_tlv_parse_integer_i32 (tlv, &ret->ver) != R_ASN1_DECODER_OK ||

--- a/rlib/crypto/red25519.c
+++ b/rlib/crypto/red25519.c
@@ -301,7 +301,9 @@ r_ed25519_sign (const RCryptoKey * key, rconstpointer msg, rsize msgsize,
   r_mpint_init_binary (&L, ed25519_L_be, sizeof (ed25519_L_be));
   r_mpint_init (&r_mp);
   r_mpint_init (&k_mp);
-  r_mpint_init (&s_mp);
+  /* s_mp is initialised by r_ed25519_le_to_mpint below; just keep it
+   * clear-safe here so an early error path can r_mpint_clear it. */
+  r_memclear (&s_mp, sizeof (s_mp));
   r_mpint_init (&S_mp);
 
   /* r = SHA-512(prefix || msg) mod L. */

--- a/rlib/crypto/red448.c
+++ b/rlib/crypto/red448.c
@@ -313,7 +313,9 @@ r_ed448_sign (const RCryptoKey * key, rconstpointer msg, rsize msgsize,
   r_mpint_init_binary (&L, ed448_L_be, sizeof (ed448_L_be));
   r_mpint_init (&r_mp);
   r_mpint_init (&k_mp);
-  r_mpint_init (&s_mp);
+  /* s_mp is initialised by r_ed448_le_to_mpint below; just keep it
+   * clear-safe here so an early error path can r_mpint_clear it. */
+  r_memclear (&s_mp, sizeof (s_mp));
   r_mpint_init (&S_mp);
 
   /* r = SHAKE256(dom4(0,"") || prefix || msg, 114) mod L. */

--- a/rlib/crypto/rhmac.c
+++ b/rlib/crypto/rhmac.c
@@ -34,6 +34,9 @@ r_hmac_new (RMsgDigestType type, rconstpointer key, rsize keysize)
 {
   RHmac * hmac;
 
+  if (R_UNLIKELY (key == NULL && keysize > 0))
+    return NULL;
+
   if ((hmac = r_mem_new0 (RHmac)) != NULL) {
     hmac->inner = r_msg_digest_new (type);
     hmac->outer = r_msg_digest_new (type);

--- a/rlib/crypto/rpem.c
+++ b/rlib/crypto/rpem.c
@@ -641,6 +641,14 @@ r_pem_block_get_key (RPemBlock * block, const rchar * passphrase, rsize ppsize)
     decrypted_size = decoded_size;
     if ((dec = r_asn1_bin_decoder_new (R_ASN1_BER, decoded, plain_size)) == NULL)
       goto out_wipe;
+  } else if (r_pem_block_get_type (block) >= R_PEM_TYPE_RSA_PRIVATE_KEY) {
+    /* Unencrypted private-key DER is still secret material; decode it
+     * into a buffer we own (so out_wipe scrubs it) and hand the decoder
+     * a borrowed reference, as the legacy path above does. */
+    if ((decrypted = r_pem_block_decode_base64 (block, &decrypted_size)) == NULL)
+      return NULL;
+    if ((dec = r_asn1_bin_decoder_new (R_ASN1_BER, decrypted, decrypted_size)) == NULL)
+      goto out_wipe;
   } else if ((dec = r_pem_block_get_asn1_decoder (block)) == NULL) {
     return NULL;
   }

--- a/rlib/crypto/rx509.c
+++ b/rlib/crypto/rx509.c
@@ -167,6 +167,10 @@ r_crypto_x509_key_usage (RCryptoX509Cert * cert,
    * encodings before they could shift past the int width. */
   if (R_UNLIKELY (bits > sizeof (RX509KeyUsage) * 8))
     return FALSE;
+  /* Only nine KeyUsage bits are defined (0..8); ignore any reserved
+   * high bits so the shift below can't reach the int sign bit. */
+  if (bits > 9)
+    bits = 9;
 
   /* RFC 5280 / X.690: BIT STRING bit N is the (N % 8)th bit from
    * the MSB of content byte (N / 8). Map each set BIT STRING bit N
@@ -404,8 +408,10 @@ r_crypto_x509_cert_init (RCryptoX509Cert * cert, RAsn1BinDecoder * dec)
 
     /* signature */
     if (R_ASN1_BIN_TLV_ID_IS_TAG (&tlv, R_ASN1_ID_BIT_STRING) &&
-        r_asn1_bin_tlv_parse_bit_string_bits (&tlv, &cert->cert.signbits) == R_ASN1_DECODER_OK) {
+        r_asn1_bin_tlv_parse_bit_string_bits (&tlv, &cert->cert.signbits) == R_ASN1_DECODER_OK &&
+        cert->cert.signbits >= 8) {
       cert->cert.sign = r_memdup (r_asn1_bin_tlv_bit_string_value (&tlv), cert->cert.signbits / 8);
+      if (R_UNLIKELY (cert->cert.sign == NULL)) goto beach;
     } else goto beach;
 
     return TRUE;

--- a/test/rcryptopem.c
+++ b/test/rcryptopem.c
@@ -782,6 +782,46 @@ RTEST (rcryptopem, legacy_decrypted_plaintext_wiped, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rcryptopem, unencrypted_privkey_der_wiped, RTEST_FAST)
+{
+  /* The unencrypted private-key path decodes its DER into a buffer that
+   * r_pem_block_get_key must wipe before freeing, just like the legacy
+   * decrypt path above. Same modulus byte-run needle (big-endian, so it
+   * lives only in the DER, not in the parsed n's word storage). */
+  RPemParser * parser;
+  RPemBlock * block;
+  RCryptoKey * key;
+  rmpint n;
+  ruint8 modulus[128];
+
+  r_assert_cmpptr (
+      (parser = r_pem_parser_new (pem_legacy_unenc, sizeof (pem_legacy_unenc))),
+      !=, NULL);
+  r_assert_cmpptr ((block = r_pem_parser_next_block (parser)), !=, NULL);
+  r_assert_cmpptr ((key = r_pem_block_get_key (block, NULL, 0)), !=, NULL);
+  r_mpint_init (&n);
+  r_assert (r_rsa_pub_key_get_n (key, &n));
+  r_assert (r_mpint_to_binary_with_size (&n, modulus, sizeof (modulus)));
+  r_mpint_clear (&n);
+  r_crypto_key_unref (key);
+  r_pem_block_unref (block);
+  r_pem_parser_unref (parser);
+
+  r_wipe_witness_install ();
+  r_assert_cmpptr (
+      (parser = r_pem_parser_new (pem_legacy_unenc, sizeof (pem_legacy_unenc))),
+      !=, NULL);
+  r_assert_cmpptr ((block = r_pem_parser_next_block (parser)), !=, NULL);
+  r_assert_cmpptr ((key = r_pem_block_get_key (block, NULL, 0)), !=, NULL);
+  r_crypto_key_unref (key);
+  r_pem_block_unref (block);
+  r_pem_parser_unref (parser);
+  r_wipe_witness_uninstall ();
+
+  r_assert (!r_wipe_witness_freed_contains (modulus + 16, 32));
+}
+RTEST_END;
+
 /* PKCS#8 EC private key (P-256), generated with:
  *   openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 \
  *     | openssl pkcs8 -topk8 -nocrypt


### PR DESCRIPTION
A low-risk cleanup sweep from an audit of the crypto subsystem. Three coherent commits: correctness defects + hardening, doc corrections, and a secret-wipe fix with its regression test.

## Defects fixed
- **raes**: the GCM `H` derivation ran *outside* the allocation guard — a NULL-deref if `r_mem_new` failed for a GCM cipher. Now guarded.
- **rdsa**: the ASN.1-imported private value `x` used a non-secure mpint, so it was left in freed heap on key destruction (every sibling, incl. the RSA/DH importers, marks it secure-clear). Now `r_mpint_init_secure`.
- **red25519 / red448**: `s_mp` was `r_mpint_init`'d and then re-initialised by `…_le_to_mpint`, leaking the first allocation on every signature. Removed the redundant init.

## Hardening
- **raes**: wipe the GCM tag mask and GHASH accumulator after computing the tag.
- **rhmac**: reject a NULL key with non-zero length (matching every sibling's guard style).
- **rdsa**: bail cleanly if the default PRNG can't be created during keygen.
- **rx509**: clamp the KeyUsage bit count to the nine defined bits (a malformed encoding could otherwise shift to the `int` sign bit), and reject a zero-length signature.

## Secret-wipe fix (+ test)
- **rpem**: `r_pem_block_get_key` routed unencrypted private keys through an owning ASN.1 decoder whose buffer was plainly freed, leaving the decoded DER (private key material) in freed heap. The legacy-decrypt path already wiped its plaintext; the unencrypted path now does too. Added a wipe-witness test for the unencrypted path — the existing one only covered the legacy-encrypted path, and the new test fails without the fix.

## Docs
Corrected stale/inaccurate Doxygen: `is_self_signed` (key-ID heuristic, not signature verification), the PEM passphrase (legacy RFC 1421, not PKCS#8), the DSA/DH ASN.1 importer formats, `clear_data` behaviour, an SRTP lookup example string, and a stale Ed448 note.

Verified under werror builds and ASan; full suite passes (one new test) and docs build with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)