### PR TITLE
Fix misspelled public symbols, broken macros, and inaccurate API docs

### DIFF
--- a/include/rlib/binfmt/relf.h
+++ b/include/rlib/binfmt/relf.h
@@ -19,7 +19,7 @@
 #define __R_ELF_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/binfmt/relfparser.h
+++ b/include/rlib/binfmt/relfparser.h
@@ -19,7 +19,7 @@
 #define __R_ELF_PARSER_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -76,9 +76,9 @@ R_BEGIN_DECLS
  * @brief Return the on-disk size of the ELF image at @p mem, or @c 0
  * if @p mem doesn't carry a valid ELF.
  *
- * Computed from the section table extent; useful for slicing a
- * blob known to contain one ELF before passing it to
- * @ref r_elf_parser_new_from_mem.
+ * Computed as the larger of the program-header and section-header
+ * table extents; useful for slicing a blob known to contain one ELF
+ * before passing it to @ref r_elf_parser_new_from_mem.
  */
 R_API rsize r_elf_calc_size (rpointer mem);
 

--- a/include/rlib/binfmt/rmacho.h
+++ b/include/rlib/binfmt/rmacho.h
@@ -19,7 +19,7 @@
 #define __R_MACHO_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -60,9 +60,10 @@ typedef ruint32 RMachoStrOffset;
  * @name Mach-O magic numbers
  *
  * Sentinel at offset 0 of the file header
