### PR TITLE
net/tls: send alert records and emit an error callback

### DIFF
--- a/include/rlib/net/proto/rtls.h
+++ b/include/rlib/net/proto/rtls.h
@@ -731,6 +731,24 @@ R_API RTLSError r_tls_write_change_cipher (rpointer data, rsize size,
 R_API RTLSError r_dtls_write_change_cipher (rpointer data, rsize size,
     rsize * out, RTLSVersion ver, ruint16 epoch, ruint64 seqno);
 
+/** @brief Write a TLS Alert record (@p level + @p type) into @p data. */
+R_API RTLSError r_tls_write_alert (rpointer data, rsize size, rsize * out,
+    RTLSVersion ver, RTLSAlertLevel level, RTLSAlertType type);
+/**
+ * @brief Write a DTLS Alert record into @p data.
+ * @param data Destination buffer.
+ * @param size Capacity of @p data in bytes.
+ * @param out Out: bytes written.
+ * @param ver Protocol version.
+ * @param epoch DTLS epoch.
+ * @param seqno DTLS record sequence number.
+ * @param level Alert severity.
+ * @param type Alert description.
+ */
+R_API RTLSError r_dtls_write_alert (rpointer data, rsize size, rsize * out,
+    RTLSVersion ver, ruint16 epoch, ruint64 seqno,
+    RTLSAlertLevel level, RTLSAlertType type);
+
 R_END_DECLS
 
 /** @} */

--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -68,6 +68,15 @@ typedef rboolean (*RTLSServerBufferCb) (rpointer ctx, RBuffer * buf, RTLSServer 
 typedef void (*RTLSServerHandshakeDoneCb) (rpointer ctx, RTLSServer * server);
 /** @brief Callback selecting the preferred cipher suites for a TLS version. */
 typedef rboolean (*RTLSPreferredCipherSuitesCb) (rpointer ctx, RTLSVersion ver, RTLSCipherSuite * cs, rsize * count);
+/**
+ * @brief Callback fired when the session aborts with a fatal alert.
+ *
+ * @p alert is the alert description sent to the peer. The session has
+ * moved to its error state; the callback may fire more than once for a
+ * session, so it should be idempotent (e.g. tear the transport down
+ * only once). May be @c NULL.
+ */
+typedef void (*RTLSServerErrorCb) (rpointer ctx, RTLSAlertType alert, RTLSServer * server);
 
 /** @brief Callback bundle wiring a session to its transport and policy. */
 typedef struct {
@@ -75,6 +84,7 @@ typedef struct {
   RTLSServerHandshakeDoneCb     handshake_done;          /**< Fired once the handshake finishes. */
   RTLSServerBufferCb            out;                     /**< Sink for outgoing encrypted records. */
   RTLSServerBufferCb            appdata;                 /**< Sink for decrypted application data. */
+  RTLSServerErrorCb             error;                   /**< Fired on a fatal alert; may be @c NULL. */
 } RTLSCallbacks;
 
 /** @brief Create a TLS server with the given callbacks and user context. */

--- a/rlib/net/proto/rtls.c
+++ b/rlib/net/proto/rtls.c
@@ -1233,3 +1233,62 @@ r_dtls_write_change_cipher (rpointer data, rsize size,
   return R_TLS_ERROR_OK;
 }
 
+RTLSError
+r_tls_write_alert (rpointer data, rsize size, rsize * out,
+    RTLSVersion ver, RTLSAlertLevel level, RTLSAlertType type)
+{
+  ruint8 * p;
+
+  if (R_UNLIKELY (data == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (size < (rsize)(R_TLS_RECORD_HDR_SIZE + 2)))
+    return R_TLS_ERROR_BUF_TOO_SMALL;
+
+  p = data;
+  p[0x00] = R_TLS_CONTENT_TYPE_ALERT;
+  p[0x01] = (ver     >>  8) & 0xff;
+  p[0x02] = (ver          ) & 0xff;
+  p[0x03] = 0;
+  p[0x04] = 2;
+  p[0x05] = (ruint8) level;
+  p[0x06] = (ruint8) type;
+
+  if (out != NULL)
+    *out = R_TLS_RECORD_HDR_SIZE + 2;
+
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_dtls_write_alert (rpointer data, rsize size, rsize * out,
+    RTLSVersion ver, ruint16 epoch, ruint64 seqno,
+    RTLSAlertLevel level, RTLSAlertType type)
+{
+  ruint8 * p;
+
+  if (R_UNLIKELY (data == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (size < (rsize)(R_DTLS_RECORD_HDR_SIZE + 2)))
+    return R_TLS_ERROR_BUF_TOO_SMALL;
+
+  p = data;
+  p[0x00] = R_TLS_CONTENT_TYPE_ALERT;
+  p[0x01] = (ver     >>  8) & 0xff;
+  p[0x02] = (ver          ) & 0xff;
+  p[0x03] = (epoch   >>  8) & 0xff;
+  p[0x04] = (epoch        ) & 0xff;
+  p[0x05] = (seqno   >> 40) & 0xff;
+  p[0x06] = (seqno   >> 32) & 0xff;
+  p[0x07] = (seqno   >> 24) & 0xff;
+  p[0x08] = (seqno   >> 16) & 0xff;
+  p[0x09] = (seqno   >>  8) & 0xff;
+  p[0x0a] = (seqno        ) & 0xff;
+  p[0x0b] = 0;
+  p[0x0c] = 2;
+  p[0x0d] = (ruint8) level;
+  p[0x0e] = (ruint8) type;
+
+  if (out != NULL)
+    *out = R_DTLS_RECORD_HDR_SIZE + 2;
+
+  return R_TLS_ERROR_OK;
+}
+

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -70,6 +70,7 @@ struct RTLSServer {
   rboolean servrandompinned;
 
   RTLSVersion version;
+  RTLSVersion recordver;        /* version of the last record seen, for pre-nego alerts */
   RTLSCompressionMethod comp;
   const RTLSCipherSuiteInfo * csinfo;
   rboolean support_renego;
@@ -1038,13 +1039,54 @@ r_tls_server_parse_finished (RTLSServer * server, const RTLSParser * parser)
 }
 
 
+static void r_tls_server_send_out (RTLSServer * server);
+
 static void
 r_tls_server_send_alert (RTLSServer * server, RTLSAlertType alert)
 {
-  /* TODO: emit error callback */
-  /* TODO: Send alert! */
+  RBuffer * buf;
+  RTLSError ret = R_TLS_ERROR_OOM;
+  /* Use the negotiated version once known, else the version of the
+   * record being processed (the handshake may have failed before
+   * negotiation). */
+  RTLSVersion ver = (server->version != 0) ? server->version : server->recordver;
 
   R_LOG_WARNING ("Sending alert: 0x%.2x in state (%d)", alert, server->state);
+
+  /* Emit a fatal alert record to the peer. Best-effort: even if it
+   * cannot be built/sent we still report and move to the error state. */
+  if ((buf = r_tls_server_alloc_buffer (server)) != NULL) {
+    RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+
+    if (r_buffer_map (buf, &info, R_MEM_MAP_WRITE)) {
+      rsize sz = 0;
+
+      if (r_tls_version_is_dtls (ver))
+        ret = r_dtls_write_alert (info.data, info.size, &sz, ver,
+            server->server.epoch, server->server.seqno,
+            R_TLS_ALERT_LEVEL_FATAL, alert);
+      else
+        ret = r_tls_write_alert (info.data, info.size, &sz, ver,
+            R_TLS_ALERT_LEVEL_FATAL, alert);
+      r_buffer_unmap (buf, &info);
+
+      if (ret == R_TLS_ERROR_OK) {
+        r_buffer_set_size (buf, sz);
+        ret = r_tls_server_send_record (server, buf);
+      }
+    }
+    r_buffer_unref (buf);
+  }
+
+  if (ret != R_TLS_ERROR_OK)
+    R_LOG_WARNING ("Failed to emit alert 0x%.2x: %d", alert, ret);
+  else
+    /* Flush now: the caller returns an error, skipping the normal
+     * send_out in r_tls_server_incoming_data. */
+    r_tls_server_send_out (server);
+
+  if (server->cb.error != NULL)
+    server->cb.error (server->userdata, alert, server);
 
   r_tls_server_change_state (server, R_TLS_SERVER_ERROR);
 }
@@ -1330,6 +1372,10 @@ r_tls_server_incoming_data (RTLSServer * server, RBuffer * buffer)
       err = r_tls_parser_init_next (&parser, &server->inbuf), server->client.seqno++) {
     r_buffer_unref (server->inbuf);
     server->inbuf = NULL;
+
+    /* Remember the record-layer version so a fatal alert can be framed
+     * correctly even before the version is negotiated. */
+    server->recordver = parser.version;
 
     if (!r_tls_parser_is_dtls (&parser) || parser.epoch == server->client.epoch) {
       if ((err = server->decrypt (&parser, server->client.cipher, server->client.hmac)) != R_TLS_ERROR_OK) {

--- a/rlib/rtc/rrtcdtlstransport.c
+++ b/rlib/rtc/rrtcdtlstransport.c
@@ -216,6 +216,7 @@ r_rtc_crypto_transport_new_dtls (RRtcIceTransport * ice, RPrng * prng,
     r_rtc_dtls_srv_hs_done,
     r_rtc_dtls_srv_buffer_out,
     r_rtc_dtls_srv_buffer_appdata,
+    NULL,
   };
 
   if (R_UNLIKELY (ice == NULL)) return NULL;

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -56,6 +56,8 @@ RTEST_FIXTURE_STRUCT (rtlsserver)
 {
   RTLSServer * server;
   rboolean hs_done;
+  rboolean got_error;
+  RTLSAlertType last_alert;
 
   RClock * clock;
   REvLoop * evloop;
@@ -71,6 +73,15 @@ r_tlsserver_test_hs_done (rpointer ctx, RTLSServer * server)
   RTEST_FIXTURE_STRUCT (rtlsserver) * fixture = ctx;
   (void) server;
   fixture->hs_done = TRUE;
+}
+
+static void
+r_tlsserver_test_error (rpointer ctx, RTLSAlertType alert, RTLSServer * server)
+{
+  RTEST_FIXTURE_STRUCT (rtlsserver) * fixture = ctx;
+  (void) server;
+  fixture->got_error = TRUE;
+  fixture->last_alert = alert;
 }
 
 static rboolean
@@ -98,6 +109,7 @@ RTEST_FIXTURE_SETUP (rtlsserver)
     r_tlsserver_test_hs_done,
     r_tlsserver_test_buffer_out,
     r_tlsserver_test_buffer_appdata,
+    r_tlsserver_test_error,
   };
   RCryptoCert * cert;
   RCryptoKey * pk;
@@ -106,6 +118,8 @@ RTEST_FIXTURE_SETUP (rtlsserver)
   r_assert_cmpptr ((fixture->clock = r_test_clock_new (FALSE)), !=, NULL);
   r_assert_cmpptr ((fixture->evloop = r_ev_loop_new_full (fixture->clock, NULL)), !=, NULL);
   fixture->hs_done = FALSE;
+  fixture->got_error = FALSE;
+  fixture->last_alert = R_TLS_ALERT_TYPE_CLOSE_NOTIFY;
 
   r_queue_init (&fixture->qout);
   r_queue_init (&fixture->qapp);
@@ -335,3 +349,74 @@ RTEST_F (rtlsserver, dtls_srtp_valid_handshake, RTEST_FAST)
 }
 RTEST_END;
 
+
+RTEST_F (rtlsserver, dtls_handshake_error_alert, RTEST_FAST)
+{
+  /* A DTLS handshake record whose type is neither ClientHello nor
+   * ServerHello (0x0b = Certificate) is unexpected in the hello state. */
+  static const ruint8 pkt_bad_hs[] = {
+    0x16, 0xfe, 0xfd, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0c,
+    0x0b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+  };
+  RBuffer * buf;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSAlertLevel alevel;
+  RTLSAlertType atype;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  r_test_tls_server_incoming_data (pkt_bad_hs);
+
+  /* The error callback fired with the alert that was sent. */
+  r_assert (fixture->got_error);
+  r_assert_cmpuint (fixture->last_alert, ==, R_TLS_ALERT_TYPE_UNEXPECTED_MESSAGE);
+  r_assert (!fixture->hs_done);
+
+  /* A fatal alert record was emitted to the peer. */
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_ALERT);
+  r_assert_cmpint (r_tls_parser_parse_alert (&parser, &alevel, &atype), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (alevel, ==, R_TLS_ALERT_LEVEL_FATAL);
+  r_assert_cmpuint (atype, ==, R_TLS_ALERT_TYPE_UNEXPECTED_MESSAGE);
+
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
+RTEST_F (rtlsserver, tls_handshake_error_alert, RTEST_FAST)
+{
+  /* As above but over a (non-DTLS) TLS 1.2 record, exercising the
+   * r_tls_write_alert framing path. 0x0b = Certificate, unexpected in
+   * the hello state. */
+  static const ruint8 pkt_bad_hs[] = {
+    0x16, 0x03, 0x03, 0x00, 0x04, 0x0b, 0x00, 0x00, 0x00
+  };
+  RBuffer * buf;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSAlertLevel alevel;
+  RTLSAlertType atype;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  r_test_tls_server_incoming_data (pkt_bad_hs);
+
+  r_assert (fixture->got_error);
+  r_assert_cmpuint (fixture->last_alert, ==, R_TLS_ALERT_TYPE_UNEXPECTED_MESSAGE);
+  r_assert (!fixture->hs_done);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_ALERT);
+  r_assert (!r_tls_parser_is_dtls (&parser));
+  r_assert_cmpint (r_tls_parser_parse_alert (&parser, &alevel, &atype), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (alevel, ==, R_TLS_ALERT_LEVEL_FATAL);
+  r_assert_cmpuint (atype, ==, R_TLS_ALERT_TYPE_UNEXPECTED_MESSAGE);
+
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+}
+RTEST_END;


### PR DESCRIPTION
`r_tls_server_send_alert` only logged a warning — it never put an alert record on the wire and never told the application, so a fatal handshake/record error left both the peer and the app uninformed.

## Changes
- New record writers `r_tls_write_alert` / `r_dtls_write_alert` (protocol layer, modeled on the ChangeCipherSpec writers).
- `r_tls_server_send_alert` now builds and sends a **fatal alert record** through the record layer (encrypted post-handshake, plaintext during), **flushes it immediately** (the error return path otherwise skips the normal `send_out`), and fires a new optional **`RTLSServerErrorCb`** on `RTLSCallbacks` with the alert description. The ~15 call sites that already computed the right `RTLSAlertType` now actually reach the peer.
- Alerts are framed with the negotiated version once known, else the version of the record being processed (tracked per record), so a fatal alert raised *before* negotiation is still framed correctly (otherwise it went out with version 0 and was unparseable).

## Tests
Drive a fatal alert (an unexpected handshake type) over **both** a DTLS and a TLS record, asserting the emitted alert record (content type, fatal level, alert code) and the error callback on each — covering both the `r_dtls_write_alert` and `r_tls_write_alert` framing paths.

This is the first slice of the #219–#222 TLS/SRTP/RTP work; the remaining #219 handshake features (client-cert/mTLS, ServerHello extensions, TLS 1.3, session tickets, extended master secret, renegotiation_info) are separate follow-ups. The lack of an HTTPS server to integration-test the TLS path end-to-end is filed as #255.

Builds clean under debug / release / gcc-warn / clang (`-werror`); full suite green under debug + ASAN (no leaks); doxygen 0 warnings.

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)