### PR TITLE
argparse: add mutually-exclusive option groups

### DIFF
--- a/include/rlib/rargparse.h
+++ b/include/rlib/rargparse.h
@@ -157,6 +157,7 @@ typedef enum {
   R_ARG_PARSE_MISSING_OPTION,                   /**< Required option was absent. */
   R_ARG_PARSE_VALUE_ERROR,                      /**< An option's value didn't parse. */
   R_ARG_PARSE_MISSING_COMMAND,                  /**< Sub-command parser didn't see a command. */
+  R_ARG_PARSE_MUTUALLY_EXCLUSIVE,               /**< Two options from a mutually-exclusive group were given. */
   R_ARG_PARSE_OOM,                              /**< Allocation failure. */
   R_ARG_PARSE_ERROR,                            /**< Generic / internal error. */
 } RArgParseResult;
@@ -321,6 +322,25 @@ typedef rboolean (*RArgOptionCallback) (const rchar * longarg,
  */
 R_API rboolean r_arg_parser_set_option_callback (RArgParser * parser,
     const rchar * longarg, RArgOptionCallback func, rpointer user);
+/**
+ * @brief Declare a set of options as mutually exclusive.
+ *
+ * @p longargs is a @c NULL-terminated array of registered option long
+ * names that may not be combined on the command line; supplying two of
+ * them fails the parse with @c R_ARG_PARSE_MUTUALLY_EXCLUSIVE. When
+ * @p required is @c TRUE, exactly one member must be given (an empty
+ * group fails with @c R_ARG_PARSE_MISSING_OPTION). The relationship is
+ * shown in @c --help as @c [--a | --b] (or @c (--a | --b) when
+ * required).
+ *
+ * The array (and its strings) is borrowed and must outlive the parser.
+ * Call after the member options have been registered.
+ *
+ * @return @c TRUE on success; @c FALSE if any name is unknown or fewer
+ *         than two are given.
+ */
+R_API rboolean r_arg_parser_add_mutex_group (RArgParser * parser,
+    const rchar * const * longargs, rboolean required);
 /** @} */
 
 /**

--- a/rlib/rargparse.c
+++ b/rlib/rargparse.c
@@ -57,7 +57,14 @@ struct RArgParser
   RDictionary * choices;
   /* longarg -> owned RArgCallbackReg (custom value handler). */
   RDictionary * callbacks;
+  /* owned RArgMutexGroup entries (mutually-exclusive option sets). */
+  RPtrArray * mutex;
 };
+
+typedef struct {
+  const rchar * const * longargs;   /* borrowed, NULL-terminated */
+  rboolean required;
+} RArgMutexGroup;
 
 static RArgParseCtx *
 r_arg_parser_parse_internal (RArgParser * parser, RArgParseFlags flags,
@@ -377,6 +384,7 @@ r_arg_parser_free (RArgParser * parser)
     r_kv_ptr_array_clear (&parser->commands);
     r_dictionary_unref (parser->choices);
     r_dictionary_unref (parser->callbacks);
+    r_ptr_array_unref (parser->mutex);
     r_free (parser);
   }
 }
@@ -412,6 +420,7 @@ r_arg_parser_new (const rchar * app, const rchar * version)
     r_kv_ptr_array_init (&ret->commands, r_str_equal);
     ret->choices = r_dictionary_new ();
     ret->callbacks = r_dictionary_new_full (r_free);
+    ret->mutex = r_ptr_array_new ();
   }
 
   return ret;
@@ -641,6 +650,14 @@ r_arg_parser_get_help (const RArgParser * parser, RArgParseFlags flags,
     else
       r_string_append_printf (str, " %s", name);
     r_free (name);
+  }
+  for (i = 0; i < r_ptr_array_size (parser->mutex); i++) {
+    const RArgMutexGroup * grp = r_ptr_array_get_const (parser->mutex, i);
+    rsize j;
+    r_string_append (str, grp->required ? " (" : " [");
+    for (j = 0; grp->longargs[j] != NULL; j++)
+      r_string_append_printf (str, "%s--%s", j > 0 ? " | " : "", grp->longargs[j]);
+    r_string_append (str, grp->required ? ")" : "]");
   }
   if (r_kv_ptr_array_size (&parser->commands) > 0)
     r_string_append (str, " <command>");
