### PR TITLE
tty: make print-handler state re-entrancy- and thread-safe

### DIFF
--- a/include/rlib/os/rtty.h
+++ b/include/rlib/os/rtty.h
@@ -148,6 +148,15 @@ R_API int r_printerr (const rchar * fmt, ...) R_ATTR_PRINTF (1, 2);
 typedef rboolean (*RPrintFunc) (const rchar * str, rsize size, rpointer data);
 /**
  * @brief Install a new sink for @ref r_print.
+ *
+ * Installing or swapping a sink is atomic with respect to concurrent
+ * @ref r_print calls: a reader never observes a new @p func paired with
+ * a previous @p data. The sink runs outside any lock, however, so a call
+ * already in flight may still invoke the previous sink after this
+ * returns — @p data's lifetime is the caller's responsibility. Keep it
+ * valid for as long as the sink may be invoked: install before
+ * concurrent use, or quiesce printing before freeing replaced data.
+ *
  * @param func     New sink, or @c NULL to restore the default.
  * @param data     Opaque pointer forwarded to @p func on every call.
  * @param oldfunc  Optional out-pointer: receives the previously-installed sink.

--- a/rlib/os/rtty.c
+++ b/rlib/os/rtty.c
@@ -18,37 +18,110 @@
 
 #include "config.h"
 #include <rlib/os/rtty.h>
+#include <rlib/concurrency/ratomic.h>
+#include <rlib/concurrency/rthreads.h>
 #include <rlib/rstr.h>
 
-static RPrintFunc printfunc         = NULL;
-static rpointer   printfuncdata     = NULL;
-static RPrintFunc printerrfunc      = NULL;
-static rpointer   printerrfuncdata  = NULL;
+#include <stdlib.h>     /* abort */
+
+/* The print / printerr handlers are process-global (func, data) pairs.
+ * Reads (r_print / r_printerr) and writes (the override setters) are
+ * kept pair-consistent with a seqlock: a writer bumps an odd
+ * "in progress" version around its two stores, a reader re-checks the
+ * version and retries if it moved, so a concurrent override can never
+ * hand a reader a freshly installed func paired with the previous
+ * handler's data. The read path takes no lock and never blocks. */
+static raptr  printfunc;        /* RPrintFunc bits, 0 => use the default */
+static raptr  printfuncdata;
+static raptr  printerrfunc;
+static raptr  printerrfuncdata;
+static rauint printseq;         /* even: stable, odd: a write is in progress */
+
+/* A print handler that calls back into the same r_print / r_printerr
+ * would recurse forever -- a bug in the handler. Trap it with a
+ * thread-local flag set only while the handler runs. */
+#define R_PRINT_REENTRY_PRINT     0x1u
+#define R_PRINT_REENTRY_PRINTERR  0x2u
+static RTss   printreentry = R_TSS_INIT (NULL);
+
+/* Seqlock read: load the (func, data) pair as a consistent snapshot. */
+static void
+r_print_handler_get (raptr * pfunc, raptr * pdata,
+    RPrintFunc * func, rpointer * data)
+{
+  ruint s0, s1;
+
+  do {
+    s0 = r_atomic_uint_load (&printseq);
+    *func = (RPrintFunc) r_atomic_ptr_load (pfunc);
+    *data = r_atomic_ptr_load (pdata);
+    s1 = r_atomic_uint_load (&printseq);
+  } while (R_UNLIKELY (s0 != s1 || (s0 & 1) != 0));
+}
+
+/* Seqlock write: publish a new (func, data) pair, returning the old one.
+ * The CAS to claim the odd version also serialises concurrent writers. */
+static void
+r_print_handler_set (raptr * pfunc, raptr * pdata,
+    RPrintFunc func, rpointer data, RPrintFunc * oldfunc, rpointer * olddata)
+{
+  ruint s;
+
+  do {
+    s = r_atomic_uint_load (&printseq);
+  } while ((s & 1) != 0 || !r_atomic_uint_cmp_xchg_weak (&printseq, &s, s + 1));
+
+  if (oldfunc != NULL)
+    *oldfunc = (RPrintFunc) r_atomic_ptr_load (pfunc);
+  if (olddata != NULL)
+    *olddata = r_atomic_ptr_load (pdata);
+
+  r_atomic_ptr_store (pfunc, (rpointer) func);
+  r_atomic_ptr_store (pdata, data);
+
+  r_atomic_uint_store (&printseq, s + 2);
+}
+
+/* Snapshot the handler, trap re-entry, then run the handler outside any
+ * lock (it may block on I/O; it must not recurse into the printer). */
+static int
+r_print_dispatch (raptr * pfunc, raptr * pdata, RPrintFunc deflt,
+    ruint rebit, const rchar * str, int ret)
+{
+  RPrintFunc func;
+  rpointer data;
+  ruint reentry;
+
+  r_print_handler_get (pfunc, pdata, &func, &data);
+  if (func == NULL) {
+    func = deflt;
+    data = NULL;
+  }
+
+  reentry = RPOINTER_TO_UINT (r_tss_get (&printreentry));
+  if (R_UNLIKELY ((reentry & rebit) != 0))
+    abort ();
+  r_tss_set (&printreentry, RUINT_TO_POINTER (reentry | rebit));
+
+  if (R_UNLIKELY (!func (str, (rsize) ret, data)))
+    ret = -1;
+
+  r_tss_set (&printreentry, RUINT_TO_POINTER (reentry));
+  return ret;
+}
 
 void
 r_override_print_handler (RPrintFunc func, rpointer data,
     RPrintFunc * oldfunc, rpointer * olddata)
 {
-  if (oldfunc != NULL)
-    *oldfunc = printfunc;
-  if (olddata != NULL)
-    *olddata = printfuncdata;
-
-  printfunc = func;
-  printfuncdata = data;
+  r_print_handler_set (&printfunc, &printfuncdata, func, data, oldfunc, olddata);
 }
 
 void
 r_override_printerr_handler (RPrintFunc func, rpointer data,
     RPrintFunc * oldfunc, rpointer * olddata)
 {
-  if (oldfunc != NULL)
-    *oldfunc = printerrfunc;
-  if (olddata != NULL)
-    *olddata = printerrfuncdata;
-
-  printerrfunc = func;
-  printerrfuncdata = data;
+  r_print_handler_set (&printerrfunc, &printerrfuncdata, func, data, oldfunc, olddata);
 }
 
 int
