### PR TITLE
sys: read per-node available memory on Linux

### DIFF
--- a/include/rlib/os/rsys.h
+++ b/include/rlib/os/rsys.h
@@ -143,7 +143,10 @@ R_API rsize r_sys_topology_node_cpu_count (const RSysNode * node);
 /** @brief Return the @p idx-th CPU of @p node as a new reference
  *  (caller @c r_sys_cpu_unref's), or @c NULL if out of range. */
 R_API RSysCpu * r_sys_topology_node_cpu (RSysNode * node, rsize idx);
-/** @brief Bytes of memory local to @p node. */
+/**
+ * @brief Bytes of available (free) memory local to @p node, or 0 when
+ * the platform does not expose it (e.g. non-NUMA macOS).
+ */
 R_API rsize r_sys_topology_node_available_memory (const RSysNode * node);
 
 /** @brief Take a reference on a topology (alias for @ref r_ref_ref). */

--- a/rlib/os/rsys.c
+++ b/rlib/os/rsys.c
@@ -605,6 +605,37 @@ r_sys_topology_prepend_cpu (rsize bit, rpointer data)
   node->cpus[node->cpucount++] = r_sys_cpu_discover (bit, node);
 }
 
+#if defined (R_OS_LINUX)
+/* Per-node available memory from /sys/devices/system/node/nodeN/meminfo,
+ * whose "Node N MemFree:" line is reported in kB (this is what libnuma's
+ * numa_node_size() ultimately reads). Returns 0 if unavailable. */
+static rsize
+r_sys_node_available_memory (rsize idx)
+{
+  rchar path[256];
+  RFile * f;
+  rsize ret = 0;
+
+  r_snprintf (path, sizeof (path), R_SYSFS_NODE_FMT "/meminfo", (ruint)idx);
+  if ((f = r_file_open (path, "r")) != NULL) {
+    rchar buf[256];
+    while (r_file_read_line (f, buf, sizeof (buf)) == R_FILE_ERROR_OK) {
+      rchar * p;
+      if ((p = r_strstr (buf, "MemFree:")) != NULL) {
+        RStrParse res;
+        ruint64 kb = r_str_to_uint64 (p + 8, NULL, 10, &res);
+        if (res == R_STR_PARSE_OK)
+          ret = (rsize) (kb * 1024);
+        break;
+      }
+    }
+    r_file_unref (f);
+  }
+
+  return ret;
+}
+#endif
+
 static RSysNode *
 r_sys_node_discover (rsize idx, RSysTopology * topo)
 {
@@ -627,9 +658,9 @@ r_sys_node_discover (rsize idx, RSysTopology * topo)
       ret->availablemem = (rsize)availmem;
     }
 #elif defined (R_OS_LINUX)
-    /* FIXME: Read out available memory */
+    ret->availablemem = r_sys_node_available_memory (idx);
 #elif defined (HAVE_SYSCTLBYNAME)
-    /* FIXME: Read out available memory */
+    /* macOS is not a NUMA platform; availablemem is left 0. */
 #endif
   }
 

--- a/test/rsys.c
+++ b/test/rsys.c
@@ -122,6 +122,12 @@ RTEST (rsys, topology, RTEST_FAST | RTEST_SYSTEM)
     r_assert (r_sys_topology_node_cpuset (node, cpuset));
     r_assert_cmpuint (cpucount, ==, r_bitset_popcount (cpuset));
 
+    r_assert_cmpuint (r_sys_topology_node_available_memory (NULL), ==, 0);
+#if defined (R_OS_LINUX)
+    /* Linux reports per-node MemFree via sysfs; an online node has some. */
+    r_assert_cmpuint (r_sys_topology_node_available_memory (node), >, 0);
+#endif
+
     r_assert_cmpptr (r_sys_topology_node_cpu (NULL, 0), ==, NULL);
     r_assert_cmpptr (r_sys_topology_node_cpu (node, cpucount), ==, NULL);
 


### PR DESCRIPTION
`r_sys_node_discover` only populated a node's `availablemem` on win32, so `r_sys_topology_node_available_memory` returned **0** on Linux (and macOS) even though its docs described it as the node's local memory.

- **Linux:** read it from `/sys/devices/system/node/nodeN/meminfo` — the `MemFree:` line (reported in kB, which is what libnuma's `numa_node_size()` ultimately uses), parsed and converted to bytes. Returns 0 gracefully if the file is missing or unparseable.
- **macOS:** not a NUMA platform, left at 0 — and the accessor's doc now says so instead of promising a value it doesn't return.

The topology test asserts the accessor rejects `NULL` and, on Linux, returns a non-zero value for an online node (verified live: node0 `MemFree` → non-zero).

Builds clean under debug / release / gcc-warn / asan (`-werror`); full suite green; `/rsys/*` ASAN-clean; doxygen 0 warnings.

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)