- * (@c magic field on @ref RMacho32Hdr / @ref RMacho64Hdr). Encodes both
- * the bitness and the host endianness of the writer; rlib's parser
- * accepts both byte orderings.
+ * (@c magic field on @ref RMacho32Hdr / @ref RMacho64Hdr). The value
+ * encodes both the bitness and the writer's byte order; rlib's parser
+ * matches only these two host-native magics and does not byte-swap
+ * reversed-endian images.
  * @{
  */
 #define R_MACHO_MAGIC_32              0xfeedface
@@ -118,11 +119,11 @@ typedef ruint32 RMachoStrOffset;
 #define R_MACH_CPU_SUBTYPE_486SX        4 + 128
 #define R_MACH_CPU_SUBTYPE_586          5
 #define R_MACH_CPU_SUBTYPE_X86_64_H     8 /**< Haswell and compatible */
-#define R_MACH_CPU_SUBTYPE_PENT         CPU_SUBTYPE_INTEL (5, 0)
-#define R_MACH_CPU_SUBTYPE_PENTPRO      CPU_SUBTYPE_INTEL (6, 1)
-#define R_MACH_CPU_SUBTYPE_PENTII_M3    CPU_SUBTYPE_INTEL (6, 3)
-#define R_MACH_CPU_SUBTYPE_PENTII_M5    CPU_SUBTYPE_INTEL (6, 5)
-#define R_MACH_CPU_SUBTYPE_PENTIUM_4    CPU_SUBTYPE_INTEL (10, 0)
+#define R_MACH_CPU_SUBTYPE_PENT         R_MACH_CPU_SUBTYPE_INTEL (5, 0)
+#define R_MACH_CPU_SUBTYPE_PENTPRO      R_MACH_CPU_SUBTYPE_INTEL (6, 1)
+#define R_MACH_CPU_SUBTYPE_PENTII_M3    R_MACH_CPU_SUBTYPE_INTEL (6, 3)
+#define R_MACH_CPU_SUBTYPE_PENTII_M5    R_MACH_CPU_SUBTYPE_INTEL (6, 5)
+#define R_MACH_CPU_SUBTYPE_PENTIUM_4    R_MACH_CPU_SUBTYPE_INTEL (10, 0)
 
 #define R_MACH_CPU_SUBTYPE_ARM_ALL        0
 #define R_MACH_CPU_SUBTYPE_ARM_A500_ARCH  1
@@ -238,11 +239,11 @@ typedef struct {
 #define R_MACHO_LC_FVMFILE            0x09  /**< fixed VM file inclusion (internal use) */
 #define R_MACHO_LC_PREPAGE            0x0a  /**< prepage command (internal use) */
 #define R_MACHO_LC_DYSYMTAB           0x0b  /**< dynamic link-edit symbol table info */
-#define R_MACHO_LC_LOAD_DYLIB         0x0c  /**< load a dynamicly linked shared library */
-#define R_MACHO_LC_ID_DYLIB           0x0d  /**< dynamicly linked shared lib identification */
+#define R_MACHO_LC_LOAD_DYLIB         0x0c  /**< load a dynamically linked shared library */
+#define R_MACHO_LC_ID_DYLIB           0x0d  /**< dynamically linked shared lib identification */
 #define R_MACHO_LC_LOAD_DYLINKER      0x0e  /**< load a dynamic linker */
 #define R_MACHO_LC_ID_DYLINKER        0x0f  /**< dynamic linker identification */
-#define R_MACHO_LC_PREBOUND_DYLIB     0x10  /**< modules prebound for a dynamicly */
+#define R_MACHO_LC_PREBOUND_DYLIB     0x10  /**< modules prebound for a dynamically */
 #define R_MACHO_LC_ROUTINES           0x11  /**< image routines */
 #define R_MACHO_LC_SUB_FRAMEWORK      0x12  /**< sub framework */
 #define R_MACHO_LC_SUB_UMBRELLA       0x13  /**< sub umbrella */
@@ -699,9 +700,9 @@ typedef struct {
   ruint32 weak_bind_off;  /* file offset to weak binding info */
   ruint32 weak_bind_size; /* size of weak binding info */
   ruint32 lazy_bind_off;  /* file offset to lazy binding info */
-  ruint32 lazy_bind_size; /* size of lazy binding infs */
-  ruint32 export_off;     /* file offset to lazy binding info */
-  ruint32 export_size;    /* size of lazy binding infs */
+  ruint32 lazy_bind_size; /* size of lazy binding info */
+  ruint32 export_off;     /* file offset to export info */
+  ruint32 export_size;    /* size of export info */
 } RMachoDyldInfoCmd;
 
 /**

--- a/include/rlib/binfmt/rmachoparser.h
+++ b/include/rlib/binfmt/rmachoparser.h
@@ -19,7 +19,7 @@
 #define __R_MACHO_PARSER_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/binfmt/rpe.h
+++ b/include/rlib/binfmt/rpe.h
@@ -19,7 +19,7 @@
 #define __R_PECOFF_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -314,7 +314,6 @@ typedef struct {
 } RPe32PlusWinOptHdr;
 
 /** @brief Data-directory entry: (RVA, size) pair. */
-/** @brief Named indices into the optional headers data-directory array (export, import, resources, ...). */
 typedef struct {
   ruint32 vmaddr;
   ruint32 size;

--- a/include/rlib/binfmt/rpeparser.h
+++ b/include/rlib/binfmt/rpeparser.h
@@ -19,7 +19,7 @@
 #define __R_PE_PARSER_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/charset/rascii.h
+++ b/include/rlib/charset/rascii.h
@@ -19,7 +19,7 @@
 #define __R_ASCII_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rtypes.h>

--- a/include/rlib/charset/runicode.h
+++ b/include/rlib/charset/runicode.h
@@ -19,7 +19,7 @@
 #define __R_UNICODE_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rtypes.h>

--- a/include/rlib/concurrency/ratomic.h
+++ b/include/rlib/concurrency/ratomic.h
@@ -19,7 +19,7 @@
 #define __R_ATOMIC_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/concurrency/rtaskqueue.h
+++ b/include/rlib/concurrency/rtaskqueue.h
@@ -19,7 +19,7 @@
 #define __R_TASK_QUEUE_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/concurrency/rthreadpool.h
+++ b/include/rlib/concurrency/rthreadpool.h
@@ -19,7 +19,7 @@
 #define __R_THREAD_POOL_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/concurrency/rthreads.h
+++ b/include/rlib/concurrency/rthreads.h
@@ -19,7 +19,7 @@
 #define __R_THREAD_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/crypto/raes.h
+++ b/include/rlib/crypto/raes.h
@@ -19,7 +19,7 @@
 #define __R_CRYPTO_AES_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rtypes.h>

--- a/include/rlib/crypto/rcert.h
+++ b/include/rlib/crypto/rcert.h
@@ -19,7 +19,7 @@
 #define __R_CRYPTO_CERT_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/crypto/rchacha20.h
+++ b/include/rlib/crypto/rchacha20.h
@@ -19,7 +19,7 @@
 #define __R_CRYPTO_CHACHA20_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rtypes.h>

--- a/include/rlib/crypto/rcipher.h
+++ b/include/rlib/crypto/rcipher.h
@@ -19,7 +19,7 @@
 #define __R_CRYPTO_CIPHER_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rtypes.h>

--- a/include/rlib/crypto/rdh.h
+++ b/include/rlib/crypto/rdh.h
@@ -19,7 +19,7 @@
 #define __R_CRYPTO_DH_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/crypto/rdsa.h
+++ b/include/rlib/crypto/rdsa.h
@@ -19,7 +19,7 @@
 #define __R_CRYPTO_DSA_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/crypto/recc.h
+++ b/include/rlib/crypto/recc.h
@@ -19,7 +19,7 @@
 #define __R_CRYPTO_ECC_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/crypto/recurve.h
+++ b/include/rlib/crypto/recurve.h
@@ -19,7 +19,7 @@
 #define __R_CRYPTO_ECURVE_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rtypes.h>
@@ -106,7 +106,7 @@ typedef enum {
   R_ECURVE_ID_SECP384R1                        = 0x0018,  /**< @brief Prime curve secp384r1 / NIST P-384 (RFC 4492). */
   R_ECURVE_ID_SECP521R1                        = 0x0019,  /**< @brief Prime curve secp521r1 / NIST P-521 (RFC 4492). */
   R_ECURVE_ID_BRAINPOOLP256R1                  = 0x001a,  /**< @brief Brainpool brainpoolP256r1 (RFC 7027; not initialised by the math layer). */
-  R_ECURVE_ID_BRAINPOOLP348R1                  = 0x001b,  /**< @brief Brainpool brainpoolP384r1 (RFC 7027; not initialised by the math layer). */
+  R_ECURVE_ID_BRAINPOOLP384R1                  = 0x001b,  /**< @brief Brainpool brainpoolP384r1 (RFC 7027; not initialised by the math layer). */
   R_ECURVE_ID_BRAINPOOLP512R1                  = 0x001c,  /**< @brief Brainpool brainpoolP512r1 (RFC 7027; not initialised by the math layer). */
   R_ECURVE_ID_X25519                           = 0x001d,  /**< @brief Curve25519, handled by @c rlib/crypto/recurve-montgomery.h. */
   R_ECURVE_ID_X448                             = 0x001e,  /**< @brief Curve448, handled by @c rlib/crypto/recurve-montgomery.h. */

--- a/include/rlib/crypto/rhmac.h
+++ b/include/rlib/crypto/rhmac.h
@@ -19,7 +19,7 @@
 #define __R_CRYPTO_MAC_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/crypto/rkey.h
+++ b/include/rlib/crypto/rkey.h
@@ -19,7 +19,7 @@
 #define __R_CRYPTO_KEY_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rtypes.h>

--- a/include/rlib/crypto/rmsgdigest.h
+++ b/include/rlib/crypto/rmsgdigest.h
@@ -19,7 +19,7 @@
 #define __R_MSG_DIGEST_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rtypes.h>
@@ -140,8 +140,8 @@ R_API RMsgDigest * r_msg_digest_new (RMsgDigestType type);
  */
 R_API void r_msg_digest_free (RMsgDigest * md);
 
-R_API RMsgDigest * r_msg_digest_new_md2 (void);     /**< @brief Construct a fresh MD2 digest. */
-R_API RMsgDigest * r_msg_digest_new_md4 (void);     /**< @brief Construct a fresh MD4 digest. */
+R_API RMsgDigest * r_msg_digest_new_md2 (void);     /**< @brief Construct a fresh MD2 digest (not yet implemented; returns @c NULL). */
+R_API RMsgDigest * r_msg_digest_new_md4 (void);     /**< @brief Construct a fresh MD4 digest (not yet implemented; returns @c NULL). */
 R_API RMsgDigest * r_msg_digest_new_md5 (void);     /**< @brief Construct a fresh MD5 digest. */
 R_API RMsgDigest * r_msg_digest_new_sha1 (void);    /**< @brief Construct a fresh SHA-1 digest. */
 R_API RMsgDigest * r_msg_digest_new_sha224 (void);  /**< @brief Construct a fresh SHA-224 digest. */

--- a/include/rlib/crypto/rpem.h
+++ b/include/rlib/crypto/rpem.h
@@ -19,7 +19,7 @@
 #define __R_CRYPTO_PEM_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/crypto/rrsa.h
+++ b/include/rlib/crypto/rrsa.h
@@ -19,7 +19,7 @@
 #define __R_CRYPTO_RSA_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/crypto/rsrtpciphersuite.h
+++ b/include/rlib/crypto/rsrtpciphersuite.h
@@ -19,7 +19,7 @@
 #define __R_CRYPTO_SRTP_CIPHER_SUITE_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/crypto/rtlsciphersuite.h
+++ b/include/rlib/crypto/rtlsciphersuite.h
@@ -19,7 +19,7 @@
 #define __R_CRYPTO_CIPHER_SUITE_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/crypto/rx509.h
+++ b/include/rlib/crypto/rx509.h
@@ -19,7 +19,7 @@
 #define __R_CRYPTO_X509_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/data/rbitset.h
+++ b/include/rlib/data/rbitset.h
@@ -19,7 +19,7 @@
 #define __R_BITSET_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/data/rcbctx.h
+++ b/include/rlib/data/rcbctx.h
@@ -19,7 +19,7 @@
 #define __R_CBCTX_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/data/rdictionary.h
+++ b/include/rlib/data/rdictionary.h
@@ -19,7 +19,7 @@
 #define __R_DICTIONARY_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -66,7 +66,9 @@ static inline rsize r_dictionary_size (RDictionary * dict);
 /** @brief Allocated bucket count. */
 static inline rsize r_dictionary_current_alloc_size (RDictionary * dict);
 
-/** @brief Insert @c (key, value); returns @c FALSE on internal failure. */
+/** @brief Insert @c (key, value). @return @c TRUE only on a fresh
+ *  insert; @c FALSE if the key already existed (its value is replaced)
+ *  or on internal failure. */
 static inline rboolean r_dictionary_insert (RDictionary * dict, const rchar * key, rpointer value);
 /** @brief Return the value associated with @p key, or @c NULL. */
 static inline rpointer r_dictionary_lookup (RDictionary * dict, const rchar * key);

--- a/include/rlib/data/rdirtree.h
+++ b/include/rlib/data/rdirtree.h
@@ -19,7 +19,7 @@
 #define __R_DIR_TREE_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -109,7 +109,7 @@ R_API RDirTreeNode * r_dir_tree_create (RDirTree * tree, const rchar * path, rss
 R_API RDirTreeNode * r_dir_tree_set_full (RDirTree * tree, const rchar * path, rssize size,
     rpointer data, RDestroyNotify notify, RFunc func) R_ATTR_WARN_UNUSED_RESULT;
 /** @brief Convenience: drop the data at @p path (destroy notifier runs). */
-#define r_dir_tree_clear_node(tree, path) r_dir_tree_set (tree, path, NULL, NULL)
+#define r_dir_tree_clear_node(tree, path) r_dir_tree_set (tree, path, -1, NULL, NULL)
 
 /**
  * @brief Remove @p node and every descendant; destroy notifiers run.

--- a/include/rlib/data/rhashfuncs.h
+++ b/include/rlib/data/rhashfuncs.h
@@ -19,7 +19,7 @@
 #define __R_HASH_FUNCS_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/data/rhashset.h
+++ b/include/rlib/data/rhashset.h
@@ -19,7 +19,7 @@
 #define __R_HASH_SET_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -76,8 +76,9 @@ R_API rsize r_hash_set_current_alloc_size (RHashSet * ht);
 /**
  * @brief Add @p item to the set.
  *
- * @return @c TRUE if @p item was newly added, @c FALSE if it was
- * already present.
+ * @return @c TRUE on success (@c FALSE only when @p ht is @c NULL). If
+ * an equal item is already present it is replaced and its destroy
+ * notifier runs.
  */
 R_API rboolean r_hash_set_insert (RHashSet * ht, rpointer item);
 

--- a/include/rlib/data/rhashtable.h
+++ b/include/rlib/data/rhashtable.h
@@ -19,7 +19,7 @@
 #define __R_HASH_TABLE_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -132,15 +132,22 @@ R_API void r_hash_table_remove_all (RHashTable * ht);
 /** @brief Remove the entry for @p key; destroy notifiers run. */
 R_API RHashTableError r_hash_table_remove (RHashTable * ht, rconstpointer key);
 /**
- * @brief Remove an entry and hand the destroy responsibility back
- * to the caller.
+ * @brief Remove the entry for @p key, running its destroy notifiers
+ * (as @ref r_hash_table_remove), and also report the removed key /
+ * value via @p keyout / @p valueout.
  *
- * Same as @ref r_hash_table_remove but returns the stored key /
- * value rather than running them through the destroy notifiers.
+ * @note If destroy notifiers are registered they have already freed
+ * the key / value by the time this returns, so the out-params are only
+ * safe to dereference when no notifier is set. To take ownership
+ * without running the notifiers, use @ref r_hash_table_steal.
  */
 R_API RHashTableError r_hash_table_remove_full (RHashTable * ht, rconstpointer key,
     rpointer * keyout, rpointer * valueout);
-/** @brief Alias for @ref r_hash_table_remove_full reflecting the "take ownership" semantics. */
+/**
+ * @brief Remove the entry for @p key @b without running its destroy
+ * notifiers, handing ownership of the key / value to the caller via
+ * @p keyout / @p valueout (the caller must free them).
+ */
 R_API RHashTableError r_hash_table_steal (RHashTable * ht, rconstpointer key,
     rpointer * keyout, rpointer * valueout);
 

--- a/include/rlib/data/rhzrptr.h
+++ b/include/rlib/data/rhzrptr.h
@@ -19,7 +19,7 @@
 #define __R_HZR_PTR_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -36,7 +36,7 @@
  *     @ref r_hzr_ptr_rec_new, freed at thread exit with
  *     @ref r_hzr_ptr_rec_free).
  *   - Accesses to a hazard pointer happen between
- *     @ref r_hzr_ptr_aqcuire and @ref r_hzr_ptr_release.
+ *     @ref r_hzr_ptr_acquire and @ref r_hzr_ptr_release.
  *   - Writers swap pointers via @ref r_hzr_ptr_replace, which
  *     defers freeing the displaced value until no
  *     @ref RHzrPtrRec still references it. The per-pointer destroy
@@ -81,8 +81,8 @@ typedef struct RHzrPtrRec RHzrPtrRec;
  * the returned pointer; while a hazard is active on the value,
  * writers will defer freeing it.
  */
-R_API rpointer r_hzr_ptr_aqcuire (rhzrptr * hzrptr, RHzrPtrRec * rec);
-/** @brief Drop the hazard published by a previous @ref r_hzr_ptr_aqcuire. */
+R_API rpointer r_hzr_ptr_acquire (rhzrptr * hzrptr, RHzrPtrRec * rec);
+/** @brief Drop the hazard published by a previous @ref r_hzr_ptr_acquire. */
 R_API void     r_hzr_ptr_release (rhzrptr * hzrptr, RHzrPtrRec * rec);
 /**
  * @brief Atomically replace @p hzrptr's value with @p ptr and

--- a/include/rlib/data/rkvptrarray.h
+++ b/include/rlib/data/rkvptrarray.h
@@ -18,6 +18,10 @@
 #ifndef __R_KV_PTR_ARRAY_H__
 #define __R_KV_PTR_ARRAY_H__
 
+#if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
+#error "#include <rlib.h> only please."
+#endif
+
 /**
  * @defgroup r_kvptrarray Key-value pointer array
  * @ingroup r_data

--- a/include/rlib/data/rlist.h
+++ b/include/rlib/data/rlist.h
@@ -19,7 +19,7 @@
 #define __R_LIST_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/data/rmpint.h
+++ b/include/rlib/data/rmpint.h
@@ -19,7 +19,7 @@
 #define __R_MPINT_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/data/rptrarray.h
+++ b/include/rlib/data/rptrarray.h
@@ -19,7 +19,7 @@
 #define __R_PTR_ARRAY_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/data/rqueue.h
+++ b/include/rlib/data/rqueue.h
@@ -19,7 +19,7 @@
 #define __R_QUEUE_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/data/rstring.h
+++ b/include/rlib/data/rstring.h
@@ -19,7 +19,7 @@
 #define __R_STRING_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rtypes.h>
@@ -45,10 +45,9 @@
  * @c r_string_free or, if you want to keep the inner @c rchar @c *
  * after, @c r_string_free_keep.
  *
- * The mutating functions return the resulting length so callers
- * can chain or detect failure (0 with no prior length is the only
- * ambiguous case; otherwise a non-zero result means the operation
- * was applied).
+ * Most mutating functions return the number of bytes they added or
+ * removed (@c r_string_reset and @c r_string_erase instead return the
+ * resulting length); a @c 0 return signals failure or a no-op.
  */
 
 R_BEGIN_DECLS
@@ -117,7 +116,10 @@ R_API int r_string_cmp_cstr (RString * str, const rchar * cstr);
 /**
  * @name Mutations
  *
- * All return the resulting length in bytes after the operation.
+ * Each returns the number of bytes added or removed by the operation,
+ * @b not the resulting total length (the exceptions are
+ * @ref r_string_reset and @ref r_string_erase, which return the
+ * resulting length).
  * Family layout: reset → append* → prepend* → insert* → overwrite*
  * → truncate / erase. The @c _len variants take an explicit byte
  * count, useful for non-NUL-terminated source spans; the @c _printf
@@ -143,7 +145,7 @@ R_API rsize r_string_append (RString * str, const rchar * cstr);
 R_API rsize r_string_append_len (RString * str, const rchar * cstr, rsize len);
 /**
  * @brief printf-format and append the result to @p str.
- * @return New length after the append.
+ * @return Number of bytes appended.
  */
 R_API rsize r_string_append_printf (RString * str, const rchar * fmt, ...) R_ATTR_PRINTF (2, 3);
 /** @brief va_list flavour of r_string_append_printf. */
@@ -161,7 +163,7 @@ R_API rsize r_string_prepend_vprintf (RString * str, const rchar * fmt, va_list 
 /**
  * @brief Insert @p cstr at byte offset @p pos, sliding the existing
  * tail to the right.
- * @return New length after the insert.
+ * @return Number of bytes inserted.
  */
 R_API rsize r_string_insert (RString * str, rsize pos, const rchar * cstr);
 /** @brief Length-bounded variant of r_string_insert. */
@@ -176,11 +178,13 @@ R_API rsize r_string_overwrite (RString * str, rsize pos, const rchar * cstr);
 /** @brief Length-bounded variant of r_string_overwrite. */
 R_API rsize r_string_overwrite_len (RString * str, rsize pos, const rchar * cstr, rsize len);
 
-/** @brief Trim @p str to @p len bytes. No-op if it's already shorter. */
+/** @brief Trim @p str to @p len bytes (no-op, returning 0, if already
+ *  shorter). @return Number of bytes removed. */
 R_API rsize r_string_truncate (RString * str, rsize len);
 /**
- * @brief Remove @p len bytes starting at byte offset @p pos.
- * @return New length after the erase.
+ * @brief Remove @p len bytes starting at byte offset @p pos (clamped to
+ * the end of the string).
+ * @return The resulting length (0 if @p pos is past the end).
  */
 R_API rsize r_string_erase (RString * str, rsize pos, rsize len);
 

--- a/include/rlib/data/rtimeoutcblist.h
+++ b/include/rlib/data/rtimeoutcblist.h
@@ -19,7 +19,7 @@
 #define __R_TIMEOUT_CBLIST_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/ev/revio.h
+++ b/include/rlib/ev/revio.h
@@ -19,7 +19,7 @@
 #define __R_EV_IO_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/ev/revloop.h
+++ b/include/rlib/ev/revloop.h
@@ -19,7 +19,7 @@
 #define __R_EV_LOOP_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -85,7 +85,8 @@ R_API REvLoop * r_ev_loop_current (void);
 
 /**
  * @brief Run the loop in @p mode.
- * @return Number of events / callbacks processed.
+ * @return Number of events still outstanding when the loop returned
+ *         (0 once it has fully drained).
  */
 R_API ruint r_ev_loop_run (REvLoop * loop, REvLoopRunMode mode);
 /** @brief Ask a running loop to stop (it returns from @ref r_ev_loop_run). */

--- a/include/rlib/ev/revresolve.h
+++ b/include/rlib/ev/revresolve.h
@@ -19,7 +19,7 @@
 #define __R_EV_RESOLVE_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/ev/revtcp.h
+++ b/include/rlib/ev/revtcp.h
@@ -19,7 +19,7 @@
 #define __R_EV_TCP_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/ev/revudp.h
+++ b/include/rlib/ev/revudp.h
@@ -19,7 +19,7 @@
 #define __R_EV_UDP_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/ev/revwakeup.h
+++ b/include/rlib/ev/revwakeup.h
@@ -19,7 +19,7 @@
 #define __R_EV_WAKEUP_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/file/rfile.h
+++ b/include/rlib/file/rfile.h
@@ -19,7 +19,7 @@
 #define __R_FILE_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/file/rfiletypes.h
+++ b/include/rlib/file/rfiletypes.h
@@ -19,7 +19,7 @@
 #define __R_FILE_TYPES_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/file/rfs.h
+++ b/include/rlib/file/rfs.h
@@ -19,7 +19,7 @@
 #define __R_FS_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/file/rio.h
+++ b/include/rlib/file/rio.h
@@ -19,7 +19,7 @@
 #define __R_FILE_IO_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/format/rasn1.h
+++ b/include/rlib/format/rasn1.h
@@ -19,7 +19,7 @@
 #define __R_ASN1_ASN1_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/format/roid.h
+++ b/include/rlib/format/roid.h
@@ -19,7 +19,7 @@
 #define __R_ASN1_OID_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/net/proto/rhttp.h
+++ b/include/rlib/net/proto/rhttp.h
@@ -19,7 +19,7 @@
 #define __R_NET_PROTO_HTTP_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/net/proto/rrtp.h
+++ b/include/rlib/net/proto/rrtp.h
@@ -19,7 +19,7 @@
 #define __R_NET_PROTO_RTP_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -213,7 +213,7 @@ typedef enum {
   R_RTCP_PT_RSI             = 209, /* Receiver Summary Information  [RFC5760] */
   R_RTCP_PT_TOKEN           = 210, /* Port Mapping                  [RFC6284] */
   R_RTCP_PT_IDMS            = 211, /* DMS Settings                  [RFC7272] */
-  R_RTCP_PT_RGRS            = 212, /* eporting Group Reporting Sources [RFC-ietf-avtcore-rtp-multi-stream-optimisation-12] */
+  R_RTCP_PT_RGRS            = 212, /* Reporting Group Reporting Sources [RFC-ietf-avtcore-rtp-multi-stream-optimisation-12] */
   R_RTCP_PT_SNM             = 213, /* Splicing Notification Message [RFC-ietf-ietf-avtext-splicing-notification-09] */
 } RRTCPPacketType;
 

--- a/include/rlib/net/proto/rsdp.h
+++ b/include/rlib/net/proto/rsdp.h
@@ -19,7 +19,7 @@
 #define __R_NET_PROTO_SDP_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/net/proto/rstun.h
+++ b/include/rlib/net/proto/rstun.h
@@ -19,7 +19,7 @@
 #define __R_NET_PROTO_STUN_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/net/proto/rtls.h
+++ b/include/rlib/net/proto/rtls.h
@@ -19,7 +19,7 @@
 #define __R_NET_PROTO_TLS_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -242,7 +242,7 @@ typedef enum {
   R_TLS_SUPPORTED_GROUP_SECP384R1                       = 0x0018, /* [RFC4492] */
   R_TLS_SUPPORTED_GROUP_SECP521R1                       = 0x0019, /* [RFC4492] */
   R_TLS_SUPPORTED_GROUP_BRAINPOOLP256R1                 = 0x001a, /* [RFC7027] */
-  R_TLS_SUPPORTED_GROUP_BRAINPOOLP348R1                 = 0x001b, /* [RFC7027] */
+  R_TLS_SUPPORTED_GROUP_BRAINPOOLP384R1                 = 0x001b, /* [RFC7027] */
   R_TLS_SUPPORTED_GROUP_BRAINPOOLP512R1                 = 0x001c, /* [RFC7027] */
   R_TLS_SUPPORTED_GROUP_X25519                          = 0x001d, /* [TLS1.3] */
   R_TLS_SUPPORTED_GROUP_X448                            = 0x001e, /* [TLS1.3] */

--- a/include/rlib/net/rhttpserver.h
+++ b/include/rlib/net/rhttpserver.h
@@ -19,7 +19,7 @@
 #define __R_NET_HTTP_SERVER_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/net/riosocket.h
+++ b/include/rlib/net/riosocket.h
@@ -19,7 +19,7 @@
 #define __R_IO_SOCKET_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/net/rresolve.h
+++ b/include/rlib/net/rresolve.h
@@ -19,7 +19,7 @@
 #define __R_RESOLVE_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/net/rsocket.h
+++ b/include/rlib/net/rsocket.h
@@ -19,7 +19,7 @@
 #define __R_SOCKET_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/net/rsocketaddress.h
+++ b/include/rlib/net/rsocketaddress.h
@@ -19,7 +19,7 @@
 #define __R_SOCKET_ADDRESS_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/net/rsrtp.h
+++ b/include/rlib/net/rsrtp.h
@@ -19,7 +19,7 @@
 #define __R_NET_SRTP_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -19,7 +19,7 @@
 #define __R_NET_TLS_SERVER_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/os/renv.h
+++ b/include/rlib/os/renv.h
@@ -19,7 +19,7 @@
 #define __R_ENV_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/os/rmodule.h
+++ b/include/rlib/os/rmodule.h
@@ -19,7 +19,7 @@
 #define __R_MODULE_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/os/rsignal.h
+++ b/include/rlib/os/rsignal.h
@@ -19,7 +19,7 @@
 #define __R_SIGNAL_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -66,9 +66,9 @@ R_API RSigAlrmTimer * r_sig_alrm_timer_new_interval (RClockTime interval,
 R_API RSigAlrmTimer * r_sig_alrm_timer_new_interval_delayed (RClockTime timeout,
     RClockTime interval, RSignalFunc func);
 
-/** @brief Stop @p timer without freeing it. */
+/** @brief Disarm and free @p timer (frees via @ref r_sig_alrm_timer_delete). */
 R_API void r_sig_alrm_timer_cancel (RSigAlrmTimer * timer);
-/** @brief Cancel and free @p timer. */
+/** @brief Free @p timer, restoring the previous @c SIGALRM handler. */
 R_API void r_sig_alrm_timer_delete (RSigAlrmTimer * timer);
 
 R_END_DECLS

--- a/include/rlib/os/rsys.h
+++ b/include/rlib/os/rsys.h
@@ -19,7 +19,7 @@
 #define __R_SYS_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -116,8 +116,9 @@ R_API rboolean r_sys_nodeset_for_cpuset (RBitset * nodeset, const RBitset * cpus
 /** @name Topology objects
  *
  * @ref RSysTopology / @ref RSysNode / @ref RSysCpu are refcounted;
- * use the @c _ref / @c _unref aliases. Nodes and CPUs are owned by
- * their parent topology.
+ * use the @c _ref / @c _unref aliases. The @c r_sys_topology_node /
+ * @c r_sys_topology_node_cpu accessors return a @b new reference that
+ * the caller must @c _unref.
  *  @{ */
 /** @brief Opaque, refcounted hardware-topology snapshot. */
 typedef struct RSysTopology  RSysTopology;
@@ -131,14 +132,16 @@ R_API RSysTopology * r_sys_topology_discover (void);
 
 /** @brief Number of NUMA nodes in @p topo. */
 R_API rsize r_sys_topology_node_count (const RSysTopology * topo);
-/** @brief Return the @p idx-th node of @p topo (borrowed). */
+/** @brief Return the @p idx-th node of @p topo as a new reference
+ *  (caller @c r_sys_node_unref's), or @c NULL if out of range. */
 R_API RSysNode * r_sys_topology_node (RSysTopology * topo, rsize idx);
 
 /** @brief Fill @p cpuset with the CPUs belonging to @p node. */
 R_API rboolean r_sys_topology_node_cpuset (const RSysNode * node, RBitset * cpuset);
 /** @brief Number of CPUs in @p node. */
 R_API rsize r_sys_topology_node_cpu_count (const RSysNode * node);
-/** @brief Return the @p idx-th CPU of @p node (borrowed). */
+/** @brief Return the @p idx-th CPU of @p node as a new reference
+ *  (caller @c r_sys_cpu_unref's), or @c NULL if out of range. */
 R_API RSysCpu * r_sys_topology_node_cpu (RSysNode * node, rsize idx);
 /** @brief Bytes of memory local to @p node. */
 R_API rsize r_sys_topology_node_available_memory (const RSysNode * node);

--- a/include/rlib/os/rtty.h
+++ b/include/rlib/os/rtty.h
@@ -19,7 +19,7 @@
 #define __R_TTY_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -95,8 +95,8 @@ R_BEGIN_DECLS
 #define R_TTY_SGR_NOBLINK_ARG     "25"  /**< Cancel @c BLINK. */
 #define R_TTY_SGR_INVERSE_ARG     "7"   /**< Swap foreground / background. */
 #define R_TTY_SGR_NOINVERSE_ARG   "27"  /**< Cancel @c INVERSE. */
-#define R_TTY_SGR_CONSEAL_ARG     "8"   /**< Conceal. */
-#define R_TTY_SGR_REVEAL_ARG      "28"  /**< Cancel @c CONSEAL. */
+#define R_TTY_SGR_CONCEAL_ARG     "8"   /**< Conceal. */
+#define R_TTY_SGR_REVEAL_ARG      "28"  /**< Cancel @c CONCEAL. */
 /** @brief Build a foreground colour token (30-39). */
 #define R_TTY_SGR_FG_ARG(CLR)     "3"R_STRINGIFY (CLR)
 /** @brief Build a background colour token (40-49). */
@@ -109,7 +109,7 @@ R_BEGIN_DECLS
  * @param str Caller-provided buffer of at least @ref R_TTY_MAX_CC bytes.
  * @return @p str, populated with a null-terminated escape sequence.
  */
-rchar * r_tty_clr_to_str (RColorFlags clr, rchar str[R_TTY_MAX_CC]);
+R_API rchar * r_tty_clr_to_str (RColorFlags clr, rchar str[R_TTY_MAX_CC]);
 
 #ifdef R_OS_WIN32
 /** @brief Portable wrapper around C-library @c isatty. */

--- a/include/rlib/rargparse.h
+++ b/include/rlib/rargparse.h
@@ -19,7 +19,7 @@
 #define __R_ARGPARSE_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rtypes.h>
@@ -58,7 +58,7 @@
  * values, required options, positional arguments, and an inverse
  * (no-foo) flag form. @c -h, @c --help, and @c --version are
  * registered for free unless suppressed by
- * @c R_ARG_PARSE_FLAG_DISALE_HELP.
+ * @c R_ARG_PARSE_FLAG_DISABLE_HELP.
  */
 
 R_BEGIN_DECLS
@@ -142,7 +142,7 @@ typedef enum {
   R_ARG_PARSE_FLAG_NONE               = 0,
   R_ARG_PARSE_FLAG_DONT_EXIT          = 1 << 0, /**< Return errors instead of calling @c exit. */
   R_ARG_PARSE_FLAG_DONT_PRINT_STDOUT  = 1 << 1, /**< Suppress automatic help / version output. */
-  R_ARG_PARSE_FLAG_DISALE_HELP        = 1 << 2, /**< Don't auto-register @c --help / @c -h. */
+  R_ARG_PARSE_FLAG_DISABLE_HELP        = 1 << 2, /**< Don't auto-register @c --help / @c -h. */
   R_ARG_PARSE_FLAG_ALLOW_UNKNOWN      = 1 << 3, /**< Pass unknown options through instead of failing. */
 } RArgParseFlags;
 

--- a/include/rlib/rassert-internal.h
+++ b/include/rlib/rassert-internal.h
@@ -19,7 +19,7 @@
 #define __R_ASSERT_INTERNAL_H__
 
 #ifndef __R_ASSERT_H__
-#error "#include <rlib.h> pelase."
+#error "#include <rlib.h> please."
 #endif
 
 #include <rlib/rlog.h>

--- a/include/rlib/rassert.h
+++ b/include/rlib/rassert.h
@@ -19,7 +19,7 @@
 #define __R_ASSERT_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/rbase64.h
+++ b/include/rlib/rbase64.h
@@ -19,7 +19,7 @@
 #define __R_BASE64_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rtypes.h>

--- a/include/rlib/rbuffer.h
+++ b/include/rlib/rbuffer.h
@@ -19,7 +19,7 @@
 #define __R_BUFFER_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/rclock.h
+++ b/include/rlib/rclock.h
@@ -19,7 +19,7 @@
 #define __R_CLOCK_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/rcpufeatures.h
+++ b/include/rlib/rcpufeatures.h
@@ -19,7 +19,7 @@
 #define __R_CPUFEATURES_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rtypes.h>
@@ -56,20 +56,20 @@
  * and every @c r_cpu_has call returns @c FALSE; callers that dispatch
  * on a feature flag transparently fall back to their software path.
  *
- * **Bit layout** (32 bits total, x86 in 0-23, AArch64 in 24-47):
+ * **Bit layout** (x86 in bits 0-23, AArch64 in bits 24-39):
  *  - x86 base SSE family: bits 0-7
  *  - x86 AVX / AVX-512 family: bits 8-15
  *  - x86 misc (SHA-NI, BMI, POPCNT, F16C, RDRAND): bits 16-23
- *  - AArch64 base + crypto: bits 24-39
- *  - AArch64 misc (atomics, dotprod, SVE): bits 40-47
+ *  - AArch64 base + crypto: bits 24-31
+ *  - AArch64 misc (atomics, dotprod, SVE): bits 32-39
  */
 
 /**
  * @brief Bitmask of CPU extension flags.
  *
  * Treat as an opaque bitfield - combine with bitwise-OR, query with
- * bitwise-AND or @c r_cpu_has. Underlying type is @c ruint64 to leave
- * headroom for future flags beyond the 32-bit cutoff.
+ * bitwise-AND or @c r_cpu_has. Underlying type is @c ruint64 so the
+ * AArch64 flags (which already run past bit 31) fit with room to spare.
  */
 typedef ruint64 RCpuFeature;
 
@@ -148,7 +148,7 @@ typedef ruint64 RCpuFeature;
  * conditioned stream. */
 #define R_CPU_FEATURE_RDSEED            R_CPU_BIT_(22)
 
-/* AArch64 base + crypto (bits 24-39) */
+/* AArch64 base + crypto (bits 24-31) */
 
 /** @brief AArch64 NEON / Advanced SIMD; 128-bit integer + FP vector
  * ops. Architecturally mandatory on AArch64 so this is always set on
@@ -172,7 +172,7 @@ typedef ruint64 RCpuFeature;
  * instructions for hardware Castagnoli CRC32C. */
 #define R_CPU_FEATURE_ARM_CRC32         R_CPU_BIT_(31)
 
-/* AArch64 misc (bits 32-47) */
+/* AArch64 misc (bits 32-39) */
 
 /** @brief ARMv8.1 LSE atomics; @c LDADD / @c CAS / @c SWP exclusive-
  * monitor-free atomics. */

--- a/include/rlib/rcrc.h
+++ b/include/rlib/rcrc.h
@@ -19,7 +19,7 @@
 #define __R_CRC_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rtypes.h>

--- a/include/rlib/rio.h
+++ b/include/rlib/rio.h
@@ -19,7 +19,7 @@
 #define __R_IO_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/rlog.h
+++ b/include/rlib/rlog.h
@@ -19,7 +19,7 @@
 #define __R_LOG_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/rmath.h
+++ b/include/rlib/rmath.h
@@ -19,7 +19,7 @@
 #define __R_MATH_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/rmem.h
+++ b/include/rlib/rmem.h
@@ -109,13 +109,13 @@ typedef struct {
 #define r_mem_newa_n(type, n) ((type*) r_alloca (sizeof (type) * (rsize) (n)))
 
 /** @brief Stack-allocate a zeroed array of @p n elements of @p type. */
-#define r_mem_newa0_n(type, n)((type*) (r_alloca0 (sizeof (type) * (rsize) (n)))
+#define r_mem_newa0_n(type, n) ((type*) r_alloca0 (sizeof (type) * (rsize) (n)))
 
 /** @brief Stack-allocate a single instance of @p type. */
 #define r_mem_newa(type)      r_mem_newa_n (type, 1)
 
 /** @brief Stack-allocate a single zeroed instance of @p type. */
-#define r_mem_newa0(type)     r_mem_newa_n0 (type, 1)
+#define r_mem_newa0(type)     r_mem_newa0_n (type, 1)
 
 
 /* ----- Heap allocations -------------------------------------------- */

--- a/include/rlib/rmemallocator.h
+++ b/include/rlib/rmemallocator.h
@@ -409,9 +409,10 @@ R_API RMemAllocator * r_mem_allocator_find            (const rchar * name) R_ATT
 /**
  * @brief Register an allocator so it can be looked up by name.
  *
- * Adds @p allocator to the process-wide registry under @p allocator->mem_type.
- * The registry takes a reference; the caller may safely drop its
- * own reference afterwards.
+ * Adds @p allocator to the process-wide registry, looked up by its
+ * @c mem_type. The registry stores the pointer but does @b not take a
+ * reference, so the caller must keep @p allocator alive for as long as
+ * it may be looked up (do not drop the last reference).
  *
  * @param allocator Allocator to register (must have a non-NULL
  *                  @c mem_type).

--- a/include/rlib/rpoll.h
+++ b/include/rlib/rpoll.h
@@ -19,7 +19,7 @@
 #define __R_POLL_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/rrand.h
+++ b/include/rlib/rrand.h
@@ -19,7 +19,7 @@
 #define __R_RAND_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/rref.h
+++ b/include/rlib/rref.h
@@ -19,7 +19,7 @@
 #define __R_REF_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/rstr.h
+++ b/include/rlib/rstr.h
@@ -19,7 +19,7 @@
 #define __R_STR_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rtypes.h>
@@ -491,12 +491,14 @@ R_API int     r_strvscanf (const rchar * str, const rchar * fmt, va_list args) R
  * @name String-to-number parsing
  *
  * Each function parses an integer from @p str using base @p base
- * (2 through 36; 0 means autodetect via the standard 0 / 0x / 0b
- * prefixes). On success the parsed value is returned and, if
- * @p endptr is non-NULL, *@p endptr is set to one past the last
- * consumed character. On failure the return value is 0 (signed)
- * or 0 (unsigned), *@p endptr equals @p str, and *@p res (if
- * non-NULL) carries @c R_STR_PARSE_INVAL or @c R_STR_PARSE_RANGE.
+ * (2 through 36; 0 means autodetect: a @c 0x / @c 0X prefix selects
+ * base 16 and a leading @c 0 selects base 8, otherwise base 10). On
+ * success the parsed value is returned and, if @p endptr is non-NULL,
+ * *@p endptr is set to one past the last consumed character. On
+ * failure the return value is 0 and *@p res (if non-NULL) carries
+ * @c R_STR_PARSE_INVAL or @c R_STR_PARSE_RANGE; *@p endptr then points
+ * at the first character that could not be consumed (equal to @p str
+ * only for a NULL / empty / bad-base input).
  *
  * The fixed-width spellings are the source of truth; @c r_str_to_int
  * / @c r_str_to_uint and the @c r_strto* shortcut macros below
@@ -666,10 +668,12 @@ R_API void r_str_chunk_lwstrip (RStrChunk * buf);
 /**
  * @brief Consume one line from @p buf into @p line.
  *
- * Updates @p buf->str / @p buf->size in place so successive calls
- * iterate the lines of the original chunk. Line terminators are not
- * included in @p line. Returns @c R_STR_PARSE_OK on success or
- * @c R_STR_PARSE_INVAL when @p buf is empty.
+ * Iteration state lives in @p line, not @p buf (which is never
+ * modified): zero-initialise @p line for the first call and pass the
+ * same @p line back on each subsequent call to advance through @p buf.
+ * Line terminators are not included in @p line. Returns
+ * @c R_STR_PARSE_OK per line, @c R_STR_PARSE_RANGE when the input is
+ * exhausted, or @c R_STR_PARSE_INVAL on bad arguments / empty @p buf.
  */
 R_API RStrParse r_str_chunk_next_line (const RStrChunk * buf, RStrChunk * line);
 /** @brief Convenience: r_str_ptr_of_c on the chunk's bytes. */
@@ -877,11 +881,13 @@ R_API RStrMatchResultType r_str_match_pattern (const rchar * str, rssize size,
 #define R_STR_MEM_DUMP_SIZE(align) \
   ((align * 4) + (align / 4) + (RLIB_SIZEOF_VOID_P * 2) + 8)
 /**
- * @brief Render @p src (@p size bytes) into the caller-supplied @p dst
- * as a hex+ASCII dump line.
+ * @brief Render the pointer of @p src followed by the printable-ASCII
+ * rendering of its @p size bytes (non-printable bytes shown as @c '.')
+ * into @p dst, NUL-terminated.
  *
- * @p dst must be at least @c R_STR_MEM_DUMP_SIZE(align) bytes for
- * each line of @p align input bytes the caller wants emitted.
+ * @p dst must hold the pointer text plus @p size bytes plus the NUL.
+ * Unlike @ref r_str_mem_dump this is ASCII-only (no hex columns) and
+ * takes no @c align argument.
  */
 R_API void r_str_dump (rchar * dst, const rchar * src, rsize size);
 /**

--- a/include/rlib/rtc/rrtccryptotransport.h
+++ b/include/rlib/rtc/rrtccryptotransport.h
@@ -19,7 +19,7 @@
 #define __R_RTC_CRYPTO_TRANSPORT_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/rtc/rrtcicecandidate.h
+++ b/include/rlib/rtc/rrtcicecandidate.h
@@ -19,7 +19,7 @@
 #define __R_RTC_ICE_CANDIDATE_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -153,7 +153,7 @@ R_API const RStrKV * r_rtc_ice_candidate_get_ext (RRtcIceCandidate * candidate, 
 R_API RRtcError r_rtc_ice_candidate_add_ext (RRtcIceCandidate * candidate,
     const rchar * key, rssize ksize, const rchar * val, rssize vsize);
 /** @brief Append an extension pair from an @ref RStrKV (wraps @ref r_rtc_ice_candidate_add_ext). */
-#define r_rtc_ice_candidate_add_ext_kv(canidate, kv) \
+#define r_rtc_ice_candidate_add_ext_kv(candidate, kv) \
   r_rtc_ice_candidate_add_ext(candidate, kv->key.str, kv->key.size, kv->val.str, kv->val.size)
 
 /** @brief Serialise the candidate to its SDP @c candidate attribute string. */

--- a/include/rlib/rtc/rrtcicetransport.h
+++ b/include/rlib/rtc/rrtcicetransport.h
@@ -19,7 +19,7 @@
 #define __R_RTC_ICE_TRANSPORT_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/rtc/rrtcrtplistener.h
+++ b/include/rlib/rtc/rrtcrtplistener.h
@@ -19,7 +19,7 @@
 #define __R_RTC_RTP_LISTENER_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/rtc/rrtcrtpparameters.h
+++ b/include/rlib/rtc/rrtcrtpparameters.h
@@ -19,7 +19,7 @@
 #define __R_RTC_RTP_PARAMETERS_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/rtc/rrtcrtpreceiver.h
+++ b/include/rlib/rtc/rrtcrtpreceiver.h
@@ -19,7 +19,7 @@
 #define __R_RTC_RTP_RECEIVER_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/rtc/rrtcrtpsender.h
+++ b/include/rlib/rtc/rrtcrtpsender.h
@@ -19,7 +19,7 @@
 #define __R_RTC_RTP_SENDER_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/rtc/rrtcrtptransceiver.h
+++ b/include/rlib/rtc/rrtcrtptransceiver.h
@@ -19,7 +19,7 @@
 #define __R_RTC_RTP_TRANSCEIVER_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/rtc/rrtcsession.h
+++ b/include/rlib/rtc/rrtcsession.h
@@ -19,7 +19,7 @@
 #define __R_RTC_SESSION_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -79,9 +79,11 @@ R_API RRtcSession * r_rtc_session_new_full (const rchar * id, rssize size,
 
 /** @brief Return the session's id string. */
 R_API const rchar * r_rtc_session_get_id (const RRtcSession * s);
-/** @brief Look up a transceiver by @p id (of @p size bytes); @c NULL if absent. */
+/** @brief Look up a transceiver by media id @p mid (of @p size bytes).
+ *  @return A new reference (caller @c r_rtc_rtp_transceiver_unref's), or
+ *  @c NULL if absent. */
 R_API RRtcRtpTransceiver * r_rtc_session_lookup_rtp_transceiver (RRtcSession * s,
-    const rchar * id, rssize size);
+    const rchar * mid, rssize size);
 
 /**
  * @brief Create an ICE transport seeded with the local @p ufrag (of
@@ -91,8 +93,8 @@ R_API RRtcIceTransport * r_rtc_session_create_ice_transport (RRtcSession * s,
     const rchar * ufrag, rssize usize, const rchar * pwd, rssize psize);
 /**
  * @brief Create a DTLS transport over @p ice with the given DTLS
- * @p role (see @ref RRtcRole), local certificate @p cert and private
- * key @p privkey.
+ * @p role (see @ref RRtcCryptoRole), local certificate @p cert and
+ * private key @p privkey.
  */
 R_API RRtcCryptoTransport * r_rtc_session_create_dtls_transport (RRtcSession * s,
     RRtcIceTransport * ice,
@@ -101,28 +103,28 @@ R_API RRtcCryptoTransport * r_rtc_session_create_dtls_transport (RRtcSession * s
 R_API RRtcCryptoTransport * r_rtc_session_create_raw_transport (RRtcSession * s,
     RRtcIceTransport * ice);
 /**
- * @brief Create an RTP sender with @p id (of @p size bytes), the
- * callback set @p cbs, and the @p rtp / @p rtcp transports it sends on.
+ * @brief Create an RTP sender with media id @p mid (of @p size bytes),
+ * the callback set @p cbs, and the @p rtp / @p rtcp transports it sends on.
  */
 R_API RRtcRtpSender * r_rtc_session_create_rtp_sender (RRtcSession * s,
-    const rchar * id, rssize size,
+    const rchar * mid, rssize size,
     const RRtcRtpSenderCallbacks * cbs, rpointer data, RDestroyNotify notify,
     RRtcCryptoTransport * rtp, RRtcCryptoTransport * rtcp) R_ATTR_MALLOC;
 /**
- * @brief Create an RTP receiver with @p id (of @p size bytes), the
- * callback set @p cbs, and the @p rtp / @p rtcp transports it receives on.
+ * @brief Create an RTP receiver with media id @p mid (of @p size bytes),
+ * the callback set @p cbs, and the @p rtp / @p rtcp transports it receives on.
  */
 R_API RRtcRtpReceiver * r_rtc_session_create_rtp_receiver (RRtcSession * s,
-    const rchar * id, rssize size,
+    const rchar * mid, rssize size,
     const RRtcRtpReceiverCallbacks * cbs, rpointer data, RDestroyNotify notify,
     RRtcCryptoTransport * rtp, RRtcCryptoTransport * rtcp) R_ATTR_MALLOC;
 /**
  * @brief Create an RTP transceiver (paired sender + receiver) with
- * @p id (of @p size bytes), the receiver callbacks @p rcbs and sender
- * callbacks @p scbs, over the @p rtp / @p rtcp transports.
+ * media id @p mid (of @p size bytes), the receiver callbacks @p rcbs and
+ * sender callbacks @p scbs, over the @p rtp / @p rtcp transports.
  */
 R_API RRtcRtpTransceiver * r_rtc_session_create_rtp_transceiver (RRtcSession * s,
-    const rchar * id, rssize size,
+    const rchar * mid, rssize size,
     const RRtcRtpReceiverCallbacks * rcbs, const RRtcRtpSenderCallbacks * scbs,
     rpointer data, RDestroyNotify notify,
     RRtcCryptoTransport * rtp, RRtcCryptoTransport * rtcp) R_ATTR_MALLOC;

--- a/include/rlib/rtc/rrtcsessiondescription.h
+++ b/include/rlib/rtc/rrtcsessiondescription.h
@@ -19,7 +19,7 @@
 #define __R_RTC_SESSION_DESCRIPTION_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/include/rlib/rtc/rrtctypes.h
+++ b/include/rlib/rtc/rrtctypes.h
@@ -19,7 +19,7 @@
 #define __R_RTC_TYPES_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -97,7 +97,8 @@ typedef enum {
 } RRtcMediaType;
 /** @brief Parse a media-kind string (e.g. @c "audio") into an @ref RRtcMediaType. */
 R_API RRtcMediaType r_rtc_media_type_from_string (const rchar * type, rssize size);
-/** @brief Return the SDP string for @p type (e.g. @c "video"). */
+/** @brief Return the SDP string for @p type (e.g. @c "video"), or
+ *  @c NULL for any type other than audio / video. */
 R_API const rchar * r_rtc_media_type_to_string (RRtcMediaType type);
 
 /** @brief Role a codec plays in a media stream. */

--- a/include/rlib/rtest-internal.h
+++ b/include/rlib/rtest-internal.h
@@ -19,7 +19,7 @@
 #define __R_TEST_INTERNAL_H__
 
 #ifndef __R_TEST_H__
-#error "#include <rlib.h> pelase."
+#error "#include <rlib.h> please."
 #endif
 
 #define RTEST_SECTION                         ".rtest"

--- a/include/rlib/rtest.h
+++ b/include/rlib/rtest.h
@@ -19,7 +19,7 @@
 #define __R_TEST_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rtypes.h>

--- a/include/rlib/rtime.h
+++ b/include/rlib/rtime.h
@@ -19,7 +19,7 @@
 #define __R_TIME_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -106,7 +106,13 @@ R_STMT_START {                                                              \
 #define R_TIME_TIMEVAL_INIT(t)  { (rlong) ( (t) / R_SECOND),                \
                                   (rlong) (((t) % R_SECOND) / R_USECOND) }
 
-/** @brief @c printf format string matching @ref R_TIME_ARGS, e.g. @c "0:01:23.456789012". */
+/**
+ * @brief @c printf conversion fragment matching @ref R_TIME_ARGS.
+ *
+ * The leading @c '%' is omitted so the macro can be string-pasted
+ * after one, i.e. use it as @c "%" @c R_TIME_FORMAT to render a time
+ * like @c "0:01:23.456789012".
+ */
 #define R_TIME_FORMAT                 "u:%02u:%02u.%09u"
 /** @brief Expand to the @c printf arguments for @ref R_TIME_FORMAT. */
 #define R_TIME_ARGS(t)                                                      \
@@ -135,14 +141,17 @@ R_API RClockTime r_time_get_ts_monotonic (void);
  */
 R_API RClockTime r_time_get_ts_raw (void);
 
-/** @brief Return system uptime in nanoseconds. */
+/** @brief Return system uptime in seconds. */
 R_API ruint64 r_time_get_uptime (void);
 
-/** @brief @c TRUE if @p year is a Gregorian leap year. */
+/** @brief @c TRUE if @p year is a Gregorian leap year. Years before
+ *  1753 always return @c FALSE. */
 R_API rboolean r_time_is_leap_year (ruint16 year);
-/** @brief Count leap years in the half-open range [@p from, @p to). */
+/** @brief Count leap years in the half-open range [@p from, @p to),
+ *  with @p from clamped up to 1753. */
 R_API ruint16 r_time_leap_years (ruint16 from, ruint16 to);
-/** @brief Days in @p month of @p year (1-12), accounting for leap years. */
+/** @brief Days in @p month (1-12) of @p year, accounting for leap
+ *  years; @c -1 if @p month is out of range or @p year is before 1753. */
 R_API rint8 r_time_days_in_month (ruint16 year, ruint8 month);
 /**
  * @brief Convert a broken-down date to a Unix timestamp (seconds since

--- a/include/rlib/rtypes.h
+++ b/include/rlib/rtypes.h
@@ -19,7 +19,7 @@
 #define __R_TYPES_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 #include <rlib/rconfig.h>

--- a/include/rlib/ruri.h
+++ b/include/rlib/ruri.h
@@ -19,7 +19,7 @@
 #define __R_URI_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**
@@ -130,10 +130,12 @@ R_API rchar * r_uri_get_pqf (const RUri * uri) R_ATTR_MALLOC;
 /** @} */
 
 /** @name Escaped component accessors (borrowed)
- *  Each returns a borrowed pointer into the URI's escaped backing
- *  store plus its length via @p size; do not free.
+ *  Each @c _ptr accessor returns a borrowed pointer into the URI's
+ *  escaped backing store plus its length via @p size; do not free.
+ *  The exception is @ref r_uri_get_escaped, which allocates a copy of
+ *  the whole escaped URI (free with @c r_free).
  *  @{ */
-/** @brief Whole URI, escaped (allocating). */
+/** @brief Whole URI, escaped (allocating; free with @c r_free). */
 R_API rchar * r_uri_get_escaped (const RUri * uri) R_ATTR_MALLOC;
 /** @brief Borrowed pointer to the whole escaped URI. */
 R_API const rchar * r_uri_get_escaped_ptr (const RUri * uri, rsize * size);

--- a/include/rlib/types/rbitops.h
+++ b/include/rlib/types/rbitops.h
@@ -19,7 +19,7 @@
 #define __R_BITOPS_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /* This header is included by rtypes.h (@ bottom of file) */

--- a/include/rlib/types/rendianness.h
+++ b/include/rlib/types/rendianness.h
@@ -19,7 +19,7 @@
 #define __R_ENDIANNESS_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /* This header is included by rtypes.h (@ bottom of file) */
@@ -60,7 +60,7 @@ R_BEGIN_DECLS
 #define R_BIG_ENDIAN            4321
 
 #if R_GNUC_PREREQ(4, 2)
-/* Appearantly 16bit byteswap is missing from some versions of GCC on x86?? */
+/* Apparently 16bit byteswap is missing from some versions of GCC on x86?? */
 #if !defined(__clang__) && !R_GNUC_PREREQ(4, 8)
 /** @brief Reverse the bytes of a 16-bit value. */
 #define RUINT16_BSWAP(val) ((ruint16) (((ruint16)(val) >> 8) | ((ruint16)(val) << 8)))

--- a/include/rlib/types/rmacros.h
+++ b/include/rlib/types/rmacros.h
@@ -19,7 +19,7 @@
 #define __R_MACROS_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /**

--- a/rlib/crypto/rmsgdigest.c
+++ b/rlib/crypto/rmsgdigest.c
@@ -344,6 +344,23 @@ r_msg_digest_get_hex_full (const RMsgDigest * md,
 }
 
 /**************************************/
+/*              MD2 / MD4             */
+/**************************************/
+/* MD2 and MD4 are declared in the public header but not implemented
+ * yet; return NULL rather than fail to link. */
+RMsgDigest *
+r_msg_digest_new_md2 (void)
+{
+  return NULL;
+}
+
+RMsgDigest *
+r_msg_digest_new_md4 (void)
+{
+  return NULL;
+}
+
+/**************************************/
 /*                MD5                 */
 /**************************************/
 RMsgDigest *

--- a/rlib/data/rhzrptr.c
+++ b/rlib/data/rhzrptr.c
@@ -42,7 +42,7 @@ struct RHzrPtrRec {
 
 
 rpointer
-r_hzr_ptr_aqcuire (rhzrptr * hzrptr, RHzrPtrRec * rec)
+r_hzr_ptr_acquire (rhzrptr * hzrptr, RHzrPtrRec * rec)
 {
   rpointer ret;
 

--- a/rlib/data/rstring.c
+++ b/rlib/data/rstring.c
@@ -323,8 +323,10 @@ r_string_erase (RString * str, rsize pos, rsize len)
 {
   if (pos > str->len)
     return 0;
-  else if (pos + len >= str->len)
-    return r_string_truncate (str, pos);
+  else if (pos + len >= str->len) {
+    r_string_truncate (str, pos);
+    return str->len;
+  }
 
   str->len -= len;
   r_memmove (str->cstr + pos, str->cstr + pos + len, str->len - pos + 1);

--- a/rlib/rargparse.c
+++ b/rlib/rargparse.c
@@ -570,7 +570,7 @@ r_arg_parser_get_help (RArgParser * parser, RArgParseFlags flags,
   r_string_append_printf (str, "\n%s:\n", parser->main->desc);
 
   i = 0;
-  if ((flags & R_ARG_PARSE_FLAG_DISALE_HELP) == R_ARG_PARSE_FLAG_DISALE_HELP)
+  if ((flags & R_ARG_PARSE_FLAG_DISABLE_HELP) == R_ARG_PARSE_FLAG_DISABLE_HELP)
     i += R_N_ELEMENTS (r_arg_version_args) + R_N_ELEMENTS (r_arg_help_args);
   for (; i < parser->main->count; i++)
     r_arg_option_entry_append_help (&parser->main->entries[i], str);
@@ -917,7 +917,7 @@ r_arg_parser_parse_options (RArgParser * parser, RArgParseCtx * ctx,
   }
 
   /* Check help */
-  if ((ctx->flags & R_ARG_PARSE_FLAG_DISALE_HELP) == 0) {
+  if ((ctx->flags & R_ARG_PARSE_FLAG_DISABLE_HELP) == 0) {
     if (r_arg_parse_ctx_get_option_bool (ctx, "help") ||
         r_arg_parse_ctx_get_option_bool (ctx, "")) {
       r_arg_parser_print_help (ctx->parser, ctx->flags, ctx->appname, 0);

--- a/rlib/rconfig.h.meson
+++ b/rlib/rconfig.h.meson
@@ -19,7 +19,7 @@
 #define __R_CONFIG_H__
 
 #if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
-#error "#include <rlib.h> only pelase."
+#error "#include <rlib.h> only please."
 #endif
 
 /* Options */

--- a/rlib/ruri.c
+++ b/rlib/ruri.c
@@ -218,7 +218,9 @@ r_uri_parse (RUri * uri)
       uri->query.ptr = p;
     }
 
-    /* fragment */
+    /* fragment (skip the leading '#', mirroring the query's '?') */
+    if (p < pend && *p == '#')
+      p++;
     uri->fragment.ptr = p;
     uri->fragment.size = RPOINTER_TO_SIZE (pend - p);
   } else {

--- a/test/rargparse.c
+++ b/test/rargparse.c
@@ -33,7 +33,7 @@ RTEST (rargparse, help_help_options, RTEST_FAST)
   r_free (help);
 
   expected = r_strprintf (rargparse_help_tmpl, exe, "", "", "");
-  r_assert_cmpstr ((help = r_arg_parser_get_help (parser, R_ARG_PARSE_FLAG_DISALE_HELP, NULL)), ==, expected);
+  r_assert_cmpstr ((help = r_arg_parser_get_help (parser, R_ARG_PARSE_FLAG_DISABLE_HELP, NULL)), ==, expected);
   r_free (expected);
   r_free (help);
   r_free (exe);

--- a/test/rhzrptr.c
+++ b/test/rhzrptr.c
@@ -39,7 +39,7 @@ RTEST (rhzrptr, read, RTEST_FAST)
   rhzrptr hp = R_HZR_PTR_INIT (NULL);
   rpointer ptr;
 
-  ptr = r_hzr_ptr_aqcuire (&hp, NULL);
+  ptr = r_hzr_ptr_acquire (&hp, NULL);
   r_assert_cmpptr (ptr, ==, NULL);
   r_hzr_ptr_release (&hp, NULL);
 }
@@ -50,13 +50,13 @@ RTEST (rhzrptr, replace, RTEST_FAST)
   rhzrptr hp = R_HZR_PTR_INIT (NULL);
   rpointer ptr;
 
-  ptr = r_hzr_ptr_aqcuire (&hp, NULL);
+  ptr = r_hzr_ptr_acquire (&hp, NULL);
   r_assert_cmpptr (ptr, ==, NULL);
   r_hzr_ptr_release (&hp, NULL);
 
   r_hzr_ptr_replace (&hp, RUINT_TO_POINTER (0xCAFEBABE));
 
-  ptr = r_hzr_ptr_aqcuire (&hp, NULL);
+  ptr = r_hzr_ptr_acquire (&hp, NULL);
   r_assert_cmpptr (ptr, ==, RUINT_TO_POINTER (0xCAFEBABE));
   r_hzr_ptr_release (&hp, NULL);
 }
@@ -74,7 +74,7 @@ RTEST (rhzrptr, read_replace, RTEST_FAST)
 
   r_hzr_ptr_replace (&hp, r_mem_new0 (TestHP));
 
-  ptr = r_hzr_ptr_aqcuire (&hp, NULL);
+  ptr = r_hzr_ptr_acquire (&hp, NULL);
   r_assert_cmpptr (ptr, !=, NULL);
   r_hzr_ptr_replace (&hp, NULL);
 
@@ -84,7 +84,7 @@ RTEST (rhzrptr, read_replace, RTEST_FAST)
 
   r_hzr_ptr_release (&hp, NULL);
 
-  ptr = r_hzr_ptr_aqcuire (&hp, NULL);
+  ptr = r_hzr_ptr_acquire (&hp, NULL);
   r_assert_cmpptr (ptr, ==, NULL);
   r_hzr_ptr_release (&hp, NULL);
 }


### PR DESCRIPTION
Audit of the whole public API surface (`include/rlib/`) for misspelled
symbols, broken declarations/macros, and documentation that contradicts
the implementation. Every claim was checked against the code before
being changed.

## Functional fixes

- **Misspelled public symbols** renamed: `…DISALE_HELP`→`…DISABLE_HELP`,
  `r_hzr_ptr_aqcuire`→`…acquire`, `R_TTY_SGR_CONSEAL_ARG`→`…CONCEAL_ARG`,
  `…BRAINPOOLP348R1`→`…P384R1` (recurve + tls), and the `canidate` macro
  parameter. Added the missing `R_API` marker on `r_tty_clr_to_str`.
- **Broken header macros**: `r_mem_newa0` referenced a non-existent
  `r_mem_newa_n0` (plus unbalanced parens); `r_dir_tree_clear_node`
  expanded to a 4-argument call of a 5-argument function. Added the
  `<rlib.h>`-only include guard that `rkvptrarray.h` was missing.
- **MD2/MD4 digests**: `r_msg_digest_new_md2/_md4` (and their aliases)
  were declared but never defined, so referencing them failed to link.
  Added NULL-returning stubs, keeping the API stable until the
  algorithms are implemented.
- **Behavioural contract fixes**: `r_string_erase` now consistently
  returns the resulting length on both branches (matching its test and
  `r_string_reset`); `r_uri_get_fragment` now strips the leading `#`,
  mirroring how `r_uri_get_query` strips `?` and matching its own doc.
  Both have no other callers or tests.

## Documentation corrections

Comments that disagreed with the implementation, including a few that
were actively dangerous:

- `r_mem_allocator_register` stores the pointer but does **not** take a
  reference — the old "safe to drop your reference" note invited
  use-after-free.
- `r_sys_topology_node` / `_node_cpu` and `r_rtc_session_lookup_rtp_transceiver`
  return a **new** reference the caller must unref.
- `r_sig_alrm_timer_cancel` frees the timer; `r_ev_loop_run` returns the
  number of events still outstanding, not processed.
- Hashtable/hashset/dictionary remover and insert semantics; rtime
  (uptime in seconds, 1753 floor, `-1` sentinel); rcpufeatures AArch64
  bit layout; rstr chunk-iteration and dump; rrtc parameter names and
  enum references; ELF/Mach-O/PE comment errors.

## Typos

Swept `pelase`→`please` out of the include guard of every header, plus
`Appearantly`, `dynamicly`, and a dropped leading letter in an RTCP
payload-type comment.

## Verification

`build-debug-test` (werror), `build-release` (werror) and `build-asan`
all build clean; the full test suite passes, including under ASAN;
Doxygen runs with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)