### PR TITLE
net: TLS server extensions — extended master secret, secure renegotiation, encrypt-then-MAC

### DIFF
--- a/include/rlib/net/proto/rtls.h
+++ b/include/rlib/net/proto/rtls.h
@@ -442,9 +442,15 @@ R_API RBuffer * r_tls_parser_next (RTLSParser * parser);
 /** @brief Release resources held by @p parser. */
 R_API void r_tls_parser_clear (RTLSParser * parser);
 
-/** @brief Decrypt and MAC-verify the current record in place. */
+/**
+ * @brief Decrypt and MAC-verify the current record in place.
+ * @param parser Parser positioned on the record to decrypt.
+ * @param cipher Record-protection cipher.
+ * @param mac Record MAC, or @c NULL.
+ * @param etm Use encrypt-then-MAC (RFC 7366) for CBC suites when @c TRUE.
+ */
 R_API RTLSError r_tls_parser_decrypt (RTLSParser * parser,
-    const RCryptoCipher * cipher, RHmac * mac);
+    const RCryptoCipher * cipher, RHmac * mac, rboolean etm);
 
 /** @brief @c TRUE if protocol @p version is a DTLS version. */
 #define r_tls_version_is_dtls(version) ((version) > RUINT16_MAX / 2)
@@ -625,20 +631,22 @@ R_API RTLSError r_tls_1_2_prf_sha512 (ruint8 * dst, rsize dsize,
  * @param cipher Record-protection cipher.
  * @param iv Explicit IV, or @c NULL.
  * @param hmac Record MAC, or @c NULL.
+ * @param etm Use encrypt-then-MAC (RFC 7366) for CBC suites when @c TRUE.
  * @return New buffer holding the protected record, or @c NULL on failure.
  */
 R_API RBuffer * r_tls_encrypt_buffer (RBuffer * buf, ruint64 seqno,
-    const RCryptoCipher * cipher, const ruint8 * iv, RHmac * hmac);
+    const RCryptoCipher * cipher, const ruint8 * iv, RHmac * hmac, rboolean etm);
 /**
  * @brief Encrypt and MAC a DTLS record buffer (sequence taken from the record).
  * @param buf Plaintext record payload.
  * @param cipher Record-protection cipher.
  * @param iv Explicit IV, or @c NULL.
  * @param hmac Record MAC, or @c NULL.
+ * @param etm Use encrypt-then-MAC (RFC 7366) for CBC suites when @c TRUE.
  * @return New buffer holding the protected record, or @c NULL on failure.
  */
 R_API RBuffer * r_dtls_encrypt_buffer (RBuffer * buf,
-    const RCryptoCipher * cipher, const ruint8 * iv, RHmac * hmac);
+    const RCryptoCipher * cipher, const ruint8 * iv, RHmac * hmac, rboolean etm);
 
 /**
  * @brief Write a TLS handshake record header into @p data.

--- a/rlib/net/proto/rtls.c
+++ b/rlib/net/proto/rtls.c
@@ -1040,6 +1040,12 @@ r_tls_hello_msg_extension_next (const RTLSHelloMsg * msg, RTLSHelloExt * ext)
   ext->type = r_load_be16 (&ext->start[0]);
   ext->len = r_load_be16 (&ext->start[2]);
   ext->data = ext->start + R_TLS_HELLO_EXT_HDR_SIZE;
+  /* The extension body must fit within the declared extensions length
+   * (mirrors the check in _first; a truncated trailing extension would
+   * otherwise leave data+len past the block and over-read it). */
+  if (R_UNLIKELY (RPOINTER_TO_SIZE (ext->data + ext->len) >
+        RPOINTER_TO_SIZE (msg->ext + msg->extlen)))
+    return R_TLS_ERROR_EOB;
 
   return R_TLS_ERROR_OK;
 }

--- a/rlib/net/proto/rtls.c
+++ b/rlib/net/proto/rtls.c
@@ -215,9 +215,104 @@ r_tls_parser_next (RTLSParser * parser)
   return ret;
 }
 
