### PR TITLE
argparse: optionally permute options past positionals

### DIFF
--- a/include/rlib/rargparse.h
+++ b/include/rlib/rargparse.h
@@ -145,6 +145,16 @@ typedef enum {
   R_ARG_PARSE_FLAG_DONT_PRINT_STDOUT  = 1 << 1, /**< Suppress automatic help / version output. */
   R_ARG_PARSE_FLAG_DISABLE_HELP        = 1 << 2, /**< Don't auto-register @c --help / @c -h. */
   R_ARG_PARSE_FLAG_ALLOW_UNKNOWN      = 1 << 3, /**< Pass unknown options through instead of failing. */
+  /**
+   * Parse options that appear after positionals too, GNU-getopt style
+   * (e.g. @c "tool file --verbose"), permuting @p argv in place so the
+   * operands end up first. Without it, option scanning stops at the
+   * first non-option token (POSIX-strict). @c -- still ends option
+   * scanning. Ignored for a parser that has sub-commands (the command
+   * boundary is kept); sub-command parsers honour it for their own
+   * arguments.
+   */
+  R_ARG_PARSE_FLAG_PERMUTE            = 1 << 4,
 } RArgParseFlags;
 
 /** @brief Result code from @c r_arg_parser_parse. */

--- a/rlib/rargparse.c
+++ b/rlib/rargparse.c
@@ -1223,7 +1223,7 @@ r_arg_parser_check_mutex_groups (RArgParser * parser, RArgParseCtx * ctx)
 }
 
 static RArgParseResult
-r_arg_parser_parse_options (RArgParser * parser, RArgParseCtx * ctx,
+r_arg_parser_scan_options_strict (RArgParser * parser, RArgParseCtx * ctx,
     int * argc, const rchar *** argv)
 {
   RArgParseResult ret = R_ARG_PARSE_OK;
@@ -1249,6 +1249,93 @@ r_arg_parser_parse_options (RArgParser * parser, RArgParseCtx * ctx,
       } while (*arg != 0 && ret == R_ARG_PARSE_OK);
     }
   }
