### PR TITLE
data: const-correct read access to rkvptrarray

### DIFF
--- a/include/rlib/data/rkvptrarray.h
+++ b/include/rlib/data/rkvptrarray.h
@@ -121,7 +121,7 @@ R_API rconstpointer r_kv_ptr_array_get_const (const RKVPtrArray * array, rsize i
  * @brief Find the first slot whose key matches @p key within
  * @c [idx, idx+size).
  */
-R_API rsize r_kv_ptr_array_find_range (RKVPtrArray * array, rconstpointer key, rsize idx, rssize size);
+R_API rsize r_kv_ptr_array_find_range (const RKVPtrArray * array, rconstpointer key, rsize idx, rssize size);
 
 /** @} */
 
@@ -165,6 +165,20 @@ R_API rsize r_kv_ptr_array_foreach_range (RKVPtrArray * array,
 /** @brief Convenience: iterate every pair. */
 #define r_kv_ptr_array_foreach(array, func, user) \
   r_kv_ptr_array_foreach_range (array, 0, -1, func, user)
+
+/**
+ * @brief Const-visitor variant of @ref r_kv_ptr_array_foreach_range.
+ *
+ * Takes a @c const array and an @ref RKeyValueConstFunc that receives
+ * @c rconstpointer key / value, so it can iterate without granting the
+ * callback mutable access to the stored pairs (the read-only mirror of
+ * @c get vs @c get_const).
+ */
+R_API rsize r_kv_ptr_array_foreach_const_range (const RKVPtrArray * array,
+    rsize idx, rssize size, RKeyValueConstFunc func, rpointer user);
+/** @brief Convenience: const-iterate every pair. */
+#define r_kv_ptr_array_foreach_const(array, func, user) \
+  r_kv_ptr_array_foreach_const_range (array, 0, -1, func, user)
 
 /** @} */
 

--- a/include/rlib/rtypes.h
+++ b/include/rlib/rtypes.h
@@ -408,6 +408,8 @@ typedef rboolean (*REqualFunc) (rconstpointer a, rconstpointer b);
 typedef rsize (*RHashFunc) (rconstpointer key);
 /** @brief Iteration callback over (key, value, user) triples. */
 typedef void (*RKeyValueFunc) (rpointer key, rpointer value, rpointer user);
+/** @brief Const-visitor iteration callback over (key, value, user) triples. */
+typedef void (*RKeyValueConstFunc) (rconstpointer key, rconstpointer value, rpointer user);
 /** @brief Iteration callback over (const char *key, value, user). */
 typedef void (*RStrKeyValueFunc) (const rchar * key, rpointer value, rpointer user);
 /**

--- a/rlib/data/rkvptrarray.c
+++ b/rlib/data/rkvptrarray.c
@@ -140,7 +140,7 @@ r_ptr_equal (rconstpointer a, rconstpointer b)
 }
 
 rsize
-r_kv_ptr_array_find_range (RKVPtrArray * array, rconstpointer key, rsize idx, rssize size)
+r_kv_ptr_array_find_range (const RKVPtrArray * array, rconstpointer key, rsize idx, rssize size)
 {
   rsize end;
   REqualFunc eqfunc;
@@ -239,6 +239,24 @@ r_kv_ptr_array_remove_key_all (RKVPtrArray * array, rpointer key)
 rsize
 r_kv_ptr_array_foreach_range (RKVPtrArray * array,
     rsize idx, rssize size, RKeyValueFunc func, rpointer user)
+{
+  rsize i, end;
+
+  if (R_UNLIKELY (func == NULL)) return 0;
+
+  if (R_UNLIKELY (idx >= array->nsize)) return 0;
+  end = (size < 0) ? array->nsize : idx + size;
+  if (R_UNLIKELY (end > array->nsize)) return 0;
+
+  for (i = idx; i < end; i++)
+    func (R_KV_PTR_ARRAY_N (array, i).key, R_KV_PTR_ARRAY_N (array, i).val, user);
+
+  return end - idx;
+}
+
+rsize
+r_kv_ptr_array_foreach_const_range (const RKVPtrArray * array,
+    rsize idx, rssize size, RKeyValueConstFunc func, rpointer user)
 {
   rsize i, end;
 

--- a/rlib/rargparse.c
+++ b/rlib/rargparse.c
@@ -546,10 +546,10 @@ r_arg_option_group_append_help (const RArgOptionGroup * group, RString * str)
 }
 
 static void
-r_arg_command_append_help (rpointer key, rpointer val, rpointer user)
+r_arg_command_append_help (rconstpointer key, rconstpointer val, rpointer user)
 {
-  rchar * cmd = key;
-  RArgParser * parser = val;
+  const rchar * cmd = key;
+  const RArgParser * parser = val;
   RString * str = user;
   rssize spacing = 32;
 
@@ -630,9 +630,7 @@ r_arg_parser_get_help (const RArgParser * parser, RArgParseFlags flags,
 
   if (r_kv_ptr_array_size (&parser->commands) > 0) {
     r_string_append (str, "\nCommands:\n");
-    /* foreach only reads; cast off the const this read-only getter added. */
-    r_kv_ptr_array_foreach ((RKVPtrArray *) &parser->commands,
-        r_arg_command_append_help, str);
+    r_kv_ptr_array_foreach_const (&parser->commands, r_arg_command_append_help, str);
   }
 
   if (parser->epilog != NULL)

--- a/test/rkvptrarray.c
+++ b/test/rkvptrarray.c
@@ -282,3 +282,45 @@ RTEST (rkvptrarray, foreach, RTEST_FAST)
 }
 RTEST_END;
 