+/* Fill the 13-byte MAC seed prefix: seq_num (epoch+seqno for DTLS) +
+ * content type + version + length, where length is the IV+ciphertext size
+ * for encrypt-then-MAC (RFC 7366) or the plaintext size for MAC-then-encrypt. */
+static void
+r_tls_mac_seed (const RTLSParser * parser, ruint8 scratch[13], rsize length)
+{
+  if (r_tls_parser_is_dtls (parser)) {
+    scratch[0x00] = (parser->epoch   >>  8) & 0xff;
+    scratch[0x01] = (parser->epoch        ) & 0xff;
+  } else {
+    scratch[0x00] = (parser->seqno   >> 56) & 0xff;
+    scratch[0x01] = (parser->seqno   >> 48) & 0xff;
+  }
+  scratch[0x02] = (parser->seqno   >> 40) & 0xff;
+  scratch[0x03] = (parser->seqno   >> 32) & 0xff;
+  scratch[0x04] = (parser->seqno   >> 24) & 0xff;
+  scratch[0x05] = (parser->seqno   >> 16) & 0xff;
+  scratch[0x06] = (parser->seqno   >>  8) & 0xff;
+  scratch[0x07] = (parser->seqno        ) & 0xff;
+  scratch[0x08] = (parser->content      ) & 0xff;
+  scratch[0x09] = (parser->version >>  8) & 0xff;
+  scratch[0x0a] = (parser->version      ) & 0xff;
+  scratch[0x0b] = (length          >>  8) & 0xff;
+  scratch[0x0c] = (length               ) & 0xff;
+}
+
+/* RFC 7366 encrypt-then-MAC decrypt: the fragment is IV || ciphertext || MAC.
+ * Verify the MAC over the IV and ciphertext first, then decrypt and strip
+ * the CBC padding. */
+static RTLSError
+r_tls_parser_decrypt_etm (RTLSParser * parser,
+    const RCryptoCipher * cipher, RHmac * mac)
+{
+  RBuffer * buf, * replace;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  rsize ivsize = cipher->info->ivsize;
+  rsize macsize = r_hmac_size (mac);
+  rsize ctlen, contentsize, padding;
+  ruint8 scratch[sizeof (ruint64) + sizeof (ruint8) + 2 * sizeof (ruint16)];
+  ruint8 * iv;
+
+  if (parser->fragment.size < ivsize + ivsize + macsize)
+    return R_TLS_ERROR_CORRUPT_RECORD;
+  ctlen = parser->fragment.size - ivsize - macsize;
+  if ((ctlen % ivsize) != 0)
+    return R_TLS_ERROR_CORRUPT_RECORD;
+
+  r_tls_mac_seed (parser, scratch, ivsize + ctlen);
+  r_hmac_reset (mac);
+  r_hmac_update (mac, scratch, sizeof (scratch));
+  r_hmac_update (mac, parser->fragment.data, ivsize + ctlen);
+  if (!r_hmac_verify (mac, parser->fragment.data + ivsize + ctlen, macsize))
+    return R_TLS_ERROR_INVALID_MAC;
+
+  if ((buf = r_buffer_new_alloc (NULL, ctlen, NULL)) == NULL)
+    return R_TLS_ERROR_OOM;
+  if (!r_buffer_map (buf, &info, R_MEM_MAP_WRITE)) {
+    r_buffer_unref (buf);
+    return R_TLS_ERROR_OOM;
+  }
+
+  iv = r_alloca (ivsize);
+  r_memcpy (iv, parser->fragment.data, ivsize);
+  if (r_crypto_cipher_decrypt (cipher, info.data, info.size,
+        parser->fragment.data + ivsize, iv, ivsize) != R_CRYPTO_CIPHER_OK) {
+    r_buffer_unmap (buf, &info);
+    r_buffer_unref (buf);
+    return R_TLS_ERROR_CORRUPT_RECORD;
+  }
+
+  padding = 1 + info.data[info.size - 1];
+  if (padding > ctlen) {
+    r_buffer_unmap (buf, &info);
+    r_buffer_unref (buf);
+    return R_TLS_ERROR_CORRUPT_RECORD;
+  }
+  contentsize = ctlen - padding;
+  r_buffer_unmap (buf, &info);
+  r_buffer_resize (buf, 0, contentsize);
+
+  replace = r_buffer_replace_byte_range (parser->buf,
+      parser->offset, parser->fragment.size, buf);
+  r_buffer_unref (buf);
+  r_buffer_unmap (parser->buf, &parser->fragment);
+  r_buffer_unref (parser->buf);
+  parser->buf = replace;
+  parser->recsize = parser->offset + contentsize;
+
+  if (!r_buffer_map_byte_range (parser->buf, parser->offset, (rssize)contentsize,
+        &parser->fragment, R_MEM_MAP_READ))
+    return R_TLS_ERROR_BUF_TOO_SMALL;
+
+  return R_TLS_ERROR_OK;
+}
+
 RTLSError
 r_tls_parser_decrypt (RTLSParser * parser,
-    const RCryptoCipher * cipher, RHmac * mac)
+    const RCryptoCipher * cipher, RHmac * mac, rboolean etm)
 {
   RBuffer * buf, * replace;
   RMemMapInfo info = R_MEM_MAP_INFO_INIT;
@@ -228,6 +323,9 @@ r_tls_parser_decrypt (RTLSParser * parser,
   if (R_UNLIKELY (cipher == NULL)) return R_TLS_ERROR_INVAL;
   if (R_UNLIKELY (cipher->info->type == R_CRYPTO_CIPHER_ALGO_NULL))
     return R_TLS_ERROR_OK;
+
+  if (etm && mac != NULL && cipher->info->mode == R_CRYPTO_CIPHER_MODE_CBC)
+    return r_tls_parser_decrypt_etm (parser, cipher, mac);
 
   ivsize = cipher->info->ivsize;
   if (R_UNLIKELY (parser->fragment.size < ivsize))
@@ -386,9 +484,75 @@ _r_tls_encrypt_buffer (const ruint8 * buf, rsize bufsize, rsize hdrsize,
   return ret;
 }
 
+/* RFC 7366 encrypt-then-MAC: emit record hdr + IV + ENC(fragment||padding),
+ * then the MAC over @aad (seq + type + version), the IV+ciphertext length and
+ * the IV+ciphertext. @aad is the 11-byte seq+type+version prefix the wrapper
+ * assembled (the length is appended here since it depends on the ciphertext). */
+static RBuffer *
+_r_tls_encrypt_buffer_etm (const ruint8 * buf, rsize bufsize, rsize hdrsize,
+    const RCryptoCipher * cipher, const ruint8 * iv, RHmac * hmac,
+    const ruint8 * aad)
+{
+  RBuffer * ret = NULL;
+  rsize ivsize = cipher->info->ivsize;
+  rsize fragsize = bufsize - hdrsize;
+  rsize macsize = r_hmac_size (hmac);
+  ruint8 padding = (ruint8)(ivsize - (fragsize % ivsize));
+  rsize ctlen = fragsize + padding;
+  rsize reclen = ivsize + ctlen + macsize;
+
+  if ((ret = r_buffer_new_alloc (NULL, hdrsize + reclen, NULL)) != NULL) {
+    RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+    RCryptoCipherResult res;
+
+    if (r_buffer_map (ret, &info, R_MEM_MAP_WRITE)) {
+      ruint8 * ivtmp = r_alloca (ivsize);
+      ruint8 * p = info.data;
+      ruint8 lenbe[sizeof (ruint16)];
+
+      /* record hdr with the IV+ciphertext+MAC length */
+      r_memcpy (p, buf, hdrsize - 2);
+      p += hdrsize - 2;
+      *p++ = (reclen >> 8) & 0xff;
+      *p++ = (reclen     ) & 0xff;
+
+      /* IV (in the clear), then fragment + padding to encrypt */
+      r_memcpy (ivtmp, iv, ivsize);
+      r_memcpy (p, iv, ivsize);
+      r_memcpy (p + ivsize, buf + hdrsize, fragsize);
+      r_memset (p + ivsize + fragsize, padding - 1, padding);
+
+      res = r_crypto_cipher_encrypt (cipher, p + ivsize, ctlen, p + ivsize, ivtmp, ivsize);
+
+      if (res == R_CRYPTO_CIPHER_OK) {
+        /* MAC over seq + type + version + length + IV + ciphertext */
+        lenbe[0] = ((ivsize + ctlen) >> 8) & 0xff;
+        lenbe[1] = ((ivsize + ctlen)     ) & 0xff;
+        r_hmac_reset (hmac);
+        r_hmac_update (hmac, aad, sizeof (ruint64) + sizeof (ruint8) + sizeof (ruint16));
+        r_hmac_update (hmac, lenbe, sizeof (lenbe));
+        r_hmac_update (hmac, p, ivsize + ctlen);
+        if (!r_hmac_get_data (hmac, p + ivsize + ctlen, macsize, &macsize))
+          res = R_CRYPTO_CIPHER_INVAL;
+      }
+
+      r_buffer_unmap (ret, &info);
+    } else {
+      res = R_CRYPTO_CIPHER_INVAL;
+    }
+
+    if (res != R_CRYPTO_CIPHER_OK) {
+      r_buffer_unref (ret);
+      ret = NULL;
+    }
+  }
+
+  return ret;
+}
+
 RBuffer *
 r_dtls_encrypt_buffer (RBuffer * buf, const RCryptoCipher * cipher,
-    const ruint8 * iv, RHmac * hmac)
+    const ruint8 * iv, RHmac * hmac, rboolean etm)
 {
   RBuffer * ret;
   RMemMapInfo info = R_MEM_MAP_INFO_INIT;
@@ -398,22 +562,32 @@ r_dtls_encrypt_buffer (RBuffer * buf, const RCryptoCipher * cipher,
   if (R_UNLIKELY (hmac == NULL)) return NULL;
 
   if (r_buffer_map (buf, &info, R_MEM_MAP_READ)) {
-    rsize macsize = r_hmac_size (hmac);
-    ruint8 * macbuf = r_alloca (macsize);
-    ruint16 fraglen = RUINT16_TO_BE ((ruint16)(info.size - R_DTLS_RECORD_HDR_SIZE));
     ruint16 hdrsize = R_DTLS_RECORD_HDR_SIZE;
 
-    r_hmac_reset (hmac);
-    r_hmac_update (hmac, info.data + 3, sizeof (ruint64)); /* epoch + seqno */
-    r_hmac_update (hmac, info.data, 1 + sizeof (ruint16)); /* type + version */
-    r_hmac_update (hmac, &fraglen, sizeof (ruint16)); /* length */
-    r_hmac_update (hmac, info.data + hdrsize, info.size - hdrsize); /* fragment */
-
-    if (r_hmac_get_data (hmac, macbuf, macsize, &macsize)) {
-      ret = _r_tls_encrypt_buffer (info.data, info.size, hdrsize,
-          cipher, iv, macbuf, macsize);
+    if (etm && cipher->info->mode == R_CRYPTO_CIPHER_MODE_CBC) {
+      ruint8 aad[sizeof (ruint64) + sizeof (ruint8) + sizeof (ruint16)];
+      r_memcpy (aad, info.data + 3, sizeof (ruint64)); /* epoch + seqno */
+      aad[8] = info.data[0];                           /* type */
+      aad[9] = info.data[1]; aad[10] = info.data[2];   /* version */
+      ret = _r_tls_encrypt_buffer_etm (info.data, info.size, hdrsize,
+          cipher, iv, hmac, aad);
     } else {
-      ret = NULL;
+      rsize macsize = r_hmac_size (hmac);
+      ruint8 * macbuf = r_alloca (macsize);
+      ruint16 fraglen = RUINT16_TO_BE ((ruint16)(info.size - R_DTLS_RECORD_HDR_SIZE));
+
+      r_hmac_reset (hmac);
+      r_hmac_update (hmac, info.data + 3, sizeof (ruint64)); /* epoch + seqno */
+      r_hmac_update (hmac, info.data, 1 + sizeof (ruint16)); /* type + version */
+      r_hmac_update (hmac, &fraglen, sizeof (ruint16)); /* length */
+      r_hmac_update (hmac, info.data + hdrsize, info.size - hdrsize); /* fragment */
+
+      if (r_hmac_get_data (hmac, macbuf, macsize, &macsize)) {
+        ret = _r_tls_encrypt_buffer (info.data, info.size, hdrsize,
+            cipher, iv, macbuf, macsize);
+      } else {
+        ret = NULL;
+      }
     }
     r_buffer_unmap (buf, &info);
   } else {
@@ -425,7 +599,7 @@ r_dtls_encrypt_buffer (RBuffer * buf, const RCryptoCipher * cipher,
 
 RBuffer *
 r_tls_encrypt_buffer (RBuffer * buf, ruint64 seqno,
-    const RCryptoCipher * cipher, const ruint8 * iv, RHmac * hmac)
+    const RCryptoCipher * cipher, const ruint8 * iv, RHmac * hmac, rboolean etm)
 {
   RBuffer * ret;
   RMemMapInfo info = R_MEM_MAP_INFO_INIT;
@@ -435,21 +609,31 @@ r_tls_encrypt_buffer (RBuffer * buf, ruint64 seqno,
   if (R_UNLIKELY (hmac == NULL)) return NULL;
 
   if (r_buffer_map (buf, &info, R_MEM_MAP_READ)) {
-    rsize macsize = r_hmac_size (hmac);
-    ruint8 * macbuf = r_alloca (macsize);
     ruint16 hdrsize = R_TLS_RECORD_HDR_SIZE;
 
     seqno = RUINT64_TO_BE (seqno);
-    r_hmac_reset (hmac);
-    r_hmac_update (hmac, &seqno, sizeof (ruint64)); /* seqno */
-    r_hmac_update (hmac, info.data, 5); /* type + version + length */
-    r_hmac_update (hmac, info.data + hdrsize, info.size - hdrsize); /* fragment */
-
-    if (r_hmac_get_data (hmac, macbuf, macsize, &macsize)) {
-      ret = _r_tls_encrypt_buffer (info.data, info.size, hdrsize,
-          cipher, iv, macbuf, macsize);
+    if (etm && cipher->info->mode == R_CRYPTO_CIPHER_MODE_CBC) {
+      ruint8 aad[sizeof (ruint64) + sizeof (ruint8) + sizeof (ruint16)];
+      r_memcpy (aad, &seqno, sizeof (ruint64));        /* seqno */
+      aad[8] = info.data[0];                           /* type */
+      aad[9] = info.data[1]; aad[10] = info.data[2];   /* version */
+      ret = _r_tls_encrypt_buffer_etm (info.data, info.size, hdrsize,
+          cipher, iv, hmac, aad);
     } else {
-      ret = NULL;
+      rsize macsize = r_hmac_size (hmac);
+      ruint8 * macbuf = r_alloca (macsize);
+
+      r_hmac_reset (hmac);
+      r_hmac_update (hmac, &seqno, sizeof (ruint64)); /* seqno */
+      r_hmac_update (hmac, info.data, 5); /* type + version + length */
+      r_hmac_update (hmac, info.data + hdrsize, info.size - hdrsize); /* fragment */
+
+      if (r_hmac_get_data (hmac, macbuf, macsize, &macsize)) {
+        ret = _r_tls_encrypt_buffer (info.data, info.size, hdrsize,
+            cipher, iv, macbuf, macsize);
+      } else {
+        ret = NULL;
+      }
     }
     r_buffer_unmap (buf, &info);
   } else {

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -948,17 +948,6 @@ r_tls_server_parse_client_key_exchange (RTLSServer * server,
         pms[1] = (((ruint16)server->version)     ) & 0xff;
       }
     }
-
-#if 0
-    R_LOG_DEBUG ("RSA PreMasterSecret:");
-    R_LOG_MEM_DUMP (R_LOG_LEVEL_DEBUG, pms, 48);
-    R_LOG_DEBUG ("Client random:");
-    R_LOG_MEM_DUMP (R_LOG_LEVEL_DEBUG,
-        server->hello.random, (rsize)R_TLS_HELLO_RANDOM_BYTES);
-    R_LOG_DEBUG ("Server random:");
-    R_LOG_MEM_DUMP (R_LOG_LEVEL_DEBUG,
-        server->servrandom, (rsize)R_TLS_HELLO_RANDOM_BYTES);
-#endif
   }
 
   return ret;
@@ -990,12 +979,6 @@ r_tls_server_derive_master_secret (RTLSServer * server, const ruint8 pms[48])
         server->servrandom, (rsize)R_TLS_HELLO_RANDOM_BYTES,
         NULL);
   }
-
-#if 0
-  R_LOG_DEBUG ("RSA MasterSecret:");
-  R_LOG_MEM_DUMP (R_LOG_LEVEL_DEBUG,
-      server->mastersecret, sizeof (server->mastersecret));
-#endif
 
   return ret;
 }

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -853,7 +853,13 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
     switch (hsext.type) {
       case R_TLS_EXT_TYPE_RENEGOTIATION_INFO:
         server->support_renego = TRUE;
-        /* FIXME: parse renego info */
+        /* RFC 5746: extension_data is renegotiated_connection<0..255> (a
+         * 1-byte length prefix). It must be empty on the initial handshake;
+         * rlib does not renegotiate, so a non-empty value is rejected. */
+        if (hsext.len < 1 || hsext.data[0] != hsext.len - 1)
+          return R_TLS_ERROR_CORRUPT_RECORD;
+        if (hsext.data[0] != 0)
+          return R_TLS_ERROR_HANDSHAKE_FAILURE;
         break;
       case R_TLS_EXT_TYPE_SESSION_TICKET:
         server->support_new_session_ticket = TRUE;
@@ -877,6 +883,12 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
         break;
     }
   }
+
+  /* RFC 5746 3.6: the SCSV signals secure-renegotiation support just like
+   * an empty renegotiation_info extension. */
+  if (r_tls_hello_msg_has_cipher_suite (&server->hello,
+        R_TLS_CS_EMPTY_RENEGOTIATION_INFO_SCSV))
+    server->support_renego = TRUE;
 
   if (server->support_new_session_ticket) {
     /* FIXME: create session ticket server->ticket, server->ticketsize */

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -41,7 +41,7 @@ typedef enum {
 typedef RTLSError (*RTLSServerStateFunc) (RTLSServer * server, const RTLSParser * parser);
 typedef RBuffer * (*RTLSServerEncryptFunc) (RTLSServer * server, RBuffer * buf);
 typedef RTLSError (*RTLSServerDecryptFunc) (RTLSParser * parser,
-    const RCryptoCipher * cipher, RHmac * mac);
+    const RCryptoCipher * cipher, RHmac * mac, rboolean etm);
 
 typedef struct {
   RHmac * hmac;
@@ -76,6 +76,7 @@ struct RTLSServer {
   rboolean support_renego;
   rboolean support_new_session_ticket;
   rboolean support_ext_master_secret;
+  rboolean encrypt_then_mac;
   RSRTPCipherSuite dtls_srtp_profile;
   ruint8 srtp_mki_size;
   const ruint8 * srtp_mki;
@@ -152,11 +153,12 @@ r_tls_server_free (RTLSServer * server)
 
 static RTLSError
 r_tls_server_null_decrypt (RTLSParser * parser, const RCryptoCipher * cipher,
-    RHmac * mac)
+    RHmac * mac, rboolean etm)
 {
   (void) parser;
   (void) cipher;
   (void) mac;
+  (void) etm;
 
   return R_TLS_ERROR_OK;
 }
@@ -262,10 +264,10 @@ r_tls_server_cipher_encrypt (RTLSServer * server, RBuffer * buf)
   r_prng_fill (server->prng, iv, server->server.cipher->info->ivsize);
   if (r_tls_version_is_dtls (server->version)) {
     ret = r_dtls_encrypt_buffer (buf,
-        server->server.cipher, iv, server->server.hmac);
+        server->server.cipher, iv, server->server.hmac, server->encrypt_then_mac);
   } else {
     ret = r_tls_encrypt_buffer (buf, server->server.seqno,
-        server->server.cipher, iv, server->server.hmac);
+        server->server.cipher, iv, server->server.hmac, server->encrypt_then_mac);
   }
 
   return ret;
@@ -318,6 +320,17 @@ r_tls_server_write_hs_ext_extended_ms (const RTLSServer * server, ruint8 * ptr)
     return 0;
 
   r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_EXTENDED_MASTER_SECRET);
+  r_store_be16 (&ptr[2], 0);
+  return 4;
+}
+
+static ruint16
+r_tls_server_write_hs_ext_encrypt_then_mac (const RTLSServer * server, ruint8 * ptr)
+{
+  if (!server->encrypt_then_mac)
+    return 0;
+
+  r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_ENCRYPT_THEN_MAC);
   r_store_be16 (&ptr[2], 0);
   return 4;
 }
