### PR TITLE
argparse: counter option type and per-option value choices

### DIFF
--- a/include/rlib/rargparse.h
+++ b/include/rlib/rargparse.h
@@ -91,6 +91,7 @@ typedef enum {
   R_ARG_OPTION_TYPE_STRING,                     /**< Single string; last occurrence wins. */
   R_ARG_OPTION_TYPE_FILENAME,                   /**< Single filename string. */
   R_ARG_OPTION_TYPE_STRING_ARRAY,               /**< Repeatable string; values accumulate in argv order. */
+  R_ARG_OPTION_TYPE_COUNTER,                    /**< Argument-less flag that tallies its occurrences (e.g. @c -vvv); read with @c r_arg_parse_ctx_get_option_count. */
   R_ARG_OPTION_TYPE_COUNT,                      /**< Sentinel: number of value types (also @c ERROR). */
   R_ARG_OPTION_TYPE_ERROR = R_ARG_OPTION_TYPE_COUNT /**< Returned by getters on unknown / wrong-typed option. */
 } RArgOptionType;
@@ -396,6 +397,8 @@ R_API rboolean r_arg_parse_ctx_get_option_value (RArgParseCtx * ctx,
 R_API rboolean r_arg_parse_ctx_get_option_bool (RArgParseCtx * ctx, const rchar * longarg);
 /** @brief @c INT value, or 0 if absent. */
 R_API int r_arg_parse_ctx_get_option_int (RArgParseCtx * ctx, const rchar * longarg);
+/** @brief @c COUNTER tally — how many times the flag was given, or 0. */
+R_API ruint r_arg_parse_ctx_get_option_count (RArgParseCtx * ctx, const rchar * longarg);
 /** @brief @c INT64 value, or 0 if absent. */
 R_API rint64 r_arg_parse_ctx_get_option_int64 (RArgParseCtx * ctx, const rchar * longarg);
 /** @brief @c DOUBLE value, or 0.0 if absent. */

--- a/include/rlib/rargparse.h
+++ b/include/rlib/rargparse.h
@@ -266,6 +266,24 @@ R_API rboolean r_arg_parser_add_option_entry (RArgParser * parser,
  */
 R_API rboolean r_arg_parser_add_option_group (RArgParser * parser,
     RArgOptionGroup * group);
+/**
+ * @brief Restrict the option named @p longarg to an enumerated set.
+ *
+ * @p choices is a @c NULL-terminated array of permitted values
+ * (matched as exact strings, so best suited to @c STRING / @c FILENAME
+ * options); pass @c NULL to clear a previously-set restriction. A
+ * command-line value outside the set is rejected with
+ * @c R_ARG_PARSE_VALUE_ERROR, and the set is shown in @c --help as
+ * @c --longarg={a,b,c}.
+ *
+ * The array (and its strings) is borrowed and must outlive the parser.
+ * Call after the option has been registered.
+ *
+ * @return @c TRUE on success; @c FALSE if @p longarg is unknown or
+ *         names an argument-less option (@c NONE / @c COUNTER).
+ */
+R_API rboolean r_arg_parser_set_option_choices (RArgParser * parser,
+    const rchar * longarg, const rchar * const * choices);
 /** @} */
 
 /**

--- a/rlib/rargparse.c
+++ b/rlib/rargparse.c
@@ -201,7 +201,8 @@ r_arg_option_entry_ctx_init (RArgOptionEntry * entry, const RArgOptionEntry * op
   if (opt->type >= R_ARG_OPTION_TYPE_COUNT)
     return FALSE;
   if ((opt->flags & R_ARG_OPTION_FLAG_POSITIONAL) &&
-      opt->type == R_ARG_OPTION_TYPE_NONE)
+      (opt->type == R_ARG_OPTION_TYPE_NONE ||
+       opt->type == R_ARG_OPTION_TYPE_COUNTER))
     return FALSE;
 
   r_memcpy (entry, opt, sizeof (RArgOptionEntry));
@@ -222,9 +223,10 @@ r_arg_option_entry_ctx_init (RArgOptionEntry * entry, const RArgOptionEntry * op
         "ignoring incompatible inverse flag for --%s", opt->longarg);
     entry->flags &= ~R_ARG_OPTION_FLAG_INVERSE;
   }
-  if (opt->defval != NULL && opt->type == R_ARG_OPTION_TYPE_NONE) {
+  if (opt->defval != NULL && (opt->type == R_ARG_OPTION_TYPE_NONE ||
+        opt->type == R_ARG_OPTION_TYPE_COUNTER)) {
     R_LOG_CAT_WARNING (&rlib_logcat,
-        "ignoring default value for boolean --%s", opt->longarg);
+        "ignoring default value for argument-less --%s", opt->longarg);
     entry->defval = NULL;
   }
   if (opt->defval != NULL && (opt->flags & R_ARG_OPTION_FLAG_REQUIRED)) {
@@ -521,6 +523,7 @@ r_arg_option_entry_append_help (const RArgOptionEntry * opt, RString * str)
   if (opt->eqname == NULL || *opt->eqname == 0) {
     switch (opt->type) {
       case R_ARG_OPTION_TYPE_NONE:
+      case R_ARG_OPTION_TYPE_COUNTER:
         break;
       case R_ARG_OPTION_TYPE_FILENAME:
         spacing -= r_string_append (str, "=FILENAME");
@@ -535,7 +538,8 @@ r_arg_option_entry_append_help (const RArgOptionEntry * opt, RString * str)
         spacing -= r_string_append (str, "=VALUE");
         break;
     }
-  } else if (opt->type != R_ARG_OPTION_TYPE_NONE) {
+  } else if (opt->type != R_ARG_OPTION_TYPE_NONE &&
+      opt->type != R_ARG_OPTION_TYPE_COUNTER) {
     spacing -= r_string_append_printf (str, "=%s", opt->eqname);
   }
 
@@ -818,6 +822,13 @@ r_arg_parser_parse_option_ctx (RArgParser * parser, RArgParseCtx * ctx,
 {
   RArgParseResult ret = R_ARG_PARSE_ERROR;
   const rchar * str;
+
+  if (entry->type == R_ARG_OPTION_TYPE_COUNTER) {
+    /* Argument-less tally: bump the stored occurrence count. */
+    rsize n = RPOINTER_TO_SIZE (r_dictionary_lookup (ctx->options, entry->longarg));
+    r_dictionary_insert (ctx->options, entry->longarg, RSIZE_TO_POINTER (n + 1));
+    return R_ARG_PARSE_OK;
+  }
 
   if (entry->type == R_ARG_OPTION_TYPE_NONE) {
     str = *arg;
@@ -1337,6 +1348,21 @@ r_arg_parse_ctx_get_option_int (RArgParseCtx * ctx, const rchar * longarg)
   }
 
   return ret;
+}
+
+ruint
+r_arg_parse_ctx_get_option_count (RArgParseCtx * ctx, const rchar * longarg)
+{
+  RArgOptionEntry * entry;
+
+  if ((entry = r_arg_parser_find_entry_by_longarg (ctx->parser, longarg)) != NULL &&
+      entry->type == R_ARG_OPTION_TYPE_COUNTER) {
+    /* Stored directly as the tally (see r_arg_parser_parse_option_ctx),
+     * NULL when the flag never appeared. */
+    return (ruint) RPOINTER_TO_SIZE (r_dictionary_lookup (ctx->options, longarg));
+  }
+
+  return 0;
 }
 
 rint64

