### PR TITLE
argparse: add a custom value callback/validator

### DIFF
--- a/include/rlib/rargparse.h
+++ b/include/rlib/rargparse.h
@@ -284,6 +284,43 @@ R_API rboolean r_arg_parser_add_option_group (RArgParser * parser,
  */
 R_API rboolean r_arg_parser_set_option_choices (RArgParser * parser,
     const rchar * longarg, const rchar * const * choices);
+/**
+ * @brief Custom value handler invoked during parsing.
+ *
+ * @param longarg  The option's long name (so one callback can serve
+ *                 several options).
+ * @param value    The raw command-line token for this occurrence.
+ * @param user     The user pointer passed to
+ *                 @c r_arg_parser_set_option_callback.
+ * @return @c TRUE to accept the value, @c FALSE to reject it (the parse
+ *         then fails with @c R_ARG_PARSE_VALUE_ERROR).
+ */
+typedef rboolean (*RArgOptionCallback) (const rchar * longarg,
+    const rchar * value, rpointer user);
+/**
+ * @brief Attach a custom value handler/validator to @p longarg.
+ *
+ * After the option's built-in type parse succeeds, @p func is called
+ * with the raw value (per occurrence, and per element for a
+ * @c STRING_ARRAY) and must return @c TRUE to accept or @c FALSE to
+ * reject (failing the parse with @c R_ARG_PARSE_VALUE_ERROR). It runs
+ * only for values given on the command line, never for a @c defval.
+ *
+ * The value is still recorded as usual (retrievable via the matching
+ * typed getter); the callback is the escape hatch for @e additionally
+ * parsing/validating it — e.g. pair it with a @c STRING option to parse
+ * arbitrary syntax and capture the result through @p user, which the
+ * caller owns. Because options are handled as they are seen, the
+ * callback may already have run for earlier options when a later one
+ * makes the parse fail. Pass @p func = @c NULL to clear.
+ *
+ * Call after the option has been registered.
+ *
+ * @return @c TRUE on success; @c FALSE if @p longarg is unknown or
+ *         names an argument-less option (@c NONE / @c COUNTER).
+ */
+R_API rboolean r_arg_parser_set_option_callback (RArgParser * parser,
+    const rchar * longarg, RArgOptionCallback func, rpointer user);
 /** @} */
 
 /**

--- a/rlib/rargparse.c
+++ b/rlib/rargparse.c
@@ -55,6 +55,8 @@ struct RArgParser
 
   /* longarg -> (const rchar * const *) allowed-value set, borrowed. */
   RDictionary * choices;
+  /* longarg -> owned RArgCallbackReg (custom value handler). */
+  RDictionary * callbacks;
 };
 
 static RArgParseCtx *
@@ -374,6 +376,7 @@ r_arg_parser_free (RArgParser * parser)
 
     r_kv_ptr_array_clear (&parser->commands);
     r_dictionary_unref (parser->choices);
+    r_dictionary_unref (parser->callbacks);
     r_free (parser);
   }
 }
@@ -408,6 +411,7 @@ r_arg_parser_new (const rchar * app, const rchar * version)
 
     r_kv_ptr_array_init (&ret->commands, r_str_equal);
     ret->choices = r_dictionary_new ();
+    ret->callbacks = r_dictionary_new_full (r_free);
   }
 
   return ret;
@@ -878,6 +882,53 @@ r_arg_parser_get_choices (const RArgParser * parser, const rchar * longarg)
   return r_dictionary_lookup (parser->choices, longarg);
 }
 