@@ -398,11 +411,11 @@ r_tls_server_write_hello (RTLSServer * server)
     extsize = 0;
     extsize += r_tls_server_write_hs_ext_renegotiation (server, ptr + 2 + extsize);
     extsize += r_tls_server_write_hs_ext_extended_ms (server, ptr + 2 + extsize);
+    extsize += r_tls_server_write_hs_ext_encrypt_then_mac (server, ptr + 2 + extsize);
     /* FIXME: Write remaining ServerHello extensions */
 #if 0
     extsize += r_tls_server_write_hs_ext_max_fragment_length (server, ptr + 2 + extsize);
     extsize += r_tls_server_write_hs_ext_truncated_hmac (server, ptr + 2 + extsize);
-    extsize += r_tls_server_write_hs_ext_encrypt_then_mac (server, ptr + 2 + extsize);
 #endif
     extsize += r_tls_server_write_hs_ext_session_ticket (server, ptr + 2 + extsize);
 #if 0
@@ -845,6 +858,7 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
   server->support_renego = FALSE;
   server->support_new_session_ticket = FALSE;
   server->support_ext_master_secret = FALSE;
+  server->encrypt_then_mac = FALSE;
   server->dtls_srtp_profile = R_SRTP_CS_NONE;
 
   for (r = r_tls_hello_msg_extension_first (&server->hello, &hsext);
@@ -875,6 +889,12 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
             server->dtls_srtp_profile = R_SRTP_CS_AES_128_CM_HMAC_SHA1_32;
           }
         }
+        break;
+      case R_TLS_EXT_TYPE_ENCRYPT_THEN_MAC:
+        /* RFC 7366: only applies to block (CBC) cipher suites; AEAD and
+         * stream/NULL suites ignore it. */
+        if (server->csinfo->cipher->mode == R_CRYPTO_CIPHER_MODE_CBC)
+          server->encrypt_then_mac = TRUE;
         break;
       case R_TLS_EXT_TYPE_EXTENDED_MASTER_SECRET:
         server->support_ext_master_secret = TRUE;
@@ -1427,7 +1447,8 @@ r_tls_server_incoming_data (RTLSServer * server, RBuffer * buffer)
     server->recordver = parser.version;
 
     if (!r_tls_parser_is_dtls (&parser) || parser.epoch == server->client.epoch) {
-      if ((err = server->decrypt (&parser, server->client.cipher, server->client.hmac)) != R_TLS_ERROR_OK) {
+      if ((err = server->decrypt (&parser, server->client.cipher, server->client.hmac,
+              server->encrypt_then_mac)) != R_TLS_ERROR_OK) {
         /* A record that fails decrypt / MAC must not be processed. */
         R_LOG_WARNING ("Decryption returned: %d", err);
         continue;

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -412,20 +412,8 @@ r_tls_server_write_hello (RTLSServer * server)
     extsize += r_tls_server_write_hs_ext_renegotiation (server, ptr + 2 + extsize);
     extsize += r_tls_server_write_hs_ext_extended_ms (server, ptr + 2 + extsize);
     extsize += r_tls_server_write_hs_ext_encrypt_then_mac (server, ptr + 2 + extsize);
-    /* FIXME: Write remaining ServerHello extensions */
-#if 0
-    extsize += r_tls_server_write_hs_ext_max_fragment_length (server, ptr + 2 + extsize);
-    extsize += r_tls_server_write_hs_ext_truncated_hmac (server, ptr + 2 + extsize);
-#endif
     extsize += r_tls_server_write_hs_ext_session_ticket (server, ptr + 2 + extsize);
-#if 0
-    extsize += r_tls_server_write_hs_ext_supported_point_formats (server, ptr + 2 + extsize);
-#endif
     extsize += r_tls_server_write_hs_ext_use_srtp (server, ptr + 2 + extsize);
-#if 0
-    extsize += r_tls_server_write_hs_ext_ecjpake_kkpp (server, ptr + 2 + extsize);
-    extsize += r_tls_server_write_hs_ext_alpn (server, ptr + 2 + extsize);
-#endif
 
     if (extsize > 0) {
       r_store_be16 (ptr, extsize);

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -312,6 +312,17 @@ r_tls_server_write_hs_ext_renegotiation (const RTLSServer * server, ruint8 * ptr
 }
 
 static ruint16
+r_tls_server_write_hs_ext_extended_ms (const RTLSServer * server, ruint8 * ptr)
+{
+  if (!server->support_ext_master_secret)
+    return 0;
+
+  r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_EXTENDED_MASTER_SECRET);
+  r_store_be16 (&ptr[2], 0);
+  return 4;
+}
+
+static ruint16
 r_tls_server_write_hs_ext_session_ticket (const RTLSServer * server, ruint8 * ptr)
 {
   if (!server->support_new_session_ticket || server->ticketsize == 0)
@@ -386,12 +397,12 @@ r_tls_server_write_hello (RTLSServer * server)
     }
     extsize = 0;
     extsize += r_tls_server_write_hs_ext_renegotiation (server, ptr + 2 + extsize);
-    /* FIXME: Write ServerHello extensions */
+    extsize += r_tls_server_write_hs_ext_extended_ms (server, ptr + 2 + extsize);
+    /* FIXME: Write remaining ServerHello extensions */
 #if 0
     extsize += r_tls_server_write_hs_ext_max_fragment_length (server, ptr + 2 + extsize);
     extsize += r_tls_server_write_hs_ext_truncated_hmac (server, ptr + 2 + extsize);
     extsize += r_tls_server_write_hs_ext_encrypt_then_mac (server, ptr + 2 + extsize);
-    extsize += r_tls_server_write_hs_ext_extended_ms (server, ptr + 2 + extsize);
 #endif
     extsize += r_tls_server_write_hs_ext_session_ticket (server, ptr + 2 + extsize);
 #if 0
@@ -859,7 +870,9 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
           }
         }
         break;
-      case R_TLS_EXT_TYPE_EXTENDED_MASTER_SECRET: /* Skip it! */
+      case R_TLS_EXT_TYPE_EXTENDED_MASTER_SECRET:
+        server->support_ext_master_secret = TRUE;
+        break;
       default:
         break;
     }
@@ -884,14 +897,13 @@ r_tls_server_parse_client_certificate (RTLSServer * server,
 
 static RTLSError
 r_tls_server_parse_client_key_exchange (RTLSServer * server,
-    const RTLSParser * parser)
+    const RTLSParser * parser, ruint8 pms[48])
 {
   const ruint8 * encpms;
   rsize size;
   RTLSError ret;
 
   if ((ret = r_tls_parser_parse_client_key_exchange_rsa (parser, &encpms, &size)) == R_TLS_ERROR_OK) {
-    ruint8 pms[48];
     ruint8 * out;
 
     /* size is the peer's encrypted-PMS length; cap it before the
@@ -901,7 +913,7 @@ r_tls_server_parse_client_key_exchange (RTLSServer * server,
       return R_TLS_ERROR_CORRUPT_RECORD;
     out = r_alloca (size);
 
-    r_prng_fill (server->prng, pms, sizeof (pms));
+    r_prng_fill (server->prng, pms, 48);
     if (r_crypto_key_decrypt (server->privkey, server->prng, encpms, size, out, &size) == R_CRYPTO_OK) {
       if (size == 48) {
         r_memcpy (pms, out, size);
@@ -919,7 +931,7 @@ r_tls_server_parse_client_key_exchange (RTLSServer * server,
 
 #if 0
     R_LOG_DEBUG ("RSA PreMasterSecret:");
-    R_LOG_MEM_DUMP (R_LOG_LEVEL_DEBUG, pms, sizeof (pms));
+    R_LOG_MEM_DUMP (R_LOG_LEVEL_DEBUG, pms, 48);
     R_LOG_DEBUG ("Client random:");
     R_LOG_MEM_DUMP (R_LOG_LEVEL_DEBUG,
         server->hello.random, (rsize)R_TLS_HELLO_RANDOM_BYTES);
@@ -927,22 +939,43 @@ r_tls_server_parse_client_key_exchange (RTLSServer * server,
     R_LOG_MEM_DUMP (R_LOG_LEVEL_DEBUG,
         server->servrandom, (rsize)R_TLS_HELLO_RANDOM_BYTES);
 #endif
+  }
 
-    /* FIXME: implement use of extended master secret */
+  return ret;
+}
 
-    /* convert to mastersecret */
+/* RFC 7627: when extended master secret is negotiated the seed is the
+ * handshake-transcript hash through ClientKeyExchange (the session hash)
+ * rather than the client/server randoms. The caller must therefore have
+ * absorbed the ClientKeyExchange into hshash before calling this. */
+static RTLSError
+r_tls_server_derive_master_secret (RTLSServer * server, const ruint8 pms[48])
+{
+  RTLSError ret;
+
+  if (server->support_ext_master_secret) {
+    rsize hashsize = r_msg_digest_size (server->hshash);
+    ruint8 * sessionhash = r_alloca (hashsize);
+
+    if (!r_msg_digest_get_data (server->hshash, sessionhash, hashsize, NULL))
+      return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
     ret = server->prf (server->mastersecret, sizeof (server->mastersecret),
-        pms, sizeof (pms), R_STR_WITH_SIZE_ARGS ("master secret"),
+        pms, 48, R_STR_WITH_SIZE_ARGS ("extended master secret"),
+        sessionhash, hashsize, NULL);
+  } else {
+    ret = server->prf (server->mastersecret, sizeof (server->mastersecret),
+        pms, 48, R_STR_WITH_SIZE_ARGS ("master secret"),
         server->hello.random, (rsize)R_TLS_HELLO_RANDOM_BYTES,
         server->servrandom, (rsize)R_TLS_HELLO_RANDOM_BYTES,
         NULL);
-    r_memclear_secure (pms, sizeof (pms));
-#if 0
-    R_LOG_DEBUG ("RSA MasterSecret:");
-    R_LOG_MEM_DUMP (R_LOG_LEVEL_DEBUG,
-        server->mastersecret, sizeof (server->mastersecret));
-#endif
   }
+
+#if 0
+  R_LOG_DEBUG ("RSA MasterSecret:");
+  R_LOG_MEM_DUMP (R_LOG_LEVEL_DEBUG,
+      server->mastersecret, sizeof (server->mastersecret));
+#endif
 
   return ret;
 }
@@ -1207,8 +1240,9 @@ static RTLSError
 r_tls_server_state_key_exchange (RTLSServer * server, const RTLSParser * parser)
 {
   RTLSError err;
+  ruint8 pms[48];
 
-  if ((err = r_tls_server_parse_client_key_exchange (server, parser)) == R_TLS_ERROR_OK)
+  if ((err = r_tls_server_parse_client_key_exchange (server, parser, pms)) == R_TLS_ERROR_OK)
     err = r_tls_server_change_state (server, R_TLS_SERVER_CHANGE_CIPHER);
 
   /* FIXME: Add proper alert codes for error scenarios */
@@ -1216,8 +1250,10 @@ r_tls_server_state_key_exchange (RTLSServer * server, const RTLSParser * parser)
     case R_TLS_ERROR_OK:
       R_LOG_TRACE ("Updating HS hash with ClientKeyExchange %u bytes",
           (ruint)parser->fragment.size);
+      /* hash CKE first: the extended-master-secret session hash covers it */
       r_msg_digest_update (server->hshash, parser->fragment.data, parser->fragment.size);
-      if ((err = r_tls_server_expand_master_secret (server)) != R_TLS_ERROR_OK)
+      if ((err = r_tls_server_derive_master_secret (server, pms)) != R_TLS_ERROR_OK ||
+          (err = r_tls_server_expand_master_secret (server)) != R_TLS_ERROR_OK)
         r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_INTERNAL_ERROR);
       break;
     case R_TLS_ERROR_CORRUPT_RECORD:
@@ -1229,6 +1265,7 @@ r_tls_server_state_key_exchange (RTLSServer * server, const RTLSParser * parser)
       break;
   }
 
