### PR TITLE
hashtable: grow before the table fills so absent-key lookups terminate

### DIFF
--- a/rlib/data/rhashtable.c
+++ b/rlib/data/rhashtable.c
@@ -177,8 +177,15 @@ r_hash_table_insert (RHashTable * ht, rpointer key, rpointer value)
 
   if (R_UNLIKELY (ht == NULL)) return R_HASH_TABLE_INVAL;
 
-  if (ht->size >= R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (ht->allocidx))
-    r_hash_table_resize (ht, ht->allocidx + 1);
+  /* Grow before the table fills. Open addressing needs at least one empty
+   * bucket for a probe to terminate -- a fully populated table makes a lookup
+   * of an absent key loop forever -- and probe chains must stay short. Resize
+   * at 3/4 load. */
+  {
+    rsize cap = R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (ht->allocidx);
+    if (ht->size >= cap - (cap >> 2))
+      r_hash_table_resize (ht, ht->allocidx + 1);
+  }
 
   idx = r_hash_table_lookup_bucket (ht, key, &hash);
   if (ht->buckets[idx].hash == hash) {

--- a/test/rhashtable.c
+++ b/test/rhashtable.c
@@ -232,3 +232,72 @@ RTEST (rhashtable, foreach, RTEST_FAST)
 }
 RTEST_END;
 
+
+RTEST (rhashtable, lookup_absent_never_loops, RTEST_FAST)
+{
+  RHashTable * ht;
+  rsize i;
+  const rsize n = 1000;
+
+  r_assert_cmpptr ((ht = r_hash_table_new (NULL, NULL)), !=, NULL);
+
+  /* Insert many entries, crossing several resizes; after every insert look up
+   * a key that was never inserted. Before the load-factor fix a fully
+   * populated table had no empty bucket, so the open-addressing probe for an
+   * absent key never terminated -- this test would hang. */
+  for (i = 0; i < n; i++) {
+    r_assert_cmpint (r_hash_table_insert (ht, RSIZE_TO_POINTER (i + 1),
+          RUINT_TO_POINTER (i + 1)), ==, R_HASH_TABLE_OK);
+    r_assert_cmpint (r_hash_table_contains (ht, RSIZE_TO_POINTER (n + i + 1)),
+        ==, R_HASH_TABLE_NOT_FOUND);
+    r_assert_cmpptr (r_hash_table_lookup (ht, RSIZE_TO_POINTER (n + i + 1)),
+        ==, NULL);
+  }
+
+  r_assert_cmpuint (r_hash_table_size (ht), ==, n);
+  /* Every inserted key still resolves (probe integrity across the resizes). */
+  for (i = 0; i < n; i++)
+    r_assert_cmpuint (RPOINTER_TO_UINT (r_hash_table_lookup (ht,
+            RSIZE_TO_POINTER (i + 1))), ==, i + 1);
+  /* And keys never inserted are absent (and the lookups terminate). */
+  for (i = 0; i < n; i++)
+    r_assert_cmpint (r_hash_table_contains (ht, RSIZE_TO_POINTER (n + i + 1)),
+        ==, R_HASH_TABLE_NOT_FOUND);
+
+  r_hash_table_unref (ht);
+}
+RTEST_END;
+
+RTEST (rhashtable, lookup_absent_str_keys, RTEST_FAST)
+{
+  RHashTable * ht;
+  rsize i;
+  const rsize n = 500;
+
+  /* As above but with string keys: more collisions / longer probe chains
+   * exercise the absent-key probe-termination path harder. */
+  r_assert_cmpptr ((ht = r_hash_table_new_full (r_str_hash, r_str_equal,
+          r_free, NULL)), !=, NULL);
+
+  for (i = 0; i < n; i++) {
+    rchar * absent = r_strprintf ("absent-%"RSIZE_FMT, i);
+    r_assert_cmpint (r_hash_table_insert (ht,
+          r_strprintf ("key-%"RSIZE_FMT, i), RUINT_TO_POINTER (i + 1)),
+        ==, R_HASH_TABLE_OK);
+    r_assert_cmpint (r_hash_table_contains (ht, absent), ==, R_HASH_TABLE_NOT_FOUND);
+    r_free (absent);
+  }
+
+  r_assert_cmpuint (r_hash_table_size (ht), ==, n);
+  for (i = 0; i < n; i++) {
+    rchar * present = r_strprintf ("key-%"RSIZE_FMT, i);
+    rchar * absent = r_strprintf ("absent-%"RSIZE_FMT, i);
+    r_assert_cmpuint (RPOINTER_TO_UINT (r_hash_table_lookup (ht, present)), ==, i + 1);
+    r_assert_cmpint (r_hash_table_contains (ht, absent), ==, R_HASH_TABLE_NOT_FOUND);
+    r_free (present);
+    r_free (absent);
+  }
+
+  r_hash_table_unref (ht);
+}
+RTEST_END;


### PR DESCRIPTION
## The bug

`r_hash_table_insert` resized only once the table was **completely full** (`size == capacity`):

```c
if (ht->size >= R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (ht->allocidx))
  r_hash_table_resize (ht, ht->allocidx + 1);
```

So a table could reach 100% occupancy with **no empty bucket**. The open-addressing probe in `r_hash_table_lookup_bucket` terminates only on an empty bucket (`while (buckets[idx].hash != R_HASH_EMPTY)`), so a lookup of an **absent** key on a full table **never terminates** — affecting `r_hash_table_lookup` / `_contains` / `_lookup_full` and callers like `r_poll_set_find`. (This is what hung `rpollset/add_grows_past_initial_alloc` mid-investigation in #272.)

The bucket array is a power of two and the triangular probe visits every slot, so the only thing missing was a guaranteed empty bucket. (The prime-modulus initial index I worried about in the issue is fine — every prime is `< its bucket count`, so it stays in bounds and the probe still covers all slots.)

## Fix

Grow at **3/4 load** instead of at 100%, so at least one empty bucket always exists (probes terminate) and chains stay short:

```c
rsize cap = R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (ht->allocidx);
if (ht->size >= cap - (cap >> 2))
  r_hash_table_resize (ht, ht->allocidx + 1);
```

## Tests

Two regression tests insert many entries (crossing several resizes) and look up **absent** keys throughout — integer keys and string keys (more collisions / longer probe chains). They also verify every inserted key still resolves across the resizes. **Confirmed they hang without the fix** (4s test timeout) and pass with it.

Verified across debug/release/gcc-warn/clang/asan/tsan under `-Werror` (ASan leak-free), full suite green, doxygen 0 warnings. The existing `insert_resize_remove_all` assertions still hold under the new threshold.

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)