### PR TITLE
ev: surface socket errors instead of abort() in TCP/UDP backends

### DIFF
--- a/include/rlib/ev/revtcp.h
+++ b/include/rlib/ev/revtcp.h
@@ -57,12 +57,18 @@ R_BEGIN_DECLS
 typedef struct REvTCP REvTCP;
 /** @brief Allocate the buffer the next receive will fill. */
 typedef RBuffer * (*REvTCPBufferAllocFunc) (rpointer data, REvTCP * evtcp);
-/** @brief Deliver a received / sent buffer. */
+/**
+ * @brief Deliver a received / sent buffer. On the receive path a
+ * @c NULL @p buf signals end-of-stream (a clean close, or — when no
+ * error handler is installed — a receive error).
+ */
 typedef void (*REvTCPBufferFunc) (rpointer data, RBuffer * buf, REvTCP * evtcp);
 /** @brief Connection-attempt result; @p status is 0 on success. */
 typedef void (*REvTCPConnectedFunc) (rpointer data, REvTCP * evtcp, int status);
 /** @brief Fired on a listening socket when a new connection @p newtcp is ready. */
 typedef void (*REvTCPConnectionReadyFunc) (rpointer data, REvTCP * newtcp, REvTCP * listening);
+/** @brief Fired on an asynchronous socket error; @p error is the failing @ref RSocketStatus. */
+typedef void (*REvTCPErrorFunc) (rpointer data, REvTCP * evtcp, RSocketStatus error);
 
 /** @brief Create an unconnected TCP socket of @p family on @p loop. */
 R_API REvTCP * r_ev_tcp_new (RSocketFamily family, REvLoop * loop);
@@ -106,6 +112,24 @@ R_API rboolean r_ev_tcp_task_recv_start (REvTCP * evtcp, ruint taskgroup,
     rpointer data, RDestroyNotify datanotify);
 /** @brief Stop receiving. */
 R_API rboolean r_ev_tcp_recv_stop (REvTCP * evtcp);
+/**
+ * @brief Install a handler for asynchronous socket errors (a failed
+ * receive or send, or an error event reported by the loop).
+ *
+ * On a receive error the handler is invoked in place of the @c recv
+ * end-of-stream notification (a @c NULL buffer), so it can tell a
+ * peer/socket failure apart from a clean close; with no handler
+ * installed, a receive error falls back to that end-of-stream
+ * notification.
+ *
+ * The handler may fire more than once for a connection (for example a
+ * receive-path error followed by a separate error event), so it should
+ * be idempotent — e.g. close the socket only once. Replaces any
+ * previously installed handler (invoking the previous @p datanotify on
+ * its data); pass @c NULL @p error to clear it.
+ */
+R_API void r_ev_tcp_set_error_handler (REvTCP * evtcp,
+    REvTCPErrorFunc error, rpointer data, RDestroyNotify datanotify);
 /** @brief Send @p buf without a completion callback. */
 #define r_ev_tcp_send_and_forget(evtcp, buf) r_ev_tcp_send (evtcp, buf, NULL, NULL, NULL)
 /** @brief Send @p buf; @p done fires when the write completes. */

--- a/include/rlib/ev/revudp.h
+++ b/include/rlib/ev/revudp.h
@@ -32,6 +32,7 @@
 
 #include <rlib/ev/revloop.h>
 #include <rlib/rbuffer.h>
+#include <rlib/net/rsocket.h>
 #include <rlib/net/rsocketaddress.h>
 #include <rlib/rref.h>
 
@@ -58,6 +59,8 @@ typedef struct REvUDP REvUDP;
 typedef RBuffer * (*REvUDPBufferAllocFunc) (rpointer data, REvUDP * evudp);
 /** @brief Deliver a datagram buffer; @p addr is the sender / destination. */
 typedef void (*REvUDPBufferFunc) (rpointer data, RBuffer * buf, RSocketAddress * addr, REvUDP * evudp);
+/** @brief Fired on an asynchronous socket error; @p error is the failing @ref RSocketStatus. */
+typedef void (*REvUDPErrorFunc) (rpointer data, REvUDP * evudp, RSocketStatus error);
 
 /** @brief Create a UDP socket of @p family on @p loop. */
 R_API REvUDP * r_ev_udp_new (RSocketFamily family, REvLoop * loop);