+  r_memclear_secure (pms, sizeof (pms));
   return err;
 }
 

--- a/test/rtls.c
+++ b/test/rtls.c
@@ -690,7 +690,7 @@ RTEST (rtls, pkt_dtls_finished_encrypted, RTEST_FAST)
   r_assert_cmpptr ((cipher = r_cipher_aes_128_cbc_new (aes_128_cbc_key)), !=, NULL);
   r_assert_cmpptr ((hmac = r_hmac_new (R_MSG_DIGEST_TYPE_SHA1, sha1_mac_key, sizeof (sha1_mac_key))), !=, NULL);
 
-  r_assert_cmpint (r_tls_parser_decrypt (&parser, cipher, hmac),
+  r_assert_cmpint (r_tls_parser_decrypt (&parser, cipher, hmac, FALSE),
       ==, R_TLS_ERROR_OK);
 
   r_assert_cmpint (r_tls_parser_parse_finished (&parser, &verify_data, &size),
@@ -976,7 +976,7 @@ RTEST (rtls, dtls_encrypt, RTEST_FAST)
   r_assert_cmpptr ((hmac = r_hmac_new (R_MSG_DIGEST_TYPE_SHA1, sha1_mac_key, sizeof (sha1_mac_key))), !=, NULL);
 
   r_assert_cmpptr ((buf = r_buffer_new_wrapped (R_MEM_FLAG_NONE, (rpointer)plaintxt, sizeof (plaintxt), sizeof (plaintxt), 0, NULL, NULL)), !=, NULL);
-  r_assert_cmpptr ((encbuf = r_dtls_encrypt_buffer (buf, cipher, iv, hmac)), !=, NULL);
+  r_assert_cmpptr ((encbuf = r_dtls_encrypt_buffer (buf, cipher, iv, hmac, FALSE)), !=, NULL);
   r_buffer_unref (buf);
 
   r_assert_cmpbufmem (encbuf, 0, -1, ==, expected, sizeof (expected));
@@ -984,12 +984,69 @@ RTEST (rtls, dtls_encrypt, RTEST_FAST)
   r_assert_cmpint (r_tls_parser_init_buffer (&parser, encbuf), ==, R_TLS_ERROR_OK);
   r_buffer_unref (encbuf);
 
-  r_assert_cmpint (r_tls_parser_decrypt (&parser, cipher, hmac), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_parser_decrypt (&parser, cipher, hmac, FALSE), ==, R_TLS_ERROR_OK);
   r_assert_cmpmem (parser.fragment.data, ==, plaintxt + R_DTLS_RECORD_HDR_SIZE,
       parser.fragment.size);
 
   r_assert_cmpint (r_tls_parser_init_next (&parser, NULL), ==, R_TLS_ERROR_EOB);
   r_tls_parser_clear (&parser);
+
+  r_crypto_cipher_unref (cipher);
+  r_hmac_free (hmac);
+}
+RTEST_END;
+
+RTEST (rtls, dtls_encrypt_then_mac, RTEST_FAST)
+{
+  static const ruint8 aes_128_cbc_key[] = {
+    0xa5, 0x37, 0x92, 0xf0, 0xc0, 0xdd, 0xe3, 0xc6, 0x7f, 0x6c, 0xae, 0xed, 0x7c, 0x81, 0x5a, 0x39
+  };
+  static const ruint8 sha1_mac_key[] = {
+    0x75, 0xed, 0x30, 0x95, 0xd8, 0x36, 0xda, 0xec, 0x4b, 0x16, 0x01, 0x94, 0x13, 0x2e, 0xd4, 0x73,
+    0x47, 0x67, 0x27, 0xaf
+  };
+  static const ruint8 iv[] = {
+    0x0b, 0x0d, 0x20, 0x44, 0xf5, 0x24, 0xaa, 0xcc, 0x7a, 0x49, 0xea, 0x18, 0xc7, 0xce, 0xd2, 0xf5
+  };
+  static const ruint8 plaintxt[] = {
+    0x16, 0xfe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x14, 0x00, 0x00,
+    0x0c, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0c, 0x73, 0xa6, 0x0a, 0x3e, 0x33, 0xde, 0xd5,
+    0x65, 0xc4, 0x73, 0x4f, 0x34
+  };
+  RBuffer * buf, * encbuf;
+  RCryptoCipher * cipher;
+  RHmac * hmac;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+
+  r_assert_cmpptr ((cipher = r_cipher_aes_128_cbc_new (aes_128_cbc_key)), !=, NULL);
+  r_assert_cmpptr ((hmac = r_hmac_new (R_MSG_DIGEST_TYPE_SHA1, sha1_mac_key, sizeof (sha1_mac_key))), !=, NULL);
+
+  /* encrypt-then-MAC round trip recovers the plaintext fragment */
+  r_assert_cmpptr ((buf = r_buffer_new_wrapped (R_MEM_FLAG_NONE, (rpointer)plaintxt, sizeof (plaintxt), sizeof (plaintxt), 0, NULL, NULL)), !=, NULL);
+  r_assert_cmpptr ((encbuf = r_dtls_encrypt_buffer (buf, cipher, iv, hmac, TRUE)), !=, NULL);
+  r_buffer_unref (buf);
+
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, encbuf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_parser_decrypt (&parser, cipher, hmac, TRUE), ==, R_TLS_ERROR_OK);
+  r_assert_cmpmem (parser.fragment.data, ==, plaintxt + R_DTLS_RECORD_HDR_SIZE,
+      parser.fragment.size);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (encbuf);
+
+  /* tampering with the ciphertext is caught by the MAC before decryption */
+  r_assert_cmpptr ((buf = r_buffer_new_wrapped (R_MEM_FLAG_NONE, (rpointer)plaintxt, sizeof (plaintxt), sizeof (plaintxt), 0, NULL, NULL)), !=, NULL);
+  r_assert_cmpptr ((encbuf = r_dtls_encrypt_buffer (buf, cipher, iv, hmac, TRUE)), !=, NULL);
+  r_buffer_unref (buf);
+
+  r_assert (r_buffer_map (encbuf, &info, R_MEM_MAP_WRITE));
+  info.data[R_DTLS_RECORD_HDR_SIZE + sizeof (iv)] ^= 0xff; /* first ciphertext byte */
+  r_buffer_unmap (encbuf, &info);
+
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, encbuf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_parser_decrypt (&parser, cipher, hmac, TRUE), ==, R_TLS_ERROR_INVALID_MAC);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (encbuf);
 
   r_crypto_cipher_unref (cipher);
   r_hmac_free (hmac);
@@ -1012,7 +1069,7 @@ RTEST (rtls, parser_decrypt_fragment_shorter_than_iv, RTEST_FAST)
   r_assert_cmpptr ((cipher = r_cipher_aes_128_cbc_new (aes_key)), !=, NULL);
   r_assert_cmpint (r_tls_parser_init (&parser, short_record, sizeof (short_record)),
       ==, R_TLS_ERROR_OK);