@@ -58,27 +131,13 @@ r_print (const rchar * fmt, ...)
   rchar *str = NULL;
   int ret;
 
-  /* TODO: Prevent re-etnry? use TLS */
-
   va_start (args, fmt);
   ret = r_vasprintf (&str, fmt, args);
   va_end (args);
 
-  if (R_LIKELY (ret > 0 && str != NULL)) {
-    RPrintFunc func;
-    rpointer data;
-
-    if (R_LIKELY (printfunc == NULL)) {
-      func = r_print_default;
-      data = NULL;
-    } else {
-      func = printfunc;
-      data = printfuncdata;
-    }
-
-    if (R_UNLIKELY (!func (str, (rsize)ret, data)))
-      ret = -1;
-  }
+  if (R_LIKELY (ret > 0 && str != NULL))
+    ret = r_print_dispatch (&printfunc, &printfuncdata, r_print_default,
+        R_PRINT_REENTRY_PRINT, str, ret);
 
   r_free (str);
   return ret;
@@ -91,27 +150,13 @@ r_printerr (const rchar * fmt, ...)
   rchar *str = NULL;
   int ret;
 
-  /* TODO: Prevent re-etnry? use TLS */
-
   va_start (args, fmt);
   ret = r_vasprintf (&str, fmt, args);
   va_end (args);
 
-  if (R_LIKELY (ret > 0 && str != NULL)) {
-    RPrintFunc func;
-    rpointer data;
-
-    if (R_LIKELY (printerrfunc == NULL)) {
-      func = r_printerr_default;
-      data = NULL;
-    } else {
-      func = printerrfunc;
-      data = printerrfuncdata;
-    }
-
-    if (R_UNLIKELY (!func (str, (rsize)ret, data)))
-      ret = -1;
-  }
+  if (R_LIKELY (ret > 0 && str != NULL))
+    ret = r_print_dispatch (&printerrfunc, &printerrfuncdata, r_printerr_default,
+        R_PRINT_REENTRY_PRINTERR, str, ret);
 
   r_free (str);
   return ret;