@@ -79,6 +82,21 @@ R_API rboolean r_ev_udp_task_recv_start (REvUDP * evudp, ruint taskgroup,
     rpointer data, RDestroyNotify datanotify);
 /** @brief Stop receiving. */
 R_API rboolean r_ev_udp_recv_stop (REvUDP * evudp);
+/**
+ * @brief Install a handler for asynchronous socket errors (a failed
+ * receive or send, or an error event reported by the loop).
+ *
+ * Unlike TCP the datagram socket stays usable: a failed send drops just
+ * that datagram and a receive error stops draining until the next
+ * event.
+ *
+ * The handler may fire more than once (once per failed datagram, or a
+ * receive error followed by a separate error event), so it should be
+ * idempotent. Replaces any previously installed handler (invoking the
+ * previous @p datanotify on its data); pass @c NULL @p error to clear it.
+ */
+R_API void r_ev_udp_set_error_handler (REvUDP * evudp,
+    REvUDPErrorFunc error, rpointer data, RDestroyNotify datanotify);
 /** @brief Send @p buf to @p address; @p done fires on completion. */
 R_API rboolean r_ev_udp_send (REvUDP * evudp, RBuffer * buf,
     RSocketAddress * address, REvUDPBufferFunc done,

--- a/rlib/ev/revtcp.c
+++ b/rlib/ev/revtcp.c
@@ -40,6 +40,14 @@ typedef struct {
       (send)->datanotify ((send)->data);                                      \
   } R_STMT_END
 
+static void
+r_ev_tcp_send_ctx_free (rpointer data)
+{
+  REvTCPSendCtx * ctx = data;
+  r_ev_tcp_send_ctx_clear (ctx);
+  r_free (ctx);
+}
+
 
 struct REvTCP {
   REvIO evio;
@@ -53,6 +61,9 @@ struct REvTCP {
   REvTCPBufferAllocFunc alloc;
   REvTCPBufferFunc recv;
   rpointer recv_data;
+  REvTCPErrorFunc error;
+  rpointer error_data;
+  RDestroyNotify error_datanotify;
   rpointer listen_iocb_ctx;
   rpointer connect_iocb_ctx;
   rpointer recv_iocb_ctx;
@@ -66,7 +77,9 @@ struct REvTCP {
 static void
 r_ev_tcp_free (REvTCP * evtcp)
 {
-  r_queue_clear (&evtcp->qsend, r_buffer_unref);
+  r_queue_clear (&evtcp->qsend, r_ev_tcp_send_ctx_free);
+  if (evtcp->error_datanotify != NULL)
+    evtcp->error_datanotify (evtcp->error_data);
   r_socket_unref (evtcp->socket);
   r_ev_io_clear (&evtcp->evio);
   r_free (evtcp);
@@ -217,10 +230,14 @@ r_ev_tcp_connect (REvTCP * evtcp, const RSocketAddress * address,
     R_LOG_DEBUG ("loop %p evio "R_EV_IO_FORMAT, evtcp->evio.loop, R_EV_IO_ARGS (evtcp));
     if ((evtcp->connect_iocb_ctx = r_ev_io_start (&evtcp->evio, R_EV_IO_WRITABLE,
         r_ev_tcp_connected_cb, data, datanotify)) == NULL) {
-      /* FIXME: What to do about this? */
+      /* Could not watch the connecting socket; report failure to the
+       * caller (connected will not fire) rather than crash. */
       R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT,
           evtcp->evio.loop, R_EV_IO_ARGS (evtcp));
-      abort ();
+      if (datanotify != NULL)
+        datanotify (data);
+      evtcp->connected = NULL;
+      ret = R_SOCKET_OOM;
     }
   }
 
@@ -262,10 +279,14 @@ r_ev_tcp_listen (REvTCP * evtcp, ruint8 backlog,
         evtcp->evio.loop, R_EV_IO_ARGS (evtcp));
     if ((evtcp->listen_iocb_ctx = r_ev_io_start (&evtcp->evio, R_EV_IO_READABLE,
         r_ev_tcp_listen_cb, data, datanotify)) == NULL) {
-      /* FIXME: What to do about this? */
+      /* Could not watch the listening socket; report failure to the
+       * caller rather than crash. */
       R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT,
           evtcp->evio.loop, R_EV_IO_ARGS (evtcp));
-      abort ();
+      if (datanotify != NULL)
+        datanotify (data);
+      evtcp->connection = NULL;
+      ret = R_SOCKET_OOM;
     }
   }
 
@@ -283,11 +304,35 @@ r_ev_tcp_buffer_alloc_default (rpointer data, REvTCP * evtcp)
   return r_buffer_new_alloc (NULL, R_EV_TCP_BUFFER_SIZE, NULL);
 }
 
+/* Stop receiving and notify the application that the stream is done.
+ * @res is R_SOCKET_OK for a clean close (end-of-stream) and a failing
+ * status for a socket error. With an error handler installed an error
+ * is reported through it; otherwise (and always on a clean close) the
+ * recv callback is invoked with a NULL buffer. The notified callback
+ * may close and even unref evtcp; the ref taken for the deferred stop
+ * keeps it alive across the call. */
+static void
+r_ev_tcp_recv_teardown (REvTCP * evtcp, RSocketStatus res)
+{
+  r_ev_loop_add_cb_after (evtcp->evio.loop, r_ev_tcp_io_stop_after,
+      r_ev_tcp_ref (evtcp), r_ev_tcp_unref, evtcp->recv_iocb_ctx, NULL);
+  evtcp->recv_iocb_ctx = NULL;
+  if (evtcp->recv_task != NULL) {
+    r_task_unref (evtcp->recv_task);
+    evtcp->recv_task = NULL;
+  }
+
+  if (res != R_SOCKET_OK && evtcp->error != NULL)
+    evtcp->error (evtcp->error_data, evtcp, res);
+  else
+    evtcp->recv (evtcp->recv_data, NULL, evtcp);
+}
+
 static void
 r_ev_tcp_recv_iocb (REvTCP * evtcp)
 {
   RBuffer * buf;
-  RSocketStatus res;
+  RSocketStatus res = R_SOCKET_WOULD_BLOCK;
   rsize size;
 
   r_atomic_uint_store (&evtcp->recv_counter, 0);
@@ -310,28 +355,13 @@ r_ev_tcp_recv_iocb (REvTCP * evtcp)
         } else {
           R_LOG_DEBUG ("loop %p evio "R_EV_IO_FORMAT" EOS",
               evtcp->evio.loop, R_EV_IO_ARGS (evtcp));
-
-          /* Almost like r_ev_tcp_recv_stop */
-          r_ev_loop_add_cb_after (evtcp->evio.loop, r_ev_tcp_io_stop_after,
-              r_ev_tcp_ref (evtcp), r_ev_tcp_unref,
-              evtcp->recv_iocb_ctx, NULL);
-          evtcp->recv_iocb_ctx = NULL;
-          if (evtcp->recv_task != NULL) {
-            r_task_unref (evtcp->recv_task);
-            evtcp->recv_task = NULL;
-          }
-
-          /* Lastly call recv handler.
-           * Be aware that handler might close and even unref
-           * Allthough we should have a ref becuase r_ev_io_stop above
-           */
-          evtcp->recv (evtcp->recv_data, NULL, evtcp);
+          r_buffer_unref (buf);
+          r_ev_tcp_recv_teardown (evtcp, R_SOCKET_OK);
           return;
         }
         break;
       case R_SOCKET_WOULD_BLOCK:
         break;
-      /* FIXME: Handle errors?? */
       default:
         R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT" res %d",
             evtcp->evio.loop, R_EV_IO_ARGS (evtcp), res);