-  r_assert_cmpint (r_tls_parser_decrypt (&parser, cipher, NULL),
+  r_assert_cmpint (r_tls_parser_decrypt (&parser, cipher, NULL, FALSE),
       ==, R_TLS_ERROR_CORRUPT_RECORD);
 
   r_tls_parser_clear (&parser);

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -184,58 +184,230 @@ static const ruint8 pkt_dtls_client_hallo[] = {
   0x06, 0x00, 0x1d, 0x00, 0x17, 0x00, 0x18
 };
 
-static const ruint8 pkt_dtls_client_finished[] = {
-  0x16, 0xfe, 0xfd, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x0e, 0x10, 0x00, 0x01,
-  0x02, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x01, 0x00, 0x76, 0x56, 0x2e, 0x83, 0xb6,
-  0x97, 0x71, 0x7d, 0x95, 0xe0, 0xaf, 0x93, 0xb7, 0xa7, 0x89, 0x34, 0x9d, 0xa4, 0x14, 0xf9, 0xbf,
-  0xe9, 0xfe, 0x16, 0xee, 0xaf, 0xb0, 0x08, 0x5c, 0x31, 0x05, 0xfc, 0xf8, 0xff, 0x54, 0x03, 0x05,
-  0xaf, 0x63, 0x82, 0xed, 0x0e, 0xae, 0x6b, 0x96, 0x9d, 0x81, 0xfb, 0x67, 0x98, 0xfd, 0x96, 0x71,
-  0x52, 0x53, 0x5f, 0x60, 0xc1, 0xac, 0x21, 0x5d, 0xc3, 0xaf, 0x1a, 0x1b, 0x39, 0x18, 0xb5, 0x10,
-  0xa7, 0x4f, 0xb8, 0x1b, 0xbe, 0xcf, 0xba, 0xbe, 0x57, 0x85, 0xbf, 0xce, 0xd0, 0x70, 0x50, 0x25,
-  0xaa, 0xe5, 0x75, 0x9c, 0x47, 0x8b, 0xc1, 0x28, 0x88, 0x07, 0xe1, 0x8a, 0x47, 0x4e, 0x14, 0x8a,
-  0x55, 0x7e, 0xb9, 0x0b, 0x81, 0x34, 0x12, 0x27, 0x5b, 0x03, 0x4c, 0x62, 0xfd, 0x95, 0x52, 0x8d,
-  0x75, 0x3a, 0xfd, 0x21, 0x00, 0xc3, 0xd7, 0xef, 0x21, 0xeb, 0x26, 0x36, 0xe2, 0xf0, 0x4a, 0x86,
-  0xc7, 0x73, 0x57, 0xb9, 0xea, 0xb7, 0xf2, 0x6b, 0x08, 0x5a, 0x2a, 0xb3, 0xbc, 0x61, 0x8f, 0xfa,
-  0xd7, 0x26, 0x1e, 0xaf, 0xf3, 0x2b, 0x8a, 0x5d, 0xa2, 0xa9, 0x14, 0xc7, 0x5b, 0x57, 0x40, 0xa1,
-  0x81, 0x72, 0x82, 0xe9, 0x79, 0x52, 0xb8, 0x04, 0x7a, 0x98, 0x1e, 0x92, 0x7e, 0x00, 0xb3, 0x24,
-  0x99, 0x6d, 0x66, 0x00, 0x2f, 0x7f, 0x97, 0x55, 0x9c, 0x80, 0xc7, 0xa4, 0x36, 0x0b, 0xff, 0xcf,
-  0x61, 0xce, 0x1c, 0x78, 0xfd, 0xba, 0x36, 0x6d, 0x31, 0x12, 0x45, 0xd9, 0xa7, 0x1e, 0xe3, 0x53,
-  0x0d, 0x99, 0x38, 0x45, 0x81, 0x1f, 0x76, 0x19, 0x9d, 0xc3, 0x76, 0x73, 0x44, 0xda, 0x84, 0xf4,
-  0x6a, 0xd2, 0x7e, 0xbb, 0xfb, 0x6b, 0x7d, 0x90, 0x5e, 0x13, 0xa2, 0xff, 0xb4, 0x33, 0x18, 0xd6,
-  0x03, 0xd3, 0xef, 0x02, 0x57, 0x80, 0xcb, 0x70, 0x49, 0x5f, 0x65, 0x14, 0xfe, 0xfd, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0x01, 0x16, 0xfe, 0xfd, 0x00, 0x01, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x4b, 0xe7, 0x61, 0xd6, 0x94, 0x4f, 0xcf, 0x54, 0x22, 0x00,
-  0x04, 0x78, 0x59, 0xaf, 0xaf, 0x57, 0xcf, 0x49, 0x38, 0x0e, 0x7a, 0xcd, 0xb5, 0xe2, 0x6f, 0x27,
-  0x9e, 0xc1, 0x6b, 0xbb, 0xaf, 0xc0, 0x4f, 0x4e, 0xae, 0x4b, 0xd0, 0xe4, 0x54, 0x2d, 0x51, 0x1c,
-  0x73, 0x4e, 0x87, 0x59, 0xce, 0x2d, 0x8b, 0xdb, 0x07, 0x0d, 0x80, 0x5b, 0x98, 0xcd, 0xcf, 0x97,
-  0xd0, 0x8f, 0x79, 0x2e, 0x35, 0xb5
-};
+/* Wrap a raw byte range in a buffer and feed it to the server. */
+static void
+r_test_tls_server_feed (RTLSServer * server, const ruint8 * data, rsize size)
+{
+  RBuffer * buf;
+
+  r_assert_cmpptr ((buf = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)data, size, size, 0, NULL, NULL)), !=, NULL);
+  r_assert (r_tls_server_incoming_data (server, buf));
+  r_buffer_unref (buf);
+}
+
+/* Absorb one (D)TLS record's handshake fragment into a transcript hash,
+ * exactly as the server does, so a test client can reproduce the
+ * handshake hashes. */
+static void
+r_test_tls_hash_record (RMsgDigest * md, const ruint8 * data, rsize size)
+{
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RBuffer * buf;
+
+  r_assert_cmpptr ((buf = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)data, size, size, 0, NULL, NULL)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_msg_digest_update (md, parser.fragment.data, parser.fragment.size);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+}
+
+/* Build a minimal DTLS 1.2 ClientHello (RSA-AES128-CBC-SHA, null
+ * compression, empty renegotiation_info, optionally extended_master_secret)
+ * into @out; returns its length. */
+static rsize
+r_test_tls_build_dtls_client_hello (RPrng * prng, rboolean ems,
+    ruint8 * out, rsize outsz)
+{
+  ruint8 body[128];
+  ruint8 * p = body;
+  ruint8 * extlenp;
+  rsize bodylen, hs;
+
+  *p++ = 0xfe; *p++ = 0xfd;                  /* client_version DTLS 1.2 */
+  r_prng_fill (prng, p, R_TLS_HELLO_RANDOM_BYTES); p += R_TLS_HELLO_RANDOM_BYTES;
+  *p++ = 0;                                  /* session id length */
+  *p++ = 0;                                  /* cookie length (DTLS) */
+  r_store_be16 (p, 2); p += 2;               /* cipher suites length */
+  r_store_be16 (p, (ruint16)R_TLS_CS_RSA_WITH_AES_128_CBC_SHA); p += 2;
+  *p++ = 1; *p++ = 0;                        /* compression: null */
+  extlenp = p; p += 2;                       /* extensions length placeholder */
+  r_store_be16 (p, (ruint16)R_TLS_EXT_TYPE_RENEGOTIATION_INFO); p += 2;
+  r_store_be16 (p, 1); p += 2; *p++ = 0;     /* empty renegotiated_connection */
+  if (ems) {
+    r_store_be16 (p, (ruint16)R_TLS_EXT_TYPE_EXTENDED_MASTER_SECRET); p += 2;
+    r_store_be16 (p, 0); p += 2;
+  }
+  r_store_be16 (extlenp, (ruint16)(p - (extlenp + 2)));
+  bodylen = (rsize)(p - body);
+
+  r_assert_cmpint (r_dtls_write_handshake (out, outsz, &hs,
+        R_TLS_VERSION_DTLS_1_2, R_TLS_HANDSHAKE_TYPE_CLIENT_HELLO,
+        (ruint16)bodylen, 0, 0, 0, 0, (ruint32)bodylen), ==, R_TLS_ERROR_OK);
+  r_memcpy (out + hs, body, bodylen);
+  return hs + bodylen;
+}
+
+/* Minimal DTLS 1.2 RSA client completing a handshake against the server
+ * under test. It mirrors the server's transcript hashing by feeding the
+ * same handshake-message fragments, derives the master secret per RFC 7627
+ * when the ServerHello negotiated extended master secret (else the legacy
+ * client+server-random seed), then sends ClientKeyExchange,
+ * ChangeCipherSpec and an encrypted Finished. The handshake completing
+ * therefore proves the server derived the same master secret. The negotiated
+ * server write keys are returned via @srv_cipher / @srv_hmac so the caller
+ * can decrypt the server's Finished. */
+static void
+r_test_tls_dtls_client_complete (RTLSServer * server, RPrng * prng,
+    const ruint8 * ch, rsize chlen, const ruint8 * srvflight, rsize srvlen,
+    rboolean ems, RCryptoCipher ** srv_cipher, RHmac ** srv_hmac)
+{
+  RCryptoKey * pk;
+  RBuffer * buf;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSHelloMsg hello;
+  RMsgDigest * md;
+  ruint8 crand[R_TLS_HELLO_RANDOM_BYTES], srand[R_TLS_HELLO_RANDOM_BYTES];
+  ruint8 pms[48], ms[48], kb[128], vd[12], iv[16];
+  ruint8 sh[64];
+  ruint8 enc[512];
+  ruint8 ckebuf[512], finbuf[64], ccsbuf[32];
+  rsize enclen = sizeof (enc), shlen, ckehs, ckelen, finhs, ccslen;
+  RCryptoCipher * cipher;
+  RHmac * hmac;
+  RBuffer * plain, * encbuf;
+  rboolean seen_ems = FALSE;
+  RTLSError e;
+
+  /* The server's RSA key: rlib's r_crypto_key_encrypt drives the public
+   * operation off the private key object (only the public exponent is used),
+   * which is exactly what a client encrypting to the cert's key needs. */
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem, -1, NULL, 0)), !=, NULL);
+  r_assert_cmpptr ((md = r_msg_digest_new_sha256 ()), !=, NULL);
+
+  /* transcript += ClientHello, and capture the client random */
+  r_assert_cmpptr ((buf = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)ch, chlen, chlen, 0, NULL, NULL)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_msg_digest_update (md, parser.fragment.data, parser.fragment.size);
+  r_assert_cmpint (r_tls_parser_parse_hello (&parser, &hello), ==, R_TLS_ERROR_OK);
+  r_memcpy (crand, hello.random, sizeof (crand));
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+
+  /* transcript += server flight; capture server random and EMS negotiation */
+  r_assert_cmpptr ((buf = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)srvflight, srvlen, srvlen, 0, NULL, NULL)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_msg_digest_update (md, parser.fragment.data, parser.fragment.size);
+  r_assert_cmpint (r_tls_parser_parse_hello (&parser, &hello), ==, R_TLS_ERROR_OK);
+  r_memcpy (srand, hello.random, sizeof (srand));
+  {
+    RTLSHelloExt ext;
+    for (e = r_tls_hello_msg_extension_first (&hello, &ext); e == R_TLS_ERROR_OK;
+        e = r_tls_hello_msg_extension_next (&hello, &ext)) {
+      if (ext.type == R_TLS_EXT_TYPE_EXTENDED_MASTER_SECRET)
+        seen_ems = TRUE;
+    }
+  }
+  while (r_tls_parser_init_next (&parser, NULL) == R_TLS_ERROR_OK)
+    r_msg_digest_update (md, parser.fragment.data, parser.fragment.size);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+  r_assert_cmpint (seen_ems, ==, ems);
+
+  /* ClientKeyExchange: RSA-encrypt a 48-byte pre-master secret */
+  pms[0] = 0xfe; pms[1] = 0xfd;
+  r_prng_fill (prng, pms + 2, sizeof (pms) - 2);
+  r_assert_cmpint (r_crypto_key_encrypt (pk, prng, pms, sizeof (pms), enc, &enclen),
+      ==, R_CRYPTO_OK);
+  r_assert_cmpint (r_dtls_write_handshake (ckebuf, sizeof (ckebuf), &ckehs,
+        R_TLS_VERSION_DTLS_1_2, R_TLS_HANDSHAKE_TYPE_CLIENT_KEY_EXCHANGE,
+        (ruint16)(2 + enclen), 0, 1, 1, 0, (ruint32)(2 + enclen)), ==, R_TLS_ERROR_OK);
+  r_store_be16 (ckebuf + ckehs, (ruint16)enclen);
+  r_memcpy (ckebuf + ckehs + 2, enc, enclen);
+  ckelen = ckehs + 2 + enclen;
+  r_test_tls_hash_record (md, ckebuf, ckelen);
+
+  /* session hash (transcript through ClientKeyExchange) drives EMS */
+  shlen = r_msg_digest_size (md);
+  r_assert (r_msg_digest_get_data (md, sh, shlen, NULL));
+
+  if (ems)
+    r_assert_cmpint (r_tls_1_2_prf_sha256 (ms, sizeof (ms), pms, sizeof (pms),
+          R_STR_WITH_SIZE_ARGS ("extended master secret"), sh, shlen, NULL),
+        ==, R_TLS_ERROR_OK);
+  else
+    r_assert_cmpint (r_tls_1_2_prf_sha256 (ms, sizeof (ms), pms, sizeof (pms),
+          R_STR_WITH_SIZE_ARGS ("master secret"),
+          crand, sizeof (crand), srand, sizeof (srand), NULL), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_1_2_prf_sha256 (kb, sizeof (kb), ms, sizeof (ms),
+        R_STR_WITH_SIZE_ARGS ("key expansion"),
+        srand, sizeof (srand), crand, sizeof (crand), NULL), ==, R_TLS_ERROR_OK);
+  /* keyblock: client MAC | server MAC | client key | server key */
+  r_assert_cmpint (r_tls_1_2_prf_sha256 (vd, sizeof (vd), ms, sizeof (ms),
+        R_STR_WITH_SIZE_ARGS ("client finished"), sh, shlen, NULL), ==, R_TLS_ERROR_OK);
+
+  /* encrypted Finished (epoch 1) */
+  r_assert_cmpint (r_dtls_write_handshake (finbuf, sizeof (finbuf), &finhs,
+        R_TLS_VERSION_DTLS_1_2, R_TLS_HANDSHAKE_TYPE_FINISHED, sizeof (vd),
+        1, 0, 2, 0, sizeof (vd)), ==, R_TLS_ERROR_OK);
+  r_memcpy (finbuf + finhs, vd, sizeof (vd));
+  r_assert_cmpptr ((plain = r_buffer_new_wrapped (R_MEM_FLAG_NONE, finbuf,
+          finhs + sizeof (vd), finhs + sizeof (vd), 0, NULL, NULL)), !=, NULL);
+  r_assert_cmpptr ((cipher = r_cipher_aes_128_cbc_new (kb + 40)), !=, NULL);
+  r_assert_cmpptr ((hmac = r_hmac_new (R_MSG_DIGEST_TYPE_SHA1, kb, 20)), !=, NULL);
+  r_prng_fill (prng, iv, sizeof (iv));
+  r_assert_cmpptr ((encbuf = r_dtls_encrypt_buffer (plain, cipher, iv, hmac)), !=, NULL);
+  r_buffer_unref (plain);
+  r_hmac_free (hmac);
+  r_crypto_cipher_unref (cipher);
+
+  /* ChangeCipherSpec (epoch 0) */
+  r_assert_cmpint (r_dtls_write_change_cipher (ccsbuf, sizeof (ccsbuf), &ccslen,
+        R_TLS_VERSION_DTLS_1_2, 0, 2), ==, R_TLS_ERROR_OK);
+
+  /* server write keys, for the caller to decrypt the server Finished */
+  r_assert_cmpptr ((*srv_cipher = r_cipher_aes_128_cbc_new (kb + 56)), !=, NULL);
+  r_assert_cmpptr ((*srv_hmac = r_hmac_new (R_MSG_DIGEST_TYPE_SHA1, kb + 20, 20)), !=, NULL);
+
+  /* send the client flight */
+  r_test_tls_server_feed (server, ckebuf, ckelen);
+  r_test_tls_server_feed (server, ccsbuf, ccslen);
+  r_assert (r_tls_server_incoming_data (server, encbuf));
+  r_buffer_unref (encbuf);
+
+  r_memclear_secure (pms, sizeof (pms));
+  r_memclear_secure (ms, sizeof (ms));
+  r_memclear_secure (kb, sizeof (kb));
+  r_msg_digest_free (md);
+  r_crypto_key_unref (pk);
+}
 
 
+/* Drive the server through a full DTLS handshake using the captured
+ * ClientHello (which offers extended_master_secret and use_srtp) and the
+ * in-test client, then verify the negotiated state and decrypt the server
+ * Finished. Exercises EMS end to end: the handshake only completes if the
+ * server derived the same RFC 7627 master secret as the client. */
 RTEST_F (rtlsserver, dtls_srtp_valid_handshake, RTEST_FAST)
 {
   RTLSParser parser = R_TLS_PARSER_INIT;
-  RCryptoCipher * cipher;
-  RHmac * hmac;
+  RCryptoCipher * cipher = NULL;
+  RHmac * hmac = NULL;
   RBuffer * buf;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
   RTLSHandshakeType hs;
   ruint32 l;
   ruint16 msgseq;
+  rboolean seen_ems;
   const RTLSCipherSuiteInfo * csinfo;
   static const ruint8 dtls_server_random[] = {
     0x58, 0x49, 0x81, 0x6a, 0x57, 0xc3, 0x49, 0x00, 0x29, 0x52, 0x8f, 0xac, 0xc7, 0x48, 0x57, 0x9e,
     0x26, 0x41, 0x87, 0xa6, 0xde, 0xd2, 0xe6, 0x72, 0x1a, 0x38, 0x08, 0x72, 0xdb, 0xd2, 0x09, 0x94
   };
-  static const ruint8 server_enc_key[] = {
-    0xba, 0x51, 0x90, 0x79, 0xa1, 0x0c, 0xa4, 0xce, 0x41, 0x0b, 0x37, 0xa2, 0x2c, 0x79, 0xca, 0x01
-  };
-  static const ruint8 server_mac_key[] = {
-    0x6b, 0x29, 0x8f, 0x66, 0x8e, 0xbc, 0x51, 0x7d, 0x81, 0xbb, 0x6d, 0xd8, 0x08, 0x93, 0x59, 0x56,
-    0x1e, 0xcf, 0x67, 0x21
-  };
-
-  r_assert_cmpptr ((cipher = r_cipher_aes_128_cbc_new (server_enc_key)), !=, NULL);
-  r_assert_cmpptr ((hmac = r_hmac_new (R_MSG_DIGEST_TYPE_SHA1, server_mac_key, sizeof (server_mac_key))), !=, NULL);
 
   r_assert_cmpint (r_tls_server_set_random (fixture->server, dtls_server_random),
       ==, R_TLS_ERROR_OK);
@@ -252,14 +424,17 @@ RTEST_F (rtlsserver, dtls_srtp_valid_handshake, RTEST_FAST)
   r_assert_cmpuint (parser.version, ==, R_TLS_VERSION_DTLS_1_2);
   r_assert_cmpuint (parser.epoch, ==, 0);
   r_assert_cmpuint (parser.seqno, ==, 0);
-  r_assert_cmpuint (parser.fragment.size, ==, 66);
+  /* 66 bytes pre-EMS; the echoed extended_master_secret extension adds 4 */
+  r_assert_cmpuint (parser.fragment.size, ==, 70);
   r_assert_cmpint (r_tls_parser_parse_handshake_full (&parser, &hs, &l,
         &msgseq, NULL, NULL), ==, R_TLS_ERROR_OK);
   r_assert_cmphex (hs, ==, R_TLS_HANDSHAKE_TYPE_SERVER_HELLO);
   r_assert_cmpuint (msgseq, ==, 0);
-  r_assert_cmpuint (l, ==, 54);
+  r_assert_cmpuint (l, ==, 58);
   {
     RTLSHelloMsg msg;
+    RTLSHelloExt ext;
+    RTLSError e;
 
     r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_parser_parse_hello (&parser, &msg));
     r_assert_cmpuint (msg.version, ==, R_TLS_VERSION_DTLS_1_2);
@@ -268,6 +443,16 @@ RTEST_F (rtlsserver, dtls_srtp_valid_handshake, RTEST_FAST)
     r_assert_cmpuint (msg.complen, ==, 1);
     r_assert_cmpuint (msg.cslen, ==, 2);
     r_assert_cmpuint (msg.extlen, >, 0);
+
+    seen_ems = FALSE;
+    for (e = r_tls_hello_msg_extension_first (&msg, &ext); e == R_TLS_ERROR_OK;
+        e = r_tls_hello_msg_extension_next (&msg, &ext)) {
+      if (ext.type == R_TLS_EXT_TYPE_EXTENDED_MASTER_SECRET) {
+        seen_ems = TRUE;
+        r_assert_cmpuint (ext.len, ==, 0);
+      }
+    }
+    r_assert (seen_ems);
   }
 
   {
@@ -301,11 +486,15 @@ RTEST_F (rtlsserver, dtls_srtp_valid_handshake, RTEST_FAST)
 
   r_assert_cmpint (r_tls_parser_init_next (&parser, NULL), ==, R_TLS_ERROR_EOB);
   r_tls_parser_clear (&parser);
-  r_buffer_unref (buf);
 
-  /* ClientKeyExchange, ChangeCipherSpec & Finished */
+  /* Complete the handshake with the in-test client over the server flight. */
   r_assert (!fixture->hs_done);
-  r_test_tls_server_incoming_data (pkt_dtls_client_finished);
+  r_assert (r_buffer_map (buf, &info, R_MEM_MAP_READ));
+  r_test_tls_dtls_client_complete (fixture->server, fixture->prng,
+      pkt_dtls_client_hallo, sizeof (pkt_dtls_client_hallo), info.data, info.size,
+      TRUE, &cipher, &hmac);
+  r_buffer_unmap (buf, &info);
+  r_buffer_unref (buf);
   r_assert (fixture->hs_done);
 
   r_assert_cmphex (r_tls_server_get_version (fixture->server), ==, R_TLS_VERSION_DTLS_1_2);
@@ -329,7 +518,8 @@ RTEST_F (rtlsserver, dtls_srtp_valid_handshake, RTEST_FAST)
   r_assert_cmpuint (parser.epoch, ==, 1);
   r_assert_cmpuint (parser.seqno, ==, 0);
 
-  /* Finished struct is encrypted! */
+  /* The server Finished is encrypted; decrypt it with the keys the client
+   * derived from the shared (EMS) master secret. */
   r_assert_cmpint (r_tls_parser_decrypt (&parser, cipher, hmac), ==, R_TLS_ERROR_OK);
   {
     const ruint8 * verify_data;
@@ -343,6 +533,54 @@ RTEST_F (rtlsserver, dtls_srtp_valid_handshake, RTEST_FAST)
   r_assert_cmpint (r_tls_parser_init_next (&parser, NULL), ==, R_TLS_ERROR_EOB);
   r_tls_parser_clear (&parser);
   r_buffer_unref (buf);
+
+  r_hmac_free (hmac);
+  r_crypto_cipher_unref (cipher);
+}
+RTEST_END;
+
+/* A ClientHello that does not offer extended_master_secret must complete on
+ * the legacy client+server-random master secret, and the ServerHello must
+ * not echo the extension. */
+RTEST_F (rtlsserver, dtls_handshake_without_ems, RTEST_FAST)
+{
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RCryptoCipher * cipher = NULL;
+  RHmac * hmac = NULL;
+  RBuffer * buf;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  ruint8 ch[256];
+  rsize chlen;
+  RTLSHelloMsg msg;
+  RTLSHelloExt ext;
+  RTLSError e;
+  rboolean seen_ems = FALSE;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  chlen = r_test_tls_build_dtls_client_hello (fixture->prng, FALSE, ch, sizeof (ch));
+  r_test_tls_server_feed (fixture->server, ch, chlen);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_HANDSHAKE);
+  r_assert_cmpint (r_tls_parser_parse_hello (&parser, &msg), ==, R_TLS_ERROR_OK);
+  for (e = r_tls_hello_msg_extension_first (&msg, &ext); e == R_TLS_ERROR_OK;
+      e = r_tls_hello_msg_extension_next (&msg, &ext)) {
+    if (ext.type == R_TLS_EXT_TYPE_EXTENDED_MASTER_SECRET)
+      seen_ems = TRUE;
+  }
+  r_assert (!seen_ems);
+  r_tls_parser_clear (&parser);
+
+  r_assert (r_buffer_map (buf, &info, R_MEM_MAP_READ));
+  r_test_tls_dtls_client_complete (fixture->server, fixture->prng,
+      ch, chlen, info.data, info.size, FALSE, &cipher, &hmac);
+  r_buffer_unmap (buf, &info);
+  r_buffer_unref (buf);
+
+  r_assert (fixture->hs_done);
 
   r_hmac_free (hmac);
   r_crypto_cipher_unref (cipher);

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -170,60 +170,6 @@ r_test_tls_server_queue_agg (RQueue * q)
   r_buffer_unref (buf);                                                       \
 } R_STMT_END
 
