### PR TITLE
format: harden ASN.1/JSON parsers and fix serializer bugs

### DIFF
--- a/include/rlib/format/rasn1.h
+++ b/include/rlib/format/rasn1.h
@@ -378,8 +378,10 @@ R_API RAsn1EncoderStatus r_asn1_bin_encoder_add_distinguished_name (RAsn1BinEnco
 /** @name Encoder output extraction
  *  @{ */
 /**
- * @brief Take ownership of the encoded bytes; the encoder is left
- * empty and can be reused.
+ * @brief Return a freshly-allocated copy of the encoded bytes.
+ *
+ * Non-destructive: the encoder retains its contents, so a subsequent
+ * encode appends to the existing buffer rather than starting fresh.
  */
 R_API ruint8 * r_asn1_bin_encoder_get_data (RAsn1BinEncoder * enc, rsize * size) R_ATTR_MALLOC;
 /** @brief Same as @ref r_asn1_bin_encoder_get_data but returns an @ref RBuffer. */

--- a/include/rlib/format/rjson.h
+++ b/include/rlib/format/rjson.h
@@ -192,15 +192,18 @@ R_API RJsonResult r_json_array_add_value (RJsonValue * array, RJsonValue * value
 R_API rsize r_json_value_get_object_field_count (const RJsonValue * value);
 /** @brief Return the @p idx-th field name (NUL-terminated, borrowed). */
 R_API const rchar * r_json_value_get_object_field_name (RJsonValue * value, rsize idx);
-/** @brief Return the @p idx-th field value (borrowed reference). */
+/** @brief Return the @p idx-th field value (owned reference; @ref
+ *  r_json_value_unref when done). */
 R_API RJsonValue * r_json_value_get_object_field_value (RJsonValue * value, rsize idx);
-/** @brief Look up a field by name (borrowed reference, @c NULL if absent). */
+/** @brief Look up a field by name (owned reference, @c NULL if absent;
+ *  @ref r_json_value_unref when done). */
 R_API RJsonValue * r_json_value_get_object_field (RJsonValue * value, const rchar * key);
 /** @brief Iterate every field, calling @p func with the key and value. */
 R_API void r_json_value_foreach_object_field (RJsonValue * value, RKeyValueFunc func, rpointer user);
 /** @brief Number of values in an array. */
 R_API rsize r_json_value_get_array_size (const RJsonValue * value);
-/** @brief Return the @p idx-th array entry (borrowed reference). */
+/** @brief Return the @p idx-th array entry (owned reference; @ref
+ *  r_json_value_unref when done). */
 R_API RJsonValue * r_json_value_get_array_value (RJsonValue * value, rsize idx);
 /** @brief Iterate every array entry, calling @p func with the value. */
 R_API void r_json_value_foreach_array_value (RJsonValue * value, RFunc func, rpointer user);

--- a/rlib/format/rasn1bin.c
+++ b/rlib/format/rasn1bin.c
@@ -36,12 +36,9 @@ r_asn1_bmp_string_to_utf8 (const ruint8 * src, rsize len)
   return r_utf16be_to_utf8_dup (src, len, NULL, NULL, NULL);
 }
 
-/* UniversalString is UCS-4 / UTF-32BE.  Encode each codepoint as UTF-8
- * directly; reject lengths that aren't a multiple of 4, codepoints in
- * the surrogate range D800..DFFF, and anything past U+10FFFF. */
 /* UniversalString is UCS-4 / UTF-32BE. Decode via the wire-endian
- * helper, which applies the same surrogate / out-of-range
- * validation the previous hand-rolled implementation did. */
+ * helper, which rejects lengths that aren't a multiple of 4, the
+ * surrogate range D800..DFFF, and anything past U+10FFFF. */
 static rchar *
 r_asn1_universal_string_to_utf8 (const ruint8 * src, rsize len)
 {
@@ -727,7 +724,10 @@ r_asn1_bin_decoder_new_file (RAsn1EncodingRules enc, const rchar * file)
   if ((memfile = r_mem_file_new (file, R_MEM_PROT_READ, FALSE)) != NULL) {
     ret = r_asn1_bin_decoder_new (enc, r_mem_file_get_mem (memfile),
         r_mem_file_get_size (memfile));
-    ret->file = memfile;
+    if (ret != NULL)
+      ret->file = memfile;
+    else
+      r_mem_file_unref (memfile);
   } else {
     ret = NULL;
   }

--- a/rlib/format/rber.c
+++ b/rlib/format/rber.c
@@ -39,7 +39,9 @@ r_asn1_ber_parse_length (const ruint8 * ptr, rsize * lensize, rsize * ret)
       /* definite long form */
       rsize i;
 
-      if ((*ptr & 0x7f) >= *lensize)
+      /* Bound the length-of-length: it must fit in the remaining bytes
+       * and in an rsize, else the accumulation below overflows. */
+      if ((*ptr & 0x7f) >= *lensize || (*ptr & 0x7f) > sizeof (rsize))
         return R_ASN1_DECODER_OVERFLOW;
 
       *lensize = *ptr++ & 0x7f;
@@ -70,6 +72,12 @@ r_asn1_ber_tlv_init (RAsn1BinTLV * tlv, const ruint8 * start, rsize size)
   lensize = size - 1;
   if ((ret = r_asn1_ber_parse_length (start + 1, &lensize, &tlv->len)) ==
       R_ASN1_DECODER_OK) {
+    /* The declared content length must fit in the surrounding buffer.
+     * Compare via subtraction so the pointer/size math can't overflow
+     * on a fabricated long-form length. An indefinite or definite-zero
+     * encoding has len == 0 and passes trivially. */
+    if (1 + lensize > size || tlv->len > size - 1 - lensize)
+      return R_ASN1_DECODER_OVERFLOW;
     tlv->start = start;
     tlv->value = start + 1 + lensize;
   }

--- a/rlib/format/rjson.c
+++ b/rlib/format/rjson.c
@@ -128,7 +128,12 @@ r_json_str_escape (RString * dst, const rchar * src, rssize size)
       case '\t': r_string_append (dst, "\\t");    break;
       default:
         if ((ruint8)src[i] < 0x80) {
-          r_string_append_c (dst, src[i]);
+          /* JSON requires every control char below 0x20 to be escaped;
+           * the common ones are handled above, the rest go as \u00xx. */
+          if ((ruint8)src[i] < 0x20)
+            r_string_append_printf (dst, "\\u%.4x", (ruint8)src[i]);
+          else
+            r_string_append_c (dst, src[i]);
         } else {
           runichar2 * uc2;
           rssize j;
@@ -226,7 +231,12 @@ r_json_append_ctx_newline (RJsonAppendCtx * ctx)
     if (ctx->indent == 0) {
       r_string_append_c (ctx->str, '\n');
     } else if ((ctx->flags & R_JSON_USE_TABS) == R_JSON_USE_TABS) {
-      r_string_append_printf (ctx->str, "\n%*c", ctx->indent, '\t');
+      int i;
+      /* "%*c" pads with spaces, so it can't emit a run of tabs - write
+       * one tab per indent level explicitly. */
+      r_string_append_c (ctx->str, '\n');
+      for (i = 0; i < ctx->indent; i++)
+        r_string_append_c (ctx->str, '\t');
     } else {
       r_string_append_printf (ctx->str, "\n%*c", ctx->indent * 2, ' ');
     }
@@ -290,8 +300,9 @@ r_json_append_ctx_number (RJsonAppendCtx * ctx, const RJsonValue * value)
   const RJsonNumber * num = (const RJsonNumber *)value;
   rdouble intpart;
 
-  if (modf (num->v, &intpart) == 0.0)
-    r_string_append_printf (ctx->str, "%d", (int)num->v);
+  if (modf (num->v, &intpart) == 0.0 &&
+      num->v >= (rdouble)RINT64_MIN && num->v <= (rdouble)RINT64_MAX)
+    r_string_append_printf (ctx->str, "%"RINT64_FMT, (rint64)num->v);
   else
     r_string_append_printf (ctx->str, "%f", num->v);
 }

--- a/rlib/format/rjsonparser.c
+++ b/rlib/format/rjsonparser.c
@@ -350,8 +350,14 @@ r_json_parser_scan_init_at (const RJsonParser * parser, RJsonScanCtx * ctx, rcha
       break;
     default:
       if (r_ascii_isdigit (ctx->data.str[0]) || ctx->data.str[0] == '-') {
+        /* Probe a bounded window so the NUL-seeking scan can't read past
+         * the input; strtod stops at the first non-numeric byte anyway. */
+        rchar tmp[128];
+        rsize n = ctx->data.size < sizeof (tmp) - 1 ? ctx->data.size : sizeof (tmp) - 1;
         RStrParse res;
-        r_str_to_double (ctx->data.str, NULL, &res);
+        r_memcpy (tmp, ctx->data.str, n);
+        tmp[n] = 0;
+        r_str_to_double (tmp, NULL, &res);
         if (res == R_STR_PARSE_OK) {
           ctx->type = R_JSON_TYPE_NUMBER;
         } else {
@@ -736,8 +742,16 @@ r_json_scan_ctx_parse_number_int (const RJsonScanCtx * ctx, int * number, rchar 
 
   if ((ret = r_json_scan_ctx_parse_number (ctx, &str, endptr)) == R_JSON_OK &&
       number != NULL) {
+    /* r_str_to_int scans a NUL-terminated string, but str.str points
+     * into the (possibly non-NUL-terminated) input; copy the bounded
+     * token out first so the scan can't run off the buffer. */
+    rchar tmp[128];
     RStrParse res;
-    *number = r_str_to_int (str.str, NULL, 10, &res);
+    if (str.size >= sizeof (tmp))
+      return R_JSON_NUMBER_NOT_PARSED;
+    r_memcpy (tmp, str.str, str.size);
+    tmp[str.size] = 0;
+    *number = r_str_to_int (tmp, NULL, 10, &res);
     if (R_UNLIKELY (res != R_STR_PARSE_OK))
       ret = R_JSON_NUMBER_NOT_PARSED;
   }
@@ -753,8 +767,15 @@ r_json_scan_ctx_parse_number_double (const RJsonScanCtx * ctx, rdouble * number,
 
   if ((ret = r_json_scan_ctx_parse_number (ctx, &str, endptr)) == R_JSON_OK &&
       number != NULL) {
+    /* See r_json_scan_ctx_parse_number_int: copy the bounded token to a
+     * NUL-terminated buffer before the (unbounded) string scan. */
+    rchar tmp[128];
     RStrParse res;
-    *number = r_str_to_double (str.str, NULL, &res);
+    if (str.size >= sizeof (tmp))
+      return R_JSON_NUMBER_NOT_PARSED;
+    r_memcpy (tmp, str.str, str.size);
+    tmp[str.size] = 0;
+    *number = r_str_to_double (tmp, NULL, &res);
     if (R_UNLIKELY (res != R_STR_PARSE_OK))
       ret = R_JSON_NUMBER_NOT_PARSED;
   }
@@ -765,28 +786,28 @@ r_json_scan_ctx_parse_number_double (const RJsonScanCtx * ctx, rdouble * number,
 RJsonResult
 r_json_scan_ctx_parse_string (const RJsonScanCtx * ctx, RStrChunk * str, rchar ** endptr)
 {
-  rssize cur;
-  rsize idx = 0;
+  rsize idx;
 
   if (R_UNLIKELY (ctx == NULL || ctx->type != R_JSON_TYPE_STRING || str == NULL))
     return R_JSON_INVAL;
 
   str->str = (rchar *)ctx->data.str + 1;
   str->size = ctx->data.size - 1;
-  if ((cur = r_str_idx_of_c (str->str + idx, str->size - idx, '"')) >= 0) {
-    do {
-      idx += cur;
-      /* idx == 0 means the closing quote is at offset 0 -- an empty
-       * string ("").  There's no preceding character to inspect, so
-       * the quote can't be escaped. */
-      if (idx == 0 || str->str[idx - 1] != '\\') {
-        str->size = idx;
-        if (endptr != NULL)
-          *endptr = r_str_chunk_end (str) + 1;
-        return R_JSON_OK;
-      }
-      idx++;
-    } while ((cur = r_str_idx_of_c (str->str + idx, str->size - idx, '"')) > 0);
+  /* Walk to the first unescaped closing quote, tracking backslash
+   * escapes properly. A simple "find a quote, peek one char back" scan
+   * mishandles an escaped backslash before the quote (\\") and a string
+   * ending in an escaped quote (\"). */
+  for (idx = 0; idx < str->size; idx++) {
+    if (str->str[idx] == '\\') {
+      idx++;                     /* skip the escaped char */
+      continue;
+    }
+    if (str->str[idx] == '"') {
+      str->size = idx;
+      if (endptr != NULL)
+        *endptr = r_str_chunk_end (str) + 1;
+      return R_JSON_OK;
+    }
   }
 
   return R_JSON_STRING_NOT_TERMINATED;

--- a/test/rasn1ber.c
+++ b/test/rasn1ber.c
@@ -13,6 +13,32 @@ RTEST (rasn1ber, new, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rasn1ber, oversized_length_rejected, RTEST_FAST)
+{
+  /* Long-form length (8 octets, all 0xff) declares ~2^64 bytes of
+   * content in a 10-byte buffer -- the pointer math for value+len wraps,
+   * so this must be rejected rather than parsed into an OOB read. */
+  static ruint8 huge_len[] = {
+    0x04, 0x88, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
+  /* Length-of-length count that can't fit in an rsize (9 octets). */
+  static ruint8 toobig_nlen[] = {
+    0x04, 0x89, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+  RAsn1BinDecoder * dec;
+  RAsn1BinTLV tlv = R_ASN1_BIN_TLV_INIT;
+  RAsn1BinTLV tlv2 = R_ASN1_BIN_TLV_INIT;
+
+  r_assert_cmpptr ((dec = r_asn1_bin_decoder_new (R_ASN1_BER,
+          huge_len, sizeof (huge_len))), !=, NULL);
+  r_assert_cmpint (r_asn1_bin_decoder_next (dec, &tlv), ==, R_ASN1_DECODER_OVERFLOW);
+  r_asn1_bin_decoder_unref (dec);
+
+  r_assert_cmpptr ((dec = r_asn1_bin_decoder_new (R_ASN1_BER,
+          toobig_nlen, sizeof (toobig_nlen))), !=, NULL);
+  r_assert_cmpint (r_asn1_bin_decoder_next (dec, &tlv2), ==, R_ASN1_DECODER_OVERFLOW);
+  r_asn1_bin_decoder_unref (dec);
+}
+RTEST_END;
+
 RTEST (rasn1ber, sequence_primitives, RTEST_FAST)
 {
   static ruint8 ber_encoded[] = { 0x30, 0x80,

--- a/test/rjson.c
+++ b/test/rjson.c
@@ -338,3 +338,55 @@ RTEST (rjson, string_escape, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rjson, serialize_control_chars, RTEST_FAST)
+{
+  RJsonValue * v;
+  rchar * str;
+
+  /* Control chars below 0x20 that lack a short escape must come out as
+   * \u00xx; emitting them raw would produce invalid JSON. */
+  r_assert_cmpptr ((v = r_json_string_new_static_unescaped ("a\x01\x1f" "b")), !=, NULL);
+  r_assert_cmpstr ((str = r_json_value_get_string_quoted (v)), ==, "\"a\\u0001\\u001fb\"");
+  r_free (str);
+  r_json_value_unref (v);
+}
+RTEST_END;
+
+RTEST (rjson, serialize_large_integer, RTEST_FAST)
+{
+  RJsonValue * v;
+  RBuffer * buf;
+  RJsonResult res;
+
+  /* Integral value past INT_MAX must not be truncated by an int cast. */
+  r_assert_cmpptr ((v = r_json_parse (R_STR_WITH_SIZE_ARGS ("2147483648"), NULL)), !=, NULL);
+  r_assert_cmpptr ((buf = r_json_value_to_buffer (v, R_JSON_COMPACT, &res)), !=, NULL);
+  r_assert_cmpbufsstr (buf, 0, -1, ==, "2147483648");
+  r_buffer_unref (buf);
+  r_json_value_unref (v);
+}
+RTEST_END;
+
+RTEST (rjson, serialize_nested_tabs, RTEST_FAST)
+{
+  RJsonValue * outer, * inner, * s;
+  RBuffer * buf;
+  RJsonResult res;
+
+  /* At depth 2 the inner element needs two tabs; the old "%*c" form
+   * emitted spaces plus a single tab. */
+  r_assert_cmpptr ((outer = r_json_array_new ()), !=, NULL);
+  r_assert_cmpptr ((inner = r_json_array_new ()), !=, NULL);
+  r_assert_cmpptr ((s = r_json_string_new_static_unescaped ("x")), !=, NULL);
+  r_assert_cmpint (r_json_array_add_value (inner, s), ==, R_JSON_OK);
+  r_json_value_unref (s);
+  r_assert_cmpint (r_json_array_add_value (outer, inner), ==, R_JSON_OK);
+  r_json_value_unref (inner);
+
+  r_assert_cmpptr ((buf = r_json_value_to_buffer (outer, R_JSON_USE_TABS, &res)), !=, NULL);
+  r_assert_cmpbufsstr (buf, 0, -1, ==, "[\n\t[\n\t\t\"x\"\n\t]\n]");
+  r_buffer_unref (buf);
+  r_json_value_unref (outer);
+}
+RTEST_END;
+

--- a/test/rjson_parser.c
+++ b/test/rjson_parser.c
@@ -207,6 +207,41 @@ RTEST (rjson_parser, string, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rjson_parser, string_escapes, RTEST_FAST)
+{
+  RJsonParser * parser;
+  RJsonScanCtx ctx = R_JSON_SCAN_CTX_INIT;
+  RStrChunk str = R_STR_CHUNK_INIT;
+  rchar * endptr;
+
+  /* "\"" -- a string whose content is a single escaped quote, so the
+   * closing quote immediately follows the escape. Must parse; the raw
+   * (still-escaped) content is the two bytes \" */
+  r_assert_cmpptr ((parser = r_json_parser_new (R_STR_WITH_SIZE_ARGS ("\"\\\"\""))), !=, NULL);
+  r_assert_cmpint (r_json_parser_scan_start (parser, &ctx), ==, R_JSON_OK);
+  r_assert_cmpint (ctx.type, ==, R_JSON_TYPE_STRING);
+  r_assert_cmpint (r_json_scan_ctx_parse_string (&ctx, &str, &endptr), ==, R_JSON_OK);
+  r_assert_cmpint (r_str_chunk_cmp (&str, R_STR_WITH_SIZE_ARGS ("\\\"")), ==, 0);
+  r_assert_cmpptr (endptr, ==, str.str + 3);
+  r_json_parser_unref (parser);
+
+  /* "\\" -- an escaped backslash directly before the closing quote.
+   * The closing quote must NOT be treated as escaped. Raw content \\ */
+  r_assert_cmpptr ((parser = r_json_parser_new (R_STR_WITH_SIZE_ARGS ("\"\\\\\""))), !=, NULL);
+  r_assert_cmpint (r_json_parser_scan_start (parser, &ctx), ==, R_JSON_OK);
+  r_assert_cmpint (r_json_scan_ctx_parse_string (&ctx, &str, &endptr), ==, R_JSON_OK);
+  r_assert_cmpint (r_str_chunk_cmp (&str, R_STR_WITH_SIZE_ARGS ("\\\\")), ==, 0);
+  r_json_parser_unref (parser);
+
+  /* "\" -- the final quote is escaped, so the string is unterminated. */
+  r_assert_cmpptr ((parser = r_json_parser_new (R_STR_WITH_SIZE_ARGS ("\"\\\""))), !=, NULL);
+  r_assert_cmpint (r_json_parser_scan_start (parser, &ctx), ==, R_JSON_OK);
+  r_assert_cmpint (r_json_scan_ctx_parse_string (&ctx, &str, &endptr), ==,
+      R_JSON_STRING_NOT_TERMINATED);
+  r_json_parser_unref (parser);
+}
+RTEST_END;
+
 static const rchar json_array_strings[] = "[ \"foo\", \"bar\" ]";
 
 RTEST (rjson_parser, to_value, RTEST_FAST)


### PR DESCRIPTION
A low-risk cleanup sweep from an audit of the `format` subsystem (ASN.1 BER/DER + JSON), focused on untrusted-input parsing. Four atomic commits, each pairing the fix with a regression test.

## Defects
- **BER out-of-bounds read** (`rber.c`): the BER decoder accepted a long-form length with no cap on the length-octet count and no check that the declared content length fits the buffer (DER has both). A crafted length produces a huge `tlv->len` whose `value + len` pointer math wraps, slips past the `_next` bounds guard, and lets the parse helpers read out of bounds. Mirrored DER's two checks. *(The test is verified to fail without the fix.)*
- **NULL-deref + leak** (`rasn1bin.c`): `r_asn1_bin_decoder_new_file` dereferenced the decoder unconditionally, but `_new` returns NULL for a zero-length (yet mappable) file — crash plus a leaked memfile.
- **JSON serializer** (`rjson.c`): emitted raw control chars `< 0x20` (invalid JSON — now `\u00xx`); truncated integral numbers past `INT_MAX` via an `(int)` cast (now a 64-bit conversion); `R_JSON_USE_TABS` produced spaces + a single tab instead of one tab per indent level.

## Parser hardening
- **JSON string scan** (`rjsonparser.c`): the "find a quote, peek one byte back" approach mis-parsed strings ending in an escaped quote (`\"`) and an escaped backslash before the close (`\\"`). Replaced with a forward escape-tracking scan.
- **Unbounded number conversion** (`rjsonparser.c`): the number accessors and the bare-number type probe ran `strtod`/`strtol` on a slice pointing into a possibly non-NUL-terminated input (mmap'd files), reading past the end. Now copies the bounded token to a NUL-terminated buffer first.

## Docs
- The JSON object/array value accessors return an **owned** reference (they ref before returning), not "borrowed" as documented — a leak trap for callers who trusted the doc.
- `r_asn1_bin_encoder_get_data` is non-destructive (copies out, leaves the encoder intact), not "left empty and reusable".

Verified under werror builds and ASan; full suite passes with 5 new tests; docs build with zero warnings. The BER and JSON-string fixes have regression tests confirmed to fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)