@@ -340,7 +370,10 @@ r_ev_tcp_recv_iocb (REvTCP * evtcp)
     r_buffer_unref (buf);
   } while (res == R_SOCKET_OK);
 
-  /* FIXME: What do we do when something fails and we are unable to drain socket? */
+  /* A socket error (anything but a would-block drain) tears the stream
+   * down and reports, instead of silently stalling. */
+  if (res != R_SOCKET_WOULD_BLOCK)
+    r_ev_tcp_recv_teardown (evtcp, res);
 }
 
 static void r_ev_tcp_iocb (rpointer data, REvIOEvents events, REvIO * evio);
@@ -376,10 +409,19 @@ r_ev_tcp_send_iocb (REvTCP * evtcp)
           r_ev_tcp_iocb, NULL, NULL);
       break;
     } else {
-      /* FIXME: What do we do when something fails and we are unable to drain send queue? */
+      /* The connection is broken: stop the writable watcher so it does
+       * not spin, report the error, and leave the unsendable queue to be
+       * released when the socket is closed / freed. */
       R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT" res %d",
           evtcp->evio.loop, R_EV_IO_ARGS (evtcp), res);
-      abort ();
+      if (evtcp->send_iocb_ctx != NULL) {
+        r_ev_loop_add_cb_after (evtcp->evio.loop, r_ev_tcp_io_stop_after,
+            r_ev_tcp_ref (evtcp), r_ev_tcp_unref, evtcp->send_iocb_ctx, NULL);
+        evtcp->send_iocb_ctx = NULL;
+      }
+      if (evtcp->error != NULL)
+        evtcp->error (evtcp->error_data, evtcp, res);
+      break;
     }
   }
 }