--- a/rlib/rargparse.c
+++ b/rlib/rargparse.c
@@ -52,6 +52,9 @@ struct RArgParser
   RSList * groups;
 
   RKVPtrArray commands;
+
+  /* longarg -> (const rchar * const *) allowed-value set, borrowed. */
+  RDictionary * choices;
 };
 
 static RArgParseCtx *
@@ -370,6 +373,7 @@ r_arg_parser_free (RArgParser * parser)
     r_slist_destroy_full (parser->groups, r_arg_option_group_unref);
 
     r_kv_ptr_array_clear (&parser->commands);
+    r_dictionary_unref (parser->choices);
     r_free (parser);
   }
 }
@@ -403,6 +407,7 @@ r_arg_parser_new (const rchar * app, const rchar * version)
         r_arg_help_args, R_N_ELEMENTS (r_arg_help_args));
 
     r_kv_ptr_array_init (&ret->commands, r_str_equal);
+    ret->choices = r_dictionary_new ();
   }
 
   return ret;
@@ -482,11 +487,15 @@ r_arg_positional_usage_name (const RArgOptionEntry * opt)
   return ret;
 }
 
+static rchar * r_arg_choices_join (const rchar * const * choices, const rchar * sep);
+
 static void
-r_arg_positional_entry_append_help (const RArgOptionEntry * opt, RString * str)
+r_arg_positional_entry_append_help (const RArgOptionEntry * opt, RString * str,
+    RDictionary * choices)
 {
   rssize spacing = 32;
   rchar * name;
+  const rchar * const * ch;
 
   if (opt->flags & R_ARG_OPTION_FLAG_HIDDEN)
     return;
@@ -499,15 +508,23 @@ r_arg_positional_entry_append_help (const RArgOptionEntry * opt, RString * str)
     spacing -= r_string_append (str, " ");
 
   r_string_append (str, opt->desc);
+  ch = (choices != NULL) ? r_dictionary_lookup (choices, opt->longarg) : NULL;
+  if (ch != NULL) {
+    rchar * list = r_arg_choices_join (ch, ", ");
+    r_string_append_printf (str, " (one of: %s)", list);
+    r_free (list);
+  }
   if (opt->defval != NULL)
     r_string_append_printf (str, " [default: %s]", opt->defval);
   r_string_append (str, "\n");
 }
 
 static void
