### PR TITLE
format: validate restricted ASN.1 strings and reject ambiguous GeneralizedTime

### DIFF
--- a/rlib/format/rasn1bin.c
+++ b/rlib/format/rasn1bin.c
@@ -20,6 +20,7 @@
 #include "rasn1-private.h"
 
 #include <rlib/format/roid.h>
+#include <rlib/charset/rascii.h>
 #include <rlib/charset/runicode.h>
 #include <rlib/rmem.h>
 #include <rlib/rstr.h>
@@ -311,6 +312,41 @@ r_asn1_bin_tlv_parse_oid (const RAsn1BinTLV * tlv, ruint32 * varray, rsize * len
   }
 }
 
+/* PrintableString (X.680 41.4): letters, digits, space and a fixed set
+ * of punctuation. */
+static rboolean
+r_asn1_is_printable_char (ruint8 c)
+{
+  return r_ascii_isalnum (c) || c == ' ' ||
+      c == '\'' || c == '(' || c == ')' || c == '+' || c == ',' ||
+      c == '-' || c == '.' || c == '/' || c == ':' || c == '=' || c == '?';
+}
+
+/* NumericString (X.680 41.2): digits and space. */
+static rboolean
+r_asn1_is_numeric_char (ruint8 c)
+{
+  return r_ascii_isdigit (c) || c == ' ';
+}
+
+/* IA5String: International Alphabet No. 5, i.e. 7-bit (ASCII) codes. */
+static rboolean
+r_asn1_is_ia5_char (ruint8 c)
+{
+  return c <= 0x7f;
+}
+
+static rboolean
+r_asn1_string_chars_valid (const ruint8 * p, rsize len, rboolean (* ok) (ruint8))
+{
+  rsize i;
+  for (i = 0; i < len; i++) {
+    if (!ok (p[i]))
+      return FALSE;
+  }
+  return TRUE;
+}
+
 RAsn1DecoderStatus
 r_asn1_bin_tlv_parse_string (const RAsn1BinTLV * tlv, rchar ** str)
 {
@@ -319,20 +355,32 @@ r_asn1_bin_tlv_parse_string (const RAsn1BinTLV * tlv, rchar ** str)
 
   switch (R_ASN1_BIN_TLV_ID_TAG (tlv)) {
     /* UTF8String: X.680 requires the encoded value to be valid UTF-8.
-     * Validate the bytes before strdup'ing them. The other byte-
-     * encoded string types pass through verbatim - their character-
-     * set restrictions are still TODO (see below). */
+     * Validate the bytes before strdup'ing them. */
     case R_ASN1_ID_UTF8_STRING:
       if (r_utf8_validate ((const rchar *)tlv->value, (rssize)tlv->len,
             NULL) != R_UNICODE_OK)
         return R_ASN1_DECODER_PARSE_ERROR;
       *str = r_strdup_size ((const rchar *) tlv->value, (rssize) tlv->len);
       break;
+    /* Restricted byte-encoded types: enforce their character sets. */
     case R_ASN1_ID_NUMERIC_STRING:
+      if (!r_asn1_string_chars_valid (tlv->value, tlv->len, r_asn1_is_numeric_char))
+        return R_ASN1_DECODER_PARSE_ERROR;
+      *str = r_strdup_size ((const rchar *) tlv->value, (rssize) tlv->len);
+      break;
     case R_ASN1_ID_PRINTABLE_STRING:
+      if (!r_asn1_string_chars_valid (tlv->value, tlv->len, r_asn1_is_printable_char))
+        return R_ASN1_DECODER_PARSE_ERROR;
+      *str = r_strdup_size ((const rchar *) tlv->value, (rssize) tlv->len);
+      break;
+    case R_ASN1_ID_IA5_STRING:
+      if (!r_asn1_string_chars_valid (tlv->value, tlv->len, r_asn1_is_ia5_char))
+        return R_ASN1_DECODER_PARSE_ERROR;
+      *str = r_strdup_size ((const rchar *) tlv->value, (rssize) tlv->len);
+      break;
+    /* Looser / deprecated byte-encoded types pass through verbatim. */
     case R_ASN1_ID_T61_STRING:
     case R_ASN1_ID_VIDEOTEX_STRING:
-    case R_ASN1_ID_IA5_STRING:
     case R_ASN1_ID_GRAPHIC_STRING:
     case R_ASN1_ID_VISIBLE_STRING:
     case R_ASN1_ID_GENERAL_STRING:
@@ -347,10 +395,6 @@ r_asn1_bin_tlv_parse_string (const RAsn1BinTLV * tlv, rchar ** str)
     default:
       return R_ASN1_DECODER_WRONG_TYPE;
   }
-
-  /* TODO: restricted character-set validation for PrintableString /
-   *       NumericString / IA5String; zero-copy variant returning an
-   *       RStrChunk into the TLV. */
 
   return (*str != NULL) ? R_ASN1_DECODER_OK : R_ASN1_DECODER_OOM;
 }