@@ -387,9 +429,14 @@ r_ev_tcp_send_iocb (REvTCP * evtcp)
 static void
 r_ev_tcp_error_iocb (REvTCP * evtcp)
 {
+  RSocketStatus err = r_socket_get_error (evtcp->socket);
   R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT" err: %d",
-      evtcp->evio.loop, R_EV_IO_ARGS (evtcp),
-      r_socket_get_error (evtcp->socket));
+      evtcp->evio.loop, R_EV_IO_ARGS (evtcp), err);
+  /* The error may already have been consumed (and reported) by the
+   * recv / send path in this same dispatch; only notify on a still-set
+   * error so the handler isn't called with a stale R_SOCKET_OK. */
+  if (err != R_SOCKET_OK && evtcp->error != NULL)
+    evtcp->error (evtcp->error_data, evtcp, err);
 }
 
 static void
@@ -508,6 +555,19 @@ r_ev_tcp_recv_stop (REvTCP * evtcp)
   }
 
   return ret;
+}
+
+void
+r_ev_tcp_set_error_handler (REvTCP * evtcp, REvTCPErrorFunc error,
+    rpointer data, RDestroyNotify datanotify)
+{
+  if (R_UNLIKELY (evtcp == NULL)) return;
+
+  if (evtcp->error_datanotify != NULL)
+    evtcp->error_datanotify (evtcp->error_data);
+  evtcp->error = error;
+  evtcp->error_data = data;
+  evtcp->error_datanotify = datanotify;
 }
 
 rboolean

--- a/rlib/ev/revudp.c
+++ b/rlib/ev/revudp.c
@@ -24,6 +24,8 @@
 
 #include <rlib/rmem.h>
 
+#define R_LOG_CAT_DEFAULT &revlogcat
+
 typedef struct {
   RBuffer * buf;
   RSocketAddress * addr;
@@ -40,6 +42,14 @@ typedef struct {
       (send)->datanotify ((send)->data);                                      \
   } R_STMT_END
 
+static void
+r_ev_udp_send_ctx_free (rpointer data)
+{
+  REvUDPSendCtx * ctx = data;
+  r_ev_udp_send_ctx_clear (ctx);
+  r_free (ctx);
+}
+
 
 struct REvUDP {
   REvIO evio;
@@ -51,6 +61,9 @@ struct REvUDP {
   REvUDPBufferAllocFunc alloc;
   REvUDPBufferFunc recv;
   rpointer recv_data;
+  REvUDPErrorFunc error;
+  rpointer error_data;
+  RDestroyNotify error_datanotify;
   rpointer recv_iocb_ctx;
   rauint recv_counter;
   RTask * recv_task;
@@ -61,7 +74,9 @@ struct REvUDP {
 static void
 r_ev_udp_free (REvUDP * evudp)
 {
-  r_queue_clear (&evudp->qsend, r_buffer_unref);
+  r_queue_clear (&evudp->qsend, r_ev_udp_send_ctx_free);
+  if (evudp->error_datanotify != NULL)
+    evudp->error_datanotify (evudp->error_data);
   r_socket_unref (evudp->socket);
   r_ev_io_clear (&evudp->evio);
   r_free (evudp);
@@ -133,16 +148,20 @@ r_ev_udp_recv_iocb (REvUDP * evudp)
         evudp->recv (evudp->recv_data, buf, copy, evudp);
         r_socket_address_unref (copy);
         break;
-      /* FIXME: Handle errors?? */
+      case R_SOCKET_WOULD_BLOCK:
+        break;
       default:
+        R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT" recv res %d",
+            evudp->evio.loop, R_EV_IO_ARGS (evudp), res);
         break;
     }
     r_buffer_unref (buf);
   } while (res == R_SOCKET_OK);
 
-  /* FIXME: What do we do when something fails and we are unable to drain socket? */
-  if (res != R_SOCKET_WOULD_BLOCK)
-    abort ();
+  /* A datagram socket stays usable on error: stop draining until the
+   * next event and report. */
+  if (res != R_SOCKET_WOULD_BLOCK && evudp->error != NULL)
+    evudp->error (evudp->error_data, evudp, res);
 }
 
 static void
@@ -163,8 +182,15 @@ r_ev_udp_send_iocb (REvUDP * evudp)
     } else if (res == R_SOCKET_WOULD_BLOCK) {
       break;
     } else {
-      /* FIXME: What do we do when something fails and we are unable to drain send queue? */
-      abort ();
+      /* This datagram cannot be sent: drop it, report, and keep
+       * draining the rest -- the socket stays usable. */
+      R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT" send res %d",
+          evudp->evio.loop, R_EV_IO_ARGS (evudp), res);
+      r_queue_pop (&evudp->qsend);
+      if (evudp->error != NULL)
+        evudp->error (evudp->error_data, evudp, res);
+      r_ev_udp_send_ctx_clear (ctx);
+      r_free (ctx);
     }
   }
 }
