### PR TITLE
Remove obsolete TODO/FIXME comments and add atomic-ops tests

### DIFF
--- a/include/rlib/concurrency/ratomic.h
+++ b/include/rlib/concurrency/ratomic.h
@@ -321,7 +321,6 @@ __extension__ ({                                              \
 #elif USE_MSC_ATOMICS
 #include <intrin.h>
 
-/* TODO: Check if this works with MSC */
 #define r_atomic_int_load(a)                    (MemoryBarrier(), *a)
 #define r_atomic_int_store(a, v)                _InterlockedExchange ((long volatile *)a, (long)v)
 #define r_atomic_int_exchange(a, v)             _InterlockedExchange ((long volatile *)a, (long)v)

--- a/rlib/concurrency/rthreads.c
+++ b/rlib/concurrency/rthreads.c
@@ -58,8 +58,6 @@
 #include <signal.h>
 #endif
 
-/* TODO: Implement support for RCond on Windows XP! */
-
 #if defined (R_OS_WIN32)
 static RSList * g__r_tss_win32_dtors = NULL;
 #endif

--- a/rlib/crypto/rpem.c
+++ b/rlib/crypto/rpem.c
@@ -753,7 +753,6 @@ r_pem_write_public_key (const RCryptoKey * key,
     ruint8 * asn1buf;
     rsize asn1bufsize;
 
-    /* FIXME: Use RBuffer instead!!! */
     if ((asn1buf = r_asn1_bin_encoder_get_data (enc, &asn1bufsize)) != NULL) {
       rchar * b64;
       rsize b64size;

--- a/rlib/crypto/rrsa.c
+++ b/rlib/crypto/rrsa.c
@@ -1405,7 +1405,6 @@ r_rsa_pkcs1v1_5_verify_msg (const RCryptoKey * key,
         rsize hashsize;
 
         if ((md = r_msg_digest_new (mdtype)) == NULL) {
-          /* FIXME: Support all hash types! */
           ret = R_CRYPTO_NOT_AVAILABLE;
         } else if ((hashsize = r_msg_digest_size (md)) == tlv.len) {
           ruint8 * hash = r_alloca (hashsize);

--- a/rlib/data/rmpint.c
+++ b/rlib/data/rmpint.c
@@ -2032,16 +2032,7 @@ r_mpint_lcm (rmpint * dst, const rmpint * a, const rmpint * b)
   r_mpint_init (&tmp);
 
   if ((ret = r_mpint_gcd (&tmp, a, b))) {
-#if 1
     ret = r_mpint_mul (dst, a, b) && r_mpint_div (dst, NULL, dst, &tmp);
-#else
-    /* FIXME: check if this is faster!? */
-    if (r_mpint_ucmp (a, b) > 0) {
-      ret = r_mpint_div (&tmp, NULL, a, &tmp) && r_mpint_mul (dst, b, &tmp);
-    } else {
-      ret = r_mpint_div (&tmp, NULL, b, &tmp) && r_mpint_mul (dst, a, &tmp);
-    }
-#endif
   }
   r_mpint_clear (&tmp);
 

--- a/rlib/rbuffer.c
+++ b/rlib/rbuffer.c
@@ -21,8 +21,6 @@
 
 #include <rlib/rmem.h>
 
-/* FIXME: Add logging??? */
-
 #define R_BUFFER_MAX_MEM    32
 
 struct RBuffer {

--- a/rlib/rmath.c
+++ b/rlib/rmath.c
@@ -21,8 +21,6 @@
 #include <rlib/rassert.h>
 #include <math.h>
 
-/* FIXME: Fix float/double classify/signbit if not C99 compiler */
-
 #define GCD_DEFINE(func, type)      \
   type func (type a, type b) {      \
     type c;                         \

--- a/rlib/rpoll.c
+++ b/rlib/rpoll.c
@@ -131,10 +131,10 @@ r_poll (RPoll * handles, ruint count, RClockTime timeout)
     } else if (res == WAIT_TIMEOUT) {
       break;
     } else if (res == WAIT_IO_COMPLETION) {
-      // FIXME: WAIT_IO_COMPLETION
+      /* FIXME: WAIT_IO_COMPLETION */
       r_assert_not_reached ();
     } else {
-      // FIXME: What to do when we get WAIT_ABANDONED_0
+      /* FIXME: What to do when we get WAIT_ABANDONED_0 */
       r_assert_not_reached ();
     }
   }

--- a/test/meson.build
+++ b/test/meson.build
@@ -5,6 +5,7 @@ rlibtest_sources = [
   'rasn1der.c',
   'rasn1enc.c',
   'rasn1oid.c',
+  'ratomic.c',
   'rargparse.c',
   'rbase64.c',
   'rbitops.c',

--- a/test/ratomic.c
+++ b/test/ratomic.c
@@ -1,0 +1,113 @@
+#include <rlib/rlib.h>
+
+RTEST (ratomic, int_load_store_exchange, R_TEST_TYPE_FAST)
+{
+  raint a = 0;
+
+  r_assert_cmpint (r_atomic_int_load (&a), ==, 0);
+  r_atomic_int_store (&a, 42);
+  r_assert_cmpint (r_atomic_int_load (&a), ==, 42);
+  r_assert_cmpint (r_atomic_int_exchange (&a, 7), ==, 42);
+  r_assert_cmpint (r_atomic_int_load (&a), ==, 7);
+}
+RTEST_END;
+
+RTEST (ratomic, int_cmp_xchg, R_TEST_TYPE_FAST)
+{
+  raint a = 10;
+  int old;
+
+  /* Success: *a matches old, gets replaced, returns TRUE. */
+  old = 10;
+  r_assert (r_atomic_int_cmp_xchg_strong (&a, &old, 20));
+  r_assert_cmpint (r_atomic_int_load (&a), ==, 20);
+
+  /* Failure: *a no longer matches old. Must return FALSE *and* write
+   * the observed value back into old (the C11 semantic the MSVC path
+   * has to emulate, otherwise retry loops spin forever). */
+  old = 10;
+  r_assert (!r_atomic_int_cmp_xchg_strong (&a, &old, 30));
+  r_assert_cmpint (old, ==, 20);
+  r_assert_cmpint (r_atomic_int_load (&a), ==, 20);
+
+  /* A retry against the written-back value now succeeds. */
+  r_assert (r_atomic_int_cmp_xchg_strong (&a, &old, 30));
+  r_assert_cmpint (r_atomic_int_load (&a), ==, 30);
+
+  /* Weak variant: same contract on the failure writeback (it may fail
+   * spuriously, so only the failure-path writeback is asserted). */
+  old = 0;
+  r_assert (!r_atomic_int_cmp_xchg_weak (&a, &old, 99));
+  r_assert_cmpint (old, ==, 30);
+}
+RTEST_END;
+
+RTEST (ratomic, int_fetch_ops, R_TEST_TYPE_FAST)
+{
+  raint a = 0;
+
+  r_assert_cmpint (r_atomic_int_fetch_add (&a, 5), ==, 0);
+  r_assert_cmpint (r_atomic_int_fetch_add (&a, 3), ==, 5);
+  r_assert_cmpint (r_atomic_int_fetch_sub (&a, 2), ==, 8);
+  r_assert_cmpint (r_atomic_int_load (&a), ==, 6);
+
+  r_atomic_int_store (&a, 0x0f);
+  r_assert_cmpint (r_atomic_int_fetch_and (&a, 0x09), ==, 0x0f);
+  r_assert_cmpint (r_atomic_int_load (&a), ==, 0x09);
+  r_assert_cmpint (r_atomic_int_fetch_or (&a, 0x06), ==, 0x09);
+  r_assert_cmpint (r_atomic_int_load (&a), ==, 0x0f);
+  r_assert_cmpint (r_atomic_int_fetch_xor (&a, 0x0a), ==, 0x0f);
+  r_assert_cmpint (r_atomic_int_load (&a), ==, 0x05);
+}
+RTEST_END;
+
+RTEST (ratomic, uint_ops, R_TEST_TYPE_FAST)
+{
+  rauint a = 0;
+  ruint old;
+
+  r_atomic_uint_store (&a, 100);
+  r_assert_cmpuint (r_atomic_uint_load (&a), ==, 100);
+  r_assert_cmpuint (r_atomic_uint_exchange (&a, 5), ==, 100);
+
+  r_assert_cmpuint (r_atomic_uint_fetch_add (&a, 10), ==, 5);
+  r_assert_cmpuint (r_atomic_uint_fetch_sub (&a, 7), ==, 15);
+  r_assert_cmpuint (r_atomic_uint_load (&a), ==, 8);
+
+  old = 8;
+  r_assert (r_atomic_uint_cmp_xchg_strong (&a, &old, 64));
+  r_assert_cmpuint (r_atomic_uint_load (&a), ==, 64);
+  old = 8;
+  r_assert (!r_atomic_uint_cmp_xchg_strong (&a, &old, 1));
+  r_assert_cmpuint (old, ==, 64);
+
+  r_atomic_uint_store (&a, 0xf0);
+  r_assert_cmpuint (r_atomic_uint_fetch_and (&a, 0xa0), ==, 0xf0);
+  r_assert_cmpuint (r_atomic_uint_fetch_or  (&a, 0x0c), ==, 0xa0);
+  r_assert_cmpuint (r_atomic_uint_fetch_xor (&a, 0xaa), ==, 0xac);
+  r_assert_cmpuint (r_atomic_uint_load (&a), ==, 0x06);
+}
+RTEST_END;
+
+RTEST (ratomic, ptr_ops, R_TEST_TYPE_FAST)
+{
+  raptr a = 0;
+  rpointer old;
+
+  r_assert_cmpptr (r_atomic_ptr_load (&a), ==, NULL);
+  r_atomic_ptr_store (&a, RSIZE_TO_POINTER (0x1000));
+  r_assert_cmpptr (r_atomic_ptr_load (&a), ==, RSIZE_TO_POINTER (0x1000));
+  r_assert_cmpptr (r_atomic_ptr_exchange (&a, RSIZE_TO_POINTER (0x2000)), ==,
+      RSIZE_TO_POINTER (0x1000));
+
+  /* cmp_xchg success + failure-writeback, same as the int case. */
+  old = RSIZE_TO_POINTER (0x2000);
+  r_assert (r_atomic_ptr_cmp_xchg_strong (&a, &old, RSIZE_TO_POINTER (0x3000)));
+  r_assert_cmpptr (r_atomic_ptr_load (&a), ==, RSIZE_TO_POINTER (0x3000));
+
+  old = RSIZE_TO_POINTER (0x2000);
+  r_assert (!r_atomic_ptr_cmp_xchg_strong (&a, &old, RSIZE_TO_POINTER (0x4000)));
+  r_assert_cmpptr (old, ==, RSIZE_TO_POINTER (0x3000));
+  r_assert_cmpptr (r_atomic_ptr_load (&a), ==, RSIZE_TO_POINTER (0x3000));
+}
+RTEST_END;


### PR DESCRIPTION
Housekeeping pass over stale `TODO`/`FIXME` markers — removing the ones
that are obsolete, dead, or non-actionable, and tidying comment style.
Genuine outstanding gaps were left in place (tracked separately); this
PR only touches markers that no longer carry their weight.

Per commit:
- **crypto** — drop two obsolete FIXMEs: the RSA "support all hash
  types" note (the signature-OID parser only yields MD5/SHA-1/SHA-2, all
  implemented) and the PEM "use RBuffer" style nag (current path is
  correct and leak-free).
- **data** — remove the dead `#else` alternative in `r_mpint_lcm` (it
  sat behind `#if 1` and was never compiled).
- **rbuffer** — drop the speculative "add logging?" FIXME.
- **rmath** — drop the pre-C99 float-classify fallback note; rlib
  targets C99+.
- **threads** — drop the Windows XP `RCond` TODO (XP is end-of-life).
- **poll** — convert the two win32 `WaitForMultipleObjects` `//` FIXMEs
  to `/* */` to match the codebase style; their content is unchanged
  (still a real gap).
- **test** — add `test/ratomic.c` covering load/store/exchange, the
  fetch ops and compare-exchange (incl. the cmp_xchg failure-writeback
  the MSVC backend emulates) for `raint`/`rauint`/`raptr`; this lets the
  MSVC CI build validate the `USE_MSC_ATOMICS` path, so its stale
  "check if this works with MSC" TODO is dropped.

## Verification
debug-test + release (werror) + ASAN build clean; full suite 1890 pass,
0 fail; Doxygen 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)