+
+  return ret;
+}
+
+/* GNU-getopt-style scan: options are parsed wherever they occur, and on
+ * success argv is reordered in place to [operands..., option region...]
+ * with *argc set to the operand count, so a later parse_positionals /
+ * parse_command sees the operands. The reorder is a true permutation —
+ * every original argv pointer survives exactly once (so a caller owning
+ * the vector can still free it). */
+static RArgParseResult
+r_arg_parser_scan_options_permuted (RArgParser * parser, RArgParseCtx * ctx,
+    int * argc, const rchar *** argv)
+{
+  const rchar ** av = *argv;
+  int n = *argc;
+  const rchar ** ops;
+  const rchar ** rest;
+  int nops = 0, nrest = 0, rd = 0;
+  RArgParseResult ret = R_ARG_PARSE_OK;
+  rboolean endopts = FALSE;
+
+  if (n <= 0)
+    return R_ARG_PARSE_OK;
+
+  ops = r_mem_new_n (const rchar *, n);
+  rest = r_mem_new_n (const rchar *, n);
+
+  while (rd < n && ret == R_ARG_PARSE_OK) {
+    const rchar * tok = av[rd];
+
+    if (!endopts && tok[0] == '-' && tok[1] == '-' && tok[2] == 0) {
+      rest[nrest++] = tok;                  /* keep "--" in the tail */
+      endopts = TRUE;
+      rd++;
+    } else if (!endopts && tok[0] == '-' && tok[1] != 0) {
+      const rchar * arg = tok + 1;
+      int sub_argc = n - rd - 1;            /* tokens after this one */
+      const rchar ** sub_argv = &av[rd + 1];
+      int consumed, k;
+
+      if (*arg == '-') {
+        arg++;
+        ret = r_arg_parser_parse_long_option (parser, ctx, &arg, &sub_argc, &sub_argv);
+      } else {
+        do {
+          ret = r_arg_parser_parse_short_option (parser, ctx, &arg, &sub_argc, &sub_argv);
+        } while (*arg != 0 && ret == R_ARG_PARSE_OK);
+      }
+      consumed = (n - rd - 1) - sub_argc;   /* value tokens taken */
+      for (k = 0; k <= consumed; k++)
+        rest[nrest++] = av[rd + k];         /* option token + its values */
+      rd += 1 + consumed;
+    } else {
+      ops[nops++] = tok;
+      rd++;
+    }
+  }
+
+  if (ret == R_ARG_PARSE_OK) {
+    if (nops > 0)
+      r_memcpy (av, ops, nops * sizeof (const rchar *));
+    if (nrest > 0)
+      r_memcpy (av + nops, rest, nrest * sizeof (const rchar *));
+    *argc = nops;
+  }
+
+  r_free (ops);
+  r_free (rest);
+  return ret;
+}
+
+static RArgParseResult
+r_arg_parser_parse_options (RArgParser * parser, RArgParseCtx * ctx,
+    int * argc, const rchar *** argv)
+{
+  RArgParseResult ret;
+
+  /* Permute only when there are no sub-commands: with commands the first
+   * operand is the command, and scanning past it would wrongly parse the
+   * sub-command's options at this level. (Sub-command parsers have no
+   * commands of their own, so they still permute their own arguments.) */
+  if ((ctx->flags & R_ARG_PARSE_FLAG_PERMUTE) &&
+      r_kv_ptr_array_size (&parser->commands) == 0)
+    ret = r_arg_parser_scan_options_permuted (parser, ctx, argc, argv);
+  else
+    ret = r_arg_parser_scan_options_strict (parser, ctx, argc, argv);
 
   /* Check version */
   if (r_arg_parse_ctx_get_option_bool (ctx, "version")) {

--- a/test/rargparse.c
+++ b/test/rargparse.c
@@ -1343,6 +1343,113 @@ RTEST (rargparse, mutex, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rargparse, permute, RTEST_FAST)
+{
+  RArgParser * parser = r_arg_parser_new ("mytool", NULL);
+  RArgParseCtx * ctx;
+  RArgParseResult res;
+  rchar ** strv, ** argv;
+  rchar * sv;
+  int argc;
+
+  r_assert (r_arg_parser_add_option_entry (parser, "verbose", 'v',
+        R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "noisy", NULL));
+  r_assert (r_arg_parser_add_option_entry (parser, "name", 'n',
+        R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_NONE, "a name", NULL));
+  r_assert (r_arg_parser_add_option_entry (parser, "file", 0,
+        R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_POSITIONAL, "input", NULL));
+
+  /* Strict (default): an option after the positional is left unparsed. */
+  strv = argv = r_strv_new ("prog", "f.txt", "--verbose", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser, RARGPARSE_ERR_FLAGS,
+          &argc, (const rchar ***)&argv, &res)), !=, NULL);
+  r_assert (!r_arg_parse_ctx_get_option_bool (ctx, "verbose"));
+  r_assert_cmpint (argc, ==, 1);
+  r_assert_cmpstr (argv[0], ==, "--verbose");
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+
+  /* PERMUTE: the same option after the positional is now parsed. */
+  strv = argv = r_strv_new ("prog", "f.txt", "--verbose", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser,
+          RARGPARSE_ERR_FLAGS | R_ARG_PARSE_FLAG_PERMUTE,
+          &argc, (const rchar ***)&argv, &res)), !=, NULL);
+  r_assert (r_arg_parse_ctx_get_option_bool (ctx, "verbose"));
+  r_assert_cmpstr ((sv = r_arg_parse_ctx_get_option_string (ctx, "file")), ==, "f.txt");
+  r_free (sv);
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+
+  /* PERMUTE: interleaved options and a separate-arg value after the operand. */
+  strv = argv = r_strv_new ("prog", "-v", "f.txt", "-n", "bob", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser,
+          RARGPARSE_ERR_FLAGS | R_ARG_PARSE_FLAG_PERMUTE,
+          &argc, (const rchar ***)&argv, &res)), !=, NULL);
+  r_assert (r_arg_parse_ctx_get_option_bool (ctx, "verbose"));
+  r_assert_cmpstr ((sv = r_arg_parse_ctx_get_option_string (ctx, "name")), ==, "bob");
+  r_free (sv);
+  r_assert_cmpstr ((sv = r_arg_parse_ctx_get_option_string (ctx, "file")), ==, "f.txt");
+  r_free (sv);
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+
+  /* PERMUTE: -- still ends option scanning; what follows is an operand. */
+  strv = argv = r_strv_new ("prog", "--", "--verbose", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser,
+          RARGPARSE_ERR_FLAGS | R_ARG_PARSE_FLAG_PERMUTE,
+          &argc, (const rchar ***)&argv, &res)), !=, NULL);
+  r_assert (!r_arg_parse_ctx_get_option_bool (ctx, "verbose"));
+  r_assert_cmpstr ((sv = r_arg_parse_ctx_get_option_string (ctx, "file")), ==, "--verbose");
+  r_free (sv);
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rargparse, permute_command, RTEST_FAST)
+{
+  RArgParser * parser = r_arg_parser_new ("mytool", NULL);
+  RArgParser * cmd;
+  RArgParseCtx * ctx, * sub;
+  RArgParseResult res;
+  rchar ** strv, ** argv;
+  rchar * sv;
+  int argc;
+
+  r_assert_cmpptr ((cmd = r_arg_parser_add_command (parser, "build", "build it")), !=, NULL);
+  r_assert (r_arg_parser_add_option_entry (cmd, "fast", 'x',
+        R_ARG_OPTION_TYPE_NONE, R_ARG_OPTION_FLAG_NONE, "go fast", NULL));
+  r_assert (r_arg_parser_add_option_entry (cmd, "target", 0,
+        R_ARG_OPTION_TYPE_STRING, R_ARG_OPTION_FLAG_POSITIONAL, "target", NULL));
+  r_arg_parser_unref (cmd);
+
+  /* PERMUTE on a parser with commands keeps the command boundary (it
+   * must not parse the sub-command's options at the top level); the
+   * sub-command then permutes its own arguments. */
+  strv = argv = r_strv_new ("prog", "build", "out.bin", "-x", NULL);
+  argc = (int) r_strv_len (argv);
+  r_assert_cmpptr ((ctx = r_arg_parser_parse (parser,
+          RARGPARSE_ERR_FLAGS | R_ARG_PARSE_FLAG_PERMUTE,
+          &argc, (const rchar ***)&argv, &res)), !=, NULL);
+  r_assert_cmpstr (r_arg_parse_ctx_get_command (ctx), ==, "build");
+  r_assert_cmpptr ((sub = r_arg_parse_ctx_get_command_ctx (ctx)), !=, NULL);
+  r_assert (r_arg_parse_ctx_get_option_bool (sub, "fast"));
+  r_assert_cmpstr ((sv = r_arg_parse_ctx_get_option_string (sub, "target")), ==, "out.bin");
+  r_free (sv);
+  r_arg_parse_ctx_unref (sub);
+  r_arg_parse_ctx_unref (ctx);
+  r_strv_free (strv);
+
+  r_arg_parser_unref (parser);
+}
+RTEST_END;
+
 RTEST (rargparse, get_value, RTEST_FAST)
 {
   static RArgOptionEntry entries[] = {


### PR DESCRIPTION
Last of the argparse feature work (#238). Option scanning stopped at the
first non-option token, so `tool file --verbose` left `--verbose`
unparsed. GNU getopt / GLib / Python permute by default.

## What's added
`R_ARG_PARSE_FLAG_PERMUTE` makes scanning GNU-getopt style: options are
parsed wherever they occur, interspersed with operands. On success argv
is reordered in place to `[operands..., option region...]` with argc set
to the operand count, so positionals/commands see the operands. The
reorder is a **true permutation** — every original argv pointer survives
exactly once, so a caller owning the vector can still free it.

The default stays **POSIX-strict** (stop at the first operand), so
existing callers are unaffected; `--` still ends option scanning.

## Sub-commands
Permutation is skipped for a parser that *has* sub-commands — there the
first operand is the command, and scanning past it would wrongly parse
the sub-command's options at the top level. Sub-command parsers (no
commands of their own) still permute their own arguments. (This was
caught and fixed during a post-implementation audit, with a regression
test.)

## Tests
Strict default leaves an option-after-positional unparsed; PERMUTE
parses it; interleaved options + a separate-arg value; `--` as an
operand under PERMUTE; and permute + sub-command routing.

## Verification
debug-test + release (werror) + ASAN build clean; full suite 1907 pass,
0 fail; Doxygen 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)