@@ -172,9 +198,13 @@ r_ev_udp_send_iocb (REvUDP * evudp)
 static void
 r_ev_udp_error_iocb (REvUDP * evudp)
 {
-  (void) evudp;
-  /* TODO */
-  abort ();
+  RSocketStatus err = r_socket_get_error (evudp->socket);
+  R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT" err: %d",
+      evudp->evio.loop, R_EV_IO_ARGS (evudp), err);
+  /* Only notify on a still-set error (the recv / send path may already
+   * have consumed and reported it in this same dispatch). */
+  if (err != R_SOCKET_OK && evudp->error != NULL)
+    evudp->error (evudp->error_data, evudp, err);
 }
 
 static void
@@ -292,6 +322,19 @@ r_ev_udp_recv_stop (REvUDP * evudp)
   }
 
   return ret;
+}
+
+void
+r_ev_udp_set_error_handler (REvUDP * evudp, REvUDPErrorFunc error,
+    rpointer data, RDestroyNotify datanotify)
+{
+  if (R_UNLIKELY (evudp == NULL)) return;
+
+  if (evudp->error_datanotify != NULL)
+    evudp->error_datanotify (evudp->error_data);
+  evudp->error = error;
+  evudp->error_data = data;
+  evudp->error_datanotify = datanotify;
 }
 
 rboolean

--- a/test/revtcp.c
+++ b/test/revtcp.c
@@ -23,9 +23,40 @@ data_received (rpointer data, RBuffer * buf, REvTCP * evtcp)
 
   (void) evtcp;
 
+  if (buf == NULL)
+    return;
   if (*b != NULL)
     r_buffer_unref (*b);
   *b = r_buffer_ref (buf);
+}
+
+static void
+error_received (rpointer data, REvTCP * evtcp, RSocketStatus error)
+{
+  (void) evtcp;
+  *((RSocketStatus *)data) = error;
+}
+
+static void
+eos_received (rpointer data, RBuffer * buf, REvTCP * evtcp)
+{
+  (void) evtcp;
+  if (buf == NULL)
+    *((rboolean *)data) = TRUE;
+}
+
+static void
+error_noop (rpointer data, REvTCP * evtcp, RSocketStatus error)
+{
+  (void) data;
+  (void) evtcp;
+  (void) error;
+}
+
+static void
+mark_true (rpointer data)
+{
+  *((rboolean *)data) = TRUE;
 }
 
 RTEST (revtcp, listen_connect_accept_send_recv, RTEST_FAST | RTEST_SYSTEM)