-/* Wrap a raw byte range in a buffer and feed it to the server. */
-static void
-r_test_tls_server_feed (RTLSServer * server, const ruint8 * data, rsize size)
-{
-  RBuffer * buf;
-
-  r_assert_cmpptr ((buf = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
-          (rpointer)data, size, size, 0, NULL, NULL)), !=, NULL);
-  r_assert (r_tls_server_incoming_data (server, buf));
-  r_buffer_unref (buf);
-}
-
-/* Build a minimal DTLS 1.2 ClientHello (RSA-AES128-CBC-SHA, null
- * compression) into @out, returning its length. When @scsv the
- * TLS_EMPTY_RENEGOTIATION_INFO_SCSV cipher is added; when @renego_ext a
- * renegotiation_info extension carrying a @renegolen-byte
- * renegotiated_connection is appended. */
-static rsize
-r_test_tls_build_dtls_client_hello (RPrng * prng, ruint8 * out, rsize outsz,
-    rboolean scsv, rboolean renego_ext, const ruint8 * renego, ruint8 renegolen)
-{
-  ruint8 body[256];
-  ruint8 * p = body;
-  ruint8 * extlenp;
-  rsize bodylen, hs, nsuites;
-
-  *p++ = 0xfe; *p++ = 0xfd;                  /* client_version DTLS 1.2 */
-  r_prng_fill (prng, p, R_TLS_HELLO_RANDOM_BYTES); p += R_TLS_HELLO_RANDOM_BYTES;
-  *p++ = 0;                                  /* session id length */
-  *p++ = 0;                                  /* cookie length (DTLS) */
-  nsuites = scsv ? 2 : 1;
-  r_store_be16 (p, (ruint16)(nsuites * sizeof (ruint16))); p += 2;
-  r_store_be16 (p, (ruint16)R_TLS_CS_RSA_WITH_AES_128_CBC_SHA); p += 2;
-  if (scsv) {
-    r_store_be16 (p, (ruint16)R_TLS_CS_EMPTY_RENEGOTIATION_INFO_SCSV); p += 2;
-  }
-  *p++ = 1; *p++ = 0;                        /* compression: null */
-  extlenp = p; p += 2;                       /* extensions length placeholder */
-  if (renego_ext) {
-    r_store_be16 (p, (ruint16)R_TLS_EXT_TYPE_RENEGOTIATION_INFO); p += 2;
-    r_store_be16 (p, (ruint16)(1 + renegolen)); p += 2;
-    *p++ = renegolen;
-    if (renegolen > 0) { r_memcpy (p, renego, renegolen); p += renegolen; }
-  }
-  r_store_be16 (extlenp, (ruint16)(p - (extlenp + 2)));
-  bodylen = (rsize)(p - body);
-
-  r_assert_cmpint (r_dtls_write_handshake (out, outsz, &hs,
-        R_TLS_VERSION_DTLS_1_2, R_TLS_HANDSHAKE_TYPE_CLIENT_HELLO,
-        (ruint16)bodylen, 0, 0, 0, 0, (ruint32)bodylen), ==, R_TLS_ERROR_OK);
-  r_memcpy (out + hs, body, bodylen);
-  return hs + bodylen;
-}
-
 static const ruint8 pkt_dtls_client_hallo[] = {
   0x16, 0xfe, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x9a, 0x01, 0x00, 0x00,
   0x8e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x8e, 0xfe, 0xfd, 0x0e, 0x49, 0x7a, 0xe5, 0x2a,
@@ -268,29 +214,45 @@ r_test_tls_hash_record (RMsgDigest * md, const ruint8 * data, rsize size)
 }
 
 /* Build a minimal DTLS 1.2 ClientHello (RSA-AES128-CBC-SHA, null
- * compression, empty renegotiation_info, optionally extended_master_secret)
- * into @out; returns its length. */
+ * compression) into @out; returns its length. @scsv adds the
+ * TLS_EMPTY_RENEGOTIATION_INFO_SCSV cipher; @renego_ext appends a
+ * renegotiation_info extension carrying a @renegolen-byte
+ * renegotiated_connection; @ems appends the extended_master_secret
+ * extension; @etm appends the encrypt_then_mac extension. */
 static rsize