@@ -991,6 +1008,36 @@ r_arg_parser_set_option_callback (RArgParser * parser, const rchar * longarg,
   return TRUE;
 }
 
+rboolean
+r_arg_parser_add_mutex_group (RArgParser * parser, const rchar * const * longargs,
+    rboolean required)
+{
+  RArgMutexGroup * grp;
+  rsize n;
+
+  if (R_UNLIKELY (parser == NULL || longargs == NULL))
+    return FALSE;
+
+  for (n = 0; longargs[n] != NULL; n++) {
+    if (r_arg_parser_find_entry_by_longarg (parser, longargs[n]) == NULL) {
+      R_LOG_CAT_WARNING (&rlib_logcat,
+          "mutex group references unknown option --%s", longargs[n]);
+      return FALSE;
+    }
+  }
+  if (n < 2) {
+    R_LOG_CAT_WARNING (&rlib_logcat,
+        "mutex group needs at least two options");
+    return FALSE;
+  }
+
+  grp = r_mem_new (RArgMutexGroup);
+  grp->longargs = longargs;
+  grp->required = required;
+  r_ptr_array_add (parser->mutex, grp, r_free);
+  return TRUE;
+}
+
 static RArgParseResult
 r_arg_parser_parse_option_ctx (RArgParser * parser, RArgParseCtx * ctx,
     RArgOptionEntry * entry, const rchar ** arg, int * argc, const rchar *** argv)
@@ -1132,6 +1179,47 @@ r_arg_parser_first_missing_required (RArgParser * parser, RArgParseCtx * ctx)
   }
 
   return NULL;
+}
+
+static RArgParseResult
+r_arg_parser_check_mutex_groups (RArgParser * parser, RArgParseCtx * ctx)
+{
+  rsize gi;
+
+  for (gi = 0; gi < r_ptr_array_size (parser->mutex); gi++) {
+    const RArgMutexGroup * grp = r_ptr_array_get_const (parser->mutex, gi);
+    const rchar * first = NULL;
+    rsize i;
+
+    for (i = 0; grp->longargs[i] != NULL; i++) {
+      if (!r_dictionary_contains (ctx->options, grp->longargs[i]))
+        continue;
+      if (first == NULL) {
+        first = grp->longargs[i];
+      } else {
+        r_arg_parser_set_error (parser,
+            "options '--%s' and '--%s' are mutually exclusive",
+            first, grp->longargs[i]);
+        return R_ARG_PARSE_MUTUALLY_EXCLUSIVE;
+      }
+    }
+
+    if (first == NULL && grp->required) {
+      RString * s = r_string_new_sized (64);
+      rchar * list;
+      for (i = 0; grp->longargs[i] != NULL; i++) {
+        if (i > 0)
+          r_string_append (s, ", ");
+        r_string_append_printf (s, "--%s", grp->longargs[i]);
+      }
+      list = r_string_free_keep (s);
+      r_arg_parser_set_error (parser, "one of %s is required", list);
+      r_free (list);
+      return R_ARG_PARSE_MISSING_OPTION;
+    }
+  }
+
+  return R_ARG_PARSE_OK;
 }
 
 static RArgParseResult
@@ -1333,7 +1421,7 @@ r_arg_parser_parse_internal (RArgParser * parser, RArgParseFlags flags,
               missing->longarg);
         }
         curres = R_ARG_PARSE_MISSING_OPTION;
-      } else {
+      } else if ((curres = r_arg_parser_check_mutex_groups (parser, ret)) == R_ARG_PARSE_OK) {
         curres = r_arg_parser_parse_command (parser, flags, ret, argc, argv);
       }
     }

