### PR TITLE
net: add a TLS/DTLS client (RTLSClient)

### DIFF
--- a/include/rlib/net/proto/rtls.h
+++ b/include/rlib/net/proto/rtls.h
@@ -710,6 +710,27 @@ R_API RTLSError r_tls_write_hs_server_hello (rpointer data, rsize size, rsize * 
 /** @brief DTLS alias for @ref r_tls_write_hs_server_hello. */
 #define r_dtls_write_hs_server_hello r_tls_write_hs_server_hello
 /**
+ * @brief Write a ClientHello handshake message into @p data.
+ * @param data Destination buffer.
+ * @param size Capacity of @p data in bytes.
+ * @param out Out: bytes written.
+ * @param ver Offered protocol version; a DTLS version emits the cookie field.
+ * @param clirand Client random field.
+ * @param sid Session ID, or @c NULL.
+ * @param sidsize Session-ID length in bytes.
+ * @param cookie DTLS cookie, or @c NULL (DTLS only).
+ * @param cookiesize DTLS cookie length in bytes.
+ * @param cs Offered cipher suites (most-preferred first).
+ * @param ncs Number of cipher suites in @p cs.
+ * @param comp Offered compression method.
+ */
+R_API RTLSError r_tls_write_hs_client_hello (rpointer data, rsize size, rsize * out,
+    RTLSVersion ver, const ruint8 clirand[R_TLS_HELLO_RANDOM_BYTES],
+    const ruint8 * sid, ruint8 sidsize, const ruint8 * cookie, ruint8 cookiesize,
+    const RTLSCipherSuite * cs, ruint16 ncs, RTLSCompressionMethod comp);
+/** @brief DTLS alias for @ref r_tls_write_hs_client_hello (cookie field emitted). */
+#define r_dtls_write_hs_client_hello r_tls_write_hs_client_hello
+/**
  * @brief Write a NewSessionTicket handshake message into @p buf.
  * @param buf Destination buffer.
  * @param size Capacity of @p buf in bytes.

--- a/include/rlib/net/rtlsclient.h
+++ b/include/rlib/net/rtlsclient.h
@@ -1,0 +1,110 @@
+/* RLIB - Convenience library for useful things
+ * Copyright (C) 2026 Haakon Sporsheim <haakon.sporsheim@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ * See the COPYING file at the root of the source repository.
+ */
+#ifndef __R_NET_TLS_CLIENT_H__
+#define __R_NET_TLS_CLIENT_H__
+
+#if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
+#error "#include <rlib.h> only please."
+#endif
+
+/**
+ * @file rlib/net/rtlsclient.h
+ * @brief Client-side TLS / DTLS session: drives the handshake, verifies the
+ * server certificate, and encrypts / decrypts record traffic via callbacks.
+ */
+
+#include <rlib/rtypes.h>
+
+#include <rlib/crypto/rcert.h>
+#include <rlib/crypto/rtlsciphersuite.h>
+#include <rlib/ev/revloop.h>
+#include <rlib/net/proto/rtls.h>
+#include <rlib/net/rtlsserver.h>   /* RTLSCallbacks (shared with the server) */
+
+#include <rlib/rbuffer.h>
+#include <rlib/rref.h>
+
+/**
+ * @defgroup r_tls_client TLS / DTLS client
+ * @ingroup r_net
+ *
+ * @brief Client-side TLS / DTLS endpoint that initiates a handshake and
+ * encrypts / decrypts record traffic via callbacks.
+ *
+ * Like @ref r_tls_server it is transport-agnostic: @ref r_tls_client_start
+ * builds and emits the ClientHello through the @c out callback, received
+ * bytes are fed in with @ref r_tls_client_incoming_data, and the
+ * @ref RTLSCallbacks deliver outgoing records (@c out) and decrypted
+ * application data (@c appdata). The server certificate is checked with the
+ * @c verify_cert callback (or inspected afterwards via
+ * @ref r_tls_client_get_peer_cert).
+ *
+ * Mirrors @ref r_tls_server with the roles reversed; the initial capability
+ * matches it (TLS / DTLS 1.2, RSA key exchange).
+ *
+ * @{
+ */
+
+R_BEGIN_DECLS
+
+/** @brief Opaque, refcounted TLS / DTLS client session. */
+typedef struct RTLSClient RTLSClient;
+
+/** @brief Create a TLS client with the given callbacks and user context. */
+R_API RTLSClient * r_tls_client_new (const RTLSCallbacks * cb,
+    rpointer userdata, RDestroyNotify notify) R_ATTR_MALLOC;
+/** @brief Take a reference (alias for @ref r_ref_ref). */
+#define r_tls_client_ref    r_ref_ref
+/** @brief Drop a reference (alias for @ref r_ref_unref). */
+#define r_tls_client_unref  r_ref_unref
+
+/** @brief Override the client-random (testing / determinism). */
+R_API RTLSError r_tls_client_set_random (RTLSClient * client,
+    const ruint8 clirandom[R_TLS_HELLO_RANDOM_BYTES]);
+/**
+ * @brief Start the session on @p loop, drawing randomness from @p prng, and
+ * emit the ClientHello offering @p version (@c R_TLS_VERSION_TLS_1_2 or
+ * @c R_TLS_VERSION_DTLS_1_2).
+ */
+R_API RTLSError r_tls_client_start (RTLSClient * client, REvLoop * loop,
+    RPrng * prng, RTLSVersion version) R_ATTR_WARN_UNUSED_RESULT;
+
+/** @brief Feed received ciphertext bytes into the session. */
+R_API rboolean r_tls_client_incoming_data (RTLSClient * client, RBuffer * buffer);
+/** @brief Encrypt and send application data through the session. */
+R_API rboolean r_tls_client_send_appdata (RTLSClient * client, RBuffer * buffer);
+
+/** @brief Export RFC 5705 keying material for an application label / context. */
+R_API RTLSError r_tls_client_export_keying_material (const RTLSClient * client,
+    ruint8 * material, rsize size, const rchar * label, rsize len,
+    const ruint8 * ctx, rsize ctxsize);
+
+/** @brief Negotiated TLS / DTLS version. */
+R_API RTLSVersion r_tls_client_get_version (const RTLSClient * client);
+/** @brief Negotiated cipher suite, or @c NULL before the ServerHello. */
+R_API const RTLSCipherSuiteInfo * r_tls_client_get_cipher_suite (const RTLSClient * client);
+/** @brief The server's end-entity certificate (borrowed), or @c NULL. */
+R_API RCryptoCert * r_tls_client_get_peer_cert (const RTLSClient * client);
+/** @brief Negotiated DTLS-SRTP protection profile (for @ref r_srtp). */
+R_API RSRTPCipherSuite r_tls_client_get_dtls_srtp_profile (const RTLSClient * client);
+
+R_END_DECLS
+
+/** @} */
+
+#endif /* __R_NET_TLS_CLIENT_H__ */

--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -77,6 +77,20 @@ typedef rboolean (*RTLSPreferredCipherSuitesCb) (rpointer ctx, RTLSVersion ver, 
  * only once). May be @c NULL.
  */
 typedef void (*RTLSServerErrorCb) (rpointer ctx, RTLSAlertType alert, RTLSServer * server);
+/**
+ * @brief Callback verifying the peer's certificate chain (leaf first).
+ *
+ * Invoked during the handshake with the parsed certificate @p chain
+ * (@p count entries, the peer's end-entity certificate first). Return
+ * @c FALSE to reject and abort the handshake with a @c bad_certificate
+ * alert. May be @c NULL, which accepts any chain — appropriate for tests
+ * and for verifying out of band (e.g. SDP fingerprint) after the
+ * handshake. The certificates are borrowed; do not unref them.
+ *
+ * Used by @ref RTLSClient to validate the server certificate (and, in
+ * future, by the server for client-certificate / mTLS checks).
+ */
+typedef rboolean (*RTLSCertVerifyCb) (rpointer ctx, RCryptoCert * const * chain, ruint count);
 
 /** @brief Callback bundle wiring a session to its transport and policy. */
 typedef struct {
@@ -85,6 +99,7 @@ typedef struct {
   RTLSServerBufferCb            out;                     /**< Sink for outgoing encrypted records. */
   RTLSServerBufferCb            appdata;                 /**< Sink for decrypted application data. */
   RTLSServerErrorCb             error;                   /**< Fired on a fatal alert; may be @c NULL. */
+  RTLSCertVerifyCb              verify_cert;             /**< Verify the peer certificate chain; may be @c NULL. */
 } RTLSCallbacks;
 
 /** @brief Create a TLS server with the given callbacks and user context. */

--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -62,10 +62,16 @@ R_BEGIN_DECLS
 /** @brief Opaque, refcounted TLS / DTLS server session. */
 typedef struct RTLSServer RTLSServer;
 
-/** @brief Callback delivering a buffer (outgoing record or app data). */
-typedef rboolean (*RTLSServerBufferCb) (rpointer ctx, RBuffer * buf, RTLSServer * server);
-/** @brief Callback fired when the handshake completes. */
-typedef void (*RTLSServerHandshakeDoneCb) (rpointer ctx, RTLSServer * server);
+/**
+ * @brief Callback delivering a buffer (outgoing record or app data).
+ *
+ * @p session is the @ref RTLSServer or @ref RTLSClient the callback bundle
+ * is attached to (the bundle is shared between both); cast to the type the
+ * caller registered it with.
+ */
+typedef rboolean (*RTLSBufferCb) (rpointer ctx, RBuffer * buf, rpointer session);
+/** @brief Callback fired when the handshake completes (@p session as above). */
+typedef void (*RTLSHandshakeDoneCb) (rpointer ctx, rpointer session);
 /** @brief Callback selecting the preferred cipher suites for a TLS version. */
 typedef rboolean (*RTLSPreferredCipherSuitesCb) (rpointer ctx, RTLSVersion ver, RTLSCipherSuite * cs, rsize * count);
 /**
@@ -74,9 +80,10 @@ typedef rboolean (*RTLSPreferredCipherSuitesCb) (rpointer ctx, RTLSVersion ver, 
  * @p alert is the alert description sent to the peer. The session has
  * moved to its error state; the callback may fire more than once for a
  * session, so it should be idempotent (e.g. tear the transport down
- * only once). May be @c NULL.
+ * only once). May be @c NULL. @p session is the @ref RTLSServer or
+ * @ref RTLSClient the bundle is attached to.
  */
-typedef void (*RTLSServerErrorCb) (rpointer ctx, RTLSAlertType alert, RTLSServer * server);
+typedef void (*RTLSErrorCb) (rpointer ctx, RTLSAlertType alert, rpointer session);
 /**
  * @brief Callback verifying the peer's certificate chain (leaf first).
  *
@@ -95,10 +102,10 @@ typedef rboolean (*RTLSCertVerifyCb) (rpointer ctx, RCryptoCert * const * chain,
 /** @brief Callback bundle wiring a session to its transport and policy. */
 typedef struct {
   RTLSPreferredCipherSuitesCb   preferred_cipher_suites; /**< Choose cipher suites; may be @c NULL for defaults. */
-  RTLSServerHandshakeDoneCb     handshake_done;          /**< Fired once the handshake finishes. */
-  RTLSServerBufferCb            out;                     /**< Sink for outgoing encrypted records. */
-  RTLSServerBufferCb            appdata;                 /**< Sink for decrypted application data. */
-  RTLSServerErrorCb             error;                   /**< Fired on a fatal alert; may be @c NULL. */
+  RTLSHandshakeDoneCb           handshake_done;          /**< Fired once the handshake finishes. */
+  RTLSBufferCb                  out;                     /**< Sink for outgoing encrypted records. */
+  RTLSBufferCb                  appdata;                 /**< Sink for decrypted application data. */
+  RTLSErrorCb                   error;                   /**< Fired on a fatal alert; may be @c NULL. */
   RTLSCertVerifyCb              verify_cert;             /**< Verify the peer certificate chain; may be @c NULL. */
 } RTLSCallbacks;
 

--- a/include/rlib/rnet.h
+++ b/include/rlib/rnet.h
@@ -49,6 +49,7 @@
 #include <rlib/net/rresolve.h>
 #include <rlib/net/rhttpserver.h>
 #include <rlib/net/rsrtp.h>
+#include <rlib/net/rtlsclient.h>
 #include <rlib/net/rtlsserver.h>
 #include <rlib/net/proto/rhttp.h>
 #include <rlib/net/proto/rrtp.h>

--- a/rlib/crypto/rrsa.c
+++ b/rlib/crypto/rrsa.c
@@ -956,13 +956,18 @@ r_rsa_pkcs1v1_5_encrypt (const RCryptoKey * key, RPrng * prng,
 
   if (R_UNLIKELY (key == NULL)) return R_CRYPTO_INVAL;
   if (R_UNLIKELY (key->algo->algo != R_CRYPTO_ALGO_RSA)) return R_CRYPTO_WRONG_TYPE;
-  if (R_UNLIKELY (key->type != R_CRYPTO_PRIVATE_KEY)) return R_CRYPTO_WRONG_TYPE;
+  /* RSA encryption is a public-key operation: accept a public key (e.g. one
+   * pulled from a peer certificate) as well as a private one. RRsaPrivKey
+   * embeds RRsaPubKey as its first member, so (RRsaPubKey *) is valid for
+   * both and r_rsa_raw_encrypt_internal uses the public exponent regardless. */
+  if (R_UNLIKELY (key->type != R_CRYPTO_PRIVATE_KEY &&
+        key->type != R_CRYPTO_PUBLIC_KEY)) return R_CRYPTO_WRONG_TYPE;
 
   if (R_UNLIKELY (prng == NULL)) return R_CRYPTO_INVAL;
   if (R_UNLIKELY (data == NULL)) return R_CRYPTO_INVAL;
   if (R_UNLIKELY (out == NULL || outsize == NULL)) return R_CRYPTO_INVAL;
 
-  k = r_mpint_digits_used (&((const RRsaPrivKey*)key)->pub.n) * sizeof (rmpint_digit);
+  k = r_mpint_digits_used (&((const RRsaPubKey*)key)->n) * sizeof (rmpint_digit);
   if (size > k - 11 || *outsize < k)
     return R_CRYPTO_WRONG_SIZE;
 

--- a/rlib/meson.build
+++ b/rlib/meson.build
@@ -108,6 +108,7 @@ rlib_sources = [
   'net/rnet.c',
   'net/rresolve.c',
   'net/rsrtp.c',
+  'net/rtlsclient.c',
   'net/rtlsserver.c',
   'os/rproc.c',
   'os/rsignal.c',

--- a/rlib/net/proto/rtls.c
+++ b/rlib/net/proto/rtls.c
@@ -1342,6 +1342,44 @@ r_tls_write_hs_server_hello (rpointer data, rsize size, rsize * out,
 }
 
 RTLSError
+r_tls_write_hs_client_hello (rpointer data, rsize size, rsize * out,
+    RTLSVersion ver, const ruint8 clirand[R_TLS_HELLO_RANDOM_BYTES],
+    const ruint8 * sid, ruint8 sidsize, const ruint8 * cookie, ruint8 cookiesize,
+    const RTLSCipherSuite * cs, ruint16 ncs, RTLSCompressionMethod comp)
+{
+  ruint8 * p;
+  rboolean dtls = r_tls_version_is_dtls (ver);
+  ruint16 i;
+  rsize need = 2 + R_TLS_HELLO_RANDOM_BYTES + 1 + sidsize +
+      (dtls ? (rsize)(1 + cookiesize) : 0) + 2 + (rsize)ncs * sizeof (ruint16) + 1 + 1;
+
+  if (R_UNLIKELY (data == NULL || cs == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (size < need)) return R_TLS_ERROR_BUF_TOO_SMALL;
+
+  p = data;
+  *p++ = (ver >> 8) & 0xff;
+  *p++ = (ver     ) & 0xff;
+  r_memcpy (p, clirand, R_TLS_HELLO_RANDOM_BYTES); p += R_TLS_HELLO_RANDOM_BYTES;
+  *p++ = sidsize;
+  if (sidsize > 0) { r_memcpy (p, sid, sidsize); p += sidsize; }
+  if (dtls) {
+    *p++ = cookiesize;
+    if (cookiesize > 0) { r_memcpy (p, cookie, cookiesize); p += cookiesize; }
+  }
+  r_store_be16 (p, (ruint16)(ncs * sizeof (ruint16))); p += 2;
+  for (i = 0; i < ncs; i++) {
+    r_store_be16 (p, (ruint16)cs[i]); p += 2;
+  }
+  *p++ = 1;                  /* one compression method follows */
+  *p++ = (comp) & 0xff;
+
+  if (out != NULL)
+    *out = need;
+
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
 r_tls_write_hs_new_session_ticket (rpointer data, rsize size, rsize * out,
     ruint32 lifetime, const ruint8 * ticket, ruint16 tsize)
 {

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -1,0 +1,1189 @@
+/* RLIB - Convenience library for useful things
+ * Copyright (C) 2026 Haakon Sporsheim <haakon.sporsheim@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ * See the COPYING file at the root of the source repository.
+ */
+
+#include "config.h"
+#include "../rlib-private.h"
+#include <rlib/net/rtlsclient.h>
+
+#include <rlib/crypto/rx509.h>
+
+#include <rlib/data/rqueue.h>
+
+#include <rlib/rmem.h>
+#include <rlib/rstr.h>
+
+#define R_TLS_CLIENT_MAX_CHAIN  16
+
+typedef enum {
+  R_TLS_CLIENT_INITIAL = 0,
+  R_TLS_CLIENT_SERVER_HELLO,        /* await ServerHello */
+  R_TLS_CLIENT_CERTIFICATE,         /* await Certificate */
+  R_TLS_CLIENT_SERVER_HELLO_DONE,   /* await ServerHelloDone (then send flight) */
+  R_TLS_CLIENT_CHANGE_CIPHER,       /* await server ChangeCipherSpec */
+  R_TLS_CLIENT_FINISHED,            /* await server Finished */
+  R_TLS_CLIENT_APPDATA,
+  R_TLS_CLIENT_ERROR,
+} RTLSClientState;
+
+typedef RTLSError (*RTLSClientStateFunc) (RTLSClient * client, const RTLSParser * parser);
+typedef RBuffer * (*RTLSClientEncryptFunc) (RTLSClient * client, RBuffer * buf);
+typedef RTLSError (*RTLSClientDecryptFunc) (RTLSParser * parser,
+    const RCryptoCipher * cipher, RHmac * mac, rboolean etm);
+
+typedef struct {
+  RHmac * hmac;
+  RCryptoCipher * cipher;
+  ruint8 * fixediv;
+
+  ruint16 epoch;
+  ruint64 seqno;
+  ruint16 msgseq;
+} RTLSConnectionState;
+
+struct RTLSClient {
+  RRef ref;
+  RTLSClientState state;
+
+  RTLSClientEncryptFunc encrypt;
+  RTLSClientDecryptFunc decrypt;
+  RTLSPrfFunc prf;
+
+  RMsgDigest * hshash;
+  ruint8 mastersecret[48];
+  ruint8 clirandom[R_TLS_HELLO_RANDOM_BYTES];
+  ruint8 servrandom[R_TLS_HELLO_RANDOM_BYTES];
+  rboolean clirandompinned;
+
+  RTLSVersion version;
+  RTLSVersion recordver;
+  RTLSCompressionMethod comp;
+  const RTLSCipherSuiteInfo * csinfo;
+  rboolean support_ext_master_secret;
+  rboolean encrypt_then_mac;
+  RSRTPCipherSuite dtls_srtp_profile;
+
+  /* write direction = client, read direction = server (reversed from the
+   * server, where the local side writes with the 'server' connection state). */
+  RTLSConnectionState client;
+  RTLSConnectionState server;
+
+  RTLSCallbacks cb;
+  rpointer userdata;
+  RDestroyNotify notify;
+
+  REvLoop * loop;
+  RPrng * prng;
+  RCryptoCert * peer_cert;
+
+  RBuffer * inbuf;
+  RQueue qsend;
+};
+
+R_LOG_CATEGORY_DEFINE_STATIC (tlsclicat, "tlsclient", "RLib TLS Client",
+    R_CLR_FG_WHITE | R_CLR_BG_BLUE | R_CLR_FMT_BOLD);
+#define R_LOG_CAT_DEFAULT &tlsclicat
+
+void
+r_tls_client_init (void)
+{
+  r_log_category_register (&tlsclicat);
+}
+
+static void
+r_tls_client_free (RTLSClient * client)
+{
+  if (client->loop != NULL)
+    r_ev_loop_unref (client->loop);
+  if (client->notify != NULL)
+    client->notify (client->userdata);
+  if (client->prng != NULL)
+    r_prng_unref (client->prng);
+  if (client->peer_cert != NULL)
+    r_crypto_cert_unref (client->peer_cert);
+  if (client->client.hmac != NULL)
+    r_hmac_free (client->client.hmac);
+  if (client->client.cipher != NULL)
+    r_crypto_cipher_unref (client->client.cipher);
+  r_free (client->client.fixediv);
+  if (client->server.hmac != NULL)
+    r_hmac_free (client->server.hmac);
+  if (client->server.cipher != NULL)
+    r_crypto_cipher_unref (client->server.cipher);
+  r_free (client->server.fixediv);
+  r_msg_digest_free (client->hshash);
+
+  if (client->inbuf != NULL)
+    r_buffer_unref (client->inbuf);
+  r_queue_clear (&client->qsend, r_buffer_unref);
+  r_memclear_secure (client->mastersecret, sizeof (client->mastersecret));
+  r_free (client);
+}
+
+static RTLSError
+r_tls_client_null_decrypt (RTLSParser * parser, const RCryptoCipher * cipher,
+    RHmac * mac, rboolean etm)
+{
+  (void) parser; (void) cipher; (void) mac; (void) etm;
+  return R_TLS_ERROR_OK;
+}
+
+static RBuffer *
+r_tls_client_null_encrypt (RTLSClient * client, RBuffer * buf)
+{
+  (void) client;
+  return r_buffer_ref (buf);
+}
+
+RTLSClient *
+r_tls_client_new (const RTLSCallbacks * cb, rpointer userdata, RDestroyNotify notify)
+{
+  RTLSClient * ret;
+
+  if ((ret = r_mem_new0 (RTLSClient)) != NULL) {
+    r_ref_init (ret, r_tls_client_free);
+
+    r_memcpy (&ret->cb, cb, sizeof (RTLSCallbacks));
+    ret->userdata = userdata;
+    ret->notify = notify;
+    r_queue_init (&ret->qsend);
+    ret->decrypt = r_tls_client_null_decrypt;
+    ret->encrypt = r_tls_client_null_encrypt;
+  }
+
+  return ret;
+}
+
+static RTLSError
+r_tls_client_change_state (RTLSClient * client, RTLSClientState state)
+{
+  if (state > client->state) {
+    R_LOG_DEBUG ("%p - state change %u -> %u", client, client->state, state);
+    client->state = state;
+    return R_TLS_ERROR_OK;
+  }
+
+  return R_TLS_ERROR_WRONG_STATE;
+}
+
+RTLSError
+r_tls_client_set_random (RTLSClient * client,
+    const ruint8 clirandom[R_TLS_HELLO_RANDOM_BYTES])
+{
+  if (R_UNLIKELY (client == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (clirandom == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (client->state != R_TLS_CLIENT_INITIAL))
+    return R_TLS_ERROR_WRONG_STATE;
+
+  r_memcpy (client->clirandom, clirandom, R_TLS_HELLO_RANDOM_BYTES);
+  client->clirandompinned = TRUE;
+
+  return R_TLS_ERROR_OK;
+}
+
+static RBuffer *
+r_tls_client_alloc_buffer (RTLSClient * client)
+{
+  (void) client;
+  return r_buffer_new_alloc (NULL, 4096, NULL);
+}
+
+static RBuffer *
+r_tls_client_cipher_encrypt (RTLSClient * client, RBuffer * buf)
+{
+  RBuffer * ret;
+  ruint8 * iv = r_alloca (client->client.cipher->info->ivsize);
+
+  r_prng_fill (client->prng, iv, client->client.cipher->info->ivsize);
+  if (r_tls_version_is_dtls (client->version)) {
+    ret = r_dtls_encrypt_buffer (buf,
+        client->client.cipher, iv, client->client.hmac, client->encrypt_then_mac);
+  } else {
+    ret = r_tls_encrypt_buffer (buf, client->client.seqno,
+        client->client.cipher, iv, client->client.hmac, client->encrypt_then_mac);
+  }
+
+  return ret;
+}
+
+static RTLSError
+r_tls_client_send_record (RTLSClient * client, RBuffer * buf)
+{
+  RTLSError ret;
+  RBuffer * encbuf;
+
+  if ((encbuf = client->encrypt (client, buf)) != NULL) {
+    if (r_queue_push (&client->qsend, encbuf) != NULL) {
+      client->client.seqno++;
+      ret = R_TLS_ERROR_OK;
+    } else {
+      r_buffer_unref (encbuf);
+      ret = R_TLS_ERROR_QUEUE_FULL;
+    }
+  } else {
+    ret = R_TLS_ERROR_ENCRYPTION_FAILED;
+  }
+
+  return ret;
+}
+
+static void
+r_tls_client_send_out (RTLSClient * client)
+{
+  RBuffer * buf;
+
+  while ((buf = r_queue_pop (&client->qsend)) != NULL) {
+    client->cb.out (client->userdata, buf, client);
+    r_buffer_unref (buf);
+  }
+}
+
+static void
+r_tls_client_send_alert (RTLSClient * client, RTLSAlertType alert)
+{
+  RBuffer * buf;
+  RTLSError ret = R_TLS_ERROR_OOM;
+  RTLSVersion ver = (client->version != 0) ? client->version : client->recordver;
+
+  R_LOG_WARNING ("Sending alert: 0x%.2x in state (%d)", alert, client->state);
+
+  if ((buf = r_tls_client_alloc_buffer (client)) != NULL) {
+    RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+
+    if (r_buffer_map (buf, &info, R_MEM_MAP_WRITE)) {
+      rsize sz = 0;
+
+      if (r_tls_version_is_dtls (ver))
+        ret = r_dtls_write_alert (info.data, info.size, &sz, ver,
+            client->client.epoch, client->client.seqno,
+            R_TLS_ALERT_LEVEL_FATAL, alert);
+      else
+        ret = r_tls_write_alert (info.data, info.size, &sz, ver,
+            R_TLS_ALERT_LEVEL_FATAL, alert);
+      r_buffer_unmap (buf, &info);
+
+      if (ret == R_TLS_ERROR_OK) {
+        r_buffer_set_size (buf, sz);
+        ret = r_tls_client_send_record (client, buf);
+      }
+    }
+    r_buffer_unref (buf);
+  }
+
+  if (ret == R_TLS_ERROR_OK)
+    r_tls_client_send_out (client);
+
+  if (client->cb.error != NULL)
+    client->cb.error (client->userdata, alert, client);
+
+  r_tls_client_change_state (client, R_TLS_CLIENT_ERROR);
+}
+
+/* ClientHello offers these extensions unconditionally (the server echoes the
+ * ones it honours); use_srtp is offered for DTLS only. */
+static ruint16
+r_tls_client_write_hs_ext_renegotiation (ruint8 * ptr)
+{
+  r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_RENEGOTIATION_INFO);
+  r_store_be16 (&ptr[2], 1);
+  ptr[4] = 0;
+  return 5;
+}
+
+static ruint16
+r_tls_client_write_hs_ext_extended_ms (ruint8 * ptr)
+{
+  r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_EXTENDED_MASTER_SECRET);
+  r_store_be16 (&ptr[2], 0);
+  return 4;
+}
+
+static ruint16
+r_tls_client_write_hs_ext_encrypt_then_mac (ruint8 * ptr)
+{
+  r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_ENCRYPT_THEN_MAC);
+  r_store_be16 (&ptr[2], 0);
+  return 4;
+}
+
+static ruint16
+r_tls_client_write_hs_ext_use_srtp (ruint8 * ptr)
+{
+  r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_USE_SRTP);
+  r_store_be16 (&ptr[2], 5);
+  r_store_be16 (&ptr[4], 1 * sizeof (ruint16));
+  r_store_be16 (&ptr[6], (ruint16)R_SRTP_CS_AES_128_CM_HMAC_SHA1_80);
+  ptr[8] = 0;                  /* empty MKI */
+  return 9;
+}
+
+static rboolean
+r_tls_client_default_cipher_suites (rpointer ctx, RTLSVersion ver,
+    RTLSCipherSuite * cs, rsize * count)
+{
+  const RTLSCipherSuite preferred[] = {
+    R_TLS_CS_RSA_WITH_AES_128_CBC_SHA256,
+    R_TLS_CS_RSA_WITH_AES_128_CBC_SHA,
+  };
+
+  (void) ctx; (void) ver;
+
+  *count = MIN (*count, R_N_ELEMENTS (preferred));
+  r_memcpy (cs, preferred, *count * sizeof (RTLSCipherSuite));
+
+  return TRUE;
+}
+
+static RTLSError
+r_tls_client_send_hello (RTLSClient * client)
+{
+  RBuffer * buf;
+  RTLSError ret;
+  RMemMapInfo info;
+  RTLSCipherSuite cs[8];
+  rsize ncs = R_N_ELEMENTS (cs);
+  rboolean dtls = r_tls_version_is_dtls (client->version);
+
+  R_LOG_DEBUG ("%p - client hello", client);
+
+  if (!client->clirandompinned) {
+    r_tls_generate_hello_random (client->clirandom, client->prng);
+    client->clirandompinned = TRUE;
+  }
+
+  if (client->cb.preferred_cipher_suites == NULL ||
+      !client->cb.preferred_cipher_suites (client->userdata, client->version, cs, &ncs)) {
+    ncs = R_N_ELEMENTS (cs);
+    r_tls_client_default_cipher_suites (client->userdata, client->version, cs, &ncs);
+  }
+
+  if ((buf = r_tls_client_alloc_buffer (client)) == NULL)
+    return R_TLS_ERROR_OOM;
+
+  if (r_buffer_map (buf, &info, R_MEM_MAP_WRITE)) {
+    ruint8 * ptr;
+    rsize hssize, size = 0;
+    ruint16 extsize;
+    ruint8 hdrsize;
+
+    if (dtls) {
+      ret = r_dtls_write_handshake (info.data, info.size, &hssize,
+          client->version, R_TLS_HANDSHAKE_TYPE_CLIENT_HELLO, 0,
+          client->client.epoch, client->client.seqno, client->client.msgseq, 0, 0);
+      hdrsize = R_DTLS_RECORD_HDR_SIZE;
+    } else {
+      ret = r_tls_write_handshake (info.data, info.size, &hssize,
+          client->version, R_TLS_HANDSHAKE_TYPE_CLIENT_HELLO, 0);
+      hdrsize = R_TLS_RECORD_HDR_SIZE;
+    }
+    ptr = info.data + hssize;
+    if (ret == R_TLS_ERROR_OK)
+      ret = r_tls_write_hs_client_hello (ptr, info.size - hssize, &size,
+          client->version, client->clirandom, NULL, 0, NULL, 0,
+          cs, (ruint16)ncs, client->comp);
+    ptr += size;
+
+    extsize = 0;
+    extsize += r_tls_client_write_hs_ext_renegotiation (ptr + 2 + extsize);
+    extsize += r_tls_client_write_hs_ext_extended_ms (ptr + 2 + extsize);
+    extsize += r_tls_client_write_hs_ext_encrypt_then_mac (ptr + 2 + extsize);
+    if (dtls)
+      extsize += r_tls_client_write_hs_ext_use_srtp (ptr + 2 + extsize);
+    r_store_be16 (ptr, extsize);
+    ptr += extsize + 2;
+
+    size = RPOINTER_TO_SIZE (ptr) - RPOINTER_TO_SIZE (info.data);
+    if (ret == R_TLS_ERROR_OK) {
+      if (dtls)
+        ret = r_dtls_update_handshake_len (info.data, info.size,
+            (ruint16)(size - hssize), 0, (ruint32)(size - hssize));
+      else
+        ret = r_tls_update_handshake_len (info.data, info.size, (ruint16)(size - hssize));
+
+      if (ret == R_TLS_ERROR_OK)
+        r_msg_digest_update (client->hshash, info.data + hdrsize, size - hdrsize);
+    }
+    r_buffer_unmap (buf, &info);
+    r_buffer_set_size (buf, size);
+
+    if (ret == R_TLS_ERROR_OK)
+      ret = r_tls_client_send_record (client, buf);
+  } else {
+    ret = R_TLS_ERROR_OOM;
+  }
+
+  r_buffer_unref (buf);
+  return ret;
+}
+
+RTLSError
+r_tls_client_start (RTLSClient * client, REvLoop * loop, RPrng * prng,
+    RTLSVersion version)
+{
+  if (R_UNLIKELY (client == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (loop == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (client->loop != NULL)) return R_TLS_ERROR_WRONG_STATE;
+  if (R_UNLIKELY (version != R_TLS_VERSION_TLS_1_2 &&
+        version != R_TLS_VERSION_DTLS_1_2))
+    return R_TLS_ERROR_VERSION;
+
+  R_LOG_DEBUG ("%p - start (ver %.4x)", client, version);
+
+  if (prng != NULL) r_prng_ref (prng);
+  client->loop = r_ev_loop_ref (loop);
+  client->prng = prng;
+  client->version = version;
+  client->comp = R_TLS_COMPRESSION_NULL;
+
+  /* TLS / DTLS 1.2 use the SHA-256 PRF and handshake-transcript hash for the
+   * RSA-AES-CBC suites the client offers. */
+  client->prf = r_tls_1_2_prf_sha256;
+  if ((client->hshash = r_sha256_new ()) == NULL)
+    return R_TLS_ERROR_OOM;
+
+  r_tls_client_change_state (client, R_TLS_CLIENT_SERVER_HELLO);
+
+  if (r_tls_client_send_hello (client) != R_TLS_ERROR_OK)
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  client->client.msgseq++;
+  r_tls_client_send_out (client);
+
+  return R_TLS_ERROR_OK;
+}
+
+static RTLSError
+r_tls_client_nego_server_hello (RTLSClient * client, const RTLSParser * parser)
+{
+  RTLSHelloMsg hello;
+  RTLSHelloExt ext;
+  RTLSError r;
+
+  if ((r = r_tls_parser_parse_hello (parser, &hello)) != R_TLS_ERROR_OK)
+    return r;
+
+  if (hello.version != client->version)
+    return R_TLS_ERROR_VERSION;
+  if (hello.cslen != sizeof (ruint16))
+    return R_TLS_ERROR_CORRUPT_RECORD;
+
+  if ((client->csinfo = r_tls_cipher_suite_get_info (
+          (RTLSCipherSuite) r_load_be16 (hello.cs))) == NULL ||
+      !r_tls_cipher_suite_is_supported (client->csinfo->suite))
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
+  r_memcpy (client->servrandom, hello.random, R_TLS_HELLO_RANDOM_BYTES);
+
+  for (r = r_tls_hello_msg_extension_first (&hello, &ext); r == R_TLS_ERROR_OK;
+      r = r_tls_hello_msg_extension_next (&hello, &ext)) {
+    switch (ext.type) {
+      case R_TLS_EXT_TYPE_EXTENDED_MASTER_SECRET:
+        client->support_ext_master_secret = TRUE;
+        break;
+      case R_TLS_EXT_TYPE_ENCRYPT_THEN_MAC:
+        if (client->csinfo->cipher->mode == R_CRYPTO_CIPHER_MODE_CBC)
+          client->encrypt_then_mac = TRUE;
+        break;
+      case R_TLS_EXT_TYPE_USE_SRTP:
+        if (r_tls_hello_ext_use_srtp_profile_count (&ext) > 0)
+          client->dtls_srtp_profile = r_tls_hello_ext_use_srtp_profile (&ext, 0);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return R_TLS_ERROR_OK;
+}
+
+/* RFC 7627: with extended master secret the seed is the handshake-transcript
+ * hash through ClientKeyExchange; otherwise the client + server randoms. The
+ * caller must have absorbed the ClientKeyExchange into hshash first. */
+static RTLSError
+r_tls_client_derive_master_secret (RTLSClient * client, const ruint8 pms[48])
+{
+  if (client->support_ext_master_secret) {
+    rsize hashsize = r_msg_digest_size (client->hshash);
+    ruint8 * sessionhash = r_alloca (hashsize);
+
+    if (!r_msg_digest_get_data (client->hshash, sessionhash, hashsize, NULL))
+      return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
+    return client->prf (client->mastersecret, sizeof (client->mastersecret),
+        pms, 48, R_STR_WITH_SIZE_ARGS ("extended master secret"),
+        sessionhash, hashsize, NULL);
+  }
+
+  return client->prf (client->mastersecret, sizeof (client->mastersecret),
+      pms, 48, R_STR_WITH_SIZE_ARGS ("master secret"),
+      client->clirandom, (rsize)R_TLS_HELLO_RANDOM_BYTES,
+      client->servrandom, (rsize)R_TLS_HELLO_RANDOM_BYTES,
+      NULL);
+}
+
+static RTLSError
+r_tls_client_expand_master_secret (RTLSClient * client)
+{
+  ruint8 keyblock[256];
+  RTLSError ret;
+
+  if (client->prf (keyblock, sizeof (keyblock),
+        client->mastersecret, sizeof (client->mastersecret),
+        R_STR_WITH_SIZE_ARGS ("key expansion"),
+        client->servrandom, (rsize)R_TLS_HELLO_RANDOM_BYTES,
+        client->clirandom, (rsize)R_TLS_HELLO_RANDOM_BYTES,
+        NULL) != R_TLS_ERROR_OK) {
+    r_memclear_secure (keyblock, sizeof (keyblock));
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  }
+
+  {
+    ruint8 * ptr = keyblock;
+    rsize size;
+
+    ret = R_TLS_ERROR_OK;
+
+    /* keyblock: client MAC | server MAC | client key | server key |
+     * client IV | server IV. The client writes with its own state and reads
+     * with the server state. */
+    if ((size = r_msg_digest_type_size (client->csinfo->mac)) > 0) {
+      client->client.hmac = r_hmac_new (client->csinfo->mac, ptr, size); ptr += size;
+      client->server.hmac = r_hmac_new (client->csinfo->mac, ptr, size); ptr += size;
+      if (client->client.hmac == NULL || client->server.hmac == NULL)
+        ret = R_TLS_ERROR_OOM;
+    }
+    if (ret == R_TLS_ERROR_OK && (size = client->csinfo->cipher->keybits / 8) > 0) {
+      client->client.cipher = r_crypto_cipher_new (client->csinfo->cipher, ptr); ptr += size;
+      client->server.cipher = r_crypto_cipher_new (client->csinfo->cipher, ptr); ptr += size;
+      if (client->client.cipher == NULL || client->server.cipher == NULL)
+        ret = R_TLS_ERROR_OOM;
+    }
+    if (ret == R_TLS_ERROR_OK && (size = client->csinfo->cipher->ivsize) > 0) {
+      client->client.fixediv = r_memdup (ptr, size); ptr += size;
+      client->server.fixediv = r_memdup (ptr, size); ptr += size;
+      if (client->client.fixediv == NULL || client->server.fixediv == NULL)
+        ret = R_TLS_ERROR_OOM;
+    }
+  }
+
+  r_memclear_secure (keyblock, sizeof (keyblock));
+  return ret;
+}
+
+static RTLSError
+r_tls_client_send_key_exchange (RTLSClient * client, ruint8 pms[48])
+{
+  RBuffer * buf;
+  RTLSError ret;
+  RMemMapInfo info;
+  RCryptoKey * pub;
+  ruint8 enc[512];
+  rsize enclen = sizeof (enc);
+
+  if ((pub = r_crypto_cert_get_public_key (client->peer_cert)) == NULL)
+    return R_TLS_ERROR_NO_CERTIFICATE;
+
+  pms[0] = (((ruint16)client->version) >> 8) & 0xff;
+  pms[1] = (((ruint16)client->version)     ) & 0xff;
+  r_prng_fill (client->prng, pms + 2, 48 - 2);
+
+  if (r_crypto_key_encrypt (pub, client->prng, pms, 48, enc, &enclen) != R_CRYPTO_OK) {
+    r_crypto_key_unref (pub);
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  }
+  r_crypto_key_unref (pub);
+
+  if ((buf = r_tls_client_alloc_buffer (client)) == NULL)
+    return R_TLS_ERROR_OOM;
+
+  if (r_buffer_map (buf, &info, R_MEM_MAP_WRITE)) {
+    rsize hssize;
+    ruint8 hdrsize;
+    ruint16 bodysize = (ruint16)(sizeof (ruint16) + enclen);
+
+    if (r_tls_version_is_dtls (client->version)) {
+      ret = r_dtls_write_handshake (info.data, info.size, &hssize,
+          client->version, R_TLS_HANDSHAKE_TYPE_CLIENT_KEY_EXCHANGE, bodysize,
+          client->client.epoch, client->client.seqno, client->client.msgseq,
+          0, bodysize);
+      hdrsize = R_DTLS_RECORD_HDR_SIZE;
+    } else {
+      ret = r_tls_write_handshake (info.data, info.size, &hssize,
+          client->version, R_TLS_HANDSHAKE_TYPE_CLIENT_KEY_EXCHANGE, bodysize);
+      hdrsize = R_TLS_RECORD_HDR_SIZE;
+    }
+
+    if (ret == R_TLS_ERROR_OK) {
+      r_store_be16 (info.data + hssize, (ruint16)enclen);
+      r_memcpy (info.data + hssize + sizeof (ruint16), enc, enclen);
+      r_msg_digest_update (client->hshash, info.data + hdrsize,
+          hssize - hdrsize + bodysize);
+      r_buffer_unmap (buf, &info);
+      r_buffer_set_size (buf, hssize + bodysize);
+
+      ret = r_tls_client_send_record (client, buf);
+    } else {
+      r_buffer_unmap (buf, &info);
+    }
+  } else {
+    ret = R_TLS_ERROR_OOM;
+  }
+
+  r_buffer_unref (buf);
+  return ret;
+}
+
+static RTLSError
+r_tls_client_send_change_cipher (RTLSClient * client)
+{
+  RBuffer * buf;
+  RTLSError ret;
+  rsize size;
+  RMemMapInfo info;
+
+  if ((buf = r_tls_client_alloc_buffer (client)) == NULL)
+    return R_TLS_ERROR_OOM;
+
+  if (r_buffer_map (buf, &info, R_MEM_MAP_WRITE)) {
+    if (r_tls_version_is_dtls (client->version))
+      ret = r_dtls_write_change_cipher (info.data, info.size, &size,
+          client->version, client->client.epoch, client->client.seqno);
+    else
+      ret = r_tls_write_change_cipher (info.data, info.size, &size, client->version);
+    r_buffer_unmap (buf, &info);
+    r_buffer_set_size (buf, size);
+
+    if (ret == R_TLS_ERROR_OK) {
+      if ((ret = r_tls_client_send_record (client, buf)) == R_TLS_ERROR_OK) {
+        client->client.epoch++;
+        client->client.seqno = 0;
+      }
+    }
+  } else {
+    ret = R_TLS_ERROR_OOM;
+  }
+
+  r_buffer_unref (buf);
+  return ret;
+}
+
+static RTLSError
+r_tls_client_send_finished (RTLSClient * client)
+{
+  RBuffer * buf;
+  RTLSError ret;
+  rsize size;
+  RMemMapInfo info;
+
+  if ((buf = r_tls_client_alloc_buffer (client)) == NULL)
+    return R_TLS_ERROR_OOM;
+
+  if (r_buffer_map (buf, &info, R_MEM_MAP_WRITE)) {
+    rsize verifysize = 12, hashsize = r_msg_digest_size (client->hshash);
+    ruint8 * hash = r_alloca (hashsize);
+    ruint8 hdrsize;
+
+    if (!r_msg_digest_get_data (client->hshash, hash, hashsize, NULL)) {
+      r_buffer_unmap (buf, &info);
+      r_buffer_unref (buf);
+      return R_TLS_ERROR_HANDSHAKE_FAILURE;
+    }
+
+    if (r_tls_version_is_dtls (client->version)) {
+      ret = r_dtls_write_handshake (info.data, info.size, &size,
+          client->version, R_TLS_HANDSHAKE_TYPE_FINISHED, (ruint16)verifysize,
+          client->client.epoch, client->client.seqno, client->client.msgseq,
+          0, (ruint32)verifysize);
+      hdrsize = R_DTLS_RECORD_HDR_SIZE;
+    } else {
+      ret = r_tls_write_handshake (info.data, info.size, &size,
+          client->version, R_TLS_HANDSHAKE_TYPE_FINISHED, (ruint16)verifysize);
+      hdrsize = R_TLS_RECORD_HDR_SIZE;
+    }
+
+    if (ret == R_TLS_ERROR_OK &&
+        (ret = client->prf (info.data + size, verifysize,
+            client->mastersecret, sizeof (client->mastersecret),
+            R_STR_WITH_SIZE_ARGS ("client finished"),
+            hash, hashsize, NULL)) == R_TLS_ERROR_OK) {
+      /* hash our own Finished into the transcript for the server-Finished
+       * verification that follows. */
+      r_msg_digest_update (client->hshash, info.data + hdrsize,
+          size - hdrsize + verifysize);
+      r_buffer_unmap (buf, &info);
+      size += verifysize;
+      r_buffer_set_size (buf, size);
+
+      ret = r_tls_client_send_record (client, buf);
+    } else {
+      r_buffer_unmap (buf, &info);
+    }
+  } else {
+    ret = R_TLS_ERROR_OOM;
+  }
+
+  r_buffer_unref (buf);
+  return ret;
+}
+
+static RTLSError
+r_tls_client_parse_finished (RTLSClient * client, const RTLSParser * parser)
+{
+  RTLSError ret;
+  const ruint8 * verify_data;
+  rsize size;
+
+  if ((ret = r_tls_parser_parse_finished (parser, &verify_data, &size)) == R_TLS_ERROR_OK) {
+    if (size >= 12 && size <= 64) {
+      ruint8 * verify_calc = r_alloca (size);
+      rsize hashsize = r_msg_digest_size (client->hshash);
+      ruint8 * hash = r_alloca (hashsize);
+      r_msg_digest_get_data (client->hshash, hash, hashsize, NULL);
+
+      if ((ret = client->prf (verify_calc, size,
+            client->mastersecret, sizeof (client->mastersecret),
+            R_STR_WITH_SIZE_ARGS ("server finished"),
+            hash, hashsize, NULL)) == R_TLS_ERROR_OK) {
+        if (r_memcmp (verify_calc, verify_data, size) != 0) {
+          R_LOG_WARNING ("Server Finished NOT verified");
+          ret = R_TLS_ERROR_HS_VERIFICATION_FAILED;
+        }
+      }
+    } else {
+      ret = R_TLS_ERROR_CORRUPT_RECORD;
+    }
+  }
+
+  return ret;
+}
+
+/* Build and send ClientKeyExchange, derive + install keys, send
+ * ChangeCipherSpec and the (now encrypted) client Finished. */
+static RTLSError
+r_tls_client_send_flight (RTLSClient * client)
+{
+  RTLSError ret;
+  ruint8 pms[48];
+
+  if ((ret = r_tls_client_send_key_exchange (client, pms)) == R_TLS_ERROR_OK)
+    client->client.msgseq++;
+
+  if (ret == R_TLS_ERROR_OK)
+    ret = r_tls_client_derive_master_secret (client, pms);
+  r_memclear_secure (pms, sizeof (pms));
+  if (ret == R_TLS_ERROR_OK)
+    ret = r_tls_client_expand_master_secret (client);
+
+  if (ret == R_TLS_ERROR_OK)
+    ret = r_tls_client_send_change_cipher (client);
+  if (ret == R_TLS_ERROR_OK) {
+    client->encrypt = r_tls_client_cipher_encrypt;
+    if ((ret = r_tls_client_send_finished (client)) == R_TLS_ERROR_OK)
+      client->client.msgseq++;
+  }
+
+  return ret;
+}
+
+static RTLSError
+r_tls_client_state_error (RTLSClient * client, const RTLSParser * parser)
+{
+  (void) client; (void) parser;
+  return R_TLS_ERROR_OK;
+}
+
+static RTLSError
+r_tls_client_state_server_hello (RTLSClient * client, const RTLSParser * parser)
+{
+  RTLSError err;
+  RTLSHandshakeType type;
+
+  if ((err = r_tls_parser_parse_handshake_peek_type (parser, &type)) == R_TLS_ERROR_OK) {
+    if (type != R_TLS_HANDSHAKE_TYPE_SERVER_HELLO)
+      err = R_TLS_ERROR_WRONG_TYPE;
+    else if ((err = r_tls_client_nego_server_hello (client, parser)) == R_TLS_ERROR_OK)
+      err = r_tls_client_change_state (client, R_TLS_CLIENT_CERTIFICATE);
+  }
+
+  switch (err) {
+    case R_TLS_ERROR_OK:
+      r_msg_digest_update (client->hshash, parser->fragment.data, parser->fragment.size);
+      break;
+    case R_TLS_ERROR_WRONG_TYPE:
+      r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_UNEXPECTED_MESSAGE);
+      break;
+    case R_TLS_ERROR_VERSION:
+      r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_PROTOCOL_VERSION);
+      break;
+    case R_TLS_ERROR_HANDSHAKE_FAILURE:
+      r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_HANDSHAKE_FAILURE);
+      break;
+    case R_TLS_ERROR_CORRUPT_RECORD:
+      r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_DECODE_ERROR);
+      break;
+    default:
+      r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_INTERNAL_ERROR);
+      break;
+  }
+
+  return err;
+}
+
+static RTLSError
+r_tls_client_state_certificate (RTLSClient * client, const RTLSParser * parser)
+{
+  RTLSError err;
+  RTLSHandshakeType type;
+  RCryptoCert * chain[R_TLS_CLIENT_MAX_CHAIN];
+  ruint n = 0, i;
+
+  if ((err = r_tls_parser_parse_handshake_peek_type (parser, &type)) == R_TLS_ERROR_OK) {
+    if (type != R_TLS_HANDSHAKE_TYPE_CERTIFICATE) {
+      err = R_TLS_ERROR_WRONG_TYPE;
+    } else {
+      RTLSCertificate tlscert = R_TLS_CERTIFICATE_INIT;
+
+      while (n < R_TLS_CLIENT_MAX_CHAIN &&
+          r_tls_parser_parse_certificate_next (parser, &tlscert) == R_TLS_ERROR_OK) {
+        if ((chain[n] = r_tls_certificate_get_cert (&tlscert)) != NULL)
+          n++;
+      }
+
+      if (n == 0) {
+        err = R_TLS_ERROR_NO_CERTIFICATE;
+      } else if (client->cb.verify_cert != NULL &&
+          !client->cb.verify_cert (client->userdata, chain, n)) {
+        err = R_TLS_ERROR_CORRUPT_CERTIFICATE;
+      } else {
+        client->peer_cert = r_crypto_cert_ref (chain[0]);
+        err = r_tls_client_change_state (client, R_TLS_CLIENT_SERVER_HELLO_DONE);
+      }
+
+      for (i = 0; i < n; i++)
+        r_crypto_cert_unref (chain[i]);
+    }
+  }
+
+  switch (err) {
+    case R_TLS_ERROR_OK:
+      r_msg_digest_update (client->hshash, parser->fragment.data, parser->fragment.size);
+      break;
+    case R_TLS_ERROR_NO_CERTIFICATE:
+      r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_NO_CERTIFICATE);
+      break;
+    case R_TLS_ERROR_CORRUPT_CERTIFICATE:
+      r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_BAD_CERTIFICATE);
+      break;
+    case R_TLS_ERROR_WRONG_TYPE:
+      r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_UNEXPECTED_MESSAGE);
+      break;
+    default:
+      r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_INTERNAL_ERROR);
+      break;
+  }
+
+  return err;
+}
+
+static RTLSError
+r_tls_client_state_server_hello_done (RTLSClient * client, const RTLSParser * parser)
+{
+  RTLSError err;
+  RTLSHandshakeType type;
+
+  if ((err = r_tls_parser_parse_handshake_peek_type (parser, &type)) == R_TLS_ERROR_OK) {
+    if (type == R_TLS_HANDSHAKE_TYPE_SERVER_HELLO_DONE) {
+      err = R_TLS_ERROR_OK;
+    } else if (type == R_TLS_HANDSHAKE_TYPE_SERVER_KEY_EXCHANGE ||
+        type == R_TLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST) {
+      /* Not used by the RSA path; fold into the transcript and keep waiting. */
+      r_msg_digest_update (client->hshash, parser->fragment.data, parser->fragment.size);
+      return R_TLS_ERROR_OK;
+    } else {
+      err = R_TLS_ERROR_WRONG_TYPE;
+    }
+  }
+
+  switch (err) {
+    case R_TLS_ERROR_OK:
+      r_msg_digest_update (client->hshash, parser->fragment.data, parser->fragment.size);
+      if ((err = r_tls_client_send_flight (client)) == R_TLS_ERROR_OK)
+        err = r_tls_client_change_state (client, R_TLS_CLIENT_CHANGE_CIPHER);
+      if (err != R_TLS_ERROR_OK)
+        r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_INTERNAL_ERROR);
+      break;
+    case R_TLS_ERROR_WRONG_TYPE:
+      r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_UNEXPECTED_MESSAGE);
+      break;
+    default:
+      r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_INTERNAL_ERROR);
+      break;
+  }
+
+  return err;
+}
+
+static RTLSError
+r_tls_client_state_change_cipher (RTLSClient * client, const RTLSParser * parser)
+{
+  RTLSError err;
+
+  if (parser->content == R_TLS_CONTENT_TYPE_CHANGE_CIPHER_SPEC)
+    err = r_tls_client_change_state (client, R_TLS_CLIENT_FINISHED);
+  else
+    err = R_TLS_ERROR_WRONG_TYPE;
+
+  switch (err) {
+    case R_TLS_ERROR_OK:
+      client->decrypt = r_tls_parser_decrypt;
+      client->server.epoch++;
+      client->server.seqno = 0;
+      break;
+    case R_TLS_ERROR_WRONG_TYPE:
+      r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_UNEXPECTED_MESSAGE);
+      break;
+    default:
+      r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_INTERNAL_ERROR);
+      break;
+  }
+
+  return err;
+}
+
+static RTLSError
+r_tls_client_state_finished (RTLSClient * client, const RTLSParser * parser)
+{
+  RTLSError err;
+
+  if ((err = r_tls_client_parse_finished (client, parser)) == R_TLS_ERROR_OK)
+    err = r_tls_client_change_state (client, R_TLS_CLIENT_APPDATA);
+
+  switch (err) {
+    case R_TLS_ERROR_OK:
+      r_msg_digest_free (client->hshash);
+      client->hshash = NULL;
+      if (client->cb.handshake_done != NULL)
+        client->cb.handshake_done (client->userdata, client);
+      break;
+    case R_TLS_ERROR_HS_VERIFICATION_FAILED:
+    case R_TLS_ERROR_HANDSHAKE_FAILURE:
+      r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_HANDSHAKE_FAILURE);
+      break;
+    case R_TLS_ERROR_CORRUPT_RECORD:
+      r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_DECODE_ERROR);
+      break;
+    default:
+      r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_INTERNAL_ERROR);
+      break;
+  }
+
+  return err;
+}
+
+static RTLSError
+r_tls_client_state_appdata (RTLSClient * client, const RTLSParser * parser)
+{
+  RBuffer * buf;
+
+  if (parser->content == R_TLS_CONTENT_TYPE_APPLICATION_DATA) {
+    if ((buf = r_buffer_view (parser->buf, parser->offset, parser->fragment.size)) != NULL) {
+      client->cb.appdata (client->userdata, buf, client);
+      r_buffer_unref (buf);
+    }
+  } else {
+    R_LOG_WARNING ("Received non-app-data record");
+  }
+
+  return R_TLS_ERROR_OK;
+}
+
+rboolean
+r_tls_client_incoming_data (RTLSClient * client, RBuffer * buffer)
+{
+  static RTLSClientStateFunc statefuncs[] = {
+    r_tls_client_state_error,
+    r_tls_client_state_server_hello,
+    r_tls_client_state_certificate,
+    r_tls_client_state_server_hello_done,
+    r_tls_client_state_change_cipher,
+    r_tls_client_state_finished,
+    r_tls_client_state_appdata,
+    r_tls_client_state_error,
+  };
+  RTLSParser parser;
+  RTLSError err;
+
+  if (R_UNLIKELY (client == NULL)) return FALSE;
+  if (R_UNLIKELY (buffer == NULL)) return FALSE;
+
+  if (client->inbuf == NULL) {
+    client->inbuf = r_buffer_ref (buffer);
+  } else {
+    if (R_UNLIKELY (!r_buffer_append_mem_from_buffer (client->inbuf, buffer)))
+      return FALSE;
+  }
+
+  for (err = r_tls_parser_init_buffer (&parser, client->inbuf);
+      err == R_TLS_ERROR_OK;
+      err = r_tls_parser_init_next (&parser, &client->inbuf)) {
+    r_buffer_unref (client->inbuf);
+    client->inbuf = NULL;
+
+    client->recordver = parser.version;
+
+    /* TLS carries no explicit record sequence number; feed the running read
+     * counter to the MAC. (DTLS reads epoch/seqno from the record header.) */
+    if (!r_tls_parser_is_dtls (&parser))
+      parser.seqno = client->server.seqno;
+
+    if (!r_tls_parser_is_dtls (&parser) || parser.epoch == client->server.epoch) {
+      if ((err = client->decrypt (&parser, client->server.cipher, client->server.hmac,
+              client->encrypt_then_mac)) != R_TLS_ERROR_OK) {
+        R_LOG_WARNING ("Decryption returned: %d", err);
+        continue;
+      }
+    }
+
+    client->server.seqno++;
+
+    if (parser.content == R_TLS_CONTENT_TYPE_ALERT) {
+      RTLSAlertLevel alevel;
+      RTLSAlertType atype;
+
+      if (r_tls_parser_parse_alert (&parser, &alevel, &atype) == R_TLS_ERROR_OK) {
+        R_LOG_WARNING ("Received Alert, %.2x %.2x", alevel, atype);
+        if (alevel == R_TLS_ALERT_LEVEL_FATAL) {
+          if (client->cb.error != NULL)
+            client->cb.error (client->userdata, atype, client);
+          r_tls_client_change_state (client, R_TLS_CLIENT_ERROR);
+        }
+      } else {
+        r_tls_client_change_state (client, R_TLS_CLIENT_ERROR);
+      }
+      continue;
+    }
+
+    do {
+      err = statefuncs[client->state] (client, &parser);
+    } while (err == R_TLS_ERROR_NOT_NEEDED);
+  }
+
+  r_tls_parser_clear (&parser);
+
+  if (err >= R_TLS_ERROR_OK) {
+    r_tls_client_send_out (client);
+  } else {
+    if (client->inbuf != NULL) {
+      r_buffer_unref (client->inbuf);
+      client->inbuf = NULL;
+    }
+    return (err == R_TLS_ERROR_BUF_TOO_SMALL);
+  }
+
+  return TRUE;
+}
+
+rboolean
+r_tls_client_send_appdata (RTLSClient * client, RBuffer * buffer)
+{
+  RBuffer * rec;
+  RMemMapInfo in = R_MEM_MAP_INFO_INIT, out = R_MEM_MAP_INFO_INIT;
+  RTLSError ret = R_TLS_ERROR_OOM;
+  rboolean dtls;
+  rsize recsize;
+
+  if (R_UNLIKELY (client == NULL || buffer == NULL)) return FALSE;
+  if (R_UNLIKELY (client->state != R_TLS_CLIENT_APPDATA)) return FALSE;
+  if (R_UNLIKELY (!r_buffer_map (buffer, &in, R_MEM_MAP_READ))) return FALSE;
+
+  dtls = r_tls_version_is_dtls (client->version);
+  recsize = (dtls ? R_DTLS_RECORD_HDR_SIZE : R_TLS_RECORD_HDR_SIZE) + in.size;
+
+  if ((rec = r_buffer_new_alloc (NULL, recsize, NULL)) != NULL) {
+    if (r_buffer_map (rec, &out, R_MEM_MAP_WRITE)) {
+      if (dtls)
+        ret = r_dtls_write_application_data (out.data, out.size, NULL,
+            client->version, client->client.epoch, client->client.seqno,
+            in.data, in.size);
+      else
+        ret = r_tls_write_application_data (out.data, out.size, NULL,
+            client->version, in.data, in.size);
+      r_buffer_unmap (rec, &out);
+    }
+  }
+  r_buffer_unmap (buffer, &in);
+
+  if (rec != NULL) {
+    if (ret == R_TLS_ERROR_OK) {
+      r_buffer_set_size (rec, recsize);
+      ret = r_tls_client_send_record (client, rec);
+    }
+    r_buffer_unref (rec);
+  }
+
+  if (ret != R_TLS_ERROR_OK)
+    return FALSE;
+
+  r_tls_client_send_out (client);
+  return TRUE;
+}
+
+RTLSError
+r_tls_client_export_keying_material (const RTLSClient * client,
+    ruint8 * material, rsize size, const rchar * label, rsize len,
+    const ruint8 * ctx, rsize ctxsize)
+{
+  if (R_UNLIKELY (client == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (material == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (size == 0)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (label == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (len == 0)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (client->state < R_TLS_CLIENT_CHANGE_CIPHER))
+    return R_TLS_ERROR_WRONG_STATE;
+
+  if (ctxsize == 0)
+    ctx = NULL;
+
+  return client->prf (material, size,
+      client->mastersecret, sizeof (client->mastersecret), label, len,
+      client->clirandom, (rsize)R_TLS_HELLO_RANDOM_BYTES,
+      client->servrandom, (rsize)R_TLS_HELLO_RANDOM_BYTES,
+      ctx, ctxsize, NULL);
+}
+
+RTLSVersion
+r_tls_client_get_version (const RTLSClient * client)
+{
+  return client->version;
+}
+
+const RTLSCipherSuiteInfo *
+r_tls_client_get_cipher_suite (const RTLSClient * client)
+{
+  return client->csinfo;
+}
+
+RCryptoCert *
+r_tls_client_get_peer_cert (const RTLSClient * client)
+{
+  return client->peer_cert;
+}
+
+RSRTPCipherSuite
+r_tls_client_get_dtls_srtp_profile (const RTLSClient * client)
+{
+  return client->dtls_srtp_profile;
+}

--- a/rlib/rlib-private.h
+++ b/rlib/rlib-private.h
@@ -57,6 +57,7 @@ R_API_HIDDEN void r_thread_deinit (void);
 
 R_API_HIDDEN void r_time_init (void);
 
+R_API_HIDDEN void r_tls_client_init (void);
 R_API_HIDDEN void r_tls_server_init (void);
 
 R_API_HIDDEN R_LOG_CATEGORY_DEFINE_EXTERN (rlib_logcat);

--- a/rlib/rlibinit.c
+++ b/rlib/rlibinit.c
@@ -51,6 +51,7 @@ R_INITIALIZER (rlib_init)
   r_task_queue_init ();
   r_thread_init ();
   r_test_init ();
+  r_tls_client_init ();
   r_tls_server_init ();
 }
 

--- a/rlib/rtc/rrtcdtlstransport.c
+++ b/rlib/rtc/rrtcdtlstransport.c
@@ -217,6 +217,7 @@ r_rtc_crypto_transport_new_dtls (RRtcIceTransport * ice, RPrng * prng,
     r_rtc_dtls_srv_buffer_out,
     r_rtc_dtls_srv_buffer_appdata,
     NULL,
+    NULL,
   };
 
   if (R_UNLIKELY (ice == NULL)) return NULL;

--- a/rlib/rtc/rrtcdtlstransport.c
+++ b/rlib/rtc/rrtcdtlstransport.c
@@ -42,9 +42,10 @@ r_rtc_dtls_transport_free (RRtcDtlsTransport * dtls)
 }
 
 static void
-r_rtc_dtls_srv_hs_done (rpointer data, RTLSServer * srv)
+r_rtc_dtls_srv_hs_done (rpointer data, rpointer session)
 {
   RRtcDtlsTransport * dtls = data;
+  RTLSServer * srv = session;
   RSRTPCipherSuite cs;
   const RSRTPCipherSuiteInfo * csinfo;
   ruint8 * material;
@@ -87,10 +88,10 @@ r_rtc_dtls_srv_hs_done (rpointer data, RTLSServer * srv)
 }
 
 static rboolean
-r_rtc_dtls_srv_buffer_out (rpointer data, RBuffer * buf, RTLSServer * srv)
+r_rtc_dtls_srv_buffer_out (rpointer data, RBuffer * buf, rpointer session)
 {
   RRtcCryptoTransport * crypto = data;
-  (void) srv;
+  (void) session;
 
   R_LOG_TRACE ("RtcCryptoTransport %p %p %"RSIZE_FMT,
       crypto, buf, r_buffer_get_size (buf));
@@ -99,12 +100,12 @@ r_rtc_dtls_srv_buffer_out (rpointer data, RBuffer * buf, RTLSServer * srv)
 }
 
 static rboolean
-r_rtc_dtls_srv_buffer_appdata (rpointer data, RBuffer * buf, RTLSServer * srv)
+r_rtc_dtls_srv_buffer_appdata (rpointer data, RBuffer * buf, rpointer session)
 {
   RRtcCryptoTransport * crypto = data;
   RMemMapInfo info = R_MEM_MAP_INFO_INIT;
   (void) crypto;
-  (void) srv;
+  (void) session;
 
   if (r_buffer_map (buf, &info, R_MEM_MAP_READ)) {
     R_LOG_MEM_DUMP (R_LOG_LEVEL_TRACE, info.data, info.size);

--- a/test/meson.build
+++ b/test/meson.build
@@ -98,6 +98,7 @@ rlibtest_sources = [
   'rtime.c',
   'rtimeoutcblist.c',
   'rtls.c',
+  'rtlsclient.c',
   'rtlsserver.c',
   'rtty.c',
   'runicode.c',

--- a/test/rrsa.c
+++ b/test/rrsa.c
@@ -108,6 +108,49 @@ RTEST (rrsa, decrypt_pkcs, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rrsa, encrypt_pkcs_with_public_key, RTEST_FAST)
+{
+  static const ruint8 plain[] = { 'h', 'e', 'l', 'l', 'o', ' ', 'r', 's', 'a' };
+  rmpint n, e, d;
+  RCryptoKey * pub, * priv;
+  RPrng * prng;
+  ruint8 enc[256], dec[sizeof (plain)];
+  rsize enclen = sizeof (enc), declen = sizeof (dec);
+
+  r_mpint_init_str (&n,
+      "0x00aa18aba43b50deef38598faf87d2ab634e4571c130a9bca7b878267414faab8b47"
+      "1bd8965f5c9fc3818485eaf529c26246f3055064a8de19c8c338be5496cbaeb059dc0b"
+      "358143b44a35449eb264113121a455bd7fde3fac919e94b56fb9bb4f651cdb23ead439"
+      "d6cd523eb08191e75b35fd13a7419b3090f24787bd4f4e1967", NULL, 16);
+  r_mpint_init_str (&d,
+      "0x1628e4a39ebea86c8df0cd11572691017cfefb14ea1c12e1dedc7856032dad0f9612"
+      "00a38684f0a36dca30102e2464989d19a805933794c7d329ebc890089d3c4c6f602766"
+      "e5d62add74e82e490bbf92f6a482153853031be2844a700557b97673e727cd1316d3e6"
+      "fa7fc991d4227366ec552cbe90d367ef2e2e79fe66d26311", NULL, 16);
+  r_mpint_init_str (&e, "65537", NULL, 10);
+
+  r_assert_cmpptr ((prng = r_prng_new_mt ()), !=, NULL);
+  r_assert_cmpptr ((pub = r_rsa_pub_key_new (&n, &e)), !=, NULL);
+  r_assert_cmpptr ((priv = r_rsa_priv_key_new (&n, &e, &d)), !=, NULL);
+
+  /* Encrypting with the PUBLIC key must succeed (it previously rejected
+   * anything but a private key) and round-trip through the private key. */
+  r_assert_cmpuint (r_crypto_key_encrypt (pub, prng, plain, sizeof (plain), enc, &enclen),
+      ==, R_CRYPTO_OK);
+  r_assert_cmpuint (r_rsa_pkcs1v1_5_decrypt (priv, enc, enclen, dec, &declen),
+      ==, R_CRYPTO_OK);
+  r_assert_cmpuint (declen, ==, sizeof (plain));
+  r_assert_cmpmem (dec, ==, plain, sizeof (plain));
+
+  r_mpint_clear (&n);
+  r_mpint_clear (&e);
+  r_mpint_clear (&d);
+  r_crypto_key_unref (pub);
+  r_crypto_key_unref (priv);
+  r_prng_unref (prng);
+}
+RTEST_END;
+
 /* The encrypted plaintext for `rsa_encrypted` above is "foobar\n",
  * 7 bytes. The implicit-rejection variant takes a fixed out_size
  * and returns either the real plaintext (when padding valid AND

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -1,0 +1,336 @@
+#include <rlib/rnet.h>
+#include <rlib/rcrypto.h>
+
+/* Self-signed test certificate + matching RSA private key (CN=rlib). */
+static const rchar testcertpem[] =
+  "-----BEGIN CERTIFICATE-----\r\n"
+  "MIIC8TCCAdmgAwIBAgIJALoi/+XOQDHjMA0GCSqGSIb3DQEBCwUAMA8xDTALBgNV\r\n"
+  "BAMMBHJsaWIwHhcNMTYxMTE1MTMzNjI0WhcNMTcxMTE1MTMzNjI0WjAPMQ0wCwYD\r\n"
+  "VQQDDARybGliMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwjolUmQU\r\n"
+  "r9Q2FZ7O3qau+Z6+VvuJROvxzjt1aIQLLO/hF0Ya56BZCZD5aKyqQM//fTm97VTb\r\n"
+  "CQYBaNg03D20XPDIWmr7EdHxYK+YI+jz7DrWqhM4jwSvvteXXXWD7bVdCq+RyveD\r\n"
+  "NrgoGZqL5UCiWS1BWkB9nS/KQtgxrT3hWSOlG1xRh6hfeIy4H2CB3Qk/Q3PHjMcH\r\n"
+  "7CKhCj+ctbqR3r2K3BLL3fgZKnfQdCPsZplN8Ey4hSOc/67NQK/yn/S0JgeHmjb8\r\n"
+  "D5xbaDiOloOHJJg6dm1QU0UuEpiK2Uda0VR6TGu9Ci05h5U3HoV9CbyAGQhmFSem\r\n"
+  "NreAELYv89sMgwIDAQABo1AwTjAdBgNVHQ4EFgQUXFVr3x4Bcglp/MP0ZFEk/Ntz\r\n"
+  "wJYwHwYDVR0jBBgwFoAUXFVr3x4Bcglp/MP0ZFEk/NtzwJYwDAYDVR0TBAUwAwEB\r\n"
+  "/zANBgkqhkiG9w0BAQsFAAOCAQEAL4ZKyDRXP3+Jr/GN+p6WbFW3tHuhxWxy8rMy\r\n"
+  "W7OHX/sHASzJiaEmjtIlPx/7uFFowktEmXyybEmBvYp64UZ2mo2v+CCm+236wPTS\r\n"
+  "gGfpcp9nP2RI0VFdJLHuqWapa5CQJZISRAO/tj7UqflOWBohm04EvmJe53JGEq+4\r\n"
+  "Dk41kC+z3jVPGHG+jR3uYOw7JCmFT+bt4P5EDxGAKe9eoweLHBJ8vlJ7cUdHhBv1\r\n"
+  "BUCMVR86kPZFzHKVQtWNXt26H/khgz7RA/qUSJA17Nk2h0h60b1AbkljkduWWIMZ\r\n"
+  "5B2DUz4MEDUHjppHF9+A2q5ZN+25eOYbrkS5Dq50VPNrvd8dSQ==\r\n"
+  "-----END CERTIFICATE-----\r\n";
+
+static const rchar testpkpem[] =
+  "-----BEGIN PRIVATE KEY-----\r\n"
+  "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDCOiVSZBSv1DYV\r\n"
+  "ns7epq75nr5W+4lE6/HOO3VohAss7+EXRhrnoFkJkPlorKpAz/99Ob3tVNsJBgFo\r\n"
+  "2DTcPbRc8MhaavsR0fFgr5gj6PPsOtaqEziPBK++15dddYPttV0Kr5HK94M2uCgZ\r\n"
+  "movlQKJZLUFaQH2dL8pC2DGtPeFZI6UbXFGHqF94jLgfYIHdCT9Dc8eMxwfsIqEK\r\n"
+  "P5y1upHevYrcEsvd+Bkqd9B0I+xmmU3wTLiFI5z/rs1Ar/Kf9LQmB4eaNvwPnFto\r\n"
+  "OI6Wg4ckmDp2bVBTRS4SmIrZR1rRVHpMa70KLTmHlTcehX0JvIAZCGYVJ6Y2t4AQ\r\n"
+  "ti/z2wyDAgMBAAECggEABJZzAzsx8eVFUcVqhX/SajsBq/RNDb+0+nYVE97qlKkl\r\n"
+  "2/Lf99ClycAO5BYP/2/qTP7sKYrzkYb+yYcx2HHsrLVTRi94trcKyIndQhvihxXs\r\n"
+  "tB+4Gki2Df/xp1d7QkYiaHo1K2IlS0mWSOSJoWShcRHMlWEolmnmkSWiJsFrbTuL\r\n"
+  "sxB/6lVmD6Bbez/ob5JzK4QBAEREd0QbUCQiDssFvf0nlDmtKrxosLFuu86z0nIR\r\n"
+  "3OKyr9n6IW64r7x7Ccv/5pY3Cmkg0/knF4bi60ssm2byY2TW3wnOT0inVrp0UUQP\r\n"
+  "ex9Dse3izVyMLaeqLh6GCQhLFROE85qslLmOYb56YQKBgQD7HHWdsrNDtkHkXvyz\r\n"
+  "TWi8dPVMVk4/X/G3vPr2nBRHj9MzXX/ZgoFpklMsR/EtKh9LBBh9vY9YnXhIGUrc\r\n"
+  "vwt1PSUIsjUuHBfhxnHxcZEu2ROw18LJmSRp6duZADFcH8ApPFg1dVZ2APyHyS4J\r\n"
+  "tTL/DIeQ6ASq0EENjuO5VgM5PwKBgQDGAiz9c3/1OPZNiENyCYbrqOzduzkoisX7\r\n"
+  "yGYFiJpLdsmrRsztqJktwiDEYYrJoV+AHmKa79Iexp6vvq9gQFN3XvFw6U1XXF5D\r\n"
+  "RtLHHqWgoj9yFIpmVXfcdFICfNdPcVn7NAE0CQBRNgBJGSvRoSeTpOyjVmF9Mu18\r\n"
+  "h2wUK0L3vQKBgBms7kXCmNvKjfA42iPHPXdPiilVBckrGT8NPqfqi5RJm3G8FK97\r\n"
+  "zZmq0YBMltdkYDC+aXap5DdOWpccpu/tRNGm/9tkxVVCoBqAvPPQBeVBYucJGKye\r\n"
+  "UP/XXpHFWEawJGjS9733knCcZzXHF0L82QsFD/N8FcYVZyFow9YWelvnAoGAIj8o\r\n"
+  "FuIOJJSojPpfZ+7b5hB+f08tcKSn34dmldhtj1XJRZVmRkidzbtAvZZ9UahWgys+\r\n"
+  "NLv75JTHx2+8l3IovYGvUq8XUF/Kcepi9EuJrAHD5XBGC7MGmxuHP6Tl/HiHbpot\r\n"
+  "Bxnzcxha7kmrOYOc+71PrGR5UhUn3Bz0BX0CBSUCgYAKxDbgtJ1NZgf33yMQb1BG\r\n"
+  "vgLQWiysO9t1dXFN9YiPsZ1Rkyj9iOdROG47T1ifcrCw45mqBF71COM23zplWz64\r\n"
+  "wUg8Baom8FExrgLtVDeyQO7qkiOoP96r9Fm34Y4Sgv1/oiO9f5KYckMcSig9zCQA\r\n"
+  "VFwqM04nD9RsYGRKy6NhrA==\r\n"
+  "-----END PRIVATE KEY-----\r\n";
+
+RTEST_FIXTURE_STRUCT (rtlsclient)
+{
+  RTLSServer * server;
+  RTLSClient * client;
+
+  rboolean srv_hs_done, cli_hs_done;
+  rboolean srv_error, cli_error;
+  ruint verify_calls;
+  rboolean verify_result;
+
+  RClock * clock;
+  REvLoop * evloop;
+  RPrng * prng;
+
+  RQueue srv_out, cli_out;       /* records each side emits */
+  RQueue srv_app, cli_app;       /* decrypted application data each side received */
+};
+
+static void
+r_tlsclient_test_srv_hs_done (rpointer ctx, rpointer session)
+{
+  RTEST_FIXTURE_STRUCT (rtlsclient) * fixture = ctx;
+  (void) session;
+  fixture->srv_hs_done = TRUE;
+}
+
+static void
+r_tlsclient_test_cli_hs_done (rpointer ctx, rpointer session)
+{
+  RTEST_FIXTURE_STRUCT (rtlsclient) * fixture = ctx;
+  (void) session;
+  fixture->cli_hs_done = TRUE;
+}
+
+static void
+r_tlsclient_test_srv_error (rpointer ctx, RTLSAlertType alert, rpointer session)
+{
+  RTEST_FIXTURE_STRUCT (rtlsclient) * fixture = ctx;
+  (void) alert; (void) session;
+  fixture->srv_error = TRUE;
+}
+
+static void
+r_tlsclient_test_cli_error (rpointer ctx, RTLSAlertType alert, rpointer session)
+{
+  RTEST_FIXTURE_STRUCT (rtlsclient) * fixture = ctx;
+  (void) alert; (void) session;
+  fixture->cli_error = TRUE;
+}
+
+static rboolean
+r_tlsclient_test_srv_out (rpointer ctx, RBuffer * buf, rpointer session)
+{
+  RTEST_FIXTURE_STRUCT (rtlsclient) * fixture = ctx;
+  (void) session;
+  return r_queue_push (&fixture->srv_out, r_buffer_ref (buf)) != NULL;
+}
+
+static rboolean
+r_tlsclient_test_cli_out (rpointer ctx, RBuffer * buf, rpointer session)
+{
+  RTEST_FIXTURE_STRUCT (rtlsclient) * fixture = ctx;
+  (void) session;
+  return r_queue_push (&fixture->cli_out, r_buffer_ref (buf)) != NULL;
+}
+
+static rboolean
+r_tlsclient_test_srv_app (rpointer ctx, RBuffer * buf, rpointer session)
+{
+  RTEST_FIXTURE_STRUCT (rtlsclient) * fixture = ctx;
+  (void) session;
+  return r_queue_push (&fixture->srv_app, r_buffer_ref (buf)) != NULL;
+}
+
+static rboolean
+r_tlsclient_test_cli_app (rpointer ctx, RBuffer * buf, rpointer session)
+{
+  RTEST_FIXTURE_STRUCT (rtlsclient) * fixture = ctx;
+  (void) session;
+  return r_queue_push (&fixture->cli_app, r_buffer_ref (buf)) != NULL;
+}
+
+static rboolean
+r_tlsclient_test_verify_cert (rpointer ctx, RCryptoCert * const * chain, ruint count)
+{
+  RTEST_FIXTURE_STRUCT (rtlsclient) * fixture = ctx;
+  (void) chain; (void) count;
+  fixture->verify_calls++;
+  return fixture->verify_result;
+}
+
+RTEST_FIXTURE_SETUP (rtlsclient)
+{
+  static RTLSCallbacks srvcbs = {
+    NULL,
+    r_tlsclient_test_srv_hs_done,
+    r_tlsclient_test_srv_out,
+    r_tlsclient_test_srv_app,
+    r_tlsclient_test_srv_error,
+    NULL,
+  };
+  static RTLSCallbacks clicbs = {
+    NULL,
+    r_tlsclient_test_cli_hs_done,
+    r_tlsclient_test_cli_out,
+    r_tlsclient_test_cli_app,
+    r_tlsclient_test_cli_error,
+    r_tlsclient_test_verify_cert,
+  };
+  RCryptoCert * cert;
+  RCryptoKey * pk;
+
+  r_assert_cmpptr ((fixture->prng = r_prng_new_mt ()), !=, NULL);
+  r_assert_cmpptr ((fixture->clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((fixture->evloop = r_ev_loop_new_full (fixture->clock, NULL)), !=, NULL);
+
+  fixture->srv_hs_done = fixture->cli_hs_done = FALSE;
+  fixture->srv_error = fixture->cli_error = FALSE;
+  fixture->verify_calls = 0;
+  fixture->verify_result = TRUE;
+
+  r_queue_init (&fixture->srv_out);
+  r_queue_init (&fixture->cli_out);
+  r_queue_init (&fixture->srv_app);
+  r_queue_init (&fixture->cli_app);
+
+  r_assert_cmpptr ((fixture->server = r_tls_server_new (&srvcbs, fixture, NULL)), !=, NULL);
+  r_assert_cmpptr ((fixture->client = r_tls_client_new (&clicbs, fixture, NULL)), !=, NULL);
+
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (testcertpem, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem, -1, NULL, 0)), !=, NULL);
+  r_assert_cmpint (R_TLS_ERROR_OK, ==,
+      r_tls_server_set_cert (fixture->server, cert, pk));
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+}
+
+RTEST_FIXTURE_TEARDOWN (rtlsclient)
+{
+  r_tls_client_unref (fixture->client);
+  r_tls_server_unref (fixture->server);
+
+  r_queue_clear (&fixture->srv_out, r_buffer_unref);
+  r_queue_clear (&fixture->cli_out, r_buffer_unref);
+  r_queue_clear (&fixture->srv_app, r_buffer_unref);
+  r_queue_clear (&fixture->cli_app, r_buffer_unref);
+
+  r_ev_loop_unref (fixture->evloop);
+  r_clock_unref (fixture->clock);
+  r_prng_unref (fixture->prng);
+}
+
+/* Shuttle records between the two endpoints until neither has anything more
+ * to send. Each out callback emits one record per buffer, so feeding them
+ * back individually works for both TLS and DTLS. */
+static void
+r_test_tls_loopback_pump (RTEST_FIXTURE_STRUCT (rtlsclient) * fixture)
+{
+  RBuffer * buf;
+  ruint i;
+
+  for (i = 0; i < 64; i++) {
+    rboolean progress = FALSE;
+
+    while ((buf = r_queue_pop (&fixture->cli_out)) != NULL) {
+      r_tls_server_incoming_data (fixture->server, buf);
+      r_buffer_unref (buf);
+      progress = TRUE;
+    }
+    while ((buf = r_queue_pop (&fixture->srv_out)) != NULL) {
+      r_tls_client_incoming_data (fixture->client, buf);
+      r_buffer_unref (buf);
+      progress = TRUE;
+    }
+
+    if (!progress)
+      break;
+  }
+}
+
+static RBuffer *
+r_test_tls_queue_agg (RQueue * q)
+{
+  RBuffer * ret, * cur;
+
+  if (r_queue_is_empty (q))
+    return NULL;
+  if ((ret = r_buffer_new ()) != NULL) {
+    while ((cur = r_queue_pop (q)) != NULL) {
+      r_buffer_append_mem_from_buffer (ret, cur);
+      r_buffer_unref (cur);
+    }
+  }
+  return ret;
+}
+
+/* Assert @q delivered exactly @data. */
+static void
+r_test_tls_assert_appdata (RQueue * q, const ruint8 * data, rsize size)
+{
+  RBuffer * buf;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+
+  r_assert_cmpptr ((buf = r_test_tls_queue_agg (q)), !=, NULL);
+  r_assert (r_buffer_map (buf, &info, R_MEM_MAP_READ));
+  r_assert_cmpuint (info.size, ==, size);
+  r_assert_cmpint (r_memcmp (info.data, data, size), ==, 0);
+  r_buffer_unmap (buf, &info);
+  r_buffer_unref (buf);
+}
+
+static void
+r_test_tls_loopback (RTEST_FIXTURE_STRUCT (rtlsclient) * fixture, RTLSVersion version)
+{
+  static const ruint8 c2s[] = { 'h', 'e', 'l', 'l', 'o', ' ', 's', 'e', 'r', 'v', 'e', 'r' };
+  static const ruint8 s2c[] = { 'h', 'i', ' ', 'c', 'l', 'i', 'e', 'n', 't' };
+  RBuffer * app;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng, version),
+      ==, R_TLS_ERROR_OK);
+
+  r_test_tls_loopback_pump (fixture);
+
+  r_assert (fixture->cli_hs_done);
+  r_assert (fixture->srv_hs_done);
+  r_assert (!fixture->cli_error);
+  r_assert (!fixture->srv_error);
+
+  r_assert_cmpuint (fixture->verify_calls, ==, 1);
+  r_assert_cmpptr (r_tls_client_get_peer_cert (fixture->client), !=, NULL);
+  r_assert_cmpuint (r_tls_client_get_version (fixture->client), ==, version);
+  r_assert_cmpptr (r_tls_client_get_cipher_suite (fixture->client), !=, NULL);
+
+  /* Application data, client -> server. */
+  r_assert_cmpptr ((app = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)c2s, sizeof (c2s), sizeof (c2s), 0, NULL, NULL)), !=, NULL);
+  r_assert (r_tls_client_send_appdata (fixture->client, app));
+  r_buffer_unref (app);
+  r_test_tls_loopback_pump (fixture);
+  r_test_tls_assert_appdata (&fixture->srv_app, c2s, sizeof (c2s));
+
+  /* Application data, server -> client. */
+  r_assert_cmpptr ((app = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)s2c, sizeof (s2c), sizeof (s2c), 0, NULL, NULL)), !=, NULL);
+  r_assert (r_tls_server_send_appdata (fixture->server, app));
+  r_buffer_unref (app);
+  r_test_tls_loopback_pump (fixture);
+  r_test_tls_assert_appdata (&fixture->cli_app, s2c, sizeof (s2c));
+}
+
+RTEST_F (rtlsclient, tls_loopback, RTEST_FAST)
+{
+  r_test_tls_loopback (fixture, R_TLS_VERSION_TLS_1_2);
+}
+RTEST_END;
+
+RTEST_F (rtlsclient, dtls_loopback, RTEST_FAST)
+{
+  r_test_tls_loopback (fixture, R_TLS_VERSION_DTLS_1_2);
+}
+RTEST_END;
+
+/* A rejecting verify_cert aborts the handshake: the client emits a fatal
+ * alert and never reports handshake_done. */
+RTEST_F (rtlsclient, tls_verify_cert_reject, RTEST_FAST)
+{
+  fixture->verify_result = FALSE;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_2), ==, R_TLS_ERROR_OK);
+
+  r_test_tls_loopback_pump (fixture);
+
+  r_assert_cmpuint (fixture->verify_calls, ==, 1);
+  r_assert (!fixture->cli_hs_done);
+  r_assert (fixture->cli_error);
+}
+RTEST_END;

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -110,6 +110,7 @@ RTEST_FIXTURE_SETUP (rtlsserver)
     r_tlsserver_test_buffer_out,
     r_tlsserver_test_buffer_appdata,
     r_tlsserver_test_error,