+typedef struct {
+  RArgOptionCallback func;
+  rpointer user;
+} RArgCallbackReg;
+
+/* Run the choices restriction and any custom callback against @p value
+ * (an already type-parsed token for @p entry); sets the parser error
+ * and returns VALUE_ERROR on rejection, OK otherwise. */
+static RArgParseResult
+r_arg_parser_validate_value (RArgParser * parser, const RArgOptionEntry * entry,
+    const rchar * value)
+{
+  rboolean positional = (entry->flags & R_ARG_OPTION_FLAG_POSITIONAL) != 0;
+  const rchar * const * ch = r_arg_parser_get_choices (parser, entry->longarg);
+  const RArgCallbackReg * cb;
+
+  if (!r_arg_value_in_choices (ch, value)) {
+    rchar * list = r_arg_choices_join (ch, ", ");
+    if (positional) {
+      rchar * pname = r_arg_positional_usage_name (entry);
+      r_arg_parser_set_error (parser,
+          "invalid value '%s' for argument '%s' (allowed: %s)", value, pname, list);
+      r_free (pname);
+    } else {
+      r_arg_parser_set_error (parser,
+          "invalid value '%s' for option '--%s' (allowed: %s)", value, entry->longarg, list);
+    }
+    r_free (list);
+    return R_ARG_PARSE_VALUE_ERROR;
+  }
+
+  cb = r_dictionary_lookup (parser->callbacks, entry->longarg);
+  if (cb != NULL && !cb->func (entry->longarg, value, cb->user)) {
+    if (positional) {
+      rchar * pname = r_arg_positional_usage_name (entry);
+      r_arg_parser_set_error (parser, "invalid value '%s' for argument '%s'", value, pname);
+      r_free (pname);
+    } else {
+      r_arg_parser_set_error (parser, "invalid value '%s' for option '--%s'",
+          value, entry->longarg);
+    }
+    return R_ARG_PARSE_VALUE_ERROR;
+  }
+
+  return R_ARG_PARSE_OK;
+}
+
 rboolean
 r_arg_parser_set_option_choices (RArgParser * parser, const rchar * longarg,
     const rchar * const * choices)