--- a/test/rargparse.c
+++ b/test/rargparse.c
@@ -1269,6 +1269,80 @@ RTEST (rargparse, callback, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rargparse, mutex, RTEST_FAST)
+{
+  static const rchar * const verbosity[] = { "quiet", "verbose", NULL };
+  static const rchar * const fmt[] = { "json", "xml", NULL };
+  static const rchar * const unknown[] = { "quiet", "nope", NULL };
+  static const rchar * const single[] = { "quiet", NULL };
+  RArgParser * parser = r_arg_parser_new ("mytool", NULL);
+  RArgParseCtx * ctx;
+  RArgParseResult res;
+  rchar ** strv, ** argv;
+  rchar * help;
+  int argc;
+
+  r_assert (r_arg_parser_add_option_entry (parser, "quiet", 'q',
+        R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "be quiet", NULL));
+  r_assert (r_arg_parser_add_option_entry (parser, "verbose", 'v',
+        R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "be noisy", NULL));
+  r_assert (r_arg_parser_add_option_entry (parser, "json", 0,
+        R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "json output", NULL));
+  r_assert (r_arg_parser_add_option_entry (parser, "xml", 0,
+        R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "xml output", NULL));
+
+  r_assert (r_arg_parser_add_mutex_group (parser, verbosity, FALSE));
+  r_assert (r_arg_parser_add_mutex_group (parser, fmt, TRUE));
+  /* Group validation: unknown member / fewer than two members. */
+  r_assert (!r_arg_parser_add_mutex_group (parser, unknown, FALSE));
+  r_assert (!r_arg_parser_add_mutex_group (parser, single, FALSE));
+
+  /* A lone optional member plus the required choice: OK. */
+  strv = argv = r_strv_new ("prog", "-q", "--json", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+          &argc, (const rchar ***)&argv, &res)), !=, NULL);
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+
+  /* Empty optional group is fine (only the required group must be met). */
+  strv = argv = r_strv_new ("prog", "--xml", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+          &argc, (const rchar ***)&argv, &res)), !=, NULL);
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+
+  /* Two members of the optional group: conflict. */
+  strv = argv = r_strv_new ("prog", "-q", "-v", "--json", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr (r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+          &argc, (const rchar ***)&argv, &res), ==, NULL);
+  r_assert_cmpint (res, ==, R_ARG_PARSE_MUTUALLY_EXCLUSIVE);
+  r_assert_cmpstr (r_arg_parser_get_error (parser), ==,
+      "options '--quiet' and '--verbose' are mutually exclusive");
+  r_strv_free (strv);
+
+  /* Required group with no member given: missing. */
+  strv = argv = r_strv_new ("prog", "-q", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr (r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+          &argc, (const rchar ***)&argv, &res), ==, NULL);
+  r_assert_cmpint (res, ==, R_ARG_PARSE_MISSING_OPTION);
+  r_assert_cmpstr (r_arg_parser_get_error (parser), ==,
+      "one of --json, --xml is required");
+  r_strv_free (strv);
+
+  /* Help synopsis shows both groups. */
+  r_assert_cmpptr ((help = r_arg_parser_get_help (parser, R_ARG_PARSE_FLAG_NONE, NULL)), !=, NULL);
+  r_assert_cmpptr (r_strstr (help, "[--quiet | --verbose]"), !=, NULL);
+  r_assert_cmpptr (r_strstr (help, "(--json | --xml)"), !=, NULL);
+  r_free (help);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
 RTEST (rargparse, get_value, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {


### PR DESCRIPTION
Fourth of the argparse feature work (#237). There was no way to declare
that options can't be combined (`--quiet` vs `--verbose`, `--json` vs
`--xml`) — callers had to detect conflicts by hand.

## What's added
`r_arg_parser_add_mutex_group(parser, longargs, required)` takes a
NULL-terminated array of registered option long names:

```c
static const rchar * const fmt[] = { "json", "xml", NULL };
r_arg_parser_add_mutex_group (parser, fmt, TRUE);   /* exactly one */
```

- Two members given → new `R_ARG_PARSE_MUTUALLY_EXCLUSIVE` code, e.g.
  `options '--quiet' and '--verbose' are mutually exclusive`.
- `required` group with none given → `R_ARG_PARSE_MISSING_OPTION`, e.g.
  `one of --json, --xml is required`.
- `--help` shows the relationship in the Usage synopsis as
  `[--a | --b]` (optional) or `(--a | --b)` (required).
- Registration rejects (with a warning) an unknown member or fewer than
  two members.

Consistent with the choices/callback work, the group is attached by
name via a setter (a borrowed array), not an `RArgOptionEntry` field.

## Tests
Lone member OK, empty optional group OK, two-member conflict (+message),
required-empty (+message), group validation (unknown member / <2), and
the help synopsis for both group kinds.

## Verification
debug-test + release (werror) + ASAN build clean; full suite 1905 pass,
0 fail; Doxygen 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)