-r_test_tls_build_dtls_client_hello (RPrng * prng, rboolean ems,
-    ruint8 * out, rsize outsz)
+r_test_tls_build_dtls_client_hello (RPrng * prng, ruint8 * out, rsize outsz,
+    rboolean ems, rboolean etm, rboolean scsv, rboolean renego_ext,
+    const ruint8 * renego, ruint8 renegolen)
 {
-  ruint8 body[128];
+  ruint8 body[256];
   ruint8 * p = body;
   ruint8 * extlenp;
-  rsize bodylen, hs;
+  rsize bodylen, hs, nsuites;
 
   *p++ = 0xfe; *p++ = 0xfd;                  /* client_version DTLS 1.2 */
   r_prng_fill (prng, p, R_TLS_HELLO_RANDOM_BYTES); p += R_TLS_HELLO_RANDOM_BYTES;
   *p++ = 0;                                  /* session id length */
   *p++ = 0;                                  /* cookie length (DTLS) */
-  r_store_be16 (p, 2); p += 2;               /* cipher suites length */
+  nsuites = scsv ? 2 : 1;
+  r_store_be16 (p, (ruint16)(nsuites * sizeof (ruint16))); p += 2;
   r_store_be16 (p, (ruint16)R_TLS_CS_RSA_WITH_AES_128_CBC_SHA); p += 2;
+  if (scsv) {
+    r_store_be16 (p, (ruint16)R_TLS_CS_EMPTY_RENEGOTIATION_INFO_SCSV); p += 2;
+  }
   *p++ = 1; *p++ = 0;                        /* compression: null */
   extlenp = p; p += 2;                       /* extensions length placeholder */
-  r_store_be16 (p, (ruint16)R_TLS_EXT_TYPE_RENEGOTIATION_INFO); p += 2;
-  r_store_be16 (p, 1); p += 2; *p++ = 0;     /* empty renegotiated_connection */
+  if (renego_ext) {
+    r_store_be16 (p, (ruint16)R_TLS_EXT_TYPE_RENEGOTIATION_INFO); p += 2;
+    r_store_be16 (p, (ruint16)(1 + renegolen)); p += 2;
+    *p++ = renegolen;
+    if (renegolen > 0) { r_memcpy (p, renego, renegolen); p += renegolen; }
+  }
   if (ems) {
     r_store_be16 (p, (ruint16)R_TLS_EXT_TYPE_EXTENDED_MASTER_SECRET); p += 2;
+    r_store_be16 (p, 0); p += 2;
+  }
+  if (etm) {
+    r_store_be16 (p, (ruint16)R_TLS_EXT_TYPE_ENCRYPT_THEN_MAC); p += 2;
     r_store_be16 (p, 0); p += 2;
   }
   r_store_be16 (extlenp, (ruint16)(p - (extlenp + 2)));
@@ -315,7 +277,7 @@ r_test_tls_build_dtls_client_hello (RPrng * prng, rboolean ems,
 static void
 r_test_tls_dtls_client_complete (RTLSServer * server, RPrng * prng,
     const ruint8 * ch, rsize chlen, const ruint8 * srvflight, rsize srvlen,
-    rboolean ems, RCryptoCipher ** srv_cipher, RHmac ** srv_hmac)
+    rboolean ems, rboolean etm, RCryptoCipher ** srv_cipher, RHmac ** srv_hmac)
 {
   RCryptoKey * pk;
   RBuffer * buf;
@@ -331,7 +293,7 @@ r_test_tls_dtls_client_complete (RTLSServer * server, RPrng * prng,
   RCryptoCipher * cipher;
   RHmac * hmac;
   RBuffer * plain, * encbuf;
-  rboolean seen_ems = FALSE;
+  rboolean seen_ems = FALSE, seen_etm = FALSE;
   RTLSError e;
 
   /* The server's RSA key: rlib's r_crypto_key_encrypt drives the public
@@ -363,6 +325,8 @@ r_test_tls_dtls_client_complete (RTLSServer * server, RPrng * prng,
         e = r_tls_hello_msg_extension_next (&hello, &ext)) {
       if (ext.type == R_TLS_EXT_TYPE_EXTENDED_MASTER_SECRET)
         seen_ems = TRUE;
+      else if (ext.type == R_TLS_EXT_TYPE_ENCRYPT_THEN_MAC)
+        seen_etm = TRUE;
     }
   }
   while (r_tls_parser_init_next (&parser, NULL) == R_TLS_ERROR_OK)
@@ -370,6 +334,7 @@ r_test_tls_dtls_client_complete (RTLSServer * server, RPrng * prng,
   r_tls_parser_clear (&parser);
   r_buffer_unref (buf);
   r_assert_cmpint (seen_ems, ==, ems);
+  r_assert_cmpint (seen_etm, ==, etm);
 
   /* ClientKeyExchange: RSA-encrypt a 48-byte pre-master secret */
   pms[0] = 0xfe; pms[1] = 0xfd;
@@ -414,7 +379,7 @@ r_test_tls_dtls_client_complete (RTLSServer * server, RPrng * prng,
   r_assert_cmpptr ((cipher = r_cipher_aes_128_cbc_new (kb + 40)), !=, NULL);
   r_assert_cmpptr ((hmac = r_hmac_new (R_MSG_DIGEST_TYPE_SHA1, kb, 20)), !=, NULL);
   r_prng_fill (prng, iv, sizeof (iv));
-  r_assert_cmpptr ((encbuf = r_dtls_encrypt_buffer (plain, cipher, iv, hmac)), !=, NULL);
+  r_assert_cmpptr ((encbuf = r_dtls_encrypt_buffer (plain, cipher, iv, hmac, etm)), !=, NULL);
   r_buffer_unref (plain);
   r_hmac_free (hmac);
   r_crypto_cipher_unref (cipher);
@@ -546,7 +511,7 @@ RTEST_F (rtlsserver, dtls_srtp_valid_handshake, RTEST_FAST)
   r_assert (r_buffer_map (buf, &info, R_MEM_MAP_READ));
   r_test_tls_dtls_client_complete (fixture->server, fixture->prng,
       pkt_dtls_client_hallo, sizeof (pkt_dtls_client_hallo), info.data, info.size,
-      TRUE, &cipher, &hmac);
+      TRUE, FALSE, &cipher, &hmac);
   r_buffer_unmap (buf, &info);
   r_buffer_unref (buf);
   r_assert (fixture->hs_done);
@@ -574,7 +539,7 @@ RTEST_F (rtlsserver, dtls_srtp_valid_handshake, RTEST_FAST)
 
   /* The server Finished is encrypted; decrypt it with the keys the client
    * derived from the shared (EMS) master secret. */
-  r_assert_cmpint (r_tls_parser_decrypt (&parser, cipher, hmac), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_parser_decrypt (&parser, cipher, hmac, FALSE), ==, R_TLS_ERROR_OK);
   {
     const ruint8 * verify_data;
     rsize verify_size;
@@ -613,7 +578,8 @@ RTEST_F (rtlsserver, dtls_handshake_without_ems, RTEST_FAST)
   r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
       ==, R_TLS_ERROR_OK);
 
-  chlen = r_test_tls_build_dtls_client_hello (fixture->prng, FALSE, ch, sizeof (ch));
+  chlen = r_test_tls_build_dtls_client_hello (fixture->prng, ch, sizeof (ch),
+      FALSE, FALSE, FALSE, TRUE, NULL, 0);
   r_test_tls_server_feed (fixture->server, ch, chlen);
 
   r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
@@ -630,11 +596,82 @@ RTEST_F (rtlsserver, dtls_handshake_without_ems, RTEST_FAST)
 
   r_assert (r_buffer_map (buf, &info, R_MEM_MAP_READ));
   r_test_tls_dtls_client_complete (fixture->server, fixture->prng,
-      ch, chlen, info.data, info.size, FALSE, &cipher, &hmac);
+      ch, chlen, info.data, info.size, FALSE, FALSE, &cipher, &hmac);
   r_buffer_unmap (buf, &info);
   r_buffer_unref (buf);
 
   r_assert (fixture->hs_done);
+
+  r_hmac_free (hmac);
+  r_crypto_cipher_unref (cipher);
+}
+RTEST_END;
+
+/* RFC 7366: a ClientHello offering encrypt_then_mac (with a CBC suite) must
+ * have the extension echoed and the handshake complete with encrypt-then-MAC
+ * record protection in both directions. */
+RTEST_F (rtlsserver, dtls_encrypt_then_mac_handshake, RTEST_FAST)
+{
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RCryptoCipher * cipher = NULL;
+  RHmac * hmac = NULL;
+  RBuffer * buf;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  RTLSHelloMsg msg;
+  RTLSHelloExt ext;
+  RTLSError e;
+  ruint8 ch[256];
+  rsize chlen;
+  rboolean seen_etm = FALSE;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  chlen = r_test_tls_build_dtls_client_hello (fixture->prng, ch, sizeof (ch),
+      FALSE, TRUE, FALSE, TRUE, NULL, 0);
+  r_test_tls_server_feed (fixture->server, ch, chlen);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_HANDSHAKE);
+  r_assert_cmpint (r_tls_parser_parse_hello (&parser, &msg), ==, R_TLS_ERROR_OK);
+  for (e = r_tls_hello_msg_extension_first (&msg, &ext); e == R_TLS_ERROR_OK;
+      e = r_tls_hello_msg_extension_next (&msg, &ext)) {
+    if (ext.type == R_TLS_EXT_TYPE_ENCRYPT_THEN_MAC) {
+      seen_etm = TRUE;
+      r_assert_cmpuint (ext.len, ==, 0);
+    }
+  }
+  r_assert (seen_etm);
+  r_tls_parser_clear (&parser);
+
+  /* Complete the handshake; the in-test client uses EtM record protection.
+   * hs_done implies the server accepted the EtM-protected client Finished. */
+  r_assert (r_buffer_map (buf, &info, R_MEM_MAP_READ));
+  r_test_tls_dtls_client_complete (fixture->server, fixture->prng,
+      ch, chlen, info.data, info.size, FALSE, TRUE, &cipher, &hmac);
+  r_buffer_unmap (buf, &info);
+  r_buffer_unref (buf);
+  r_assert (fixture->hs_done);
+
+  /* The server Finished must be EtM-protected: decrypt it with EtM. */
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_CHANGE_CIPHER_SPEC);
+  r_assert_cmpint (r_tls_parser_init_next (&parser, NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.epoch, ==, 1);
+  r_assert_cmpint (r_tls_parser_decrypt (&parser, cipher, hmac, TRUE), ==, R_TLS_ERROR_OK);
+  {
+    const ruint8 * verify_data;
+    rsize verify_size;
+
+    r_assert_cmpint (r_tls_parser_parse_finished (&parser, &verify_data, &verify_size),
+        ==, R_TLS_ERROR_OK);
+    r_assert_cmpuint (verify_size, ==, 12);
+  }
+
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
 
   r_hmac_free (hmac);
   r_crypto_cipher_unref (cipher);
@@ -729,7 +766,7 @@ RTEST_F (rtlsserver, dtls_renegotiation_info_not_empty, RTEST_FAST)
       ==, R_TLS_ERROR_OK);
 
   chlen = r_test_tls_build_dtls_client_hello (fixture->prng, ch, sizeof (ch),
-      FALSE, TRUE, renego, sizeof (renego));
+      FALSE, FALSE, FALSE, TRUE, renego, sizeof (renego));
   r_test_tls_server_feed (fixture->server, ch, chlen);
 
   r_assert (fixture->got_error);
