### PR TITLE
crypto: PBES2 encrypted PKCS#8 key loading + PBKDF2 primitive

### DIFF
--- a/include/rlib/crypto/rkdf.h
+++ b/include/rlib/crypto/rkdf.h
@@ -1,0 +1,71 @@
+/* RLIB - Convenience library for useful things
+ * Copyright (C) 2026 Haakon Sporsheim <haakon.sporsheim@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ * See the COPYING file at the root of the source repository.
+ */
+#ifndef __R_KDF_H__
+#define __R_KDF_H__
+
+#if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
+#error "#include <rlib.h> only please."
+#endif
+
+#include <rlib/rtypes.h>
+#include <rlib/crypto/rmsgdigest.h>
+
+/**
+ * @defgroup r_crypto_kdf Key derivation functions
+ * @ingroup r_crypto
+ * @brief Password-based key derivation.
+ * @{
+ */
+
+/**
+ * @file rlib/crypto/rkdf.h
+ * @brief Key derivation functions.
+ */
+
+R_BEGIN_DECLS
+
+/**
+ * @brief PBKDF2 (RFC 8018 / PKCS#5 v2.1, section 5.2).
+ *
+ * Derive @p outlen key bytes from @p password and @p salt by iterating
+ * an HMAC built on @p prf @p iterations times per output block.
+ *
+ * @param prf         Digest backing the HMAC PRF (e.g.
+ *                    @c R_MSG_DIGEST_TYPE_SHA256). Extendable-output
+ *                    functions are not valid PRFs.
+ * @param password    Password bytes; may be empty but not @c NULL.
+ * @param passlen     Length of @p password in bytes.
+ * @param salt        Salt bytes.
+ * @param saltlen     Length of @p salt in bytes.
+ * @param iterations  Iteration count; must be at least 1.
+ * @param out         Destination buffer for @p outlen derived bytes.
+ * @param outlen      Number of key bytes to derive; must be > 0.
+ * @return @c TRUE on success; @c FALSE on invalid arguments (a @c NULL
+ *         pointer, zero @p iterations or @p outlen, or a @p prf with no
+ *         fixed output size).
+ */
+R_API rboolean r_kdf_pbkdf2 (RMsgDigestType prf,
+    const ruint8 * password, rsize passlen,
+    const ruint8 * salt, rsize saltlen,
+    ruint iterations, ruint8 * out, rsize outlen);
+
+R_END_DECLS
+
+/** @} */
+
+#endif /* __R_KDF_H__ */

--- a/include/rlib/crypto/rkdf.h
+++ b/include/rlib/crypto/rkdf.h
@@ -50,7 +50,7 @@ R_BEGIN_DECLS
  *                    functions are not valid PRFs.
  * @param password    Password bytes; may be empty but not @c NULL.
  * @param passlen     Length of @p password in bytes.
- * @param salt        Salt bytes.
+ * @param salt        Salt bytes; may be empty but not @c NULL.
  * @param saltlen     Length of @p salt in bytes.
  * @param iterations  Iteration count; must be at least 1.
  * @param out         Destination buffer for @p outlen derived bytes.

