### PR TITLE
ev: make the low-level REvIO watcher API internal

### DIFF
--- a/include/rlib/ev/revio.h
+++ b/include/rlib/ev/revio.h
@@ -24,77 +24,30 @@
 
 /**
  * @file rlib/ev/revio.h
- * @brief Event-loop I/O watcher over an @c RIOHandle: start / stop
- * readiness notifications and close.
+ * @brief Shared event-loop I/O types.
+ *
+ * The low-level I/O-watcher API (@c r_ev_io_*) is internal to rlib: it is a
+ * readiness-based (reactor) interface with no equivalent on a completion-based
+ * (IOCP / proactor) backend, and applications use the higher-level
+ * @ref r_evtcp / @ref r_evudp sources instead. Only the shared types those
+ * public APIs reference live here.
  */
 
 #include <rlib/rtypes.h>
 
-#include <rlib/rref.h>
-
 /**
- * @defgroup r_evio Event-loop I/O watcher
+ * @defgroup r_evio Event-loop I/O types
  * @ingroup r_ev
- *
- * @brief Watch an @c RIOHandle on an @ref REvLoop and fire a callback
- * when it becomes readable / writable (or errors / hangs up).
- *
- * Create an @ref REvIO for a handle, then @ref r_ev_io_start with the
- * @ref REvIOEvents of interest and a callback; the loop invokes it on
- * the loop thread each time the requested events occur. Higher-level
- * sources (@ref r_evtcp, @ref r_evudp) build on this. The
- * @ref r_evtcp / @ref r_evudp wrappers are usually more convenient
- * than driving @ref REvIO directly.
- *
+ * @brief Shared types for the event-loop I/O sources.
  * @{
  */
 
 R_BEGIN_DECLS
 
-/** @brief I/O readiness event bits. */
-typedef enum {
-  R_EV_IO_READABLE    = (1 << 0), /**< Handle is readable. */
-  /*R_EV_IO_PRI         = (1 << 1),*/
-  R_EV_IO_WRITABLE    = (1 << 2), /**< Handle is writable. */
-  R_EV_IO_ERROR       = (1 << 3), /**< Error condition on the handle. */
-  R_EV_IO_HANGUP      = (1 << 4), /**< Peer hung up / handle closed. */
-} REvIOEvent;
-/** @brief Bitwise-OR of @ref REvIOEvent values. */
-typedef ruint REvIOEvents;
-
-/** @brief Opaque event-loop handle (defined in @ref r_evloop). */
-typedef struct REvLoop REvLoop;
-/** @brief Opaque, refcounted I/O watcher. */
+/** @brief Opaque, refcounted I/O watcher (internal to rlib). */
 typedef struct REvIO REvIO;
 /** @brief Plain watcher callback (e.g. close completion). */
 typedef void (*REvIOFunc) (rpointer data, REvIO * evio);
-/** @brief Readiness callback; @p events is the set that fired. */
-typedef void (*REvIOCB) (rpointer data, REvIOEvents events, REvIO * evio);
-
-
-/** @brief Create an I/O watcher for @p handle on @p loop. */
-R_API REvIO * r_ev_io_new (REvLoop * loop, RIOHandle handle);
-/** @brief Take a reference (alias for @ref r_ref_ref). */
-#define r_ev_io_ref r_ref_ref
-/** @brief Drop a reference (alias for @ref r_ref_unref). */
-#define r_ev_io_unref r_ref_unref
-
-/** @brief Attach an opaque user pointer (freed via @p notify). */
-R_API void r_ev_io_set_user (REvIO * evio, rpointer user, RDestroyNotify notify);
-/** @brief Retrieve the user pointer set by @ref r_ev_io_set_user. */
-R_API rpointer r_ev_io_get_user (REvIO * evio) R_ATTR_WARN_UNUSED_RESULT;
-
-/**
- * @brief Start watching @p events, invoking @p io_cb when they fire.
- * @return An opaque start context to pass to @ref r_ev_io_stop.
- */
-R_API rpointer r_ev_io_start (REvIO * evio, REvIOEvents events, REvIOCB io_cb,
-    rpointer data, RDestroyNotify datanotify) R_ATTR_WARN_UNUSED_RESULT;
-/** @brief Stop a watch started with @ref r_ev_io_start (@p ctx from that call). */
-R_API rboolean r_ev_io_stop (REvIO * evio, rpointer ctx);
-/** @brief Close the watched handle; @p close_cb fires once closed. */
-R_API rboolean r_ev_io_close (REvIO * evio, REvIOFunc close_cb,
-    rpointer data, RDestroyNotify datanotify);
 
 R_END_DECLS
 

