### PR TITLE
ev: skip invalid handles in the Win32 poll instead of failing the wait

### DIFF
--- a/rlib/rpoll.c
+++ b/rlib/rpoll.c
@@ -111,22 +111,39 @@ r_poll (RPoll * handles, ruint count, RClockTime timeout)
       i += res;
       handles[i].revents = handles[i].events;
     } else if (res == WAIT_FAILED) {
-      DWORD dw;
-      LPVOID lpMsgBuf;
+      DWORD dw = GetLastError ();
 
-      switch ((dw = GetLastError ())) {
-      case ERROR_INVALID_HANDLE:
-        errno = EINVAL;
+      if (dw == ERROR_INVALID_HANDLE) {
+        /* A handle in [i, count) went invalid since the wait set was built (a
+         * socket closed concurrently, or via a deferred io-watch teardown).
+         * Unlike poll()/ppoll(), which flag a closed descriptor with POLLNVAL
+         * and still report the rest, WaitForMultipleObjectsEx fails the whole
+         * wait on one bad handle -> r_poll would return -1 and the loop would
+         * dispatch nothing, stalling every other ready handle. Instead skip
+         * the invalid handle: dispatch any ready handle among the rest and
+         * return promptly, so the loop runs its pending callbacks (which drop
+         * the closed handle from the set on the next turn). */
+        ruint j;
+        for (j = i; j < count; j++) {
+          if (WaitForSingleObject (win32_handles[j], 0) == WAIT_OBJECT_0) {
+            handles[j].revents = handles[j].events;
+            ret++;
+          } else {
+            handles[j].revents = 0;
+          }
+        }
         break;
-      /* FIXME: Add more error codes? */
-      default:
-        errno = EIO;
       }
 
-      FormatMessageA (FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-          NULL, dw, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR) &lpMsgBuf, 0, NULL);
-      R_LOG_CAT_ERROR (R_LOG_CAT_ASSERT, "WaitForMultipleObjectsEx error '%s'", lpMsgBuf);
-      LocalFree (lpMsgBuf);
+      {
+        LPVOID lpMsgBuf;
+
+        errno = EIO;
+        FormatMessageA (FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+            NULL, dw, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR) &lpMsgBuf, 0, NULL);
+        R_LOG_CAT_ERROR (R_LOG_CAT_ASSERT, "WaitForMultipleObjectsEx error '%s'", lpMsgBuf);
+        LocalFree (lpMsgBuf);
+      }
       return -1;
     } else if (res == WAIT_TIMEOUT) {
       break;


### PR DESCRIPTION
Fixes the flaky Windows ARM hang in `/revtcp/recv_error_no_handler` (#257).

## Root cause
`#254` added a test that closes a peer and waits for the resulting end-of-stream notification. On Win32, `r_poll` hands the whole handle array to `WaitForMultipleObjectsEx`, and a **single** invalid handle fails the entire wait with `ERROR_INVALID_HANDLE` → `r_poll` returns -1 → the event loop dispatches nothing that turn (`revloop.c`: `ret >= 0` gate), starving every other ready handle. A socket closed since the wait set was built (the io-watch teardown is deferred via `r_ev_loop_add_cb_after`) thus stalls the loop, and the test's end-of-stream notification never arrives → 36s harness timeout. POSIX backends don't hit this because the kernel drops a closed fd from the wait set; hence Windows-only and flaky (a close-vs-poll race — the master-push full sweeps for #254 and #265 failed, #268 passed).

## Fix
On `ERROR_INVALID_HANDLE`, probe the remaining handles individually (`WaitForSingleObject(h, 0)`), dispatch the ready ones and skip the invalid/idle ones, instead of failing the whole wait — bringing the Win32 backend to parity with how epoll/kqueue tolerate a closed descriptor.

Also bound the test's previously-unbounded `while (!eos)` loop so a missing notification fails fast instead of spinning to the harness timeout.

## Validation
The Win32 `r_poll` branch only compiles on Windows, so **Windows ARM CI is the validator** for the backend change. On Linux the revtcp suite (incl. the bounded test) and full matrix pass (debug/release/gcc-warn/clang/ASan/TSan under `-Werror`). A deeper hardening — prompt handle removal on close + handle-reuse aliasing — is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)