--- a/test/meson.build
+++ b/test/meson.build
@@ -99,6 +99,7 @@ rlibtest_sources = [
   'rtimeoutcblist.c',
   'rtls.c',
   'rtlsserver.c',
+  'rtty.c',
   'runicode.c',
   'runicode-props.c',
   'ruri.c',

--- a/test/rtty.c
+++ b/test/rtty.c
@@ -1,0 +1,111 @@
+#include <rlib/rlib.h>
+
+typedef struct {
+  rchar buf[256];
+  rsize len;
+  ruint calls;
+} RTtyCapture;
+
+static rboolean
+tty_capture (const rchar * str, rsize size, rpointer data)
+{
+  RTtyCapture * c = data;
+  c->calls++;
+  if (c->len + size < sizeof (c->buf)) {
+    r_memcpy (c->buf + c->len, str, size);
+    c->len += size;
+    c->buf[c->len] = 0;
+  }
+  return TRUE;
+}
+
+RTEST (rtty, print_override, RTEST_FAST)
+{
+  RTtyCapture cap = { { 0, }, 0, 0 };
+  RPrintFunc oldf = NULL;
+  rpointer olddata = NULL;
+
+  r_override_print_handler (tty_capture, &cap, &oldf, &olddata);
+  r_assert_cmpint (r_print ("hello %d!", 42), ==, 9);
+  r_override_print_handler (oldf, olddata, NULL, NULL);
+
+  r_assert_cmpuint (cap.calls, ==, 1);
+  r_assert_cmpuint (cap.len, ==, 9);
+  r_assert_cmpstr (cap.buf, ==, "hello 42!");
+}
+RTEST_END;
+
+RTEST (rtty, printerr_override, RTEST_FAST)
+{
+  RTtyCapture cap = { { 0, }, 0, 0 };
+  RPrintFunc oldf = NULL;
+  rpointer olddata = NULL;
+
+  r_override_printerr_handler (tty_capture, &cap, &oldf, &olddata);
+  r_assert_cmpint (r_printerr ("err %s", "!"), ==, 5);
+  r_override_printerr_handler (oldf, olddata, NULL, NULL);
+
+  r_assert_cmpuint (cap.calls, ==, 1);
+  r_assert_cmpstr (cap.buf, ==, "err !");
+}
+RTEST_END;
+
+/* The two handlers verify that the data they receive is the data that
+ * was installed alongside them. If the seqlock ever handed a reader a
+ * torn pair (one handler with the other's data) they abort, and
+ * ThreadSanitizer additionally flags any unsynchronised access. */
+static rboolean
+tty_expect_a (const rchar * str, rsize size, rpointer data)
+{
+  (void) str; (void) size;
+  if (R_UNLIKELY (data != RUINT_TO_POINTER (0xAu)))
+    abort ();
+  return TRUE;
+}
+
+static rboolean
+tty_expect_b (const rchar * str, rsize size, rpointer data)
+{
+  (void) str; (void) size;
+  if (R_UNLIKELY (data != RUINT_TO_POINTER (0xBu)))
+    abort ();
+  return TRUE;
+}
+
+static rpointer
+tty_print_loop (rpointer data)
+{
+  ruint i;
+  (void) data;
+  for (i = 0; i < 4000; i++)
+    r_print ("x");
+  return NULL;
+}
+
+RTEST (rtty, override_concurrent, RTEST_FAST)
+{
+  RThread * t[3];
+  RPrintFunc oldf = NULL;
+  rpointer olddata = NULL;
+  ruint i;
+
+  r_override_print_handler (tty_expect_a, RUINT_TO_POINTER (0xAu), &oldf, &olddata);
+
+  for (i = 0; i < R_N_ELEMENTS (t); i++)
+    t[i] = r_thread_new ("tty-print", tty_print_loop, NULL);
+
+  /* Swap the handler under the readers; each func must stay paired with
+   * its own data, or the handlers abort the (forked) test. */
+  for (i = 0; i < 2000; i++) {
+    if (i & 1)
+      r_override_print_handler (tty_expect_a, RUINT_TO_POINTER (0xAu), NULL, NULL);
+    else
+      r_override_print_handler (tty_expect_b, RUINT_TO_POINTER (0xBu), NULL, NULL);
+  }
+
+  for (i = 0; i < R_N_ELEMENTS (t); i++)
+    r_thread_join (t[i]);
+
+  r_override_print_handler (oldf, olddata, NULL, NULL);
+}
+RTEST_END;


### PR DESCRIPTION
`r_print` / `r_printerr` touch process-global `(handler, data)` pairs without any guard (the old `/* prevent re-entry? use TLS */` TODOs). Two distinct concerns:

## Re-entrancy
A print handler that calls back into the same `r_print`/`r_printerr` recurses forever. A per-thread flag (`RTss`), set only while the handler runs, traps it and `abort()`s — such a handler is a bug. (The functions are otherwise already re-entrant: they use only local buffers.)

## Concurrency
A thread reading the `(func, data)` pair while another runs an override could pair a freshly installed handler with the previous handler's data (a torn two-word read). The pair is now published/read through a **seqlock**: a writer bumps an odd "in-progress" version around its two stores (a CAS serialises concurrent writers), readers retry if the version moved. The read path takes **no lock** and the handler runs **outside** the seqlock, so printing never blocks and a handler may freely block on I/O. It is allocation-free, so there is no record to reclaim.

The seqlock makes the *pair read* consistent but not the lifetime of the object `data` points to — a call already in flight may still use the previous `data` after an override. That is the caller's contract (as for any callback registry) and is now documented on `r_override_print_handler`.

## Tests
New `test/rtty.c`: handler override + save/restore for both streams, and a threaded test that swaps the handler under concurrent printers — the handlers `abort()` on a mismatched pair, and ThreadSanitizer additionally proves the seqlock race-free. (The re-entry `abort()` path itself isn't unit-tested; the harness has no death-test support.)

Builds clean under debug / release / gcc-warn / clang / tsan (`-werror`); full suite green under debug, **TSan** and **ASAN** (no races, no leaks); doxygen 0 warnings.

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)