+    NULL,
   };
   RCryptoCert * cert;
   RCryptoKey * pk;

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -68,36 +68,36 @@ RTEST_FIXTURE_STRUCT (rtlsserver)
 };
 
 static void
-r_tlsserver_test_hs_done (rpointer ctx, RTLSServer * server)
+r_tlsserver_test_hs_done (rpointer ctx, rpointer session)
 {
   RTEST_FIXTURE_STRUCT (rtlsserver) * fixture = ctx;
-  (void) server;
+  (void) session;
   fixture->hs_done = TRUE;
 }
 
 static void
-r_tlsserver_test_error (rpointer ctx, RTLSAlertType alert, RTLSServer * server)
+r_tlsserver_test_error (rpointer ctx, RTLSAlertType alert, rpointer session)
 {
   RTEST_FIXTURE_STRUCT (rtlsserver) * fixture = ctx;
-  (void) server;
+  (void) session;
   fixture->got_error = TRUE;
   fixture->last_alert = alert;
 }
 
 static rboolean
-r_tlsserver_test_buffer_out (rpointer ctx, RBuffer * buf, RTLSServer * server)
+r_tlsserver_test_buffer_out (rpointer ctx, RBuffer * buf, rpointer session)
 {
   RTEST_FIXTURE_STRUCT (rtlsserver) * fixture = ctx;
-  (void) server;
+  (void) session;
 
   return r_queue_push (&fixture->qout, r_buffer_ref (buf)) != NULL;
 }
 
 static rboolean