-r_arg_option_entry_append_help (const RArgOptionEntry * opt, RString * str)
+r_arg_option_entry_append_help (const RArgOptionEntry * opt, RString * str,
+    RDictionary * choices)
 {
   rssize spacing = 32;
+  const rchar * const * ch;
 
   if (opt->flags & R_ARG_OPTION_FLAG_HIDDEN)
     return;
@@ -520,7 +537,12 @@ r_arg_option_entry_append_help (const RArgOptionEntry * opt, RString * str)
     spacing -= r_string_append_printf (str, "-%c, ", opt->shortarg);
 
   spacing -= r_string_append_printf (str, "--%s", opt->longarg);
-  if (opt->eqname == NULL || *opt->eqname == 0) {
+  ch = (choices != NULL) ? r_dictionary_lookup (choices, opt->longarg) : NULL;
+  if (ch != NULL) {
+    rchar * list = r_arg_choices_join (ch, ",");
+    spacing -= r_string_append_printf (str, "={%s}", list);
+    r_free (list);
+  } else if (opt->eqname == NULL || *opt->eqname == 0) {
     switch (opt->type) {
       case R_ARG_OPTION_TYPE_NONE:
       case R_ARG_OPTION_TYPE_COUNTER:
@@ -553,7 +575,8 @@ r_arg_option_entry_append_help (const RArgOptionEntry * opt, RString * str)
 }
 
 static void
-r_arg_option_group_append_help (const RArgOptionGroup * group, RString * str)
+r_arg_option_group_append_help (const RArgOptionGroup * group, RString * str,
+    RDictionary * choices)
 {
   rsize i;
 
@@ -562,7 +585,7 @@ r_arg_option_group_append_help (const RArgOptionGroup * group, RString * str)
     r_string_append_printf (str, "%s:\n", group->desc);
 
   for (i = 0; i < group->count; i++)
-    r_arg_option_entry_append_help (&group->entries[i], str);
+    r_arg_option_entry_append_help (&group->entries[i], str, choices);
 }
 
 static void
@@ -628,9 +651,13 @@ r_arg_parser_get_help (const RArgParser * parser, RArgParseFlags flags,
   if ((flags & R_ARG_PARSE_FLAG_DISABLE_HELP) == R_ARG_PARSE_FLAG_DISABLE_HELP)
     i += R_N_ELEMENTS (r_arg_version_args) + R_N_ELEMENTS (r_arg_help_args);
   for (; i < parser->main->count; i++)
-    r_arg_option_entry_append_help (&parser->main->entries[i], str);
+    r_arg_option_entry_append_help (&parser->main->entries[i], str, parser->choices);
 
-  r_slist_foreach (parser->groups, (RFunc)r_arg_option_group_append_help, str);
+  {
+    RSList * it;
+    for (it = parser->groups; it != NULL; it = it->next)
+      r_arg_option_group_append_help (it->data, str, parser->choices);
+  }
 
   {
     rboolean any = FALSE;
@@ -644,7 +671,7 @@ r_arg_parser_get_help (const RArgParser * parser, RArgParseFlags flags,
         r_string_append (str, "\nArguments:\n");
         any = TRUE;
       }
-      r_arg_positional_entry_append_help (opt, str);
+      r_arg_positional_entry_append_help (opt, str, parser->choices);
     }
   }
 
@@ -816,6 +843,74 @@ r_arg_option_parser_string (const rchar ** str, rchar ** val)
   return R_ARG_PARSE_OK;
 }
 
+static rboolean
+r_arg_value_in_choices (const rchar * const * choices, const rchar * value)
+{
+  rsize i;
+
+  if (choices == NULL)
+    return TRUE;
+  for (i = 0; choices[i] != NULL; i++) {
+    if (r_str_equal (choices[i], value))
+      return TRUE;
+  }
+  return FALSE;
+}
+
+static rchar *
+r_arg_choices_join (const rchar * const * choices, const rchar * sep)
+{
+  RString * s = r_string_new_sized (64);
+  rsize i;
+
+  for (i = 0; choices != NULL && choices[i] != NULL; i++) {
+    if (i > 0)
+      r_string_append (s, sep);
+    r_string_append (s, choices[i]);
+  }
+  return r_string_free_keep (s);
+}
+
+/* Allowed-value set registered for @p longarg, or NULL for unrestricted. */
+static const rchar * const *
+r_arg_parser_get_choices (const RArgParser * parser, const rchar * longarg)
+{
+  return r_dictionary_lookup (parser->choices, longarg);
+}
+
+rboolean
+r_arg_parser_set_option_choices (RArgParser * parser, const rchar * longarg,
+    const rchar * const * choices)
+{
+  RArgOptionEntry * entry;
+
+  if (R_UNLIKELY (parser == NULL || longarg == NULL))
+    return FALSE;
+  if ((entry = r_arg_parser_find_entry_by_longarg (parser, longarg)) == NULL)
+    return FALSE;
+  if (entry->type == R_ARG_OPTION_TYPE_NONE ||
+      entry->type == R_ARG_OPTION_TYPE_COUNTER) {
+    R_LOG_CAT_WARNING (&rlib_logcat,
+        "ignoring choices for argument-less --%s", entry->longarg);
+    return FALSE;
+  }
+
+  if (choices != NULL) {
+    if (entry->defval != NULL && !r_arg_value_in_choices (choices, entry->defval))
+      R_LOG_CAT_WARNING (&rlib_logcat,
+          "default value '%s' for --%s is not among its choices",
+          entry->defval, entry->longarg);
+    /* Both key and value are borrowed; the caller must keep them alive
+     * for the parser's lifetime (as with the rest of RArgOptionEntry). */
+    r_dictionary_insert (parser->choices, (rpointer) entry->longarg,
+        (rpointer) choices);
+  } else {
+    r_dictionary_remove (parser->choices, entry->longarg);
+  }
+
+  return TRUE;
+}
+
 static RArgParseResult
 r_arg_parser_parse_option_ctx (RArgParser * parser, RArgParseCtx * ctx,
     RArgOptionEntry * entry, const rchar ** arg, int * argc, const rchar *** argv)
@@ -873,6 +968,18 @@ r_arg_parser_parse_option_ctx (RArgParser * parser, RArgParseCtx * ctx,
         (*argc)--;
         (*argv)++;
       }
+    }
+  }
+
+  if (ret == R_ARG_PARSE_OK && entry->type != R_ARG_OPTION_TYPE_NONE) {
+    const rchar * const * ch = r_arg_parser_get_choices (parser, entry->longarg);
+    if (!r_arg_value_in_choices (ch, str)) {
+      rchar * list = r_arg_choices_join (ch, ", ");
+      r_arg_parser_set_error (parser,
+          "invalid value '%s' for option '--%s' (allowed: %s)",
+          str, entry->longarg, list);
+      r_free (list);
+      return R_ARG_PARSE_VALUE_ERROR;
     }
   }
 