@@ -906,6 +957,35 @@ r_arg_parser_set_option_choices (RArgParser * parser, const rchar * longarg,
         (rpointer) choices);
   } else {
     r_dictionary_remove (parser->choices, entry->longarg);
+  }
+
+  return TRUE;
+}
+
+rboolean
+r_arg_parser_set_option_callback (RArgParser * parser, const rchar * longarg,
+    RArgOptionCallback func, rpointer user)
+{
+  RArgOptionEntry * entry;
+
+  if (R_UNLIKELY (parser == NULL || longarg == NULL))
+    return FALSE;
+  if ((entry = r_arg_parser_find_entry_by_longarg (parser, longarg)) == NULL)
+    return FALSE;
+  if (entry->type == R_ARG_OPTION_TYPE_NONE ||
+      entry->type == R_ARG_OPTION_TYPE_COUNTER) {
+    R_LOG_CAT_WARNING (&rlib_logcat,
+        "ignoring callback for argument-less --%s", entry->longarg);
+    return FALSE;
+  }
+
+  if (func != NULL) {
+    RArgCallbackReg * reg = r_mem_new (RArgCallbackReg);
+    reg->func = func;
+    reg->user = user;
+    r_dictionary_insert (parser->callbacks, (rpointer) entry->longarg, reg);
+  } else {
+    r_dictionary_remove (parser->callbacks, entry->longarg);
   }
 
   return TRUE;
@@ -972,15 +1052,9 @@ r_arg_parser_parse_option_ctx (RArgParser * parser, RArgParseCtx * ctx,
   }
 
   if (ret == R_ARG_PARSE_OK && entry->type != R_ARG_OPTION_TYPE_NONE) {
-    const rchar * const * ch = r_arg_parser_get_choices (parser, entry->longarg);
-    if (!r_arg_value_in_choices (ch, str)) {
-      rchar * list = r_arg_choices_join (ch, ", ");
-      r_arg_parser_set_error (parser,
-          "invalid value '%s' for option '--%s' (allowed: %s)",
-          str, entry->longarg, list);
-      r_free (list);
-      return R_ARG_PARSE_VALUE_ERROR;
-    }
+    RArgParseResult v = r_arg_parser_validate_value (parser, entry, str);
+    if (v != R_ARG_PARSE_OK)
+      return v;
   }
 
   if (entry->type == R_ARG_OPTION_TYPE_STRING_ARRAY) {
@@ -1156,16 +1230,9 @@ r_arg_parser_parse_positionals (RArgParser * parser, RArgParseCtx * ctx,
     }
 
     {
-      const rchar * const * ch = r_arg_parser_get_choices (parser, entry->longarg);
-      if (!r_arg_value_in_choices (ch, str)) {
-        rchar * pname = r_arg_positional_usage_name (entry);
-        rchar * list = r_arg_choices_join (ch, ", ");
-        r_arg_parser_set_error (parser,
-            "invalid value '%s' for argument '%s' (allowed: %s)", str, pname, list);
-        r_free (pname);
-        r_free (list);
-        return R_ARG_PARSE_VALUE_ERROR;
-      }
+      RArgParseResult v = r_arg_parser_validate_value (parser, entry, str);
+      if (v != R_ARG_PARSE_OK)
+        return v;
     }
 
     r_dictionary_insert (ctx->options, entry->longarg, (rpointer) str);

--- a/test/rargparse.c
+++ b/test/rargparse.c
@@ -1204,6 +1204,71 @@ RTEST (rargparse, choices_positional, RTEST_FAST)
 }
 RTEST_END;
 
+static rboolean
+rargparse_cb_even (const rchar * longarg, const rchar * value, rpointer user)
+{
+  int * captured = user;
+  const rchar * end;
+  RStrParse err;
+  int v;
+
+  r_assert_cmpstr (longarg, ==, "num");   /* the option name is threaded through */
+  v = r_str_to_int (value, &end, 0, &err);
+  if (err != R_STR_PARSE_OK || (v & 1) != 0)  /* accept even ints only */
+    return FALSE;
+  if (captured != NULL)
+    *captured = v;
+  return TRUE;
+}
+
+RTEST (rargparse, callback, RTEST_FAST)
+{
+  RArgParser * parser = r_arg_parser_new ("mytool", NULL);
+  RArgParseCtx * ctx;
+  RArgParseResult res;
+  rchar ** strv, ** argv;
+  int argc;
+  int captured = -1;
+
+  r_assert (r_arg_parser_add_option_entry (parser, "num", 'n',
+        R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_NONE, "an even number", NULL));
+  r_assert (r_arg_parser_set_option_callback (parser, "num", rargparse_cb_even, &captured));
+  /* Unknown option is rejected. */
+  r_assert (!r_arg_parser_set_option_callback (parser, "nope", rargparse_cb_even, NULL));
+
+  /* Accepted, and the value is captured through the user pointer. */
+  strv = argv = r_strv_new ("prog", "--num=4", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+          &argc, (const rchar ***)&argv, &res)), !=, NULL);
+  r_assert_cmpint (captured, ==, 4);
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+
+  /* Rejected; user pointer is left untouched. */
+  captured = -1;
+  strv = argv = r_strv_new ("prog", "--num=5", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr (r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+          &argc, (const rchar ***)&argv, &res), ==, NULL);
+  r_assert_cmpint (res, ==, R_ARG_PARSE_VALUE_ERROR);
+  r_assert_cmpstr (r_arg_parser_get_error (parser), ==, "invalid value '5' for option '--num'");
+  r_assert_cmpint (captured, ==, -1);
+  r_strv_free (strv);
+
+  /* Clearing the callback removes the restriction. */
+  r_assert (r_arg_parser_set_option_callback (parser, "num", NULL, NULL));
+  strv = argv = r_strv_new ("prog", "--num=5", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+          &argc, (const rchar ***)&argv, &res)), !=, NULL);
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
 RTEST (rargparse, get_value, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {


### PR DESCRIPTION
Third of the argparse feature work (#236). For options needing parsing
or validation beyond the built-in types — GLib's
`G_OPTION_ARG_CALLBACK`, Python's `type=` callable — there was no escape
hatch.

## What's added
`r_arg_parser_set_option_callback(parser, longarg, func, user)` attaches
a handler invoked with the raw value after the option's built-in type
parse, per occurrence (and per element for a `STRING_ARRAY`):

```c
static rboolean parse_port (const rchar *opt, const rchar *val, rpointer user)
{ /* custom-parse val, store via user, return FALSE to reject */ }

r_arg_parser_add_option_entry (p, "port", 'p', R_ARG_OPTION_TYPE_STRING, ...);
r_arg_parser_set_option_callback (p, "port", parse_port, &cfg);
```

Returning `FALSE` fails the parse with `R_ARG_PARSE_VALUE_ERROR`. Pair
it with a `STRING` option to parse arbitrary syntax and capture the
result through `user`; the value is also still recorded normally
(retrievable via the typed getter). Argument-less options
(`NONE` / `COUNTER`) are rejected; `NULL` clears.

## Design
Consistent with the `choices` work, the callback is attached **by name
via a setter**, not an `RArgOptionEntry` field — under
`warning_level=2 + werror` a new struct field would force a trailing
initializer onto every existing `RArgOptionEntry` literal. Functionally
`STRING` + callback is the equivalent of GLib's `G_OPTION_ARG_CALLBACK`.
Choices and callback now share one value-validation helper, removing the
duplicated choices blocks in the option and positional paths.

## Tests
Accept + user-data capture, reject (with message; user pointer left
untouched), clearing, unknown-option rejection, and `longarg`
threaded through.

## Verification
debug-test + release (werror) + ASAN build clean; full suite 1904 pass,
0 fail; Doxygen 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)