--- a/include/rlib/ev/revloop.h
+++ b/include/rlib/ev/revloop.h
@@ -28,8 +28,6 @@
  * hooks and task-queue integration.
  */
 
-#include <rlib/ev/revio.h>
-
 #include <rlib/rclock.h>
 #include <rlib/rref.h>
 #include <rlib/concurrency/rtaskqueue.h>
@@ -46,9 +44,8 @@
  *
  * An @ref REvLoop owns an @ref RClock (for timers) and optionally an
  * @ref RTaskQueue (for offloading work via @ref r_ev_loop_add_task).
- * I/O sources (@ref r_evio, @ref r_evtcp, @ref r_evudp,
- * @ref r_evresolve, @ref r_evwakeup) register against it and fire
- * their callbacks on the loop thread, so callbacks must not block —
+ * I/O sources (@ref r_evtcp, @ref r_evudp, @ref r_evresolve) register
+ * against it and fire their callbacks on the loop thread, so callbacks must not block —
  * push long-running work to a task group instead.
  *
  * @{
@@ -143,10 +140,6 @@ R_API RTask * r_ev_loop_add_task_full (REvLoop * loop, ruint taskgroup,
 R_API RTask * r_ev_loop_add_task_full_v (REvLoop * loop, ruint taskgroup,
     RTaskFunc task, REvFunc done, rpointer data, RDestroyNotify datanotify,
     va_list args);
-
-/** @brief Convenience: create an @ref REvIO watcher for @p handle on @p loop. */
-static inline REvIO * r_ev_loop_create_ev_io (REvLoop * loop, RIOHandle handle)
-{ return r_ev_io_new (loop, handle); }
 
 R_END_DECLS
 

--- a/include/rlib/ev/revtcp.h
+++ b/include/rlib/ev/revtcp.h
@@ -30,6 +30,7 @@
 
 #include <rlib/rtypes.h>
 
+#include <rlib/ev/revio.h>
 #include <rlib/ev/revloop.h>
 #include <rlib/rbuffer.h>
 #include <rlib/net/rsocketaddress.h>

--- a/rlib/ev/rev-private.h
+++ b/rlib/ev/rev-private.h
@@ -22,6 +22,7 @@
 #error "rev-private.h should only be used internally in rlib!"
 #endif
 
+#include <rlib/ev/revio.h>
 #include <rlib/ev/revloop.h>
 #include <rlib/ev/revwakeup.h>
 
@@ -40,6 +41,19 @@ R_API_HIDDEN R_LOG_CATEGORY_DEFINE_EXTERN (revlogcat);
 
 R_API_HIDDEN void r_ev_loop_add_cb_after (REvLoop * loop, RFunc func,
     rpointer data, RDestroyNotify datanotify, rpointer user, RDestroyNotify usernotify);
+
+/* I/O readiness event bits (reactor backends: epoll / kqueue / rpoll). */
+typedef enum {
+  R_EV_IO_READABLE    = (1 << 0), /* Handle is readable. */
+  /*R_EV_IO_PRI         = (1 << 1),*/
+  R_EV_IO_WRITABLE    = (1 << 2), /* Handle is writable. */
+  R_EV_IO_ERROR       = (1 << 3), /* Error condition on the handle. */
+  R_EV_IO_HANGUP      = (1 << 4), /* Peer hung up / handle closed. */
+} REvIOEvent;
+/* Bitwise-OR of REvIOEvent values. */
+typedef ruint REvIOEvents;
+/* Readiness callback; events is the set that fired. */
+typedef void (*REvIOCB) (rpointer data, REvIOEvents events, REvIO * evio);
 
 typedef enum {
   R_EV_IO_FLAGS_NONE  = 0,
@@ -142,6 +156,19 @@ R_API_HIDDEN void r_ev_io_init (REvIO * evio, REvLoop * loop, RIOHandle handle,
     RDestroyNotify notify);
 R_API_HIDDEN void r_ev_io_clear (REvIO * evio);
 R_API_HIDDEN rboolean r_ev_io_validate_taskgroup (REvIO * evio, ruint taskgroup);
+
+/* Low-level readiness watcher API -- internal: applications use r_evtcp /
+ * r_evudp. Readiness has no equivalent on a completion (IOCP) backend. */
+R_API_HIDDEN REvIO * r_ev_io_new (REvLoop * loop, RIOHandle handle);
+#define r_ev_io_ref r_ref_ref
+#define r_ev_io_unref r_ref_unref
+R_API_HIDDEN void r_ev_io_set_user (REvIO * evio, rpointer user, RDestroyNotify notify);
+R_API_HIDDEN rpointer r_ev_io_get_user (REvIO * evio) R_ATTR_WARN_UNUSED_RESULT;
+R_API_HIDDEN rpointer r_ev_io_start (REvIO * evio, REvIOEvents events, REvIOCB io_cb,
+    rpointer data, RDestroyNotify datanotify) R_ATTR_WARN_UNUSED_RESULT;
+R_API_HIDDEN rboolean r_ev_io_stop (REvIO * evio, rpointer ctx);
+R_API_HIDDEN rboolean r_ev_io_close (REvIO * evio, REvIOFunc close_cb,
+    rpointer data, RDestroyNotify datanotify);
 
 #define r_ev_io_invoke_iocb(evio, events)                                     \
   R_STMT_START {                                                              \

--- a/test/revloop.c
+++ b/test/revloop.c
@@ -272,77 +272,6 @@ RTEST (revloop, callback_later_cancel, RTEST_FAST)
 }
 RTEST_END;
 
-#if defined (R_OS_UNIX)
-typedef struct {
-  REvIO * evio;
-  rpointer ctx;
-  int fd[2];
-  rsize iocount;
-} RTestEvIOStartCtx;
-
-static void
-io_count_cb (rpointer data, REvIOEvents events, REvIO * evio)
-{
-  RTestEvIOStartCtx * ctx = data;
-
-  (void) evio;
-
-  ctx->iocount++;
-
-  int r;
-  ruint64 buf;
-  if (events & R_EV_IO_READABLE) {
-    do {
-      r = r_io_read (ctx->fd[0], &buf, sizeof (ruint64));
-    } while (r > 0);
-  }
-}
-
-static rboolean
-idle_stop_evio_cb (rpointer data, REvLoop * loop)
-{
-  RTestEvIOStartCtx * ctx = data;
-  (void) loop;
-  r_ev_io_stop (ctx->evio, ctx->ctx);
-  return FALSE;
-}
-
-RTEST (revloop, evio_handle, RTEST_FAST)
-{
-  REvLoop * loop;
-  RClock * clock;
-  RTestEvIOStartCtx ctx = { NULL, NULL, { -1, -1 }, 0 };
-
-  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
-  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
-
-  r_assert_cmpint (pipe (ctx.fd), ==, 0);
-
-  r_assert_cmpptr (r_ev_loop_create_ev_io (loop, R_IO_HANDLE_INVALID), ==, NULL);
-  r_assert_cmpptr ((ctx.evio = r_ev_loop_create_ev_io (loop, ctx.fd[0])), !=, NULL);
-  r_assert_cmpptr ((ctx.ctx = r_ev_io_start (ctx.evio, R_EV_IO_READABLE, io_count_cb, &ctx, NULL)), !=, NULL);
-  r_assert_cmpint (write (ctx.fd[1], "test", 4), ==, 4);
-  r_assert_cmpuint (r_ev_loop_run (loop, R_EV_LOOP_RUN_NOWAIT), ==, 1);
-  r_assert_cmpuint (ctx.iocount, ==, 1);
-  r_assert_cmpuint (r_ev_loop_get_iterations (loop), ==, 1);
-  r_assert_cmpuint (r_ev_loop_get_idle_count (loop), ==, 0);
-
-  r_assert (r_ev_loop_add_idle (loop, idle_stop_evio_cb, &ctx, NULL));
-  r_assert_cmpuint (r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP), ==, 0);
-  r_assert_cmpuint (ctx.iocount, ==, 1);
-  r_assert_cmpuint (r_ev_loop_get_iterations (loop), ==, 2);
-  r_assert_cmpuint (r_ev_loop_get_idle_count (loop), ==, 1);
-
-  close (ctx.fd[0]);
-  close (ctx.fd[1]);
-  r_ev_io_unref (ctx.evio);
-  r_assert_cmpuint (r_ref_refcount (loop), ==, 1);
-  r_ev_loop_unref (loop);
-  r_clock_unref (clock);
-}
-RTEST_END;
-#endif
-
 static void
 register_thread_task (rpointer data, RTaskQueue * queue, RTask * task)
 {
@@ -433,29 +362,6 @@ RTEST (revloop, add_task_with_taskgroup, RTEST_FAST)
   r_ev_loop_unref (loop);
   r_clock_unref (clock);
   r_task_queue_unref (tq);
-}
-RTEST_END;
-
-RTEST (revio, user, RTEST_FAST)
-{
-  REvLoop * loop;
-  RClock * clock;
-  REvIO * evio;
-  rpointer data;
-
-  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
-  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
-  r_clock_unref (clock);
-
-  /* dummy fd/handle 42 */
-  r_assert_cmpptr ((evio = r_ev_loop_create_ev_io (loop, (RIOHandle)(ruintptr)42)), !=, NULL);
-  r_assert_cmpptr (r_ev_io_get_user (evio), ==, NULL);
-
-  r_assert_cmpptr ((data = r_malloc (42)), !=, NULL);
-  r_ev_io_set_user (evio, data, r_free);
-  r_assert_cmpptr (r_ev_io_get_user (evio), ==, data);
-  r_ev_io_unref (evio);
-  r_ev_loop_unref (loop);
 }
 RTEST_END;
 


### PR DESCRIPTION
First step toward the Windows IOCP backend (#34).

## Why

`REvLoop`'s low-level `REvIO` API (`r_ev_io_new/start/stop/close/set_user/get_user`, `r_ev_loop_create_ev_io`) is a **readiness/reactor** interface — "tell me when this handle is readable/writable, then I'll read." That has **no equivalent on a completion (IOCP/proactor) backend**, and it has **no external users**: applications use the higher-level `r_evtcp` / `r_evudp` sources (which deliver data in their callbacks and map cleanly onto epoll, kqueue, *and* IOCP). This mirrors libuv, where the primary API is the high-level handles and the low-level readiness watcher (`uv_poll_t`) is a documented special case.

Hiding it keeps the one unmappable API off the public surface, so each backend only has to implement what the high-level API needs.

## What

- Move the `r_ev_io_*` declarations and the readiness types (`REvIOEvents`, `REvIOCB`) into the internal `rev-private.h` as `R_API_HIDDEN`; the symbols are no longer exported.
- Slim public `revio.h` to just the shared types the public TCP/UDP API references — the opaque `REvIO` and `REvIOFunc` (used by `r_ev_tcp_close`).
- Drop the `revio.h` include from public `revloop.h`; `revtcp.h` includes it directly for `REvIOFunc`.
- Remove the two direct `REvIO` unit tests: the test binary links the shared library and can no longer reach the now-hidden symbols. The readiness mechanism stays covered by the `revtcp`/`revudp` socket tests, which exercise `r_ev_io_start/stop/close` end-to-end on every backend.

No functional change; backend-independent.

## Validation

Built clean on debug/release/gcc-warn/clang/asan/tsan under `-Werror`; full suite green; doxygen 0 warnings. Confirmed `r_ev_io_*` are no longer exported from `librlib.so` while the high-level `r_ev_tcp_*`/`r_ev_loop_*` API still is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)