### PR TITLE
argparse: parser config accessors (appname/options/version) + const getters

### DIFF
--- a/include/rlib/rargparse.h
+++ b/include/rlib/rargparse.h
@@ -185,10 +185,33 @@ R_API RArgParser * r_arg_parser_new (const rchar * app, const rchar * version) R
  * @name Parser configuration
  * @{
  */
+/**
+ * @brief Override the program name shown in @c --help and the Usage
+ * line (default: the @p app passed to @c r_arg_parser_new, or
+ * @c argv[0] at parse time).
+ *
+ * Set this before adding sub-commands, since their composed names are
+ * derived from the program name at @c r_arg_parser_add_command time.
+ * Pass @c NULL to clear it.
+ */
+R_API void r_arg_parser_set_appname (RArgParser * parser, const rchar * appname);
+/**
+ * @brief Override the options-summary token printed after the program
+ * name in the Usage line (default: @c "[options]").
+ *
+ * This is the synopsis fragment, @b not the option set itself (use
+ * @c r_arg_parser_add_option_entries for that). Pass @c NULL to omit
+ * the token entirely.
+ */
+R_API void r_arg_parser_set_options (RArgParser * parser, const rchar * options);
 /** @brief Set the prologue paragraph shown above option help. */
 R_API void r_arg_parser_set_summary (RArgParser * parser, const rchar * summary);
 /** @brief Set the epilogue paragraph shown below option help. */
 R_API void r_arg_parser_set_epilog (RArgParser * parser, const rchar * epilog);
+/** @brief Return the program name, or @c NULL. */
+R_API const rchar * r_arg_parser_get_appname (RArgParser * parser);
+/** @brief Return the Usage-line options-summary token, or @c NULL. */
+R_API const rchar * r_arg_parser_get_options (RArgParser * parser);
 /** @brief Return the previously-set summary, or @c NULL. */
 R_API const rchar * r_arg_parser_get_summary (RArgParser * parser);
 /** @brief Return the previously-set epilog, or @c NULL. */

--- a/include/rlib/rargparse.h
+++ b/include/rlib/rargparse.h
@@ -204,6 +204,14 @@ R_API void r_arg_parser_set_appname (RArgParser * parser, const rchar * appname)
  * the token entirely.
  */
 R_API void r_arg_parser_set_options (RArgParser * parser, const rchar * options);
+/**
+ * @brief Replace the version string reported by @c --version and
+ * @c r_arg_parser_get_version (overriding the @p version passed to
+ * @c r_arg_parser_new).
+ *
+ * Pass @c NULL to report "version not specified".
+ */
+R_API void r_arg_parser_set_version (RArgParser * parser, const rchar * version);
 /** @brief Set the prologue paragraph shown above option help. */
 R_API void r_arg_parser_set_summary (RArgParser * parser, const rchar * summary);
 /** @brief Set the epilogue paragraph shown below option help. */

--- a/include/rlib/rargparse.h
+++ b/include/rlib/rargparse.h
@@ -170,8 +170,10 @@ typedef enum {
  *
  * @param app      Program name shown in @c --help and the Usage line;
  *                 @c NULL falls back to @c argv[0] at parse time.
- * @param version  Version string returned by @c --version; @c NULL
- *                 omits the auto-registered @c --version option.
+ * @param version  Version string reported by @c --version; @c NULL
+ *                 reports "version not specified". The @c --version
+ *                 option is auto-registered either way (override the
+ *                 string later with @c r_arg_parser_set_version).
  * @return Newly-allocated parser; release with @c r_arg_parser_unref.
  */
 R_API RArgParser * r_arg_parser_new (const rchar * app, const rchar * version) R_ATTR_MALLOC;

--- a/include/rlib/rargparse.h
+++ b/include/rlib/rargparse.h
@@ -185,6 +185,10 @@ R_API RArgParser * r_arg_parser_new (const rchar * app, const rchar * version) R
 
 /**
  * @name Parser configuration
+ *
+ * The @c _get_ accessors below return a borrowed pointer owned by the
+ * parser (or @c NULL); it stays valid only until the matching @c _set_
+ * call or @c r_arg_parser_unref. Do not free it.
  * @{
  */
 /**
@@ -218,14 +222,14 @@ R_API void r_arg_parser_set_version (RArgParser * parser, const rchar * version)
 R_API void r_arg_parser_set_summary (RArgParser * parser, const rchar * summary);
 /** @brief Set the epilogue paragraph shown below option help. */
 R_API void r_arg_parser_set_epilog (RArgParser * parser, const rchar * epilog);
-/** @brief Return the program name, or @c NULL. */
-R_API const rchar * r_arg_parser_get_appname (RArgParser * parser);
-/** @brief Return the Usage-line options-summary token, or @c NULL. */
-R_API const rchar * r_arg_parser_get_options (RArgParser * parser);
-/** @brief Return the previously-set summary, or @c NULL. */
-R_API const rchar * r_arg_parser_get_summary (RArgParser * parser);
-/** @brief Return the previously-set epilog, or @c NULL. */
-R_API const rchar * r_arg_parser_get_epilog (RArgParser * parser);
+/** @brief Return the program name, or @c NULL (borrowed). */
+R_API const rchar * r_arg_parser_get_appname (const RArgParser * parser);
+/** @brief Return the Usage-line options-summary token, or @c NULL (borrowed). */
+R_API const rchar * r_arg_parser_get_options (const RArgParser * parser);
+/** @brief Return the previously-set summary, or @c NULL (borrowed). */
+R_API const rchar * r_arg_parser_get_summary (const RArgParser * parser);
+/** @brief Return the previously-set epilog, or @c NULL (borrowed). */
+R_API const rchar * r_arg_parser_get_epilog (const RArgParser * parser);
 /** @} */
 
 /**
@@ -281,13 +285,15 @@ R_API RArgParser * r_arg_parser_add_command (RArgParser * parser,
  * @name Help and version output
  * @{
  */
-/** @brief Render the help text as a newly-allocated string. */
+/** @brief Render the help text as a newly-allocated string; caller
+ *  frees with @c r_free. */
 R_ATTR_WARN_UNUSED_RESULT
-R_API rchar * r_arg_parser_get_help (RArgParser * parser, RArgParseFlags flags,
+R_API rchar * r_arg_parser_get_help (const RArgParser * parser, RArgParseFlags flags,
     const rchar * appname) R_ATTR_MALLOC;
-/** @brief Render the version line as a newly-allocated string. */
+/** @brief Render the version line as a newly-allocated string; caller
+ *  frees with @c r_free. */
 R_ATTR_WARN_UNUSED_RESULT
-R_API rchar * r_arg_parser_get_version (RArgParser * parser) R_ATTR_MALLOC;
+R_API rchar * r_arg_parser_get_version (const RArgParser * parser) R_ATTR_MALLOC;
 /**
  * @brief Print the version line to stdout.
  *

--- a/rlib/rargparse.c
+++ b/rlib/rargparse.c
@@ -404,6 +404,13 @@ r_arg_parser_set_options (RArgParser * parser, const rchar * options)
   parser->options = r_strdup (options);
 }
 
+void
+r_arg_parser_set_version (RArgParser * parser, const rchar * version)
+{
+  r_free (parser->version);
+  parser->version = r_strdup (version);
+}
+
 const rchar *
 r_arg_parser_get_appname (RArgParser * parser)
 {

--- a/rlib/rargparse.c
+++ b/rlib/rargparse.c
@@ -412,13 +412,13 @@ r_arg_parser_set_version (RArgParser * parser, const rchar * version)
 }
 
 const rchar *
-r_arg_parser_get_appname (RArgParser * parser)
+r_arg_parser_get_appname (const RArgParser * parser)
 {
   return parser->appname;
 }
 
 const rchar *
-r_arg_parser_get_options (RArgParser * parser)
+r_arg_parser_get_options (const RArgParser * parser)
 {
   return parser->options;
 }
@@ -438,13 +438,13 @@ r_arg_parser_set_epilog (RArgParser * parser, const rchar * epilog)
 }
 
 const rchar *
-r_arg_parser_get_summary (RArgParser * parser)
+r_arg_parser_get_summary (const RArgParser * parser)
 {
   return parser->summary;
 }
 
 const rchar *
-r_arg_parser_get_epilog (RArgParser * parser)
+r_arg_parser_get_epilog (const RArgParser * parser)
 {
   return parser->epilog;
 }
@@ -564,7 +564,7 @@ r_arg_command_append_help (rpointer key, rpointer val, rpointer user)
 }
 
 rchar *
-r_arg_parser_get_help (RArgParser * parser, RArgParseFlags flags,
+r_arg_parser_get_help (const RArgParser * parser, RArgParseFlags flags,
     const rchar * appname)
 {
   RString * str;
@@ -630,7 +630,9 @@ r_arg_parser_get_help (RArgParser * parser, RArgParseFlags flags,
 
   if (r_kv_ptr_array_size (&parser->commands) > 0) {
     r_string_append (str, "\nCommands:\n");
-    r_kv_ptr_array_foreach (&parser->commands, r_arg_command_append_help, str);
+    /* foreach only reads; cast off the const this read-only getter added. */
+    r_kv_ptr_array_foreach ((RKVPtrArray *) &parser->commands,
+        r_arg_command_append_help, str);
   }
 
   if (parser->epilog != NULL)
@@ -640,7 +642,7 @@ r_arg_parser_get_help (RArgParser * parser, RArgParseFlags flags,
 }
 
 rchar *
-r_arg_parser_get_version (RArgParser * parser)
+r_arg_parser_get_version (const RArgParser * parser)
 {
   const rchar * prefix, * real;
 

--- a/rlib/rargparse.c
+++ b/rlib/rargparse.c
@@ -34,8 +34,6 @@
 #include <rlib/rstr.h>
 #include <rlib/os/rtty.h>
 
-/* TODO: Add API to customize options usage string + (get|set)ters appname++ */
-
 struct RArgParser
 {
   RRef ref;
@@ -393,6 +391,32 @@ r_arg_parser_new (const rchar * app, const rchar * version)
 }
 
 void
+r_arg_parser_set_appname (RArgParser * parser, const rchar * appname)
+{
+  r_free (parser->appname);
+  parser->appname = r_strdup (appname);
+}
+
+void
+r_arg_parser_set_options (RArgParser * parser, const rchar * options)
+{
+  r_free (parser->options);
+  parser->options = r_strdup (options);
+}
+
+const rchar *
+r_arg_parser_get_appname (RArgParser * parser)
+{
+  return parser->appname;
+}
+
+const rchar *
+r_arg_parser_get_options (RArgParser * parser)
+{
+  return parser->options;
+}
+
+void
 r_arg_parser_set_summary (RArgParser * parser, const rchar * summary)
 {
   r_free (parser->summary);
@@ -542,9 +566,13 @@ r_arg_parser_get_help (RArgParser * parser, RArgParseFlags flags,
   if (R_UNLIKELY (parser == NULL))
     return NULL;
 
+  if (appname == NULL)
+    appname = parser->appname;
+
   str = r_string_new_sized (1024);
-  r_string_append_printf (str, "Usage:\n  %s %s",
-      appname != NULL ? appname : parser->appname, parser->options);
+  r_string_append_printf (str, "Usage:\n  %s", appname != NULL ? appname : "");
+  if (parser->options != NULL)
+    r_string_append_printf (str, " %s", parser->options);
   for (i = 0; i < parser->main->count; i++) {
     const RArgOptionEntry * opt = &parser->main->entries[i];
     rchar * name;
@@ -620,7 +648,8 @@ r_arg_parser_get_version (RArgParser * parser)
     real = "(\"version not specified\")";
   }
 
-  return r_strprintf ("%s %s%s\n", parser->appname, prefix, real);
+  return r_strprintf ("%s %s%s\n",
+      parser->appname != NULL ? parser->appname : "", prefix, real);
 }
 
 rboolean

--- a/test/rargparse.c
+++ b/test/rargparse.c
@@ -78,6 +78,71 @@ RTEST (rargparse, help_epilog, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rargparse, set_get_appname_options, RTEST_FAST)
+{
+  RArgParser * parser = r_arg_parser_new ("origapp", NULL);
+
+  r_assert_cmpstr (r_arg_parser_get_appname (parser), ==, "origapp");
+  r_assert_cmpstr (r_arg_parser_get_options (parser), ==, "[options]");
+
+  r_arg_parser_set_appname (parser, "tool");
+  r_arg_parser_set_options (parser, "[OPTS] FILE");
+  r_assert_cmpstr (r_arg_parser_get_appname (parser), ==, "tool");
+  r_assert_cmpstr (r_arg_parser_get_options (parser), ==, "[OPTS] FILE");
+
+  r_arg_parser_set_options (parser, NULL);
+  r_assert_cmpptr (r_arg_parser_get_options (parser), ==, NULL);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, help_custom_appname_options, RTEST_FAST)
+{
+  rchar * expected, * help;
+  RArgParser * parser = r_arg_parser_new ("ignored", NULL);
+
+  r_arg_parser_set_appname (parser, "mytool");
+  r_arg_parser_set_options (parser, "[FLAGS] SRC DST");
+  expected = r_strprintf ("Usage:\n  %s %s\n\nOptions:\n%s",
+      "mytool", "[FLAGS] SRC DST", rargparse_helpopt);
+  r_assert_cmpstr ((help = r_arg_parser_get_help (parser, R_ARG_PARSE_FLAG_NONE, NULL)), ==, expected);
+  r_free (expected);
+  r_free (help);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, help_no_options_token, RTEST_FAST)
+{
+  rchar * expected, * help;
+  RArgParser * parser = r_arg_parser_new ("mytool", NULL);
+
+  r_arg_parser_set_options (parser, NULL);
+  expected = r_strprintf ("Usage:\n  %s\n\nOptions:\n%s", "mytool", rargparse_helpopt);
+  r_assert_cmpstr ((help = r_arg_parser_get_help (parser, R_ARG_PARSE_FLAG_NONE, NULL)), ==, expected);
+  r_free (expected);
+  r_free (help);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, version_custom_appname, RTEST_FAST)
+{
+  rchar * verstr;
+  RArgParser * parser = r_arg_parser_new ("orig", "1.2.3");
+
+  r_arg_parser_set_appname (parser, "renamed");
+  r_assert_cmpptr ((verstr = r_arg_parser_get_version (parser)), !=, NULL);
+  r_assert_cmpstr (verstr, ==, "renamed version 1.2.3\n");
+  r_free (verstr);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
 RTEST (rargparse, group, RTEST_FAST)
 {
   RArgOptionGroup * group;

--- a/test/rargparse.c
+++ b/test/rargparse.c
@@ -143,6 +143,25 @@ RTEST (rargparse, version_custom_appname, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rargparse, set_version, RTEST_FAST)
+{
+  rchar * verstr;
+  RArgParser * parser = r_arg_parser_new ("app", "1.0");
+
+  r_arg_parser_set_version (parser, "2.5-rc1");
+  r_assert_cmpptr ((verstr = r_arg_parser_get_version (parser)), !=, NULL);
+  r_assert_cmpstr (verstr, ==, "app version 2.5-rc1\n");
+  r_free (verstr);
+
+  r_arg_parser_set_version (parser, NULL);
+  r_assert_cmpptr ((verstr = r_arg_parser_get_version (parser)), !=, NULL);
+  r_assert_cmpstr (verstr, ==, "app (\"version not specified\")\n");
+  r_free (verstr);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
 RTEST (rargparse, group, RTEST_FAST)
 {
   RArgOptionGroup * group;


### PR DESCRIPTION
Completes the parser configuration accessor surface and tidies the
getters.

Per commit:
- **appname / usage-options getters & setters** — the program name and
  the Usage-line options token (default `"[options]"`) were stored but
  only settable at construction. Adds `r_arg_parser_{set,get}_appname`
  and `r_arg_parser_{set,get}_options`, mirroring the existing
  summary/epilog accessors. Both accept `NULL`; `get_help` omits the
  options token when it is `NULL`, and the help/version paths tolerate a
  `NULL` program name. Removes the long-standing TODO that asked for
  exactly this. Closes #225.
- **version setter** — `r_arg_parser_set_version` rounds out the set
  (version was construction-only); `NULL` reports "version not
  specified".
- **doc fix** — `r_arg_parser_new`'s `version=NULL` doc claimed it
  "omits the auto-registered --version option", but the option is
  registered unconditionally; corrected to describe the real behaviour.
- **const getters + lifetimes** — all six `r_arg_parser_get_*` take
  `const RArgParser *`; the four config getters document their borrowed
  return (valid until the matching setter / parser unref), and
  get_help / get_version document that the caller frees the result.

## Verification
debug-test + release (werror) + ASAN build clean; full suite 1895 pass,
0 fail; Doxygen 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)