@@ -72,6 +103,145 @@ RTEST (revtcp, listen_connect_accept_send_recv, RTEST_FAST | RTEST_SYSTEM)
 
   r_ev_tcp_unref (client);
   r_ev_tcp_unref (servcli);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+RTEST (revtcp, recv_error_handler, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RSocketAddress * addr;
+  REvTCP * server, * servcli = NULL, * client;
+  rboolean conn = FALSE;
+  RBuffer * buf = NULL;
+  RSocketStatus err = R_SOCKET_OK;
+  ruint i;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((client = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpptr ((server = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x6364)), !=, NULL);
+  r_assert_cmpint (r_ev_tcp_bind (server, addr, TRUE), ==, R_SOCKET_OK);
+  r_assert_cmpint (r_ev_tcp_listen (server, 10, new_connection_ready, &servcli, NULL), ==, R_SOCKET_OK);
+  r_assert_cmpint (r_ev_tcp_connect (client, addr, client_connected, &conn, NULL), ==, R_SOCKET_WOULD_BLOCK);
+  r_socket_address_unref (addr);
+
+  while (servcli == NULL)
+    r_assert_cmpuint (r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE), >, 0);
+  r_assert (conn);
+  r_assert (r_ev_tcp_close (server, NULL, NULL, NULL));
+  r_ev_tcp_unref (server);
+
+  /* Client receives + reports errors; it sends data the server side
+   * never reads. */
+  r_ev_tcp_set_error_handler (client, error_received, &err, NULL);
+  r_assert (r_ev_tcp_recv_start (client, NULL, data_received, &buf, NULL));
+  r_assert (r_ev_tcp_send_dup (client, "foobar", 6, NULL, NULL, NULL));
+
+  /* Let the datagram reach the server's socket, then close it abruptly:
+   * closing with unread data makes the kernel send an RST, which the
+   * client observes as a connection-reset error rather than EOF. */
+  for (i = 0; i < 8; i++)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_NOWAIT);
+  r_assert (r_ev_tcp_close (servcli, NULL, NULL, NULL));
+  r_ev_tcp_unref (servcli);
+
+  /* Process the deferred close (which sends the RST) and the reset the
+   * client then observes; fall back to a blocking run if the reset has
+   * not landed yet. */
+  for (i = 0; i < 16 && err == R_SOCKET_OK; i++)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_NOWAIT);
+  while (err == R_SOCKET_OK)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE);
+
+  r_assert_cmpint (err, !=, R_SOCKET_OK);
+  r_assert_cmpptr (buf, ==, NULL);          /* no data, only the error */
+
+  r_assert (r_ev_tcp_close (client, NULL, NULL, NULL));
+  r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
+  r_ev_tcp_unref (client);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+/* Same reset as above, but with no error handler installed: the receive
+ * error must fall back to the end-of-stream notification (recv NULL)
+ * rather than abort or stall. */
+RTEST (revtcp, recv_error_no_handler, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RSocketAddress * addr;
+  REvTCP * server, * servcli = NULL, * client;
+  rboolean conn = FALSE, eos = FALSE;
+  ruint i;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((client = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpptr ((server = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x6365)), !=, NULL);
+  r_assert_cmpint (r_ev_tcp_bind (server, addr, TRUE), ==, R_SOCKET_OK);
+  r_assert_cmpint (r_ev_tcp_listen (server, 10, new_connection_ready, &servcli, NULL), ==, R_SOCKET_OK);
+  r_assert_cmpint (r_ev_tcp_connect (client, addr, client_connected, &conn, NULL), ==, R_SOCKET_WOULD_BLOCK);
+  r_socket_address_unref (addr);
+
+  while (servcli == NULL)
+    r_assert_cmpuint (r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE), >, 0);
+  r_assert (conn);
+  r_assert (r_ev_tcp_close (server, NULL, NULL, NULL));
+  r_ev_tcp_unref (server);
+
+  r_assert (r_ev_tcp_recv_start (client, NULL, eos_received, &eos, NULL));
+  r_assert (r_ev_tcp_send_dup (client, "foobar", 6, NULL, NULL, NULL));
+  for (i = 0; i < 8; i++)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_NOWAIT);
+  r_assert (r_ev_tcp_close (servcli, NULL, NULL, NULL));
+  r_ev_tcp_unref (servcli);
+
+  for (i = 0; i < 16 && !eos; i++)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_NOWAIT);
+  while (!eos)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE);
+  r_assert (eos);
+
+  r_assert (r_ev_tcp_close (client, NULL, NULL, NULL));
+  r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
+  r_ev_tcp_unref (client);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+/* The error handler's data is released (via datanotify) both when it is
+ * replaced and when the socket is freed. */
+RTEST (revtcp, error_handler_data_freed, RTEST_FAST)
+{
+  REvLoop * loop;
+  RClock * clock;
+  REvTCP * evtcp;
+  rboolean freed = FALSE;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((evtcp = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+
+  r_ev_tcp_set_error_handler (evtcp, error_noop, &freed, mark_true);
+  r_ev_tcp_set_error_handler (evtcp, NULL, NULL, NULL);   /* replace -> frees old */
+  r_assert (freed);
+
+  freed = FALSE;
+  r_ev_tcp_set_error_handler (evtcp, error_noop, &freed, mark_true);
+  r_ev_tcp_unref (evtcp);                                  /* free -> frees data */
+  r_assert (freed);
+
   r_ev_loop_unref (loop);
 }
 RTEST_END;

--- a/test/revudp.c
+++ b/test/revudp.c
@@ -172,3 +172,42 @@ RTEST (revudp, task_recv, RTEST_FAST | RTEST_SYSTEM)
 }
 RTEST_END;
 
+
+static void
+udp_error_received (rpointer data, REvUDP * evudp, RSocketStatus error)
+{
+  (void) evudp;
+  *((RSocketStatus *)data) = error;
+}
+
+RTEST (revudp, send_error_handler, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RSocketAddress * addr;
+  REvUDP * evudp;
+  RSocketStatus err = R_SOCKET_OK;
+  ruint i;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((evudp = r_ev_udp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x4243)), !=, NULL);
+  r_ev_udp_set_error_handler (evudp, udp_error_received, &err, NULL);
+
+  /* A datagram larger than the IPv4 UDP maximum (65507) cannot be sent;
+   * the failed datagram is dropped and reported, the socket stays usable. */
+  r_assert (r_ev_udp_send_take (evudp, r_malloc0 (70000), 70000, addr, NULL, NULL, NULL));
+
+  for (i = 0; i < 8 && err == R_SOCKET_OK; i++)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_NOWAIT);
+
+  r_assert_cmpint (err, !=, R_SOCKET_OK);
+
+  r_socket_address_unref (addr);
+  r_ev_udp_unref (evudp);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;