--- a/include/rlib/format/roid.h
+++ b/include/rlib/format/roid.h
@@ -210,6 +210,13 @@ R_API rboolean r_asn1_oid_has_dot_prefix (const ruint32 * oid, rsize oidlen,
 #define R_RSA_OID_PBES2                         R_RSA_OID_PKCS_5"\x0d"
 #define R_RSA_OID_PBMAC1                        R_RSA_OID_PKCS_5"\x0e"
 
+/* PBKDF2 PRFs: rsadsi digestAlgorithm (1.2.840.113549.2.x). */
+#define R_RSA_OID_HMAC_WITH_SHA1                R_RSA_OID_RSADSI"\x02\x07"
+#define R_RSA_OID_HMAC_WITH_SHA224              R_RSA_OID_RSADSI"\x02\x08"
+#define R_RSA_OID_HMAC_WITH_SHA256              R_RSA_OID_RSADSI"\x02\x09"
+#define R_RSA_OID_HMAC_WITH_SHA384              R_RSA_OID_RSADSI"\x02\x0a"
+#define R_RSA_OID_HMAC_WITH_SHA512              R_RSA_OID_RSADSI"\x02\x0b"
+
 #define R_OIW_OID                               R_ASN1_OID_ISO_ID_ORG"\x0e"
 #define R_OIW_SECSIG_OID                        R_OIW_OID"\x03"
 #define R_OIW_SECSIG_OID_MD4_RSA                R_OIW_SECSIG_OID"\x02\x02"
@@ -226,6 +233,10 @@ R_API rboolean r_asn1_oid_has_dot_prefix (const ruint32 * oid, rsize oidlen,
 #define R_OID_DIGEST_ALG_SHA384                 R_US_GOV_OID"\x03\x04\x02\x02"
 #define R_OID_DIGEST_ALG_SHA512                 R_US_GOV_OID"\x03\x04\x02\x03"
 #define R_OID_DIGEST_ALG_SHA224                 R_US_GOV_OID"\x03\x04\x02\x04"
+/* NIST AES-CBC (2.16.840.1.101.3.4.1.{2,22,42}). */
+#define R_OID_AES_128_CBC                       R_US_GOV_OID"\x03\x04\x01\x02"
+#define R_OID_AES_192_CBC                       R_US_GOV_OID"\x03\x04\x01\x16"
+#define R_OID_AES_256_CBC                       R_US_GOV_OID"\x03\x04\x01\x2a"
 
 #define R_X9CM_OID                              R_ASN1_OID_ISO_US"\xce\x38"
 #define R_ANSI_X9_62_OID                        R_ASN1_OID_ISO_US"\xce\x3d"

--- a/include/rlib/rcrypto.h
+++ b/include/rlib/rcrypto.h
@@ -107,6 +107,7 @@
 #include <rlib/crypto/red448.h>
 #include <rlib/crypto/recurve-montgomery.h>
 #include <rlib/crypto/rhmac.h>
+#include <rlib/crypto/rkdf.h>
 #include <rlib/crypto/rkey.h>
 #include <rlib/crypto/rmsgdigest.h>
 #include <rlib/crypto/rpem.h>

--- a/include/rlib/rcrypto.h
+++ b/include/rlib/rcrypto.h
@@ -29,6 +29,7 @@
  *
  *   - @ref r_crypto_symmetric — block / stream cipher base, AES and ChaCha20.
  *   - @ref r_crypto_hash — message digests and HMAC.
+ *   - @ref r_crypto_kdf — password-based key derivation (PBKDF2).
  *   - @ref r_crypto_key — polymorphic asymmetric-key handle plus the
  *     concrete key kinds (RSA, DSA, DH) that plug into it.
  *   - @ref r_crypto_ec — elliptic-curve arithmetic and the EdDSA /

--- a/rlib/crypto/rkdf.c
+++ b/rlib/crypto/rkdf.c
@@ -1,0 +1,91 @@
+/* RLIB - Convenience library for useful things
+ * Copyright (C) 2026 Haakon Sporsheim <haakon.sporsheim@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ * See the COPYING file at the root of the source repository.
+ */
+
+#include "config.h"
+#include <rlib/crypto/rkdf.h>
+
+#include <rlib/crypto/rhmac.h>
+#include <rlib/rmem.h>
+
+#define R_KDF_MAX_HASH    64    /* SHA-512 output, the largest PRF here */
+
+rboolean
+r_kdf_pbkdf2 (RMsgDigestType prf, const ruint8 * password, rsize passlen,
+    const ruint8 * salt, rsize saltlen, ruint iterations,
+    ruint8 * out, rsize outlen)
+{
+  RHmac * hmac;
+  rsize hlen, done = 0;
+  ruint block = 1;
+
+  hlen = r_msg_digest_type_size (prf);
+  if (R_UNLIKELY (password == NULL || out == NULL || outlen == 0 ||
+        iterations == 0 || hlen == 0 || hlen > R_KDF_MAX_HASH))
+    return FALSE;
+
+  if ((hmac = r_hmac_new (prf, password, passlen)) == NULL)
+    return FALSE;
+
+  while (done < outlen) {
+    /* T_block = U_1 ^ U_2 ^ ... ^ U_iterations, with
+     * U_1 = PRF(P, salt || INT32BE(block)) and U_j = PRF(P, U_{j-1}). */
+    ruint8 u[R_KDF_MAX_HASH], t[R_KDF_MAX_HASH];
+    ruint8 be[4];
+    rsize i, n;
+    ruint j;
+
+    be[0] = (ruint8) (block >> 24);
+    be[1] = (ruint8) (block >> 16);
+    be[2] = (ruint8) (block >> 8);
+    be[3] = (ruint8) block;
+
+    r_hmac_reset (hmac);
+    if (!r_hmac_update (hmac, salt, saltlen) ||
+        !r_hmac_update (hmac, be, sizeof (be)) ||
+        !r_hmac_get_data (hmac, u, sizeof (u), NULL))
+      goto fail;
+    r_memcpy (t, u, hlen);
+
+    for (j = 1; j < iterations; j++) {
+      r_hmac_reset (hmac);
+      if (!r_hmac_update (hmac, u, hlen) ||
+          !r_hmac_get_data (hmac, u, sizeof (u), NULL))
+        goto fail;
+      for (i = 0; i < hlen; i++)
+        t[i] ^= u[i];
+    }
+
+    n = (outlen - done < hlen) ? outlen - done : hlen;
+    r_memcpy (out + done, t, n);
+    done += n;
+    block++;
+
+    r_memclear_secure (u, sizeof (u));
+    r_memclear_secure (t, sizeof (t));
+    continue;
+
+fail:
+    r_memclear_secure (u, sizeof (u));
+    r_memclear_secure (t, sizeof (t));
+    r_hmac_free (hmac);
+    return FALSE;
+  }
+
+  r_hmac_free (hmac);
+  return TRUE;
+}

--- a/rlib/crypto/rkdf.c
+++ b/rlib/crypto/rkdf.c
@@ -34,8 +34,8 @@ r_kdf_pbkdf2 (RMsgDigestType prf, const ruint8 * password, rsize passlen,
   ruint block = 1;
 
   hlen = r_msg_digest_type_size (prf);
-  if (R_UNLIKELY (password == NULL || out == NULL || outlen == 0 ||
-        iterations == 0 || hlen == 0 || hlen > R_KDF_MAX_HASH))
+  if (R_UNLIKELY (password == NULL || salt == NULL || out == NULL ||
+        outlen == 0 || iterations == 0 || hlen == 0 || hlen > R_KDF_MAX_HASH))
     return FALSE;
 
   if ((hmac = r_hmac_new (prf, password, passlen)) == NULL)

--- a/rlib/crypto/rpem.c
+++ b/rlib/crypto/rpem.c
@@ -21,6 +21,7 @@
 
 #include <rlib/crypto/raes.h>
 #include <rlib/crypto/rcipher.h>
+#include <rlib/crypto/rkdf.h>
 #include <rlib/crypto/rdh.h>
 #include <rlib/crypto/rdsa.h>
 #include <rlib/crypto/rrsa.h>
@@ -603,6 +604,180 @@ r_pem_decrypt_legacy (RPemBlock * block, const ruint8 * passphrase, rsize ppsize
   return cipherbuf;
 }
 
+/* Map a PBKDF2 PRF AlgorithmIdentifier OID (tlv at the OID) to a digest. */
+static rboolean
+r_pem_pbes2_prf_md (const RAsn1BinTLV * tlv, RMsgDigestType * md)
+{
+  if (r_asn1_oid_bin_equals (tlv->value, tlv->len, R_RSA_OID_HMAC_WITH_SHA1))
+    *md = R_MSG_DIGEST_TYPE_SHA1;
+  else if (r_asn1_oid_bin_equals (tlv->value, tlv->len, R_RSA_OID_HMAC_WITH_SHA224))
+    *md = R_MSG_DIGEST_TYPE_SHA224;
+  else if (r_asn1_oid_bin_equals (tlv->value, tlv->len, R_RSA_OID_HMAC_WITH_SHA256))
+    *md = R_MSG_DIGEST_TYPE_SHA256;
+  else if (r_asn1_oid_bin_equals (tlv->value, tlv->len, R_RSA_OID_HMAC_WITH_SHA384))
+    *md = R_MSG_DIGEST_TYPE_SHA384;
+  else if (r_asn1_oid_bin_equals (tlv->value, tlv->len, R_RSA_OID_HMAC_WITH_SHA512))
+    *md = R_MSG_DIGEST_TYPE_SHA512;
+  else
+    return FALSE;
+  return TRUE;
+}
+
+/* Decrypt a PKCS#8 EncryptedPrivateKeyInfo (RFC 5958) protected with
+ * PBES2 (RFC 8018 §6.2): PBKDF2 key derivation over an HMAC PRF feeding
+ * AES-CBC. @a dec must be positioned at the outer SEQUENCE (@a tlv). On
+ * success returns a newly allocated buffer holding the recovered
+ * PrivateKeyInfo DER; the caller must wipe and free it. Legacy PBES1 and
+ * non-AES schemes are intentionally unsupported and return NULL. */
+static ruint8 *
+r_pem_decrypt_pkcs8 (RAsn1BinDecoder * dec, RAsn1BinTLV * tlv,
+    const rchar * passphrase, rsize ppsize, rsize * out_size)
+{
+  RMsgDigestType prf = R_MSG_DIGEST_TYPE_SHA1;  /* PBKDF2 default PRF */
+  const ruint8 * salt = NULL;
+  const ruint8 * iv = NULL;
+  const ruint8 * ciphertext = NULL;
+  rsize saltlen = 0, ctlen = 0;
+  ruint32 iterations = 0;
+  ruint keybits = 0;
+  ruint8 key[32];
+  ruint8 ivbuf[16];
+  RCryptoCipher * cipher;
+  ruint8 * plain;
+  ruint8 pad;
+  rsize i;
+
+  if (passphrase == NULL)
+    return NULL;
+
+  /* encryptionAlgorithm AlgorithmIdentifier, then its algorithm OID. */
+  if (r_asn1_bin_decoder_into (dec, tlv) != R_ASN1_DECODER_OK)
+    return NULL;
+  if (r_asn1_bin_decoder_into (dec, tlv) != R_ASN1_DECODER_OK)
+    return NULL;
+  if (!R_ASN1_BIN_TLV_ID_IS_TAG (tlv, R_ASN1_ID_OBJECT_IDENTIFIER) ||
+      !r_asn1_oid_bin_equals (tlv->value, tlv->len, R_RSA_OID_PBES2))
+    return NULL;
+
+  /* parameters: PBES2-params { keyDerivationFunc, encryptionScheme }.
+   * Descend into keyDerivationFunc and check it is PBKDF2. */
+  if (r_asn1_bin_decoder_next (dec, tlv) != R_ASN1_DECODER_OK)
+    return NULL;
+  if (r_asn1_bin_decoder_into (dec, tlv) != R_ASN1_DECODER_OK)
+    return NULL;
+  if (r_asn1_bin_decoder_into (dec, tlv) != R_ASN1_DECODER_OK)
+    return NULL;
+  if (!R_ASN1_BIN_TLV_ID_IS_TAG (tlv, R_ASN1_ID_OBJECT_IDENTIFIER) ||
+      !r_asn1_oid_bin_equals (tlv->value, tlv->len, R_RSA_OID_PBKDF2))
+    return NULL;
+
+  /* PBKDF2-params { salt, iterationCount, keyLength OPT, prf OPT }. */
+  if (r_asn1_bin_decoder_next (dec, tlv) != R_ASN1_DECODER_OK)
+    return NULL;
+  if (r_asn1_bin_decoder_into (dec, tlv) != R_ASN1_DECODER_OK)
+    return NULL;
+  if (!R_ASN1_BIN_TLV_ID_IS_TAG (tlv, R_ASN1_ID_OCTET_STRING))
+    return NULL;  /* salt CHOICE 'otherSource' is unsupported */
+  salt = tlv->value;
+  saltlen = tlv->len;
+  if (r_asn1_bin_decoder_next (dec, tlv) != R_ASN1_DECODER_OK ||
+      r_asn1_bin_tlv_parse_integer_u32 (tlv, &iterations) != R_ASN1_DECODER_OK ||
+      iterations == 0)
+    return NULL;
+  for (;;) {
+    RAsn1DecoderStatus st = r_asn1_bin_decoder_next (dec, tlv);
+    if (st != R_ASN1_DECODER_OK)
+      break;
+    if (R_ASN1_BIN_TLV_ID_IS_TAG (tlv, R_ASN1_ID_INTEGER)) {
+      continue;  /* keyLength: key size is taken from the AES scheme below */
+    } else if (R_ASN1_BIN_TLV_ID_IS_TAG (tlv, R_ASN1_ID_SEQUENCE)) {
+      if (r_asn1_bin_decoder_into (dec, tlv) != R_ASN1_DECODER_OK)
+        return NULL;
+      if (!R_ASN1_BIN_TLV_ID_IS_TAG (tlv, R_ASN1_ID_OBJECT_IDENTIFIER) ||
+          !r_pem_pbes2_prf_md (tlv, &prf))
+        return NULL;
+      r_asn1_bin_decoder_out (dec, tlv);
+      break;  /* prf is the last PBKDF2-params field */
+    } else {
+      break;
+    }
+  }
+
+  /* Ascend out of PBKDF2-params and keyDerivationFunc; the second out
+   * lands on encryptionScheme (the sibling of keyDerivationFunc). */
+  r_asn1_bin_decoder_out (dec, tlv);
+  if (r_asn1_bin_decoder_out (dec, tlv) != R_ASN1_DECODER_OK)
+    return NULL;
+  if (r_asn1_bin_decoder_into (dec, tlv) != R_ASN1_DECODER_OK)
+    return NULL;
+  if (!R_ASN1_BIN_TLV_ID_IS_TAG (tlv, R_ASN1_ID_OBJECT_IDENTIFIER))
+    return NULL;
+  if (r_asn1_oid_bin_equals (tlv->value, tlv->len, R_OID_AES_128_CBC))
+    keybits = 128;
+  else if (r_asn1_oid_bin_equals (tlv->value, tlv->len, R_OID_AES_192_CBC))
+    keybits = 192;
+  else if (r_asn1_oid_bin_equals (tlv->value, tlv->len, R_OID_AES_256_CBC))
+    keybits = 256;
+  else
+    return NULL;
+  if (r_asn1_bin_decoder_next (dec, tlv) != R_ASN1_DECODER_OK ||
+      !R_ASN1_BIN_TLV_ID_IS_TAG (tlv, R_ASN1_ID_OCTET_STRING) ||
+      tlv->len != sizeof (ivbuf))
+    return NULL;
+  iv = tlv->value;
+
+  /* Ascend back to the outer SEQUENCE; the third out lands on
+   * encryptedData (the sibling of encryptionAlgorithm). */
+  r_asn1_bin_decoder_out (dec, tlv);
+  r_asn1_bin_decoder_out (dec, tlv);
+  if (r_asn1_bin_decoder_out (dec, tlv) != R_ASN1_DECODER_OK)
+    return NULL;
+  if (!R_ASN1_BIN_TLV_ID_IS_TAG (tlv, R_ASN1_ID_OCTET_STRING))
+    return NULL;
+  ciphertext = tlv->value;
+  ctlen = tlv->len;
+  if (ctlen == 0 || (ctlen & 0xf) != 0)
+    return NULL;  /* AES-CBC ciphertext must be a whole number of blocks */
+
+  if (!r_kdf_pbkdf2 (prf, (const ruint8 *) passphrase, ppsize,
+        salt, saltlen, iterations, key, keybits / 8))
+    return NULL;
+  cipher = r_cipher_aes_new (R_CRYPTO_CIPHER_MODE_CBC, keybits, key);
+  r_memclear_secure (key, sizeof (key));
+  if (cipher == NULL)
+    return NULL;
+
+  if ((plain = r_malloc (ctlen)) == NULL) {
+    r_crypto_cipher_unref (cipher);
+    return NULL;
+  }
+  r_memcpy (ivbuf, iv, sizeof (ivbuf));
+  if (r_crypto_cipher_decrypt (cipher, plain, ctlen, ciphertext,
+        ivbuf, sizeof (ivbuf)) != R_CRYPTO_CIPHER_OK) {
+    r_crypto_cipher_unref (cipher);
+    goto fail;
+  }
+  r_crypto_cipher_unref (cipher);
+
+  /* PKCS#7 padding: a wrong passphrase yields garbage plaintext, which
+   * this check (and the subsequent ASN.1 parse) almost always rejects. */
+  pad = plain[ctlen - 1];
+  if (pad == 0 || pad > sizeof (ivbuf) || pad > ctlen)
+    goto fail;
+  for (i = ctlen - pad; i < ctlen; i++) {
+    if (plain[i] != pad)
+      goto fail;
+  }
+
+  *out_size = ctlen - pad;
+  return plain;
+
+fail:
+  r_memclear_secure (plain, ctlen);
+  r_free (plain);
+  return NULL;
+}
+
 RCryptoKey *
 r_pem_block_get_key (RPemBlock * block, const rchar * passphrase, rsize ppsize)
 {
@@ -669,7 +844,27 @@ r_pem_block_get_key (RPemBlock * block, const rchar * passphrase, rsize ppsize)
     case R_PEM_TYPE_PRIVATE_KEY:
       ret = r_crypto_key_from_asn1_private_key (dec, &tlv);
       break;
-    /* TODO: PKCS#8 EncryptedPrivateKeyInfo */
+    case R_PEM_TYPE_ENCRYPTED_PRIVATE_KEY: {
+      ruint8 * plain;
+      rsize plain_size = 0;
+
+      if ((plain = r_pem_decrypt_pkcs8 (dec, &tlv, passphrase, ppsize,
+              &plain_size)) != NULL) {
+        RAsn1BinDecoder * pdec;
+        RAsn1BinTLV ptlv = R_ASN1_BIN_TLV_INIT;
+
+        /* The recovered DER is a PrivateKeyInfo; parse it with a borrowed
+         * decoder over our plaintext buffer, then wipe the plaintext. */
+        if ((pdec = r_asn1_bin_decoder_new (R_ASN1_BER, plain, plain_size)) != NULL) {
+          if (r_asn1_bin_decoder_next (pdec, &ptlv) == R_ASN1_DECODER_OK)
+            ret = r_crypto_key_from_asn1_private_key (pdec, &ptlv);
+          r_asn1_bin_decoder_unref (pdec);
+        }
+        r_memclear_secure (plain, plain_size);
+        r_free (plain);
+      }
+      break;
+    }
     default:
       break;
   }

--- a/rlib/meson.build
+++ b/rlib/meson.build
@@ -66,6 +66,7 @@ rlib_sources = [
   'crypto/red448.c',
   'crypto/recurve-montgomery.c',
   'crypto/rhmac.c',
+  'crypto/rkdf.c',
   'crypto/rkey.c',
   'crypto/rpem.c',
   'crypto/rrsa.c',

--- a/test/meson.build
+++ b/test/meson.build
@@ -53,6 +53,7 @@ rlibtest_sources = [
   'rhzrptr.c',
   'rjson.c',
   'rjson_parser.c',
+  'rkdf.c',
   'rkvptrarray.c',
   'rlist.c',
   'rlog.c',

--- a/test/rcryptopem.c
+++ b/test/rcryptopem.c
@@ -736,6 +736,182 @@ RTEST (rcryptopem, legacy_encrypted_rsa_aes256, RTEST_FAST)
 }
 RTEST_END;
 
+/* The same RSA key as pem_legacy_unenc, re-wrapped as PKCS#8
+ * EncryptedPrivateKeyInfo with PBES2 (PBKDF2 + AES-CBC), generated with:
+ *   openssl pkcs8 -topk8 -v2 <cipher> -v2prf <prf> -passout pass:test123
+ * The three fixtures exercise AES-128/192/256 and the SHA1/256/512 PRFs. */
+static const rchar pem_pkcs8_aes256_sha256[] =
+  "-----BEGIN ENCRYPTED PRIVATE KEY-----\n"
+  "MIIC5TBfBgkqhkiG9w0BBQ0wUjAxBgkqhkiG9w0BBQwwJAQQz2Q59bpbOyvHjcFU\n"
+  "G0uP0gICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEEPMhOdTSTYGk355Z\n"
+  "ApZAcLEEggKAsCkU8aBDR7j++/m1GCiJdQNORzfzNpU7SFR9vFEojfeMCkTejnN/\n"
+  "XjcXYrFedQJGWnmbrKwofHgl9fpoEJzeCONm6crXywnFd3P5REIIctbjdwmYgNtx\n"
+  "SgiHyeWoCVV0JlFf5u24OOqGpltYg6idV3y9c2PuFg2G2Nhu6H42L1oxVVp66qV4\n"
+  "8LFlK1ttPhdtymE7+4r9qld1W12ZZklBc4sQYJciBJrT8p8WLP71cfh8x4XqmiNy\n"
+  "I/EPrOyn5BOGLNplsOAJ3+/MwYLYogXwZ8iyO1DrlzyM5iNyQsP+cdDKQlTsqy2H\n"
+  "h27l0NybgW8TC1KbTBuHkEKC7MPwYA6EWwxUF9geOQbVp0QGyRmb3voPFkirrY3D\n"
+  "sXlOwlRz7lkmUkObRSGJhAoNF0W0a9fsQaw+xsStqBPcHyy2KJoiAusZa8hr8QH/\n"
+  "sRKmdGSfN/cL5GajfZNPUKqMb7Om4hWvSg1Zo3TTqf+v8B3d6kxZErmPPhzW+Jjx\n"
+  "clJjpCzU1QGCAuTIzqO65EwP2Ngr5wIvsrNuD2aaJMgWK2EKjh19HObjj7pFZksZ\n"
+  "vz0IQMbRp7teuQl5j86Bxf6FcFgY9VtPKSZqfIIUVCsTN41vpIVdn2HDx82Vgayi\n"
+  "LvLgNPlU+teKrCt1MqadXrAFPh2iSKs5dIkjM6KmDqOh8YKQY6/+9MfKS5pBxKRe\n"
+  "NmwNaaicEToOAT+BGntlXxuvyjmPA6nqx5aKKhlqVT9COL4EHomzx0od/DGyGC/h\n"
+  "CcvBRtoe5nKXoSTMhwSKsISUyhGyFuFYgFaa48shnpvacQ/KvmQU8+37LcTFhMvN\n"
+  "DvSM2QybDXybh2g/h4VEnxSM23UGju6NgQ==\n"
+  "-----END ENCRYPTED PRIVATE KEY-----\n";
+
+static const rchar pem_pkcs8_aes128_sha1[] =
+  "-----BEGIN ENCRYPTED PRIVATE KEY-----\n"
+  "MIIC1zBRBgkqhkiG9w0BBQ0wRDAjBgkqhkiG9w0BBQwwFgQQXnPAyk3QKZyXru4G\n"
+  "kcSzBQICCAAwHQYJYIZIAWUDBAECBBAdK/50ZfvVm0xjR3xIg9ugBIICgCZl9NYU\n"
+  "cOlphrsbjzSSEVKo4I5LUO0ty9umQNYrdsY9EoxmFTtP6LA7PUmY6dkRkFFGa7/B\n"
+  "J1tW4G2CKndAEKyQu0hfFIBd+GSMdgssl8cluQHjZuKQc9ygycSK6KzHJKM527vu\n"
+  "RaVxr30pdYVaic+U91NgI16kKiGu2AhWvIutWiVYrUWPxmLWqiUlA1OFPWwTFgXf\n"
+  "HpnlpyufqVaFid7Y5FeBeswZq9nxYBrbcaKn4hTAUfXT6ua59kNm3UHVzSQrOnR+\n"
+  "ynpTQOoxRtCKZ2hHKnyPx9zUE1GCYfBRPzHIVnE91UM+TmHP4YHxqfSjNTJRUeI5\n"
+  "flwXfho8K9ko8l7ELOfuFpATOrrWwPcq9NzZeZYitk1pQiMQAGOENdIyYoPmIQaX\n"
+  "dCI5eZD9C3X45JFsHIsPjYs0jAx6iRMBUgt8q64ovlryc8AtAbbWpILWmuj2f1Dp\n"
+  "zMw02t19xn2C6WGdlOTXQD9k1gEfmrFsHH707fbu57LLMJlilycZeAP0Fzltz9yh\n"
+  "Am3l35CnuT5zlSVWrpKwe71eeTY3qxjmUz8puEainADG95J6Eao03V4LIxVxmvFL\n"
+  "BLQ9VcxYnBpGzl72cVYGJNBkAMjQcbq8/dYtTFhiR0ShRJy9zPotluDJ/VHCF80M\n"
+  "owP3856TfM1sNUQ/tlMAE+EAlA9hJIGhIcLSf7C4HvYO8vPVF/y15wthFyeyqnkd\n"
+  "TrA2yH+gYaHbzzET76ztaoJnhuOwPQDoaUt1ZpQj6lhw1BbJvb0hvRVI/04ey3na\n"
+  "pFogUIGlzotUvMiVT+BjTH6hf106qEAYkP8g0WdIt9q2pVQU+DOXYwcT+gSCYKny\n"
+  "yUBmcsv1nv/smHU=\n"
+  "-----END ENCRYPTED PRIVATE KEY-----\n";
+
+static const rchar pem_pkcs8_aes192_sha512[] =
+  "-----BEGIN ENCRYPTED PRIVATE KEY-----\n"
+  "MIIC5TBfBgkqhkiG9w0BBQ0wUjAxBgkqhkiG9w0BBQwwJAQQ1iexcuZI77yRGtme\n"
+  "ObeJVgICCAAwDAYIKoZIhvcNAgsFADAdBglghkgBZQMEARYEEC5pcG2S8Z33xDqZ\n"
+  "0ZbuCWEEggKAX+L1ipgZtQfTCSuV+TdpeWM+b8x5LHmd/NKpvDe2o+CD6eW8foWZ\n"
+  "KMHM76HT0Xin/rHEVVCCUTcWiBNNWBS+gOh8zL2/WDI9xg5loqexRviuAYQpr7FP\n"
+  "GtN9OAKnnwHMK40U5g9pcCD/6nG/Z3/WSeyTOlEqM2cFZL+XEO0FLneAwuF8C/of\n"
+  "P5XjjuxKpFsAgsUIB3hvYgk72wgfs7BIy2+Y9YRu8YK8JFUBCtk067mQEmJoYfe5\n"
+  "0/MfSgCzoGT+V3MLNCDclWzmcEUNOASrJqvNrhwRfvJ1lTxgs2hp82+lxX7PdGWb\n"
+  "SAk3pDrztn2ziIita772Z0auoCCT2dcGOqJ4grpHE3Vr0VOvkfIGs96j765r3sA0\n"
+  "V5eCSE2ODmFlYM9JIIu4UP+4nycl3bdUG6Ha2Q89QiJ0QkIuOlEC9pCGC/XHuxXm\n"
+  "tD0dAZcXOUAyzJ+EkmSQ5jAaAiOl2+flprmhx9tug+XlEthVnHUFkBL1OYGuQdWI\n"
+  "t4Ar3T4fLDtlbL+h12NmVaBFD8o3YbeX77kDZYMMmOBYg6UXSfHojewBRgtfen+L\n"
+  "iO9C7acYhAPkpZOadl07W+g3loNmek5MQbnOz++DCFUbex+0Y1vYloGbQE4joNQr\n"
+  "ijSuLJmtlvhmIt/mCbtcyP6fT/gIfq0n0QLMJvJPUKEj2+hpry/jytxr1ahrV/cg\n"
+  "ZrOZmkT4IfmLfsBjpneKmFfbWTMYVuJkACpw0I/vSUgALxXl/DjXKpkBjYZwOO8e\n"
+  "e5Jjm5fVT0YRttx2tdfeU156yR6FLn++8hg8+m/lg7tVELJnJQgeDC6pzUA4n0Gm\n"
+  "Cf/XksbXfELWPpuNBbiseaJKd3jss3Cxnw==\n"
+  "-----END ENCRYPTED PRIVATE KEY-----\n";
+
+static void
+verify_pkcs8_pbes2_pem (const rchar * pem, rsize size, const rchar * pass)
+{
+  RPemParser * parser;
+  RPemBlock * block;
+  RCryptoKey * key, * expected;
+  rmpint n, e;
+
+  /* Decode the unencrypted reference key. */
+  r_assert_cmpptr (
+      (parser = r_pem_parser_new (pem_legacy_unenc, sizeof (pem_legacy_unenc))),
+      !=, NULL);
+  r_assert_cmpptr ((block = r_pem_parser_next_block (parser)), !=, NULL);
+  r_assert_cmpptr ((expected = r_pem_block_get_key (block, NULL, 0)), !=, NULL);
+  r_pem_block_unref (block);
+  r_pem_parser_unref (parser);
+
+  r_assert_cmpptr ((parser = r_pem_parser_new (pem, size)), !=, NULL);
+  r_assert_cmpptr ((block = r_pem_parser_next_block (parser)), !=, NULL);
+  r_assert_cmpint (r_pem_block_get_type (block), ==,
+      R_PEM_TYPE_ENCRYPTED_PRIVATE_KEY);
+  /* A missing or wrong passphrase must fail without producing a key. */
+  r_assert_cmpptr (r_pem_block_get_key (block, NULL, 0), ==, NULL);
+  r_assert_cmpptr (r_pem_block_get_key (block, "wrongpass", 9), ==, NULL);
+
+  r_assert_cmpptr ((key = r_pem_block_get_key (block, pass, r_strlen (pass))),
+      !=, NULL);
+
+  /* Compare modulus + exponent of decrypted key vs reference key. */
+  r_mpint_init (&n);
+  r_mpint_init (&e);
+  r_assert (r_rsa_pub_key_get_n (key, &n));
+  r_assert (r_rsa_pub_key_get_e (key, &e));
+  {
+    rmpint en, ee;
+    r_mpint_init (&en);
+    r_mpint_init (&ee);
+    r_assert (r_rsa_pub_key_get_n (expected, &en));
+    r_assert (r_rsa_pub_key_get_e (expected, &ee));
+    r_assert_cmpint (r_mpint_cmp (&n, &en), ==, 0);
+    r_assert_cmpint (r_mpint_cmp (&e, &ee), ==, 0);
+    r_mpint_clear (&en);
+    r_mpint_clear (&ee);
+  }
+  r_mpint_clear (&n);
+  r_mpint_clear (&e);
+
+  r_crypto_key_unref (key);
+  r_crypto_key_unref (expected);
+  r_pem_block_unref (block);
+  r_pem_parser_unref (parser);
+}
+
+RTEST (rcryptopem, pkcs8_pbes2_aes256_sha256, RTEST_FAST)
+{
+  verify_pkcs8_pbes2_pem (pem_pkcs8_aes256_sha256,
+      sizeof (pem_pkcs8_aes256_sha256), "test123");
+}
+RTEST_END;
+
+RTEST (rcryptopem, pkcs8_pbes2_aes128_sha1, RTEST_FAST)
+{
+  verify_pkcs8_pbes2_pem (pem_pkcs8_aes128_sha1,
+      sizeof (pem_pkcs8_aes128_sha1), "test123");
+}
+RTEST_END;
+
+RTEST (rcryptopem, pkcs8_pbes2_aes192_sha512, RTEST_FAST)
+{
+  verify_pkcs8_pbes2_pem (pem_pkcs8_aes192_sha512,
+      sizeof (pem_pkcs8_aes192_sha512), "test123");
+}
+RTEST_END;
+
+RTEST (rcryptopem, pkcs8_pbes2_plaintext_wiped, RTEST_FAST)
+{
+  /* The PBES2 path AES-decrypts into a buffer holding the recovered
+   * PrivateKeyInfo DER, which r_pem_block_get_key must wipe before
+   * freeing. Same modulus byte-run needle as the legacy wipe test. */
+  RPemParser * parser;
+  RPemBlock * block;
+  RCryptoKey * key;
+  rmpint n;
+  ruint8 modulus[128];
+
+  r_assert_cmpptr (
+      (parser = r_pem_parser_new (pem_legacy_unenc, sizeof (pem_legacy_unenc))),
+      !=, NULL);
+  r_assert_cmpptr ((block = r_pem_parser_next_block (parser)), !=, NULL);
+  r_assert_cmpptr ((key = r_pem_block_get_key (block, NULL, 0)), !=, NULL);
+  r_mpint_init (&n);
+  r_assert (r_rsa_pub_key_get_n (key, &n));
+  r_assert (r_mpint_to_binary_with_size (&n, modulus, sizeof (modulus)));
+  r_mpint_clear (&n);
+  r_crypto_key_unref (key);
+  r_pem_block_unref (block);
+  r_pem_parser_unref (parser);
+
+  r_wipe_witness_install ();
+  r_assert_cmpptr ((parser = r_pem_parser_new (pem_pkcs8_aes256_sha256,
+          sizeof (pem_pkcs8_aes256_sha256))), !=, NULL);
+  r_assert_cmpptr ((block = r_pem_parser_next_block (parser)), !=, NULL);
+  r_assert_cmpptr ((key = r_pem_block_get_key (block, "test123", 7)), !=, NULL);
+  r_crypto_key_unref (key);
+  r_pem_block_unref (block);
+  r_pem_parser_unref (parser);
+  r_wipe_witness_uninstall ();
+
+  r_assert (!r_wipe_witness_freed_contains (modulus + 16, 32));
+}
+RTEST_END;
+
 RTEST (rcryptopem, legacy_decrypted_plaintext_wiped, RTEST_FAST)
 {
   /* Decrypt a legacy-encrypted PEM and verify that the DER-encoded

--- a/test/rkdf.c
+++ b/test/rkdf.c
@@ -46,6 +46,8 @@ RTEST (rkdf, pbkdf2_invalid_args, R_TEST_TYPE_FAST)
   r_assert (!r_kdf_pbkdf2 (R_MSG_DIGEST_TYPE_SHA256,
         NULL, 0, (const ruint8 *) "s", 1, 1, dk, 16));            /* NULL password */
   r_assert (!r_kdf_pbkdf2 (R_MSG_DIGEST_TYPE_SHA256,
+        (const ruint8 *) "p", 1, NULL, 0, 1, dk, 16));            /* NULL salt */
+  r_assert (!r_kdf_pbkdf2 (R_MSG_DIGEST_TYPE_SHA256,
         (const ruint8 *) "p", 1, (const ruint8 *) "s", 1, 0, dk, 16)); /* 0 iterations */
   r_assert (!r_kdf_pbkdf2 (R_MSG_DIGEST_TYPE_SHA256,
         (const ruint8 *) "p", 1, (const ruint8 *) "s", 1, 1, NULL, 16)); /* NULL out */

--- a/test/rkdf.c
+++ b/test/rkdf.c
@@ -1,0 +1,57 @@
+#include <rlib/rcrypto.h>
+
+RTEST (rkdf, pbkdf2_sha1_rfc6070, R_TEST_TYPE_FAST)
+{
+  ruint8 dk[32];
+
+  /* RFC 6070 PBKDF2-HMAC-SHA1 test vectors. */
+  r_assert (r_kdf_pbkdf2 (R_MSG_DIGEST_TYPE_SHA1,
+        (const ruint8 *) "password", 8, (const ruint8 *) "salt", 4, 1, dk, 20));
+  r_assert_cmpmem (dk, ==,
+      "\x0c\x60\xc8\x0f\x96\x1f\x0e\x71\xf3\xa9\xb5\x24\xaf\x60\x12\x06"
+      "\x2f\xe0\x37\xa6", 20);
+
+  r_assert (r_kdf_pbkdf2 (R_MSG_DIGEST_TYPE_SHA1,
+        (const ruint8 *) "password", 8, (const ruint8 *) "salt", 4, 2, dk, 20));
+  r_assert_cmpmem (dk, ==,
+      "\xea\x6c\x01\x4d\xc7\x2d\x6f\x8c\xcd\x1e\xd9\x2a\xce\x1d\x41\xf0"
+      "\xd8\xde\x89\x57", 20);
+
+  r_assert (r_kdf_pbkdf2 (R_MSG_DIGEST_TYPE_SHA1,
+        (const ruint8 *) "password", 8, (const ruint8 *) "salt", 4, 4096, dk, 20));
+  r_assert_cmpmem (dk, ==,
+      "\x4b\x00\x79\x01\xb7\x65\x48\x9a\xbe\xad\x49\xd9\x26\xf7\x21\xd0"
+      "\x65\xa4\x29\xc1", 20);
+
+  /* dkLen 25 > SHA-1's 20: exercises multi-block output. */
+  r_assert (r_kdf_pbkdf2 (R_MSG_DIGEST_TYPE_SHA1,
+        (const ruint8 *) "passwordPASSWORDpassword", 24,
+        (const ruint8 *) "saltSALTsaltSALTsaltSALTsaltSALTsalt", 36, 4096, dk, 25));
+  r_assert_cmpmem (dk, ==,
+      "\x3d\x2e\xec\x4f\xe4\x1c\x84\x9b\x80\xc8\xd8\x36\x62\xc0\xe4\x4a"
+      "\x8b\x29\x1a\x96\x4c\xf2\xf0\x70\x38", 25);
+
+  /* Embedded NUL in both password and salt. */
+  r_assert (r_kdf_pbkdf2 (R_MSG_DIGEST_TYPE_SHA1,
+        (const ruint8 *) "pass\0word", 9, (const ruint8 *) "sa\0lt", 5, 4096, dk, 16));
+  r_assert_cmpmem (dk, ==,
+      "\x56\xfa\x6a\xa7\x55\x48\x09\x9d\xcc\x37\xd7\xf0\x34\x25\xe0\xc3", 16);
+}
+RTEST_END;
+
+RTEST (rkdf, pbkdf2_invalid_args, R_TEST_TYPE_FAST)
+{
+  ruint8 dk[16];
+
+  r_assert (!r_kdf_pbkdf2 (R_MSG_DIGEST_TYPE_SHA256,
+        NULL, 0, (const ruint8 *) "s", 1, 1, dk, 16));            /* NULL password */
+  r_assert (!r_kdf_pbkdf2 (R_MSG_DIGEST_TYPE_SHA256,
+        (const ruint8 *) "p", 1, (const ruint8 *) "s", 1, 0, dk, 16)); /* 0 iterations */
+  r_assert (!r_kdf_pbkdf2 (R_MSG_DIGEST_TYPE_SHA256,
+        (const ruint8 *) "p", 1, (const ruint8 *) "s", 1, 1, NULL, 16)); /* NULL out */
+  r_assert (!r_kdf_pbkdf2 (R_MSG_DIGEST_TYPE_SHA256,
+        (const ruint8 *) "p", 1, (const ruint8 *) "s", 1, 1, dk, 0));    /* 0 outlen */
+  r_assert (!r_kdf_pbkdf2 (R_MSG_DIGEST_TYPE_SHAKE256,
+        (const ruint8 *) "p", 1, (const ruint8 *) "s", 1, 1, dk, 16));   /* XOF prf */
+}
+RTEST_END;


### PR DESCRIPTION
Adds support for loading passphrase-protected PKCS#8 private keys (`ENCRYPTED PRIVATE KEY` PEM blocks) and the PBKDF2 primitive they build on.

## PBKDF2 (`r_kdf_pbkdf2`)
New public KDF primitive in `<rlib/crypto/rkdf.h>` implementing PBKDF2 (RFC 8018 / PKCS#5 v2.1 §5.2) over any of rlib's HMAC PRFs. A single `RHmac` is reused across the iteration loop. Validated against the RFC 6070 HMAC-SHA1 known-answer vectors (including multi-block output and embedded-NUL password/salt), plus invalid-argument rejection (NULL password/salt/out, zero iterations/outlen, XOF PRFs).

## PBES2 PKCS#8 (`r_pem_block_get_key`)
Decrypts `EncryptedPrivateKeyInfo` (RFC 5958) when protected with PBES2 (RFC 8018 §6.2): parses the PBKDF2 parameters and AES-CBC scheme, derives the key from the passphrase, AES-CBC decrypts, strips PKCS#7 padding, wipes the recovered plaintext after parsing, and feeds the inner `PrivateKeyInfo` through the existing unencrypted path.

- PRFs: HMAC-SHA{1,224,256,384,512} (default SHA-1 when omitted, per spec).
- Ciphers: AES-{128,192,256}-CBC.
- Legacy PBES1 and non-AES schemes are rejected.

Round-trip tested against three OpenSSL-generated fixtures (AES-256/SHA-256, AES-128/SHA-1, AES-192/SHA-512) of the same RSA key, comparing the decrypted modulus/exponent to the cleartext reference; wrong/missing passphrase is rejected, and a wipe-witness test confirms the decrypted DER does not survive in any freed allocation.

Builds clean under debug/release/gcc-warn/asan (`-werror`); full suite green under ASAN with no leaks; doxygen 0 warnings.

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)