### PR TITLE
argparse: report which argument failed and print errors

### DIFF
--- a/example/rargparse.c
+++ b/example/rargparse.c
@@ -37,7 +37,10 @@ main (int argc, char ** argv)
 
     r_arg_parse_ctx_unref (ctx);
   } else {
-    ret = r_arg_parser_print_help (parser, R_ARG_PARSE_FLAG_DONT_EXIT, NULL, -1);
+    /* Parse failed: report exactly what was wrong (with a --help hint)
+     * on stderr, rather than dumping the whole help text. */
+    r_arg_parser_print_error (parser, R_ARG_PARSE_FLAG_NONE);
+    ret = -1;
   }
 
   r_arg_parser_unref (parser);

--- a/include/rlib/rargparse.h
+++ b/include/rlib/rargparse.h
@@ -308,6 +308,26 @@ R_API void r_arg_parser_print_version (RArgParser * parser, RArgParseFlags flags
  */
 R_API int r_arg_parser_print_help (RArgParser * parser, RArgParseFlags flags,
     const rchar * appname, int exitval);
+/**
+ * @brief Human-readable reason the most recent @c r_arg_parser_parse
+ * failed (e.g. @c "unrecognized option '--foo'").
+ *
+ * @return Borrowed message string, valid until the next parse or
+ *         @c r_arg_parser_unref; @c NULL if the last parse succeeded,
+ *         none has run, or it failed without a specific reason (e.g.
+ *         @c R_ARG_PARSE_ARG_ERROR / @c R_ARG_PARSE_OOM). Do not free.
+ */
+R_API const rchar * r_arg_parser_get_error (const RArgParser * parser);
+/**
+ * @brief Print the recorded parse error and a @c --help hint to stderr.
+ *
+ * Opt-in: call it after @c r_arg_parser_parse returns @c NULL with an
+ * error code (unlike help / version, it is not emitted automatically).
+ * No-op when there is no recorded error or
+ * @c R_ARG_PARSE_FLAG_DONT_PRINT_STDOUT is set; the hint is omitted
+ * under @c R_ARG_PARSE_FLAG_DISABLE_HELP.
+ */
+R_API void r_arg_parser_print_error (RArgParser * parser, RArgParseFlags flags);
 /** @} */
 
 /**

--- a/rlib/rargparse.c
+++ b/rlib/rargparse.c
@@ -34,6 +34,8 @@
 #include <rlib/rstr.h>
 #include <rlib/os/rtty.h>
 
+#include <stdarg.h>
+
 struct RArgParser
 {
   RRef ref;
@@ -43,6 +45,8 @@ struct RArgParser
   rchar * version;
   rchar * summary;
   rchar * epilog;
+
+  rchar * errmsg;       /* reason the most recent parse failed, or NULL */
 
   RArgOptionGroup * main;
   RSList * groups;
@@ -268,8 +272,8 @@ r_arg_option_group_find_entry_by_longarg (const RArgOptionGroup * group,
   return NULL;
 }
 
-static rboolean
-r_arg_option_group_check_required_options (const RArgOptionGroup * group, RDictionary * options)
+static const RArgOptionEntry *
+r_arg_option_group_first_missing_required (const RArgOptionGroup * group, RDictionary * options)
 {
   rsize i;
 
@@ -277,11 +281,11 @@ r_arg_option_group_check_required_options (const RArgOptionGroup * group, RDicti
     RArgOptionEntry * opt = &group->entries[i];
     if ((opt->flags & R_ARG_OPTION_FLAG_REQUIRED) &&
         !r_dictionary_contains (options, opt->longarg)) {
-      return FALSE;
+      return opt;
     }
   }
 
-  return TRUE;
+  return NULL;
 }
 
 static rboolean
@@ -358,6 +362,7 @@ r_arg_parser_free (RArgParser * parser)
     r_free (parser->version);
     r_free (parser->summary);
     r_free (parser->epilog);
+    r_free (parser->errmsg);
 
     r_arg_option_group_unref (parser->main);
     r_slist_destroy_full (parser->groups, r_arg_option_group_unref);
@@ -365,6 +370,17 @@ r_arg_parser_free (RArgParser * parser)
     r_kv_ptr_array_clear (&parser->commands);
     r_free (parser);
   }