### PR DESCRIPTION
The event-loop TCP/UDP backends `abort()`ed on several error paths — recv/send drain failures, the unimplemented UDP error iocb, and `r_ev_io_start` failure on connect/listen — crashing the whole process on an ordinary peer/socket error. This replaces every `abort()` with graceful handling and gives callers a way to observe the error.

## New API
Optional error handler on each backend:
```c
typedef void (*REvTCPErrorFunc) (rpointer data, REvTCP * evtcp, RSocketStatus error);
typedef void (*REvUDPErrorFunc) (rpointer data, REvUDP * evudp, RSocketStatus error);
void r_ev_tcp_set_error_handler (REvTCP *, REvTCPErrorFunc, rpointer, RDestroyNotify);
void r_ev_udp_set_error_handler (REvUDP *, REvUDPErrorFunc, rpointer, RDestroyNotify);
```

## Behaviour
- **TCP recv error** → stop the watcher and report via the handler, or fall back to the existing end-of-stream `recv(NULL)` when none is installed.
- **TCP send error** → stop the writable watcher and report.
- **UDP recv error** → stop draining until the next event; **UDP send error** → drop just that datagram and continue (the socket stays usable).
- **`R_EV_IO_ERROR` event** → reports `r_socket_get_error`, but only when still set, so it isn't re-reported as `R_SOCKET_OK` after the recv/send path already consumed it.
- **connect / listen** → return `R_SOCKET_OOM` when the io watcher can't be started, instead of aborting (with proper `datanotify` cleanup).

The handler may fire more than once for a connection, so it is documented as needing to be idempotent; the `recv(NULL)` end-of-stream convention it falls back to is now documented too.

## Bonus fix
`r_ev_*_free` cleared the send queue with `r_buffer_unref`, but the queue holds send-context structs, not buffers — a latent heap-corruption-on-free, now fixed with a proper context free (newly reachable since an error can leave the queue non-empty). Also fixes a buffer leak on TCP EOS.

## Tests
TCP recv error via RST reported through the handler, its no-handler `recv(NULL)` fallback, error-handler data release on replace and free, and UDP send error via an oversized datagram. (TCP send-error / UDP recv-error / connect-listen OOM aren't deterministically inducible via the public API and are left to inspection.)

Builds clean under debug / release / gcc-warn / clang / tsan (`-werror`); full suite green under debug + ASAN (no leaks); TSan clean on the ev tests; doxygen 0 warnings.

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)