+static void
+rkvptrarray_str_concat_const (rconstpointer key, rconstpointer val, rpointer user)
+{
+  RString * str = user;
+  const rchar * strkey = key;
+  r_string_append_printf (str, "/%s:%u", strkey, RPOINTER_TO_UINT (val));
+}
+
+RTEST (rkvptrarray, foreach_const, RTEST_FAST)
+{
+  RKVPtrArray * array;
+  const RKVPtrArray * carray;
+  RString * str;
+  rchar * tmp;
+
+  r_assert_cmpptr ((array = r_kv_ptr_array_new_str ()), !=, NULL);
+  r_kv_ptr_array_add (array, "foo", NULL, RUINT_TO_POINTER (22), NULL);
+  r_kv_ptr_array_add (array, "bar", NULL, RUINT_TO_POINTER (32), NULL);
+  r_kv_ptr_array_add (array, "foobar", NULL, RUINT_TO_POINTER (42), NULL);
+
+  /* Drive the const-visitor iteration and find through a const handle. */
+  carray = array;
+
+  r_assert_cmpptr ((str = r_string_new_sized (128)), !=, NULL);
+  r_assert_cmpuint (r_kv_ptr_array_foreach_const (carray,
+          rkvptrarray_str_concat_const, str), ==, 3);
+  r_assert_cmpstr ((tmp = r_string_free_keep (str)), ==, "/foo:22/bar:32/foobar:42");
+  r_free (tmp);
+
+  r_assert_cmpptr ((str = r_string_new_sized (128)), !=, NULL);
+  r_assert_cmpuint (r_kv_ptr_array_foreach_const_range (carray, 1, 2,
+          rkvptrarray_str_concat_const, str), ==, 2);
+  r_assert_cmpstr ((tmp = r_string_free_keep (str)), ==, "/bar:32/foobar:42");
+  r_free (tmp);
+
+  r_assert_cmpuint (r_kv_ptr_array_find (carray, "bar"), ==, 1);
+  r_assert_cmpuint (r_kv_ptr_array_find (carray, "nope"), ==, R_KV_PTR_ARRAY_INVALID_IDX);
+
+  r_kv_ptr_array_unref (array);
+}
+RTEST_END;
+


### PR DESCRIPTION
Makes the genuinely read-only `RKVPtrArray` access const-correct,
without opening a const hole, and uses it from argparse.

The guiding rule: a `const` container must not hand out *mutable* access
to its elements. Splitting the accessors by that test:

- **`r_kv_ptr_array_find_range`** now takes a `const` array — it returns
  an index and leaks no mutable handle, so it is genuinely read-only.
- **iteration gets two versions.** Added `RKeyValueConstFunc`
  (`rconstpointer key/value`) plus `r_kv_ptr_array_foreach_const_range`
  / `_foreach_const`, a const-array iteration whose visitor only gets
  const access. The mutable `foreach_range` stays non-const on purpose:
  `RKeyValueFunc` hands the callback mutable `rpointer`, so a const
  array there would be dishonest.
- **`get` / `get_key` / `get_val` stay non-const** — they return mutable
  element handles; const callers use the existing
  `r_kv_ptr_array_get_const`. This mirrors the established
  `get`/`get_const` split, now extended to iteration.

`r_arg_parser_get_help` (const, read-only) switches to the const-visitor
`foreach_const`, so it no longer casts the const away.

Adds a `foreach_const` test that also exercises `find` through a `const`
handle.

## Verification
debug-test + release (werror) + ASAN build clean; full suite 1896 pass,
0 fail; Doxygen 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)