@@ -500,7 +544,10 @@ r_asn1_bin_tlv_parse_time (const RAsn1BinTLV * tlv, ruint64 * time)
     if (end - ptr == 1 && *ptr == 'Z') {
       ptr++;
     } else if (ptr == end) {
-      /* TODO: Adjust for Local time */
+      /* Bare local time (no Z and no +hhmm/-hhmm offset) names no zone,
+       * so it can't be resolved to an instant; reject it rather than
+       * silently treat it as UTC. DER (X.509) mandates Z anyway. */
+      return R_ASN1_DECODER_PARSE_ERROR;
     }
   } else {
     return R_ASN1_DECODER_WRONG_TYPE;

--- a/test/rasn1der.c
+++ b/test/rasn1der.c
@@ -354,6 +354,39 @@ RTEST (rasn1der, parse_time_heap_buffer, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rasn1der, parse_time_generalized_local, RTEST_FAST)
+{
+  /* GeneralizedTime with Z (UTC) or a +/-hhmm offset resolves to an
+   * instant; a bare value with no zone is ambiguous and is rejected. */
+  static const ruint8 gt_utc[] = { 0x18, 0x0f,
+      '2','0','2','3','1','2','0','1','0','8','3','0','0','0','Z' };
+  static const ruint8 gt_offset[] = { 0x18, 0x13,
+      '2','0','2','3','1','2','0','1','0','8','3','0','0','0','+','0','1','0','0' };
+  static const ruint8 gt_local[] = { 0x18, 0x0a,
+      '2','0','2','3','1','2','0','1','0','8' };
+  static const struct { const ruint8 * der; rsize len; RAsn1DecoderStatus exp; }
+  cases[] = {
+    { gt_utc,    sizeof (gt_utc),    R_ASN1_DECODER_OK },
+    { gt_offset, sizeof (gt_offset), R_ASN1_DECODER_OK },
+    { gt_local,  sizeof (gt_local),  R_ASN1_DECODER_PARSE_ERROR },
+  };
+  rsize i;
+
+  for (i = 0; i < R_N_ELEMENTS (cases); i++) {
+    RAsn1BinDecoder * dec;
+    RAsn1BinTLV tlv = (RAsn1BinTLV)R_ASN1_BIN_TLV_INIT;
+    ruint64 t = 0;
+
+    r_assert_cmpptr ((dec = r_asn1_bin_decoder_new (R_ASN1_DER,
+            cases[i].der, cases[i].len)), !=, NULL);
+    r_assert_cmpint (r_asn1_bin_decoder_next (dec, &tlv), ==, R_ASN1_DECODER_OK);
+    r_assert (R_ASN1_BIN_TLV_ID_IS_TAG (&tlv, R_ASN1_ID_GENERALIZED_TIME));
+    r_assert_cmpint (r_asn1_bin_tlv_parse_time (&tlv, &t), ==, cases[i].exp);
+    r_asn1_bin_decoder_unref (dec);
+  }
+}
+RTEST_END;
+
 RTEST (rasn1der, parse_empty_bit_string, RTEST_FAST)
 {
   /* BIT STRING with zero content bytes. parse_bit_string_bits used
@@ -650,6 +683,41 @@ RTEST (rasn1der, parse_string_rejects_malformed_utf8, RTEST_FAST)
   r_assert_cmpint (r_asn1_bin_tlv_parse_string (&tlv, &str),
       ==, R_ASN1_DECODER_PARSE_ERROR);
   r_asn1_bin_decoder_unref (dec);
+}
+RTEST_END;
+
+RTEST (rasn1der, parse_string_charset, RTEST_FAST)
+{
+  /* PrintableString punctuation that IS in the X.680 set ("a-b.c") is
+   * accepted; "@" is not, and must be rejected. NumericString rejects a
+   * letter; IA5String rejects a byte > 0x7f. */
+  static const ruint8 print_ok[]   = { 0x13, 0x05, 'a', '-', 'b', '.', 'c' };
+  static const ruint8 print_bad[]  = { 0x13, 0x03, 'a', '@', 'b' };
+  static const ruint8 numeric_ok[] = { 0x12, 0x03, '1', ' ', '2' };
+  static const ruint8 numeric_bad[]= { 0x12, 0x02, '1', 'a' };
+  static const ruint8 ia5_bad[]    = { 0x16, 0x02, 'a', 0x80 };
+  static const struct { const ruint8 * der; rsize len; RAsn1DecoderStatus exp; }
+  cases[] = {
+    { print_ok,    sizeof (print_ok),    R_ASN1_DECODER_OK },
+    { print_bad,   sizeof (print_bad),   R_ASN1_DECODER_PARSE_ERROR },
+    { numeric_ok,  sizeof (numeric_ok),  R_ASN1_DECODER_OK },
+    { numeric_bad, sizeof (numeric_bad), R_ASN1_DECODER_PARSE_ERROR },
+    { ia5_bad,     sizeof (ia5_bad),     R_ASN1_DECODER_PARSE_ERROR },
+  };
+  rsize i;
+
+  for (i = 0; i < R_N_ELEMENTS (cases); i++) {
+    RAsn1BinDecoder * dec;
+    RAsn1BinTLV tlv = (RAsn1BinTLV)R_ASN1_BIN_TLV_INIT;
+    rchar * str = NULL;
+
+    r_assert_cmpptr ((dec = r_asn1_bin_decoder_new (R_ASN1_DER,
+          cases[i].der, cases[i].len)), !=, NULL);
+    r_assert_cmpint (r_asn1_bin_decoder_next (dec, &tlv), ==, R_ASN1_DECODER_OK);
+    r_assert_cmpint (r_asn1_bin_tlv_parse_string (&tlv, &str), ==, cases[i].exp);
+    r_free (str);
+    r_asn1_bin_decoder_unref (dec);
+  }
 }
 RTEST_END;
 


### PR DESCRIPTION
Two ASN.1 decoder-correctness fixes in `rlib/format/rasn1bin.c`.

## #215 — restricted string character sets
`r_asn1_bin_tlv_parse_string` validated `UTF8String` as UTF-8 but passed
`PrintableString` / `NumericString` / `IA5String` through verbatim. It
now enforces their X.680 character sets, rejecting out-of-set bytes with
`R_ASN1_DECODER_PARSE_ERROR`:
- PrintableString: letters, digits, space, and `' ( ) + , - . / : = ?`
- NumericString: digits and space
- IA5String: 7-bit (ASCII)

The looser/deprecated byte types (T61, Videotex, Graphic, Visible,
General) still pass through unchanged.

**Note:** this is a deliberate tightening — a mis-encoded but
previously-accepted `PrintableString` (e.g. a cert DN with `@`/`_`/`*`)
will now be rejected. The optional zero-copy `RStrChunk` variant from
the issue is not included.

## #216 — ambiguous GeneralizedTime
`r_asn1_bin_tlv_parse_time` treated a bare local GeneralizedTime (no `Z`,
no `+hhmm`/`-hhmm` offset) as UTC. With no zone it names no instant, so
it is now rejected. The `Z` and offset forms are unchanged (offsets were
already handled); UTCTime is left as-is.

## Tests
`parse_string_charset` (accept valid Printable punctuation; reject bad
Printable / Numeric / IA5) and `parse_time_generalized_local` (accept
`Z` and offset, reject bare local).

## Verification
debug-test + release (werror) + ASAN build clean; full suite 1909 pass,
0 fail (incl. the crypto/cert fixtures); Doxygen 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)