+}
+
+static void R_ATTR_PRINTF (2, 3)
+r_arg_parser_set_error (RArgParser * parser, const rchar * fmt, ...)
+{
+  va_list args;
+
+  r_free (parser->errmsg);
+  va_start (args, fmt);
+  parser->errmsg = r_strvprintf (fmt, args);
+  va_end (args);
 }
 
 RArgParser *
@@ -803,8 +819,6 @@ r_arg_parser_parse_option_ctx (RArgParser * parser, RArgParseCtx * ctx,
   RArgParseResult ret = R_ARG_PARSE_ERROR;
   const rchar * str;
 
-  (void) parser;
-
   if (entry->type == R_ARG_OPTION_TYPE_NONE) {
     str = *arg;
     ret = r_arg_option_parse_none (arg, NULL,
@@ -816,6 +830,7 @@ r_arg_parser_parse_option_ctx (RArgParser * parser, RArgParseCtx * ctx,
     } else if (*argc > 0) {
       str = **argv;
     } else {
+      r_arg_parser_set_error (parser, "option '--%s' requires a value", entry->longarg);
       return R_ARG_PARSE_ERROR;
     }
 
@@ -861,6 +876,10 @@ r_arg_parser_parse_option_ctx (RArgParser * parser, RArgParseCtx * ctx,
     r_dictionary_insert (ctx->options, entry->longarg, (rpointer)str);
   }
 
+  if (ret != R_ARG_PARSE_OK)
+    r_arg_parser_set_error (parser, "invalid value '%s' for option '--%s'",
+        str, entry->longarg);
+
   return ret;
 }
 
@@ -876,6 +895,7 @@ r_arg_parser_parse_short_option (RArgParser * parser, RArgParseCtx * ctx,
       (*arg)++;
     return r_arg_parser_parse_option_ctx (parser, ctx, entry, arg, argc, argv);
   } else if ((ctx->flags & R_ARG_PARSE_FLAG_ALLOW_UNKNOWN) == 0) {
+    r_arg_parser_set_error (parser, "unrecognized option '-%c'", **arg);
     return R_ARG_PARSE_UNKNOWN_OPTION;
   }
 
@@ -896,26 +916,30 @@ r_arg_parser_parse_long_option (RArgParser * parser, RArgParseCtx * ctx,
 
     return r_arg_parser_parse_option_ctx (parser, ctx, entry, arg, argc, argv);
   } else if ((ctx->flags & R_ARG_PARSE_FLAG_ALLOW_UNKNOWN) == 0) {
+    const rchar * eq = r_strchr (*arg, (int)'=');
+    int nlen = (eq != NULL) ? (int)(eq - *arg) : (int)r_strlen (*arg);
+    r_arg_parser_set_error (parser, "unrecognized option '--%.*s'", nlen, *arg);
     return R_ARG_PARSE_UNKNOWN_OPTION;
   }
 
   return R_ARG_PARSE_OK;
 }
 
-static rboolean
-r_arg_parser_check_required_options (RArgParser * parser, RArgParseCtx * ctx)
+static const RArgOptionEntry *
+r_arg_parser_first_missing_required (RArgParser * parser, RArgParseCtx * ctx)
 {
+  const RArgOptionEntry * missing;
   RSList * it;
 
-  if (!r_arg_option_group_check_required_options (parser->main, ctx->options))
-    return FALSE;
+  if ((missing = r_arg_option_group_first_missing_required (parser->main, ctx->options)) != NULL)
+    return missing;
 
   for (it = parser->groups; it != NULL; it = it->next) {
-    if (!r_arg_option_group_check_required_options (it->data, ctx->options))
-      return FALSE;
+    if ((missing = r_arg_option_group_first_missing_required (it->data, ctx->options)) != NULL)
+      return missing;
   }
 
-  return TRUE;
+  return NULL;
 }
 
 static RArgParseResult
@@ -998,10 +1022,20 @@ r_arg_parser_parse_positionals (RArgParser * parser, RArgParseCtx * ctx,
         parsed = r_arg_option_parser_string (&end, NULL);
         break;
       default:
+        {
+          rchar * pname = r_arg_positional_usage_name (entry);
+          r_arg_parser_set_error (parser, "argument '%s' has an unsupported type", pname);
+          r_free (pname);
+        }
         return R_ARG_PARSE_ERROR;
     }
-    if (parsed != R_ARG_PARSE_OK)
+    if (parsed != R_ARG_PARSE_OK) {
+      rchar * pname = r_arg_positional_usage_name (entry);
+      r_arg_parser_set_error (parser, "invalid value '%s' for argument '%s'",
+          str, pname);
+      r_free (pname);
       return R_ARG_PARSE_VALUE_ERROR;
+    }
 
     r_dictionary_insert (ctx->options, entry->longarg, (rpointer) str);
     (*argv)++;
@@ -1064,7 +1098,14 @@ r_arg_parser_parse_command (RArgParser * parser, RArgParseFlags flags,
     ret = R_ARG_PARSE_OK;
     ctx->cmdctx = r_arg_parser_parse_internal (cmdparser, flags,
         cmd, argc, argv, &ret);
+    /* Surface the sub-command's error on the parser the caller holds. */
+    if (ret != R_ARG_PARSE_OK && cmdparser->errmsg != NULL)
+      r_arg_parser_set_error (parser, "%s", cmdparser->errmsg);
   } else {
+    if (cmd != NULL)
+      r_arg_parser_set_error (parser, "unknown command '%s'", cmd);
+    else
+      r_arg_parser_set_error (parser, "missing command");
     ret = R_ARG_PARSE_MISSING_COMMAND;
   }
 
@@ -1082,10 +1123,21 @@ r_arg_parser_parse_internal (RArgParser * parser, RArgParseFlags flags,
   if ((ret = r_arg_parse_ctx_new (parser, flags, appname)) != NULL) {
     if ((curres = r_arg_parser_parse_options (parser, ret, argc, argv)) == R_ARG_PARSE_OK &&
         (curres = r_arg_parser_parse_positionals (parser, ret, argc, argv)) == R_ARG_PARSE_OK) {
-      if (!r_arg_parser_check_required_options (parser, ret))
+      const RArgOptionEntry * missing =
+          r_arg_parser_first_missing_required (parser, ret);
+      if (missing != NULL) {
+        if (missing->flags & R_ARG_OPTION_FLAG_POSITIONAL) {
+          rchar * pname = r_arg_positional_usage_name (missing);
+          r_arg_parser_set_error (parser, "missing required argument '%s'", pname);
+          r_free (pname);
+        } else {
+          r_arg_parser_set_error (parser, "required option '--%s' is missing",
+              missing->longarg);
+        }
         curres = R_ARG_PARSE_MISSING_OPTION;
-      else
+      } else {
         curres = r_arg_parser_parse_command (parser, flags, ret, argc, argv);
+      }
     }
 
     if (curres != R_ARG_PARSE_OK) {
@@ -1107,6 +1159,17 @@ r_arg_parser_parse (RArgParser * parser, RArgParseFlags flags,
 {
   const rchar * appname;
 
+  if (R_UNLIKELY (parser == NULL)) {
+    if (res != NULL)
+      *res = R_ARG_PARSE_ARG_ERROR;
+    return NULL;
+  }
+
+  /* Clear any error from a previous parse up front, so get_error stays
+   * honest even on the malformed-argv early-out below. */
+  r_free (parser->errmsg);
+  parser->errmsg = NULL;
+
   if (R_UNLIKELY (argc == NULL || *argc < 1 || argv == NULL)) {
     if (res != NULL)
       *res = R_ARG_PARSE_ARG_ERROR;
@@ -1117,6 +1180,28 @@ r_arg_parser_parse (RArgParser * parser, RArgParseFlags flags,
   (*argv)++;
   (*argc)--;
   return r_arg_parser_parse_internal (parser, flags, appname, argc, argv, res);
+}
+
+const rchar *
+r_arg_parser_get_error (const RArgParser * parser)
+{
+  return parser != NULL ? parser->errmsg : NULL;
+}
+
+void
+r_arg_parser_print_error (RArgParser * parser, RArgParseFlags flags)
+{
+  const rchar * app;
+
+  if (parser == NULL || parser->errmsg == NULL)
+    return;
+  if ((flags & R_ARG_PARSE_FLAG_DONT_PRINT_STDOUT) != 0)
+    return;
+
+  app = parser->appname != NULL ? parser->appname : "";
+  r_printerr ("%s: %s\n", app, parser->errmsg);
+  if ((flags & R_ARG_PARSE_FLAG_DISABLE_HELP) == 0)
+    r_printerr ("Try '%s --help' for more information.\n", app);
 }
 
 void

--- a/test/rargparse.c
+++ b/test/rargparse.c
@@ -879,6 +879,195 @@ RTEST (rargparse, parse_unknown_option, RTEST_FAST)
 }
 RTEST_END;
 
+#define RARGPARSE_ERR_FLAGS \
+  (R_ARG_PARSE_FLAG_DONT_EXIT | R_ARG_PARSE_FLAG_DONT_PRINT_STDOUT)
+
+RTEST (rargparse, error_messages, RTEST_FAST)
+{
+  RArgParser * parser = r_arg_parser_new ("mytool", NULL);
+  RArgParseCtx * ctx;
+  RArgParseResult res;
+  rchar ** strv, ** argv;
+  int argc;
+
+  r_assert (r_arg_parser_add_option_entry (parser, "num", 'n',
+        R_ARG_OPTION_TYPE_INT, R_ARG_OPTION_FLAG_NONE, "a number", NULL));
+  r_assert (r_arg_parser_add_option_entry (parser, "name", 0,
+        R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_REQUIRED, "a name", NULL));
+
+  /* No parse has run: no error recorded. */
+  r_assert_cmpptr (r_arg_parser_get_error (parser), ==, NULL);
+
+  strv = argv = r_strv_new ("prog", "--bogus", "--name=x", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr (r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+          &argc, (const rchar ***)&argv, &res), ==, NULL);
+  r_assert_cmpint (res, ==, R_ARG_PARSE_UNKNOWN_OPTION);
+  r_assert_cmpstr (r_arg_parser_get_error (parser), ==, "unrecognized option '--bogus'");
+  r_strv_free (strv);
+
+  strv = argv = r_strv_new ("prog", "-z", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr (r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+          &argc, (const rchar ***)&argv, &res), ==, NULL);
+  r_assert_cmpint (res, ==, R_ARG_PARSE_UNKNOWN_OPTION);
+  r_assert_cmpstr (r_arg_parser_get_error (parser), ==, "unrecognized option '-z'");
+  r_strv_free (strv);
+
+  strv = argv = r_strv_new ("prog", "--name=x", "--num=abc", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr (r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+          &argc, (const rchar ***)&argv, &res), ==, NULL);
+  r_assert_cmpint (res, ==, R_ARG_PARSE_VALUE_ERROR);
+  r_assert_cmpstr (r_arg_parser_get_error (parser), ==,
+      "invalid value 'abc' for option '--num'");
+  r_strv_free (strv);
+
+  strv = argv = r_strv_new ("prog", "--num=1", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr (r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+          &argc, (const rchar ***)&argv, &res), ==, NULL);
+  r_assert_cmpint (res, ==, R_ARG_PARSE_MISSING_OPTION);
+  r_assert_cmpstr (r_arg_parser_get_error (parser), ==,
+      "required option '--name' is missing");
+  r_strv_free (strv);
+
+  /* A subsequent successful parse clears the recorded error. */
+  strv = argv = r_strv_new ("prog", "--name=ok", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+          &argc, (const rchar ***)&argv, &res)), !=, NULL);
+  r_assert_cmpint (res, ==, R_ARG_PARSE_OK);
+  r_assert_cmpptr (r_arg_parser_get_error (parser), ==, NULL);
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+static RString * g_rargparse_capture;
+static rboolean
+rargparse_capture_printerr (const rchar * str, rsize size, rpointer data)
+{
+  (void) data;
+  r_string_append_len (g_rargparse_capture, str, size);
+  return TRUE;
+}
+
+RTEST (rargparse, error_print, RTEST_FAST)
+{
+  RArgParser * parser = r_arg_parser_new ("mytool", NULL);
+  RArgParseResult res;
+  RPrintFunc oldfunc;
+  rpointer olddata;
+  rchar ** strv, ** argv;
+  rchar * tmp;
+  int argc;
+
+  strv = argv = r_strv_new ("prog", "--bogus", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr (r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+          &argc, (const rchar ***)&argv, &res), ==, NULL);
+  r_assert_cmpint (res, ==, R_ARG_PARSE_UNKNOWN_OPTION);
+  r_strv_free (strv);
+
+  /* print_error writes the message and the hint to stderr. */
+  g_rargparse_capture = r_string_new_sized (128);
+  r_override_printerr_handler (rargparse_capture_printerr, NULL, &oldfunc, &olddata);
+  r_arg_parser_print_error (parser, R_ARG_PARSE_FLAG_NONE);
+  r_override_printerr_handler (oldfunc, olddata, NULL, NULL);
+  r_assert_cmpstr ((tmp = r_string_free_keep (g_rargparse_capture)), ==,
+      "mytool: unrecognized option '--bogus'\n"
+      "Try 'mytool --help' for more information.\n");
+  r_free (tmp);
+
+  /* DONT_PRINT_STDOUT suppresses it entirely. */
+  g_rargparse_capture = r_string_new_sized (128);
+  r_override_printerr_handler (rargparse_capture_printerr, NULL, &oldfunc, &olddata);
+  r_arg_parser_print_error (parser, R_ARG_PARSE_FLAG_DONT_PRINT_STDOUT);
+  r_override_printerr_handler (oldfunc, olddata, NULL, NULL);
+  r_assert_cmpuint (r_string_length (g_rargparse_capture), ==, 0);
+  r_string_free (g_rargparse_capture);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, error_positional, RTEST_FAST)
+{
+  RArgParser * parser = r_arg_parser_new ("mytool", NULL);
+  RArgParseResult res;
+  rchar ** strv, ** argv;
+
+  r_assert (r_arg_parser_add_option_entry (parser, "count", 0,
+        R_ARG_OPTION_TYPE_INT, R_ARG_OPTION_FLAG_POSITIONAL, "how many", NULL));
+
+  strv = argv = r_strv_new ("prog", NULL);
+  {
+    int argc = (int) r_strv_len (argv);
+    r_assert_cmpptr (r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+            &argc, (const rchar ***)&argv, &res), ==, NULL);
+  }
+  r_assert_cmpint (res, ==, R_ARG_PARSE_MISSING_OPTION);
+  r_assert_cmpstr (r_arg_parser_get_error (parser), ==,
+      "missing required argument 'COUNT'");
+  r_strv_free (strv);
+
+  strv = argv = r_strv_new ("prog", "abc", NULL);
+  {
+    int argc = (int) r_strv_len (argv);
+    r_assert_cmpptr (r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+            &argc, (const rchar ***)&argv, &res), ==, NULL);
+  }
+  r_assert_cmpint (res, ==, R_ARG_PARSE_VALUE_ERROR);
+  r_assert_cmpstr (r_arg_parser_get_error (parser), ==,
+      "invalid value 'abc' for argument 'COUNT'");
+  r_strv_free (strv);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, error_subcommand, RTEST_FAST)
+{
+  RArgParser * parser = r_arg_parser_new ("mytool", NULL);
+  RArgParser * cmd;
+  RArgParseResult res;
+  rchar ** strv, ** argv;
+
+  r_assert_cmpptr ((cmd = r_arg_parser_add_command (parser, "build", "Build it")), !=, NULL);
+  r_assert (r_arg_parser_add_option_entry (cmd, "target", 't',
+        R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_REQUIRED, "target", NULL));
+  r_arg_parser_unref (cmd);
+
+  /* A sub-command's error must surface on the root parser the caller holds. */
+  strv = argv = r_strv_new ("prog", "build", NULL);
+  {
+    int argc = (int) r_strv_len (argv);
+    r_assert_cmpptr (r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+            &argc, (const rchar ***)&argv, &res), ==, NULL);
+  }
+  r_assert_cmpint (res, ==, R_ARG_PARSE_MISSING_OPTION);
+  r_assert_cmpstr (r_arg_parser_get_error (parser), ==,
+      "required option '--target' is missing");
+  r_strv_free (strv);
+
+  /* Unknown command. */
+  strv = argv = r_strv_new ("prog", "nope", NULL);
+  {
+    int argc = (int) r_strv_len (argv);
+    r_assert_cmpptr (r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+            &argc, (const rchar ***)&argv, &res), ==, NULL);
+  }
+  r_assert_cmpint (res, ==, R_ARG_PARSE_MISSING_COMMAND);
+  r_assert_cmpstr (r_arg_parser_get_error (parser), ==, "unknown command 'nope'");
+  r_strv_free (strv);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
 RTEST (rargparse, get_value, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {


### PR DESCRIPTION
First of the argparse feature work (#234–#239). `r_arg_parser_parse`
previously returned only a coarse `RArgParseResult` — callers couldn't
tell *which* option/value was at fault, and nothing was printed.

## What's added
- **`r_arg_parser_get_error`** — a human-readable reason for the most
  recent parse failure (unrecognized option, missing value, invalid
  value, missing required option/argument, unknown/missing command).
  Borrowed string, cleared at the start of each parse (including the
  malformed-argv early-out); a sub-command's error surfaces on the root
  parser the caller holds.
- **`r_arg_parser_print_error`** — writes `<app>: <message>` plus a
  `Try '<app> --help'` hint to stderr. **Opt-in**: the caller invokes it
  after a `NULL` return (it is *not* auto-emitted), so existing callers
  see no behaviour change. Honours `DONT_PRINT_STDOUT` and
  `DISABLE_HELP`.
- The required-option check now reports the first missing entry so the
  message can name it.

## Example

```
$ rargparse --bogus
rargparse: unrecognized option '--bogus'
Try 'rargparse --help' for more information.

$ rargparse -r abc
rargparse: invalid value 'abc' for option '--ret'
Try 'rargparse --help' for more information.
```

`example/rargparse.c` is updated to use this instead of dumping the full
`--help` on every error.

## Why opt-in (not auto-printed)
Mirroring `--help`/`--version` auto-output would have changed behaviour
for every existing caller (most use `R_ARG_PARSE_FLAG_NONE`) and spewed
to stderr during the suite. Opt-in keeps the change additive; flipping
it to automatic later is a one-liner if desired.

## Tests
Cover unrecognized long/short option, missing value, invalid value,
missing required option and positional argument, unknown command,
sub-command error propagation, error-cleared-on-success, and
`print_error` output + suppression (via a captured stderr handler).

## Verification
debug-test + release (werror) + ASAN build clean; full suite 1900 pass,
0 fail; Doxygen 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)