@@ -766,7 +803,7 @@ RTEST_F (rtlsserver, dtls_renegotiation_info_scsv, RTEST_FAST)
       ==, R_TLS_ERROR_OK);
 
   chlen = r_test_tls_build_dtls_client_hello (fixture->prng, ch, sizeof (ch),
-      TRUE, FALSE, NULL, 0);
+      FALSE, FALSE, TRUE, FALSE, NULL, 0);
   r_test_tls_server_feed (fixture->server, ch, chlen);
 
   r_assert (!fixture->got_error);

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -826,3 +826,56 @@ RTEST_F (rtlsserver, dtls_renegotiation_info_scsv, RTEST_FAST)
   r_buffer_unref (buf);
 }
 RTEST_END;
+
+/* A ClientHello whose trailing extension declares a body that isn't present
+ * must be parsed without reading past the extensions block: the extension
+ * iterator stops at the truncated entry and the handshake proceeds from the
+ * valid ones. (Regression for the missing body-bounds check in
+ * r_tls_hello_msg_extension_next.) */
+RTEST_F (rtlsserver, dtls_clienthello_truncated_extension, RTEST_FAST)
+{
+  ruint8 body[128];
+  ruint8 * p = body;
+  ruint8 * extlenp;
+  ruint8 ch[256];
+  rsize bodylen, hs, chlen;
+  RBuffer * buf;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+
+  *p++ = 0xfe; *p++ = 0xfd;                  /* client_version DTLS 1.2 */
+  r_prng_fill (fixture->prng, p, R_TLS_HELLO_RANDOM_BYTES); p += R_TLS_HELLO_RANDOM_BYTES;
+  *p++ = 0;                                  /* session id length */
+  *p++ = 0;                                  /* cookie length */
+  r_store_be16 (p, 2); p += 2;
+  r_store_be16 (p, (ruint16)R_TLS_CS_RSA_WITH_AES_128_CBC_SHA); p += 2;
+  *p++ = 1; *p++ = 0;                        /* compression: null */
+  extlenp = p; p += 2;
+  /* valid empty renegotiation_info */
+  r_store_be16 (p, (ruint16)R_TLS_EXT_TYPE_RENEGOTIATION_INFO); p += 2;
+  r_store_be16 (p, 1); p += 2; *p++ = 0;
+  /* trailing renegotiation_info declaring 10 bytes with none present */
+  r_store_be16 (p, (ruint16)R_TLS_EXT_TYPE_RENEGOTIATION_INFO); p += 2;
+  r_store_be16 (p, 10); p += 2;
+  r_store_be16 (extlenp, (ruint16)(p - (extlenp + 2)));
+  bodylen = (rsize)(p - body);
+
+  r_assert_cmpint (r_dtls_write_handshake (ch, sizeof (ch), &hs,
+        R_TLS_VERSION_DTLS_1_2, R_TLS_HANDSHAKE_TYPE_CLIENT_HELLO,
+        (ruint16)bodylen, 0, 0, 0, 0, (ruint32)bodylen), ==, R_TLS_ERROR_OK);
+  r_memcpy (ch + hs, body, bodylen);
+  chlen = hs + bodylen;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_test_tls_server_feed (fixture->server, ch, chlen);
+
+  /* Handled without an over-read: the truncated extension is dropped and the
+   * server answers from the valid first extension. */
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_HANDSHAKE);
+
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+}
+RTEST_END;

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -170,6 +170,60 @@ r_test_tls_server_queue_agg (RQueue * q)
   r_buffer_unref (buf);                                                       \
 } R_STMT_END
 
+/* Wrap a raw byte range in a buffer and feed it to the server. */
+static void
+r_test_tls_server_feed (RTLSServer * server, const ruint8 * data, rsize size)
+{
+  RBuffer * buf;
+
+  r_assert_cmpptr ((buf = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)data, size, size, 0, NULL, NULL)), !=, NULL);
+  r_assert (r_tls_server_incoming_data (server, buf));
+  r_buffer_unref (buf);
+}
+
+/* Build a minimal DTLS 1.2 ClientHello (RSA-AES128-CBC-SHA, null
+ * compression) into @out, returning its length. When @scsv the
+ * TLS_EMPTY_RENEGOTIATION_INFO_SCSV cipher is added; when @renego_ext a
+ * renegotiation_info extension carrying a @renegolen-byte
+ * renegotiated_connection is appended. */
+static rsize
+r_test_tls_build_dtls_client_hello (RPrng * prng, ruint8 * out, rsize outsz,
+    rboolean scsv, rboolean renego_ext, const ruint8 * renego, ruint8 renegolen)
+{
+  ruint8 body[256];
+  ruint8 * p = body;
+  ruint8 * extlenp;
+  rsize bodylen, hs, nsuites;
+
+  *p++ = 0xfe; *p++ = 0xfd;                  /* client_version DTLS 1.2 */
+  r_prng_fill (prng, p, R_TLS_HELLO_RANDOM_BYTES); p += R_TLS_HELLO_RANDOM_BYTES;
+  *p++ = 0;                                  /* session id length */
+  *p++ = 0;                                  /* cookie length (DTLS) */
+  nsuites = scsv ? 2 : 1;
+  r_store_be16 (p, (ruint16)(nsuites * sizeof (ruint16))); p += 2;
+  r_store_be16 (p, (ruint16)R_TLS_CS_RSA_WITH_AES_128_CBC_SHA); p += 2;
+  if (scsv) {
+    r_store_be16 (p, (ruint16)R_TLS_CS_EMPTY_RENEGOTIATION_INFO_SCSV); p += 2;
+  }
+  *p++ = 1; *p++ = 0;                        /* compression: null */
+  extlenp = p; p += 2;                       /* extensions length placeholder */
+  if (renego_ext) {
+    r_store_be16 (p, (ruint16)R_TLS_EXT_TYPE_RENEGOTIATION_INFO); p += 2;
+    r_store_be16 (p, (ruint16)(1 + renegolen)); p += 2;
+    *p++ = renegolen;
+    if (renegolen > 0) { r_memcpy (p, renego, renegolen); p += renegolen; }
+  }
+  r_store_be16 (extlenp, (ruint16)(p - (extlenp + 2)));
+  bodylen = (rsize)(p - body);
+
+  r_assert_cmpint (r_dtls_write_handshake (out, outsz, &hs,
+        R_TLS_VERSION_DTLS_1_2, R_TLS_HANDSHAKE_TYPE_CLIENT_HELLO,
+        (ruint16)bodylen, 0, 0, 0, 0, (ruint32)bodylen), ==, R_TLS_ERROR_OK);
+  r_memcpy (out + hs, body, bodylen);
+  return hs + bodylen;
+}
+
 static const ruint8 pkt_dtls_client_hallo[] = {
   0x16, 0xfe, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x9a, 0x01, 0x00, 0x00,
   0x8e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x8e, 0xfe, 0xfd, 0x0e, 0x49, 0x7a, 0xe5, 0x2a,
@@ -653,6 +707,83 @@ RTEST_F (rtlsserver, tls_handshake_error_alert, RTEST_FAST)
   r_assert_cmpint (r_tls_parser_parse_alert (&parser, &alevel, &atype), ==, R_TLS_ERROR_OK);
   r_assert_cmpuint (alevel, ==, R_TLS_ALERT_LEVEL_FATAL);
   r_assert_cmpuint (atype, ==, R_TLS_ALERT_TYPE_UNEXPECTED_MESSAGE);
+
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
+/* RFC 5746: a non-empty renegotiated_connection in the initial ClientHello
+ * (rlib does not renegotiate) must abort with a fatal handshake_failure. */
+RTEST_F (rtlsserver, dtls_renegotiation_info_not_empty, RTEST_FAST)
+{
+  static const ruint8 renego[] = { 0xde, 0xad, 0xbe, 0xef };
+  ruint8 ch[256];
+  rsize chlen;
+  RBuffer * buf;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSAlertLevel alevel;
+  RTLSAlertType atype;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  chlen = r_test_tls_build_dtls_client_hello (fixture->prng, ch, sizeof (ch),
+      FALSE, TRUE, renego, sizeof (renego));
+  r_test_tls_server_feed (fixture->server, ch, chlen);
+
+  r_assert (fixture->got_error);
+  r_assert_cmpuint (fixture->last_alert, ==, R_TLS_ALERT_TYPE_HANDSHAKE_FAILURE);
+  r_assert (!fixture->hs_done);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_ALERT);
+  r_assert_cmpint (r_tls_parser_parse_alert (&parser, &alevel, &atype), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (alevel, ==, R_TLS_ALERT_LEVEL_FATAL);
+  r_assert_cmpuint (atype, ==, R_TLS_ALERT_TYPE_HANDSHAKE_FAILURE);
+
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
+/* RFC 5746 3.6: TLS_EMPTY_RENEGOTIATION_INFO_SCSV signals secure
+ * renegotiation like an empty renegotiation_info extension, so the
+ * ServerHello must echo a renegotiation_info extension. */
+RTEST_F (rtlsserver, dtls_renegotiation_info_scsv, RTEST_FAST)
+{
+  ruint8 ch[256];
+  rsize chlen;
+  RBuffer * buf;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSHelloMsg msg;
+  RTLSHelloExt ext;
+  RTLSError e;
+  rboolean seen_renego = FALSE;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  chlen = r_test_tls_build_dtls_client_hello (fixture->prng, ch, sizeof (ch),
+      TRUE, FALSE, NULL, 0);
+  r_test_tls_server_feed (fixture->server, ch, chlen);
+
+  r_assert (!fixture->got_error);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_HANDSHAKE);
+  r_assert_cmpint (r_tls_parser_parse_hello (&parser, &msg), ==, R_TLS_ERROR_OK);
+  for (e = r_tls_hello_msg_extension_first (&msg, &ext); e == R_TLS_ERROR_OK;
+      e = r_tls_hello_msg_extension_next (&msg, &ext)) {
+    if (ext.type == R_TLS_EXT_TYPE_RENEGOTIATION_INFO) {
+      seen_renego = TRUE;
+      r_assert_cmpuint (ext.len, ==, 1);  /* empty renegotiated_connection */
+      r_assert_cmpuint (ext.data[0], ==, 0);
+    }
+  }
+  r_assert (seen_renego);
 
   r_tls_parser_clear (&parser);
   r_buffer_unref (buf);


### PR DESCRIPTION
Completes three TLS/DTLS server-side extension features and clears the dead extension stubs from the ServerHello chain. Advances #219 (does not close it — client-cert/mTLS, session tickets, ECDHE and version negotiation remain).

## Extended master secret (RFC 7627)
Echo the `extended_master_secret` extension when offered and derive the master secret from the handshake-transcript session hash instead of the client/server randoms, closing the triple-handshake / unknown-key-share class of attacks (and required by modern WebRTC). The ClientKeyExchange is folded into the handshake hash before derivation; the pre-master secret moves to a caller-owned, wiped buffer.

## Secure renegotiation (RFC 5746)
Validate the client's `renegotiated_connection`: malformed → `decode_error`, non-empty on the initial handshake → `handshake_failure` (rlib does not renegotiate). Treat `TLS_EMPTY_RENEGOTIATION_INFO_SCSV` as equivalent to an empty `renegotiation_info` so SCSV-only clients still get the extension echoed.

## Encrypt-then-MAC (RFC 7366)
Negotiate `encrypt_then_mac` for CBC suites and protect records by encrypting first, then MACing the header + IV + ciphertext and verifying that MAC before decrypting — closing the padding-oracle weaknesses of CBC MAC-then-encrypt. The shared record helpers (`r_tls_parser_decrypt`, `r_tls_encrypt_buffer` / `r_dtls_encrypt_buffer`) gain an `etm` mode; the server threads its negotiated state through.

## Cleanup
Remove the commented-out (`#if 0`) references to unimplemented extension writers (truncated_hmac, supported_point_formats, ec_jpake, alpn) from the ServerHello chain.

## Testing
The in-test DTLS client gained EMS and EtM modes, so the handshake tests drive real end-to-end handshakes (the server accepts the client Finished and emits a Finished the test decrypts) across the legacy, EMS and EtM paths, plus negotiation/structure tests for renegotiation_info and SCSV and a record-level encrypt-then-MAC round-trip with tamper detection. Full matrix green (debug/release/gcc-warn/clang/ASan/TSan under `-Werror`, leak-free, Doxygen 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)