@@ -1046,6 +1153,19 @@ r_arg_parser_parse_positionals (RArgParser * parser, RArgParseCtx * ctx,
           str, pname);
       r_free (pname);
       return R_ARG_PARSE_VALUE_ERROR;
+    }
+
+    {
+      const rchar * const * ch = r_arg_parser_get_choices (parser, entry->longarg);
+      if (!r_arg_value_in_choices (ch, str)) {
+        rchar * pname = r_arg_positional_usage_name (entry);
+        rchar * list = r_arg_choices_join (ch, ", ");
+        r_arg_parser_set_error (parser,
+            "invalid value '%s' for argument '%s' (allowed: %s)", str, pname, list);
+        r_free (pname);
+        r_free (list);
+        return R_ARG_PARSE_VALUE_ERROR;
+      }
     }
 
     r_dictionary_insert (ctx->options, entry->longarg, (rpointer) str);

--- a/test/rargparse.c
+++ b/test/rargparse.c
@@ -1111,6 +1111,99 @@ RTEST (rargparse, counter, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rargparse, choices, RTEST_FAST)
+{
+  static const rchar * const modes[] = { "fast", "slow", NULL };
+  RArgParser * parser = r_arg_parser_new ("mytool", NULL);
+  RArgParseCtx * ctx;
+  RArgParseResult res;
+  rchar ** strv, ** argv;
+  rchar * help, * val;
+  int argc;
+
+  r_assert (r_arg_parser_add_option_entry (parser, "mode", 'm',
+        R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_NONE, "the mode", NULL));
+  r_assert (r_arg_parser_add_option_entry (parser, "verbose", 'v',
+        R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "noisy", NULL));
+
+  r_assert (r_arg_parser_set_option_choices (parser, "mode", modes));
+  /* Unknown option and argument-less options are rejected. */
+  r_assert (!r_arg_parser_set_option_choices (parser, "nope", modes));
+  r_assert (!r_arg_parser_set_option_choices (parser, "verbose", modes));
+
+  /* Accepted value. */
+  strv = argv = r_strv_new ("prog", "--mode=fast", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+          &argc, (const rchar ***)&argv, &res)), !=, NULL);
+  r_assert_cmpstr ((val = r_arg_parse_ctx_get_option_string (ctx, "mode")), ==, "fast");
+  r_free (val);
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+
+  /* Rejected value, with an explanatory error listing the set. */
+  strv = argv = r_strv_new ("prog", "--mode=wat", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr (r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+          &argc, (const rchar ***)&argv, &res), ==, NULL);
+  r_assert_cmpint (res, ==, R_ARG_PARSE_VALUE_ERROR);
+  r_assert_cmpstr (r_arg_parser_get_error (parser), ==,
+      "invalid value 'wat' for option '--mode' (allowed: fast, slow)");
+  r_strv_free (strv);
+
+  /* Help shows the set as the value placeholder. */
+  r_assert_cmpptr ((help = r_arg_parser_get_help (parser, R_ARG_PARSE_FLAG_NONE, NULL)), !=, NULL);
+  r_assert_cmpptr (r_strstr (help, "--mode={fast,slow}"), !=, NULL);
+  r_free (help);
+
+  /* NULL clears the restriction. */
+  r_assert (r_arg_parser_set_option_choices (parser, "mode", NULL));
+  strv = argv = r_strv_new ("prog", "--mode=anything", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+          &argc, (const rchar ***)&argv, &res)), !=, NULL);
+  r_assert_cmpstr ((val = r_arg_parse_ctx_get_option_string (ctx, "mode")), ==, "anything");
+  r_free (val);
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, choices_positional, RTEST_FAST)
+{
+  static const rchar * const colors[] = { "red", "green", NULL };
+  RArgParser * parser = r_arg_parser_new ("mytool", NULL);
+  RArgParseResult res;
+  rchar ** strv, ** argv;
+  int argc;
+
+  r_assert (r_arg_parser_add_option_entry (parser, "color", 0,
+        R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_POSITIONAL, "a color", NULL));
+  r_assert (r_arg_parser_set_option_choices (parser, "color", colors));
+
+  strv = argv = r_strv_new ("prog", "blue", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr (r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+          &argc, (const rchar ***)&argv, &res), ==, NULL);
+  r_assert_cmpint (res, ==, R_ARG_PARSE_VALUE_ERROR);
+  r_assert_cmpstr (r_arg_parser_get_error (parser), ==,
+      "invalid value 'blue' for argument 'COLOR' (allowed: red, green)");
+  r_strv_free (strv);
+
+  /* The Arguments help section lists the allowed set. */
+  {
+    rchar * help = r_arg_parser_get_help (parser, R_ARG_PARSE_FLAG_NONE, NULL);
+    r_assert_cmpptr (help, !=, NULL);
+    r_assert_cmpptr (r_strstr (help, "(one of: red, green)"), !=, NULL);
+    r_free (help);
+  }
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
 RTEST (rargparse, get_value, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {

--- a/test/rargparse.c
+++ b/test/rargparse.c
@@ -1068,6 +1068,49 @@ RTEST (rargparse, error_subcommand, RTEST_FAST)
 }
 RTEST_END;
 
+static ruint
+rargparse_count_of (RArgParser * parser, const rchar * a, const rchar * b)
+{
+  RArgParseCtx * ctx;
+  rchar ** strv, ** argv;
+  int argc;
+  ruint ret;
+
+  strv = argv = r_strv_new ("prog", a, b, NULL);  /* a / b may be NULL */
+  argc = (int) r_strv_len (argv);
+  ctx = r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+      &argc, (const rchar ***)&argv, NULL);
+  r_assert_cmpptr (ctx, !=, NULL);
+  ret = r_arg_parse_ctx_get_option_count (ctx, "verbose");
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+  return ret;
+}
+
+RTEST (rargparse, counter, RTEST_FAST)
+{
+  RArgParser * parser = r_arg_parser_new ("mytool", NULL);
+  rchar * help;
+
+  r_assert (r_arg_parser_add_option_entry (parser, "verbose", 'v',
+        R_ARG_OPTION_TYPE_COUNTER, R_ARG_OPTION_FLAG_NONE, "be more verbose", NULL));
+
+  r_assert_cmpuint (rargparse_count_of (parser, NULL, NULL),         ==, 0);
+  r_assert_cmpuint (rargparse_count_of (parser, "-v", NULL),         ==, 1);
+  r_assert_cmpuint (rargparse_count_of (parser, "-vvv", NULL),       ==, 3);
+  r_assert_cmpuint (rargparse_count_of (parser, "-v", "-v"),         ==, 2);
+  r_assert_cmpuint (rargparse_count_of (parser, "--verbose", "--verbose"), ==, 2);
+
+  /* Help shows the flag without a value placeholder. */
+  r_assert_cmpptr ((help = r_arg_parser_get_help (parser, R_ARG_PARSE_FLAG_NONE, NULL)), !=, NULL);
+  r_assert_cmpptr (r_strstr (help, "-v, --verbose "), !=, NULL);
+  r_assert_cmpptr (r_strstr (help, "verbose="), ==, NULL);
+  r_free (help);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
 RTEST (rargparse, get_value, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {


### PR DESCRIPTION
Second of the argparse feature work — #234 and #235, two related
"richer option" additions.

## #234 — counter type (`-vvv`)
`R_ARG_OPTION_TYPE_COUNTER` is an argument-less flag that tallies its
occurrences (`-vvv`, `-v -v`, repeated `--verbose`), read with the new
`r_arg_parse_ctx_get_option_count` (0 when absent). It's rejected as a
positional, ignores `defval`, and renders in `--help` without a value
placeholder. The enum value is inserted before the
`R_ARG_OPTION_TYPE_COUNT` sentinel so that sentinel still equals the
number of value types.

## #235 — choices
`r_arg_parser_set_option_choices(parser, longarg, choices)` restricts an
option or positional to a NULL-terminated set of permitted values:

```
$ tool --mode=wat
tool: invalid value 'wat' for option '--mode' (allowed: fast, slow)
```

`--help` shows the set (`--mode={fast,slow}` for options, `(one of: …)`
for positionals). Argument-less options are rejected; a `defval` outside
the set warns; `NULL` clears.

### Why a setter, not an `RArgOptionEntry` field
Adding a struct field under `warning_level=2 + werror` would trip
`-Werror=missing-field-initializers` on every existing `RArgOptionEntry`
literal (≈60 in-repo, plus every caller's). Storing choices in a
parser-side table keyed by long name keeps all existing initializers
untouched, mirroring how GLib keeps `GOptionEntry` stable rather than
growing the entry struct.

## Tests
counter (short-chaining, separate/repeated, default 0, help) and choices
(accept, reject-with-message, help rendering for options and
positionals, clearing, argument-less rejection, positional validation).

## Verification
debug-test + release (werror) + ASAN build clean; full suite 1903 pass,
0 fail; Doxygen 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)