### PR TITLE
net: self-contained IPv4/IPv6 address parsing and formatting

### DIFF
--- a/include/rlib/net/rsocketaddress.h
+++ b/include/rlib/net/rsocketaddress.h
@@ -51,6 +51,29 @@ R_BEGIN_DECLS
  * etc.) only return meaningful data when @ref r_socket_address_get_family
  * matches; calling them on the wrong family is a programmer error.
  *
+ * @par Coming from libc inet_*
+ * rlib parses and formats IP addresses itself, with no dependency on
+ * @c inet_pton / @c inet_aton / @c inet_ntop. The equivalents wrap the
+ * result in an @ref RSocketAddress and fold in the port:
+ *   - @c inet_pton(AF_INET,...) / @c inet_aton -> @ref r_socket_address_ipv4_new_from_string
+ *   - @c inet_pton(AF_INET6,...) -> @ref r_socket_address_ipv6_new_from_string
+ *   - @c inet_ntop(AF_INET,...) -> @ref r_socket_address_ipv4_to_str / @ref r_socket_address_ipv4_build_str
+ *   - @c inet_ntop(AF_INET6,...) -> @ref r_socket_address_ipv6_to_str / @ref r_socket_address_ipv6_build_str
+ *
+ * The @c _new_from_string parsers return @c NULL on malformed input
+ * (the same reject set as @c inet_pton, e.g. leading-zero octets);
+ * recover the raw network-order bytes with @ref r_socket_address_ipv4_get_ip
+ * or @ref r_socket_address_ipv6_get_ip_bytes. The @c _to_str /
+ * @c _build_str formatters emit the RFC 5952 canonical text and, when
+ * asked, append @c :port (bracketing IPv6 as @c [addr]:port).
+ *
+ * @code
+ * RSocketAddress * a = r_socket_address_ipv6_new_from_string ("2001:db8::1", 443);
+ * rchar * s = r_socket_address_ipv6_to_str (a, TRUE);  // "[2001:db8::1]:443"
+ * r_free (s);
+ * r_socket_address_unref (a);
+ * @endcode
+ *
  * @{
  */
 

--- a/meson.build
+++ b/meson.build
@@ -336,8 +336,6 @@ check_funcs = [
   [ 'clock_gettime', 'time.h' ],
   [ 'setitimer', 'sys/time.h' ],
   # arpa/inet
-  [ 'inet_aton', 'arpa/inet.h' ],
-  [ 'inet_pton', 'arpa/inet.h' ],
   [ 'inet_ntop', 'arpa/inet.h' ],
   # other
   [ 'fcntl', 'fcntl.h' ],

--- a/meson.build
+++ b/meson.build
@@ -335,8 +335,6 @@ check_funcs = [
   [ 'timer_create', 'time.h' ],
   [ 'clock_gettime', 'time.h' ],
   [ 'setitimer', 'sys/time.h' ],
-  # arpa/inet
-  [ 'inet_ntop', 'arpa/inet.h' ],
   # other
   [ 'fcntl', 'fcntl.h' ],
   [ 'ioctl', 'sys/ioctl.h' ],

--- a/rlib/net/rnet-private.h
+++ b/rlib/net/rnet-private.h
@@ -38,7 +38,6 @@
 R_BEGIN_DECLS
 
 #ifdef R_OS_WIN32
-R_API_HIDDEN int (__stdcall * r_win32_inet_pton) (int, const rchar *, rpointer);
 R_API_HIDDEN const rchar * (__stdcall * r_win32_inet_ntop) (int, rpointer, rchar *, size_t);
 #endif
 

--- a/rlib/net/rnet-private.h
+++ b/rlib/net/rnet-private.h
@@ -37,10 +37,6 @@
 
 R_BEGIN_DECLS
 
-#ifdef R_OS_WIN32
-R_API_HIDDEN const rchar * (__stdcall * r_win32_inet_ntop) (int, rpointer, rchar *, size_t);
-#endif
-
 R_END_DECLS
 
 #endif /* __R_NET_PRIV_H__ */

--- a/rlib/net/rnet.c
+++ b/rlib/net/rnet.c
@@ -26,7 +26,6 @@
 #include <rlib/charset/runicode.h>
 #include <rlib/os/rmodule.h>
 
-static int __stdcall r_win32_sim_inet_pton (int family, const rchar * src, rpointer dst);
 static const rchar * __stdcall r_win32_sim_inet_ntop (int family, rconstpointer src,
     rchar * dst, size_t size);
 static RMODULE g_r_win32_ws2_32_dll = NULL;
@@ -43,10 +42,8 @@ r_networking_init (void)
 
 #ifdef R_OS_WIN32
   if ((g_r_win32_ws2_32_dll = r_module_open ("ws2_32.dll", TRUE, NULL)) != NULL) {
-    r_win32_inet_pton = r_module_lookup (g_r_win32_ws2_32_dll, "inet_pton");
     r_win32_inet_ntop = r_module_lookup (g_r_win32_ws2_32_dll, "inet_ntop");
   } else {
-    r_win32_inet_pton = r_win32_sim_inet_pton;
     r_win32_inet_ntop = r_win32_sim_inet_ntop;
   }
 #endif
@@ -69,40 +66,6 @@ r_networking_deinit (void)
  * helpers round-trip them losslessly. WCHAR is 16-bit on Windows
  * and identical in layout to runichar2 -- cast for the WSA W APIs. */
 #define R_NET_WIN32_ADDR_STR_MAX  64
-
-static int __stdcall
-r_win32_sim_inet_pton (int family, const rchar * src, rpointer dst)
-{
-  struct sockaddr_storage ss;
-  int len = sizeof (ss);
-  runichar2 wsrc[R_NET_WIN32_ADDR_STR_MAX];
-
-  if (family != R_AF_INET && family != R_AF_INET6) {
-    WSASetLastError (WSAEAFNOSUPPORT);
-    return -1;
-  }
-
-  if (r_utf8_to_utf16 (wsrc, R_N_ELEMENTS (wsrc), src, -1, NULL, NULL) != R_UNICODE_OK)
-    return 0;
-
-  if (r_strchr (src, (int)':') == NULL) {
-    struct sockaddr_in * sin = (struct sockaddr_in *)&ss;
-    if (WSAStringToAddressW ((WCHAR *)wsrc, R_AF_INET, NULL, (struct sockaddr *) &ss, &len) == 0) {
-      r_memcpy (dst, &sin->sin_addr, sizeof (sin->sin_addr));
-      return 1;
-    }
-  }
-
-  if (r_strchr (src, (int)']') == NULL) {
-    struct sockaddr_in6 * sin6 = (struct sockaddr_in6 *)&ss;
-    if (WSAStringToAddressW ((WCHAR *)wsrc, R_AF_INET6, NULL, (struct sockaddr *) &ss, &len) == 0) {
-      r_memcpy (dst, &sin6->sin6_addr, sizeof (sin6->sin6_addr));
-      return 1;
-    }
-  }
-
-  return 0;
-}
 
 static const rchar * __stdcall
 r_win32_sim_inet_ntop (int family, rconstpointer src, rchar * dst, size_t size)

--- a/rlib/net/rnet.c
+++ b/rlib/net/rnet.c
@@ -20,17 +20,6 @@
 #include "rsocket-private.h"
 #include "rnet-private.h"
 
-#include <rlib/rstr.h>
-
-#ifdef R_OS_WIN32
-#include <rlib/charset/runicode.h>
-#include <rlib/os/rmodule.h>
-
-static const rchar * __stdcall r_win32_sim_inet_ntop (int family, rconstpointer src,
-    rchar * dst, size_t size);
-static RMODULE g_r_win32_ws2_32_dll = NULL;
-#endif
-
 void
 r_networking_init (void)
 {
@@ -39,66 +28,13 @@ r_networking_init (void)
   WSADATA wsaData;
   WSAStartup (req, &wsaData);
 #endif
-
-#ifdef R_OS_WIN32
-  if ((g_r_win32_ws2_32_dll = r_module_open ("ws2_32.dll", TRUE, NULL)) != NULL) {
-    r_win32_inet_ntop = r_module_lookup (g_r_win32_ws2_32_dll, "inet_ntop");
-  } else {
-    r_win32_inet_ntop = r_win32_sim_inet_ntop;
-  }
-#endif
 }
 
 void
 r_networking_deinit (void)
 {
-#ifdef R_OS_WIN32
-  if (g_r_win32_ws2_32_dll != NULL)
-    r_module_close (g_r_win32_ws2_32_dll);
-#endif
 #ifdef HAVE_WINSOCK2
   WSACleanup ();
 #endif
 }
-
-#ifdef R_OS_WIN32
-/* IP address literals are pure ASCII so the UTF-8 <-> UTF-16
- * helpers round-trip them losslessly. WCHAR is 16-bit on Windows
- * and identical in layout to runichar2 -- cast for the WSA W APIs. */
-#define R_NET_WIN32_ADDR_STR_MAX  64
-
-static const rchar * __stdcall
-r_win32_sim_inet_ntop (int family, rconstpointer src, rchar * dst, size_t size)
-{
-  DWORD len, wdstsize = R_NET_WIN32_ADDR_STR_MAX;
-  struct sockaddr_storage ss;
-  runichar2 wdst[R_NET_WIN32_ADDR_STR_MAX];
-
-  r_memset (&ss, 0, sizeof (ss));
-  ss.ss_family = family;
-
-  if (ss.ss_family == R_AF_INET) {
-    struct sockaddr_in * sin = (struct sockaddr_in *) &ss;
-
-    len = sizeof (struct sockaddr_in);
-    r_memcpy (&sin->sin_addr, src, sizeof (sin->sin_addr));
-  } else if (ss.ss_family == R_AF_INET6) {
-    struct sockaddr_in6 * sin6 = (struct sockaddr_in6 *) &ss;
-
-    len = sizeof (struct sockaddr_in6);
-    r_memcpy (&sin6->sin6_addr, src, sizeof (sin6->sin6_addr));
-  } else {
-    WSASetLastError (WSAEAFNOSUPPORT);
-    return NULL;
-  }
-
-  if (WSAAddressToStringW ((struct sockaddr *) &ss, len, NULL,
-        (WCHAR *)wdst, &wdstsize) != 0)
-    return NULL;
-
-  if (r_utf16_to_utf8 (dst, size, wdst, wdstsize, NULL, NULL) != R_UNICODE_OK)
-    return NULL;
-  return dst;
-}
-#endif
 

--- a/rlib/net/rsocketaddress.c
+++ b/rlib/net/rsocketaddress.c
@@ -21,6 +21,7 @@
 #include "rsocket-private.h"
 #include "net/rnet-private.h"
 
+#include <rlib/charset/rascii.h>
 #include <rlib/rmem.h>
 #include <rlib/rstr.h>
 
@@ -117,22 +118,140 @@ r_socket_address_ipv6_new_from_bytes (const ruint8 ip[16], ruint16 port)
   return ret;
 }
 
+/* Parse a strict dotted-quad "d.d.d.d" (decimal octets 0-255, no leading
+ * zeros), as accepted by inet_pton(AF_INET); @p src is NUL-terminated. */
+static rboolean
+r_socket_address_parse_ipv4 (const rchar * src, ruint8 out[4])
+{
+  ruint8 tmp[4];
+  ruint8 * tp = tmp;
+  ruint octets = 0;
+  rboolean saw_digit = FALSE;
+  rchar ch;
+
+  *tp = 0;
+  while ((ch = *src++) != 0) {
+    if (r_ascii_isdigit (ch)) {
+      ruint nw = (ruint) *tp * 10 + (ruint) (ch - '0');
+      if (saw_digit && *tp == 0)        /* reject a leading zero */
+        return FALSE;
+      if (nw > 255)
+        return FALSE;
+      *tp = (ruint8) nw;
+      if (!saw_digit) {
+        if (++octets > 4)
+          return FALSE;
+        saw_digit = TRUE;
+      }
+    } else if (ch == '.' && saw_digit) {
+      if (octets == 4)
+        return FALSE;
+      *++tp = 0;
+      saw_digit = FALSE;
+    } else {
+      return FALSE;
+    }
+  }
+  if (octets != 4)
+    return FALSE;
+
+  r_memcpy (out, tmp, sizeof (tmp));
+  return TRUE;
+}
+
+/* Parse an RFC 4291 IPv6 text address — "::" zero-compression and an
+ * optional trailing embedded IPv4 included — into 16 network-order
+ * bytes. Mirrors the classic inet_pton6 state machine. */
+static rboolean
+r_socket_address_parse_ipv6 (const rchar * src, ruint8 out[16])
+{
+  ruint8 tmp[16], * tp, * endp, * colonp;
+  const rchar * curtok;
+  ruint val = 0;
+  ruint xdigits = 0;
+  rchar ch;
+
+  r_memset (tmp, 0, sizeof (tmp));
+  tp = tmp;
+  endp = tmp + sizeof (tmp);
+  colonp = NULL;
+
+  /* A leading ':' is only valid as part of "::". */
+  if (*src == ':') {
+    if (*++src != ':')
+      return FALSE;
+  }
+  curtok = src;
+
+  while ((ch = *src++) != 0) {
+    if (r_ascii_isxdigit (ch)) {
+      val = (val << 4) | (ruint) r_ascii_xdigit_value (ch);
+      if (++xdigits > 4)
+        return FALSE;
+      continue;
+    }
+    if (ch == ':') {
+      curtok = src;
+      if (xdigits == 0) {
+        if (colonp != NULL)             /* only one "::" permitted */
+          return FALSE;
+        colonp = tp;
+        continue;
+      }
+      if (*src == 0)                    /* a trailing single ':' is invalid */
+        return FALSE;
+      if (tp + 2 > endp)
+        return FALSE;
+      *tp++ = (ruint8) (val >> 8);
+      *tp++ = (ruint8) val;
+      xdigits = 0;
+      val = 0;
+      continue;
+    }
+    if (ch == '.' && tp + 4 <= endp &&
+        r_socket_address_parse_ipv4 (curtok, tp)) {
+      tp += 4;                          /* embedded trailing IPv4 */
+      xdigits = 0;
+      break;                            /* parse_ipv4 consumed up to the NUL */
+    }
+    return FALSE;
+  }
+
+  if (xdigits > 0) {
+    if (tp + 2 > endp)
+      return FALSE;
+    *tp++ = (ruint8) (val >> 8);
+    *tp++ = (ruint8) val;
+  }
+
+  if (colonp != NULL) {
+    /* Slide the groups after "::" to the end, zero-filling the gap. */
+    rsize n = (rsize) (tp - colonp);
+    rsize i;
+    if (tp == endp)                     /* "::" with no room to expand */
+      return FALSE;
+    for (i = 1; i <= n; i++) {
+      *(endp - i) = colonp[n - i];
+      colonp[n - i] = 0;
+    }
+    tp = endp;
+  }
+  if (tp != endp)
+    return FALSE;
+
+  r_memcpy (out, tmp, sizeof (tmp));
+  return TRUE;
+}
+
 RSocketAddress *
 r_socket_address_ipv6_new_from_string (const rchar * ip, ruint16 port)
 {
   ruint8 buf[16];
 
   if (R_UNLIKELY (ip == NULL)) return NULL;
+  if (!r_socket_address_parse_ipv6 (ip, buf))
+    return NULL;
 
-#if defined (HAVE_INET_PTON)
-  if (inet_pton (R_AF_INET6, ip, buf) < 1)
-    return NULL;
-#elif defined (R_OS_WIN32)
-  if (r_win32_inet_pton (R_AF_INET6, ip, buf) < 1)
-    return NULL;
-#else
-  return NULL;
-#endif
   return r_socket_address_ipv6_new_from_bytes (buf, port);
 }
 
@@ -157,43 +276,13 @@ r_socket_address_ipv4_new_uint8 (ruint8 a, ruint8 b, ruint8 c, ruint8 d, ruint16
 RSocketAddress *
 r_socket_address_ipv4_new_from_string (const rchar * ip, ruint16 port)
 {
-  RSocketAddress * ret;
-  ruint32 a;
+  ruint8 b[4];
 
   if (R_UNLIKELY (ip == NULL)) return NULL;
-
-  {
-#if defined (HAVE_INET_PTON)
-    struct in_addr in;
-    if (inet_pton (R_AF_INET, ip, &in) < 1)
-      return NULL;
-    a = in.s_addr;
-#elif defined (R_OS_WIN32)
-    struct in_addr in;
-    if (r_win32_inet_pton (R_AF_INET, ip, &in) < 1)
-      return NULL;
-    a = in.s_addr;
-#elif defined (HAVE_INET_ATON)
-    struct in_addr in;
-    if (inet_aton (ip, &in) < 1)
-      return NULL;
-    a = in.s_addr;
-#else
-    /* FIXME: Implement parsing and remove inet_pton/inet_aton */
+  if (!r_socket_address_parse_ipv4 (ip, b))
     return NULL;
-#endif
-  }
 
-  if ((ret = r_mem_new0 (RSocketAddress)) != NULL) {
-    r_ref_init (ret, r_free);
-
-    ret->addrlen = R_SOCKET_ADDRESS_IPV4_SIZE;
-    R_SOCKET_ADDRESS_FAMILY (ret) = R_SOCKET_FAMILY_IPV4;
-    R_SOCKET_ADDRESS_IPV4_PORT (ret) = r_htons (port);
-    R_SOCKET_ADDRESS_IPV4_ADDR (ret) = a;
-  }
-
-  return ret;
+  return r_socket_address_ipv4_new_uint8 (b[0], b[1], b[2], b[3], port);
 }
 
 RSocketFamily
@@ -280,7 +369,7 @@ r_socket_address_ipv4_build_str (const RSocketAddress * addr, rboolean port,
 {
   if (R_UNLIKELY (addr == NULL)) return FALSE;
 
-#if defined (HAVE_INET_PTON)
+#if defined (HAVE_INET_NTOP)
   if (inet_ntop (R_AF_INET, &((struct sockaddr_in *)&addr->addr)->sin_addr, str, size) == NULL)
     return FALSE;
   if (port) {
@@ -339,9 +428,9 @@ r_socket_address_ipv6_build_str (const RSocketAddress * addr, rboolean port,
   if (R_UNLIKELY (addr == NULL || str == NULL)) return FALSE;
   if (r_socket_address_get_family (addr) != R_SOCKET_FAMILY_IPV6) return FALSE;
 
-#if defined (HAVE_INET_PTON) || defined (R_OS_WIN32)
+#if defined (HAVE_INET_NTOP) || defined (R_OS_WIN32)
   {
-#if defined (HAVE_INET_PTON)
+#if defined (HAVE_INET_NTOP)
     if (inet_ntop (R_AF_INET6, R_SOCKET_ADDRESS_IPV6_ADDR (addr),
             port ? str + 1 : str, port ? size - 1 : size) == NULL)
       return FALSE;

--- a/rlib/net/rsocketaddress.c
+++ b/rlib/net/rsocketaddress.c
@@ -363,53 +363,84 @@ r_socket_address_ipv6_get_ip_bytes (const RSocketAddress * addr, ruint8 ip[16])
   return TRUE;
 }
 
+/* Longest text forms incl. NUL: "255.255.255.255" and
+ * "ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255". */
+#define R_SOCKET_ADDRESS_IPV4_STRLEN  16
+#define R_SOCKET_ADDRESS_IPV6_STRLEN  46
+
+/* Write the dotted-quad for four network-order octets; returns length. */
+static rsize
+r_socket_address_format_ipv4 (const ruint8 ip[4], rchar * dst)
+{
+  return (rsize) r_sprintf (dst, "%"RUINT8_FMT".%"RUINT8_FMT".%"RUINT8_FMT".%"RUINT8_FMT,
+      ip[0], ip[1], ip[2], ip[3]);
+}
+
+/* Format 16 network-order bytes as a canonical RFC 5952 IPv6 address:
+ * lowercase, the longest run of zero groups (leftmost on ties) collapsed
+ * to "::", and a trailing embedded IPv4 for the v4-mapped / v4-compatible
+ * forms — matching inet_ntop. @p dst must hold R_SOCKET_ADDRESS_IPV6_STRLEN. */
+static void
+r_socket_address_format_ipv6 (const ruint8 ip[16], rchar * dst)
+{
+  ruint words[8];
+  int best_base = -1, best_len = 0, cur_base = -1, cur_len = 0, i;
+  rchar * tp = dst;
+
+  for (i = 0; i < 8; i++)
+    words[i] = ((ruint) ip[i * 2] << 8) | (ruint) ip[i * 2 + 1];
+
+  /* Longest run of consecutive zero groups, leftmost winning on a tie. */
+  for (i = 0; i < 8; i++) {
+    if (words[i] == 0) {
+      if (cur_base == -1) { cur_base = i; cur_len = 1; }
+      else cur_len++;
+      if (cur_len > best_len) { best_base = cur_base; best_len = cur_len; }
+    } else {
+      cur_base = -1;
+    }
+  }
+  if (best_len < 2)             /* "::" only collapses two or more groups */
+    best_base = -1;
+
+  for (i = 0; i < 8; i++) {
+    if (best_base != -1 && i >= best_base && i < best_base + best_len) {
+      if (i == best_base)
+        *tp++ = ':';
+      continue;
+    }
+    if (i != 0)
+      *tp++ = ':';
+    if (i == 6 && best_base == 0 &&
+        (best_len == 6 || (best_len == 5 && words[5] == 0xffff))) {
+      tp += r_socket_address_format_ipv4 (ip + 12, tp);
+      break;
+    }
+    tp += (rsize) r_sprintf (tp, "%x", words[i]);
+  }
+  if (best_base != -1 && best_base + best_len == 8)
+    *tp++ = ':';
+  *tp = 0;
+}
+
 rboolean
 r_socket_address_ipv4_build_str (const RSocketAddress * addr, rboolean port,
     rchar * str, rsize size)
 {
-  if (R_UNLIKELY (addr == NULL)) return FALSE;
+  rchar tmp[R_SOCKET_ADDRESS_IPV4_STRLEN + 8];
+  rsize n;
 
-#if defined (HAVE_INET_NTOP)
-  if (inet_ntop (R_AF_INET, &((struct sockaddr_in *)&addr->addr)->sin_addr, str, size) == NULL)
+  if (R_UNLIKELY (addr == NULL || str == NULL)) return FALSE;
+
+  n = r_socket_address_format_ipv4 (
+      (const ruint8 *) &R_SOCKET_ADDRESS_IPV4_ADDR (addr), tmp);
+  if (port)
+    n += (rsize) r_sprintf (tmp + n, ":%"RUINT16_FMT,
+        r_ntohs (R_SOCKET_ADDRESS_IPV4_PORT (addr)));
+
+  if (n + 1 > size)
     return FALSE;
-  if (port) {
-    rchar p[8];
-    r_sprintf (p, ":%"RUINT16_FMT, r_ntohs (R_SOCKET_ADDRESS_IPV4_PORT (addr)));
-    if (size <= r_strlen (str) + r_strlen (p))
-      return FALSE;
-
-    r_strcat (str, p);
-  }
-#elif defined (R_OS_WIN32)
-  if (r_win32_inet_ntop (R_AF_INET, &((struct sockaddr_in *)&addr->addr)->sin_addr, str, size) == NULL)
-    return FALSE;
-  if (port) {
-    rchar p[8];
-    r_sprintf (p, ":%"RUINT16_FMT, r_ntohs (R_SOCKET_ADDRESS_IPV4_PORT (addr)));
-    if (size <= r_strlen (str) + r_strlen (p))
-      return FALSE;
-
-    r_strcat (str, p);
-  }
-#else
-  if (port) {
-    return r_snprintf (str, size,
-        "%"RUINT8_FMT".%"RUINT8_FMT".%"RUINT8_FMT".%"RUINT8_FMT":%"RUINT16_FMT,
-        (ruint8)((R_SOCKET_ADDRESS_IPV4_ADDR (addr)      ) & 0xff),
-        (ruint8)((R_SOCKET_ADDRESS_IPV4_ADDR (addr) >>  8) & 0xff),
-        (ruint8)((R_SOCKET_ADDRESS_IPV4_ADDR (addr) >> 16) & 0xff),
-        (ruint8)((R_SOCKET_ADDRESS_IPV4_ADDR (addr) >> 24) & 0xff),
-        r_ntohs (R_SOCKET_ADDRESS_IPV4_PORT (addr))) < (int)size;
-  } else {
-    return r_snprintf (str, size,
-        "%"RUINT8_FMT".%"RUINT8_FMT".%"RUINT8_FMT".%"RUINT8_FMT,
-        (ruint8)((R_SOCKET_ADDRESS_IPV4_ADDR (addr)      ) & 0xff),
-        (ruint8)((R_SOCKET_ADDRESS_IPV4_ADDR (addr) >>  8) & 0xff),
-        (ruint8)((R_SOCKET_ADDRESS_IPV4_ADDR (addr) >> 16) & 0xff),
-        (ruint8)((R_SOCKET_ADDRESS_IPV4_ADDR (addr) >> 24) & 0xff)) < (int)size;
-  }
-#endif
-
+  r_memcpy (str, tmp, n + 1);
   return TRUE;
 }
 
@@ -425,38 +456,28 @@ rboolean
 r_socket_address_ipv6_build_str (const RSocketAddress * addr, rboolean port,
     rchar * str, rsize size)
 {
+  rchar tmp[R_SOCKET_ADDRESS_IPV6_STRLEN + 10];   /* "[" + addr + "]:65535" */
+  rsize n;
+
   if (R_UNLIKELY (addr == NULL || str == NULL)) return FALSE;
   if (r_socket_address_get_family (addr) != R_SOCKET_FAMILY_IPV6) return FALSE;
 
-#if defined (HAVE_INET_NTOP) || defined (R_OS_WIN32)
-  {
-#if defined (HAVE_INET_NTOP)
-    if (inet_ntop (R_AF_INET6, R_SOCKET_ADDRESS_IPV6_ADDR (addr),
-            port ? str + 1 : str, port ? size - 1 : size) == NULL)
-      return FALSE;
-#else
-    if (r_win32_inet_ntop (R_AF_INET6, R_SOCKET_ADDRESS_IPV6_ADDR (addr),
-            port ? str + 1 : str, port ? size - 1 : size) == NULL)
-      return FALSE;
-#endif
-    if (port) {
-      /* RFC 3986 / 2732: bracket the address and append :port. */
-      rsize ipsize = r_strlen (str + 1);
-      rchar suffix[8];
-      rsize suffix_len = r_sprintf (suffix, "]:%"RUINT16_FMT,
-          r_ntohs (R_SOCKET_ADDRESS_IPV6_PORT (addr)));
-      if (1 + ipsize + suffix_len + 1 > size)
-        return FALSE;
-      str[0] = '[';
-      r_memcpy (&str[1 + ipsize], suffix, suffix_len + 1);
-    }
-    return TRUE;
+  if (port) {
+    /* RFC 3986 / 2732: bracket the address and append :port. */
+    tmp[0] = '[';
+    r_socket_address_format_ipv6 (R_SOCKET_ADDRESS_IPV6_ADDR (addr), tmp + 1);
+    n = r_strlen (tmp);
+    n += (rsize) r_sprintf (tmp + n, "]:%"RUINT16_FMT,
+        r_ntohs (R_SOCKET_ADDRESS_IPV6_PORT (addr)));
+  } else {
+    r_socket_address_format_ipv6 (R_SOCKET_ADDRESS_IPV6_ADDR (addr), tmp);
+    n = r_strlen (tmp);
   }
-#else
-  (void) port;
-  (void) size;
-  return FALSE;
-#endif
+
+  if (n + 1 > size)
+    return FALSE;
+  r_memcpy (str, tmp, n + 1);
+  return TRUE;
 }
 
 rchar *

--- a/test/rsocketaddress.c
+++ b/test/rsocketaddress.c
@@ -58,6 +58,83 @@ RTEST (rsocketaddress, ipv4_new, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rsocketaddress, ipv4_parse, RTEST_FAST)
+{
+  RSocketAddress * a;
+  static const rchar * invalid[] = {
+    "", "foobar", "1.2.3", "1.2.3.4.5", "256.1.1.1", "1.2.3.256",
+    "01.2.3.4", "1.2.3.04", "1.2.3.4.", ".1.2.3", "1..2.3", "1.2.3.4 ",
+    " 1.2.3.4", "1.2.3.4a", "00.0.0.0",
+  };
+  rsize i;
+
+  r_assert_cmpptr ((a = r_socket_address_ipv4_new_from_string ("0.0.0.0", 0)), !=, NULL);
+  r_assert_cmpuint (r_socket_address_ipv4_get_ip (a), ==, 0);
+  r_socket_address_unref (a);
+
+  r_assert_cmpptr ((a = r_socket_address_ipv4_new_from_string ("255.255.255.255", 7)), !=, NULL);
+  r_assert_cmphex (r_socket_address_ipv4_get_ip (a), ==, 0xffffffff);
+  r_assert_cmpuint (r_socket_address_ipv4_get_port (a), ==, 7);
+  r_socket_address_unref (a);
+
+  r_assert_cmpptr ((a = r_socket_address_ipv4_new_from_string ("192.168.100.200", 0)), !=, NULL);
+  r_assert_cmphex (r_socket_address_ipv4_get_ip (a), ==, 0xc0a864c8);
+  r_socket_address_unref (a);
+
+  for (i = 0; i < R_N_ELEMENTS (invalid); i++)
+    r_assert_cmpptr (r_socket_address_ipv4_new_from_string (invalid[i], 0), ==, NULL);
+}
+RTEST_END;
+
+RTEST (rsocketaddress, ipv6_parse, RTEST_FAST)
+{
+  RSocketAddress * a;
+  ruint8 b[16];
+  static const ruint8 loop[16]     = { 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,1 };
+  static const ruint8 zero[16]     = { 0, };
+  static const ruint8 v4mapped[16] = { 0,0,0,0, 0,0,0,0, 0,0,0xff,0xff, 1,2,3,4 };
+  static const ruint8 doc[16]      = { 0x20,0x01,0x0d,0xb8, 0,0,0,0, 0,0,0,0, 0,0,0,1 };
+  static const rchar * invalid[] = {
+    "", ":", ":::", "1::2::3", "1:2:3:4:5:6:7:8:9", "1:2:3:4:5:6:7",
+    "12345::", "g::1", "1.2.3.4", "::ffff:1.2.3.256", "::ffff:1.2.3",
+    "1:2:3:4:5:6:7:8:", ":1:2:3:4:5:6:7:8", "::1.2.3.4.5", "2001:db8:::1",
+  };
+  rsize i;
+
+  r_assert_cmpptr ((a = r_socket_address_ipv6_new_from_string ("::1", 42)), !=, NULL);
+  r_assert (r_socket_address_ipv6_get_ip_bytes (a, b));
+  r_assert_cmpmem (b, ==, loop, 16);
+  r_assert_cmpuint (r_socket_address_ipv6_get_port (a), ==, 42);
+  r_socket_address_unref (a);
+
+  r_assert_cmpptr ((a = r_socket_address_ipv6_new_from_string ("::", 0)), !=, NULL);
+  r_assert (r_socket_address_ipv6_get_ip_bytes (a, b));
+  r_assert_cmpmem (b, ==, zero, 16);
+  r_socket_address_unref (a);
+
+  /* embedded trailing IPv4 */
+  r_assert_cmpptr ((a = r_socket_address_ipv6_new_from_string ("::ffff:1.2.3.4", 0)), !=, NULL);
+  r_assert (r_socket_address_ipv6_get_ip_bytes (a, b));
+  r_assert_cmpmem (b, ==, v4mapped, 16);
+  r_socket_address_unref (a);
+
+  /* zero-compression yields the same bytes as the fully-written form */
+  r_assert_cmpptr ((a = r_socket_address_ipv6_new_from_string ("2001:db8::1", 0)), !=, NULL);
+  r_assert (r_socket_address_ipv6_get_ip_bytes (a, b));
+  r_assert_cmpmem (b, ==, doc, 16);
+  r_socket_address_unref (a);
+  r_assert_cmpptr ((a = r_socket_address_ipv6_new_from_string (
+        "2001:0db8:0000:0000:0000:0000:0000:0001", 0)), !=, NULL);
+  r_assert (r_socket_address_ipv6_get_ip_bytes (a, b));
+  r_assert_cmpmem (b, ==, doc, 16);
+  r_socket_address_unref (a);
+
+  r_assert_cmpptr (r_socket_address_ipv6_new_from_string (NULL, 0), ==, NULL);
+  for (i = 0; i < R_N_ELEMENTS (invalid); i++)
+    r_assert_cmpptr (r_socket_address_ipv6_new_from_string (invalid[i], 0), ==, NULL);
+}
+RTEST_END;
+
 RTEST (rsocketaddress, ipv4_to_str, RTEST_FAST)
 {
   RSocketAddress * addr_u32, * addr_str;

--- a/test/rsocketaddress.c
+++ b/test/rsocketaddress.c
@@ -135,6 +135,67 @@ RTEST (rsocketaddress, ipv6_parse, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rsocketaddress, ipv6_to_str, RTEST_FAST)
+{
+  static const struct { const rchar * in; const rchar * out; } cases[] = {
+    { "::",                                       "::" },
+    { "::1",                                      "::1" },
+    { "2001:db8::1",                              "2001:db8::1" },
+    { "2001:0db8:0000:0000:0000:0000:0000:0001",  "2001:db8::1" },  /* canonicalised */
+    { "fe80:0:0:0:0:0:0:1",                       "fe80::1" },
+    { "1:2:3:4:5:6:7:8",                          "1:2:3:4:5:6:7:8" },
+    { "1:0:0:2:0:0:0:3",                          "1:0:0:2::3" },    /* longest run wins */
+    { "1:0:2:3:4:5:6:7",                          "1:0:2:3:4:5:6:7" }, /* single 0 not collapsed */
+    { "::ffff:1.2.3.4",                           "::ffff:1.2.3.4" }, /* v4-mapped */
+    { "::1.2.3.4",                                 "::1.2.3.4" },     /* v4-compatible */
+    { "ABCD::",                                   "abcd::" },        /* lowercased */
+  };
+  /* Round-trip stability: parse -> format -> parse yields the same bytes. */
+  static const rchar * roundtrip[] = {
+    "::1", "2001:db8::1", "::ffff:1.2.3.4", "::1.2.3.4", "fe80::1",
+    "1:2:3:4:5:6:7:8", "1:0:0:2::3",
+  };
+  RSocketAddress * a;
+  rchar * s;
+  rchar buf[8];
+  rsize i;
+
+  for (i = 0; i < R_N_ELEMENTS (cases); i++) {
+    r_assert_cmpptr ((a = r_socket_address_ipv6_new_from_string (cases[i].in, 0)), !=, NULL);
+    r_assert_cmpptr ((s = r_socket_address_ipv6_to_str (a, FALSE)), !=, NULL);
+    r_assert_cmpstr (s, ==, cases[i].out);
+    r_free (s);
+    r_socket_address_unref (a);
+  }
+
+  /* Bracketed host:port form. */
+  r_assert_cmpptr ((a = r_socket_address_ipv6_new_from_string ("2001:db8::1", 443)), !=, NULL);
+  r_assert_cmpptr ((s = r_socket_address_ipv6_to_str (a, TRUE)), !=, NULL);
+  r_assert_cmpstr (s, ==, "[2001:db8::1]:443");
+  r_free (s);
+
+  /* Too-small / NULL output buffers fail rather than overrun. */
+  r_assert (!r_socket_address_ipv6_build_str (a, FALSE, buf, sizeof (buf))); /* needs 12 */
+  r_assert (!r_socket_address_ipv6_build_str (a, FALSE, NULL, 64));
+  r_socket_address_unref (a);
+
+  for (i = 0; i < R_N_ELEMENTS (roundtrip); i++) {
+    RSocketAddress * b;
+    ruint8 b1[16], b2[16];
+
+    r_assert_cmpptr ((a = r_socket_address_ipv6_new_from_string (roundtrip[i], 0)), !=, NULL);
+    r_assert (r_socket_address_ipv6_get_ip_bytes (a, b1));
+    r_assert_cmpptr ((s = r_socket_address_ipv6_to_str (a, FALSE)), !=, NULL);
+    r_assert_cmpptr ((b = r_socket_address_ipv6_new_from_string (s, 0)), !=, NULL);
+    r_assert (r_socket_address_ipv6_get_ip_bytes (b, b2));
+    r_assert_cmpmem (b1, ==, b2, 16);
+    r_free (s);
+    r_socket_address_unref (a);
+    r_socket_address_unref (b);
+  }
+}
+RTEST_END;
+
 RTEST (rsocketaddress, ipv4_to_str, RTEST_FAST)
 {
   RSocketAddress * addr_u32, * addr_str;


### PR DESCRIPTION
Removes rlib's dependency on libc `inet_pton` / `inet_aton` / `inet_ntop` for IP address text conversion, parsing **and** formatting both families natively. Closes the `/* FIXME: Implement parsing and remove inet_pton/inet_aton */` in `rsocketaddress.c`.

## Parsing (text -> binary)
- `r_socket_address_ipv4_new_from_string`: strict dotted-quad (decimal octets 0-255, leading zeros rejected) — matches `inet_pton(AF_INET)`.
- `r_socket_address_ipv6_new_from_string`: the classic `inet_pton6` state machine — `::` zero-compression (start/middle/end), one-`::`-only, optional trailing embedded IPv4, group length/count checks.
- Collapses the old four-way `inet_pton` / win32 / `inet_aton` / `#else return NULL` branches to one path each.

## Formatting (binary -> text)
- `r_socket_address_ipv4_build_str` / `_ipv6_build_str` now format in rlib. IPv6 follows the classic `inet_ntop6`: lowercase groups, longest zero-run (leftmost on ties) collapsed to `::`, and embedded IPv4 for v4-mapped/compat — RFC 5952 canonical, byte-identical to `inet_ntop` (verified over structured + ~20k randomised addresses during development).

## Cleanup
- Drops the now-dead win32 `r_win32_inet_pton` / `r_win32_inet_ntop` pointers and their WSA simulations, the `ws2_32.dll` module load that existed only for them, and the `inet_pton` / `inet_aton` / `inet_ntop` meson feature checks. `r_networking_init`/`deinit` are now just `WSAStartup`/`WSACleanup`.

## Docs & tests
- The `r_socketaddress` group docs gain a "Coming from libc inet_*" section mapping the libc calls to the rlib equivalents, with a worked example.
- New `ipv4_parse` / `ipv6_parse` (valid + malformed vectors) and `ipv6_to_str` (canonical forms, v4-mapped/compat, lowercasing, truncation, parse->format->parse round-trip) tests.

Builds clean under debug / release / gcc-warn / clang (`-werror`); full suite green in debug + ASAN (no leaks); doxygen 0 warnings.

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)