-r_tlsserver_test_buffer_appdata (rpointer ctx, RBuffer * buf, RTLSServer * server)
+r_tlsserver_test_buffer_appdata (rpointer ctx, RBuffer * buf, rpointer session)
 {
   RTEST_FIXTURE_STRUCT (rtlsserver) * fixture = ctx;
-  (void) server;
+  (void) session;
 
   return r_queue_push (&fixture->qapp, r_buffer_ref (buf)) != NULL;
 }


### PR DESCRIPTION
Adds `RTLSClient`, the client-side counterpart to `RTLSServer`: a transport-agnostic, callback-driven TLS/DTLS session that initiates the handshake. It sends the ClientHello, parses the server flight, verifies the server certificate, performs the RSA key exchange, and verifies the server Finished — giving rlib true client↔server end-to-end coverage and the basis for outbound TLS.

## Scope
- **TLS/DTLS 1.2, RSA key exchange**, with the `RSA-AES-128-CBC-SHA(256)` suites.
- Offers `extended_master_secret`, secure renegotiation, `encrypt_then_mac`, and (DTLS) `use_srtp`.
- Mirrors `RTLSServer` with the roles reversed: the write direction uses the `client` connection state, the read direction the `server` state.
- Server-certificate validation via the `verify_cert` callback (or inspected afterwards via `r_tls_client_get_peer_cert`).

Deferred (grows with the server): client certificate / mTLS, ECDHE, DTLS HelloVerifyRequest/cookie, session resumption.

## Notable changes
- `RTLSCallbacks` is now shared between server and client; its per-callback session pointer became `rpointer` and the three callback typedefs were renamed `RTLSServer*Cb` → `RTLS*Cb`. The RTC DTLS transport and server tests are updated accordingly.
- RSA `r_crypto_key_encrypt` now accepts a public key — the client encrypts the pre-master secret with the server cert's public key (previously only private keys were accepted).

## Tests
A socket-free client↔server loopback wires each side's `out` callback into the other's `incoming_data` and drives the handshake to completion, for **TLS and DTLS**:
- both sides reach `handshake_done`; application data round-trips in both directions;
- the extended-master-secret and encrypt-then-MAC paths are exercised;
- a rejecting `verify_cert` aborts the handshake with a fatal alert and no `handshake_done`;
- `get_peer_cert` returns the server leaf after the handshake.

Green across debug/release/gcc-warn/clang/asan/tsan under `-Werror`; ASan leak-free, TSan clean; doxygen 0 warnings.

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)