### PR TITLE
ev: IOCP completion-port event-loop backend, default on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,35 @@ jobs:
           name: testlog-windows-arm-${{ matrix.buildtype }}
           path: build/meson-logs/
 
+  windows-rpoll:
+    name: Windows rpoll / MSVC / ${{ matrix.buildtype }}
+    # IOCP is the default Windows backend (covered by the Windows / MSVC job);
+    # this one forces the WSAEventSelect/poll readiness backend (-Drpoll) so the
+    # opt-out path keeps building and passing (minus the recv-error tests, which
+    # a readiness backend cannot satisfy and which gate themselves off).
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        buildtype: ${{ fromJSON(github.event_name == 'pull_request' && '["debugoptimized"]' || '["debugoptimized","release"]') }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Install meson + ninja
+        run: pip install meson ninja
+      - name: Configure
+        run: meson setup build --buildtype=${{ matrix.buildtype }} -Drpoll=enabled
+      - name: Build
+        run: meson compile -C build
+      - name: Test
+        run: meson test -C build --print-errorlogs --timeout-multiplier 6
+      - name: Upload test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: testlog-windows-rpoll-${{ matrix.buildtype }}
+          path: build/meson-logs/
+
   sanitizers:
     name: Sanitizers / ${{ matrix.name }}
     runs-on: ubuntu-latest

--- a/include/rlib/net/riosocket.h
+++ b/include/rlib/net/riosocket.h
@@ -91,6 +91,7 @@ typedef enum {
   R_SOCKET_CONN_REFUSED     = -10,/**< Peer refused the connection. */
   R_SOCKET_CONN_RESET       = -11,/**< Connection reset by peer. */
   R_SOCKET_NOT_SUPPORTED    = -12,/**< Op not supported on this platform. */
+  R_SOCKET_MSG_SIZE         = -13,/**< Datagram exceeds the size limit (or was truncated on receive). */
 } RSocketStatus;
 
 

--- a/include/rlib/rpoll.h
+++ b/include/rlib/rpoll.h
@@ -47,7 +47,8 @@
  *
  * This is the synchronous polling primitive; for high-throughput
  * event-driven I/O use @c r_evloop (ev/) which sits on @c epoll /
- * @c kqueue, falling back to @ref r_poll elsewhere (including Windows).
+ * @c kqueue, IOCP on Windows, and falls back to @ref r_poll elsewhere
+ * (or on any platform when built with @c -Drpoll).
  *
  * @{
  */

--- a/meson.build
+++ b/meson.build
@@ -517,6 +517,14 @@ foreach d : rconf_defines
   rconf.set(d[0], d[1].strip() != '' ? d[1] : d[2])
 endforeach
 
+# -Drpoll=enabled forces the WSAEventSelect/poll readiness event-loop backend,
+# overriding epoll/kqueue/IOCP on any platform. On Windows this opts out of the
+# default IOCP (completion-port) backend (which, unlike rpoll, can observe an
+# abortive peer close).
+if get_option('rpoll').enabled()
+  rconf.set('R_EV_USE_RPOLL', 1)
+endif
+
 configure_file(input : 'config.h.meson', output : 'config.h', configuration : conf)
 
 ###############################################################################

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -23,3 +23,8 @@ option('enable_sockets',
     value : true,
     description : 'build with sockets support')
 
+option('rpoll',
+    type : 'feature',
+    value : 'disabled',
+    description : 'Windows: use the WSAEventSelect/poll readiness event-loop backend instead of the default IOCP (completion-port) backend')
+

--- a/rlib/ev/rev-iocp-private.h
+++ b/rlib/ev/rev-iocp-private.h
@@ -1,0 +1,88 @@
+/* RLIB - Convenience library for useful things
+ * Copyright (C) 2026 Haakon Sporsheim <haakon.sporsheim@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ * See the COPYING file at the root of the source repository.
+ */
+#ifndef __R_EV_IOCP_PRIV_H__
+#define __R_EV_IOCP_PRIV_H__
+
+#if !defined(RLIB_COMPILATION)
+#error "rev-iocp-private.h should only be used internally in rlib!"
+#endif
+
+#include "config.h"
+#include <rlib/rtypes.h>
+
+/* IOCP (completion-port) backend: the Windows default, opt out with -Drpoll. */
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+
+#include <rlib/rmem.h>
+#include <rlib/ev/revloop.h>
+
+/* GetQueuedCompletionStatusEx / ConnectEx need Vista+ headers. */
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#endif
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <mswsock.h>
+
+R_BEGIN_DECLS
+
+/* Completion key reserved for r_ev_loop_wakeup's PostQueuedCompletionStatus;
+ * every real I/O completion is recovered from its OVERLAPPED instead. */
+#define R_EV_IOCP_WAKEUP_KEY    ((ULONG_PTR) 1)
+
+typedef struct REvIOCPOp REvIOCPOp;
+
+/* Completion handler for one overlapped op. @bytes is the transfer count the
+ * port reported; the handler reads the authoritative status itself (via
+ * WSAGetOverlappedResult on its own socket) since the port does not carry it. */
+typedef void (*REvIOCPOpFunc) (REvIOCPOp * op, REvLoop * loop, rsize bytes);
+
+/* One in-flight overlapped operation. The OVERLAPPED must be the first member
+ * so the loop can recover the op from a completion's lpOverlapped via
+ * CONTAINING_RECORD. The op (and any buffer it points at) must outlive the
+ * in-flight operation -- including @wbuf: WSARecv/WSASend keep the WSABUF
+ * descriptor referenced until the overlapped op completes, so it cannot live on
+ * the caller's stack. */
+struct REvIOCPOp {
+  OVERLAPPED overlapped;
+  REvIOCPOpFunc cb;
+  rpointer data;
+  WSABUF wbuf;
+};
+
+static inline void
+r_ev_iocp_op_init (REvIOCPOp * op, REvIOCPOpFunc cb, rpointer data)
+{
+  r_memclear (&op->overlapped, sizeof (OVERLAPPED));
+  op->cb = cb;
+  op->data = data;
+}
+
+/* Associate @handle (a socket) with the loop's completion port; completions
+ * for overlapped ops on it are then delivered to r_ev_loop_io_wait. */
+R_API_HIDDEN rboolean r_ev_loop_iocp_associate (REvLoop * loop, RIOHandle handle);
+/* Account for one overlapped op being posted / failing to post: a submitted
+ * op keeps the loop alive until its completion arrives. */
+R_API_HIDDEN void r_ev_loop_iocp_submit (REvLoop * loop);
+R_API_HIDDEN void r_ev_loop_iocp_unsubmit (REvLoop * loop);
+
+R_END_DECLS
+
+#endif /* R_OS_WIN32 && !R_EV_USE_RPOLL */
+
+#endif /* __R_EV_IOCP_PRIV_H__ */

--- a/rlib/ev/revloop.c
+++ b/rlib/ev/revloop.c
@@ -17,6 +17,8 @@
  */
 
 #include "config.h"
+/* Before rlib-private.h: pulls in <winsock2.h> ahead of any <windows.h>. */
+#include "rev-iocp-private.h"
 #include "../rlib-private.h"
 #include "rev-private.h"
 
@@ -43,12 +45,20 @@
 #include <errno.h>
 
 
-/* Setup MACROS to select evloop backend! */
-#if defined (HAVE_KQUEUE)
+/* Setup MACROS to select evloop backend!
+ * R_EV_USE_RPOLL (-Drpoll) forces the readiness/poll backend on any platform;
+ * otherwise it is kqueue, epoll, IOCP on Windows, and poll as the fallback. */
+#if defined (R_EV_USE_RPOLL)
+#define USE_RPOLL   1
+#define USE_WAKEUP  1
+#elif defined (HAVE_KQUEUE)
 #define USE_KQUEUE  1
 #elif defined (HAVE_EPOLL_CTL)
 #define USE_EPOLL   1
 #define USE_WAKEUP  1
+#elif defined (R_OS_WIN32)
+/* IOCP wakes via PostQueuedCompletionStatus, so no separate USE_WAKEUP. */
+#define USE_IOCP    1
 #else
 #define USE_RPOLL   1
 #define USE_WAKEUP  1
@@ -108,6 +118,11 @@ struct REvLoop {
   RIOHandle handle;
 #ifdef USE_RPOLL
   RPollSet pollset;
+#endif
+#ifdef USE_IOCP
+  /* In-flight overlapped ops; keeps the loop alive until they all complete
+   * (the completion backend has no 'active' readiness watchers). */
+  rsize iocp_inflight;
 #endif
   RQueue active;
   RQueue chg;
@@ -191,6 +206,15 @@ r_ev_loop_setup (REvLoop * loop, RClock * clock, RTaskQueue * tq)
   }
 #elif defined (USE_EPOLL)
  loop->handle = epoll_create1 (0);
+#elif defined (USE_IOCP)
+  loop->iocp_inflight = 0;
+  loop->handle = (RIOHandle) CreateIoCompletionPort (INVALID_HANDLE_VALUE,
+      NULL, 0, 0);
+  if (R_UNLIKELY (loop->handle == NULL)) {
+    R_LOG_ERROR ("Failed to create IOCP port for loop %p (%lu)",
+        loop, (unsigned long) GetLastError ());
+    loop->handle = R_IO_HANDLE_INVALID;
+  }
 #elif defined (USE_RPOLL)
   loop->handle = R_IO_HANDLE_INVALID;
   r_poll_set_init (&loop->pollset, 0);
@@ -264,6 +288,9 @@ r_ev_loop_next_deadline (REvLoop * loop, REvLoopRunMode mode)
   if (r_cbqueue_size (&loop->acbs) > 0) return loop->ts;
   if (r_clock_timeout_count (loop->clock) == 0 &&
       r_queue_size (&loop->active) == 0 &&
+#ifdef USE_IOCP
+      loop->iocp_inflight == 0 &&
+#endif
       r_atomic_uint_load (&loop->tqitems) == 0)
     return loop->ts;
 
@@ -609,8 +636,62 @@ r_ev_loop_io_wait (REvLoop * loop, RClockTime deadline)
 
   return ret;
 }
+#elif defined (USE_IOCP)
+static int
+r_ev_loop_io_wait (REvLoop * loop, RClockTime deadline)
+{
+  OVERLAPPED_ENTRY entries[R_EV_LOOP_MAX_EVENTS];
+  ULONG count = 0, i;
+  DWORD timeout;
+  int total = 0;
+
+  if (deadline != R_CLOCK_TIME_INFINITE)
+    timeout = (DWORD) R_TIME_AS_MSECONDS (deadline - loop->ts) + 1;
+  else
+    timeout = INFINITE;
+
+  /* Block (up to the deadline) for the first batch, then drain every other
+   * completion that is already ready with a non-blocking poll. This keeps one
+   * loop iteration from leaving a ready completion behind -- e.g. a loopback
+   * datagram whose recv completes just after the send that triggered it. */
+  for (;;) {
+    if (!GetQueuedCompletionStatusEx (loop->handle, entries,
+          (ULONG) R_N_ELEMENTS (entries), &count, timeout, FALSE)) {
+      DWORD err = GetLastError ();
+      if (err == WAIT_TIMEOUT)
+        break;
+      R_LOG_ERROR ("GetQueuedCompletionStatusEx for loop %p failed (%lu)",
+          loop, (unsigned long) err);
+      return total > 0 ? total : -1;
+    }
+
+    R_LOG_DEBUG ("IOCP for loop %p with %lu completions", loop,
+        (unsigned long) count);
+    for (i = 0; i < count; i++) {
+      OVERLAPPED_ENTRY * e = &entries[i];
+      REvIOCPOp * op;
+
+      /* A NULL overlapped on the reserved key is a r_ev_loop_wakeup post. */
+      if (e->lpOverlapped == NULL) {
+        if (e->lpCompletionKey == R_EV_IOCP_WAKEUP_KEY)
+          r_ev_loop_move_done_callbacks (loop);
+        continue;
+      }
+
+      op = CONTAINING_RECORD (e->lpOverlapped, REvIOCPOp, overlapped);
+      if (R_LIKELY (loop->iocp_inflight > 0))
+        loop->iocp_inflight--;
+      op->cb (op, loop, (rsize) e->dwNumberOfBytesTransferred);
+    }
+
+    total += (int) count;
+    timeout = 0;
+  }
+
+  return total;
+}
 #else
-/* TODO: Implement win32 backend */
+/* No IO backend (e.g. bare metal): the loop still drives timers / callbacks. */
 static int
 r_ev_loop_io_wait (REvLoop * loop, RClockTime deadline)
 {
@@ -623,6 +704,32 @@ r_ev_loop_io_wait (REvLoop * loop, RClockTime deadline)
 }
 #endif
 
+#ifdef USE_IOCP
+rboolean
+r_ev_loop_iocp_associate (REvLoop * loop, RIOHandle handle)
+{
+  if (CreateIoCompletionPort ((HANDLE) handle, loop->handle, 0, 0) == NULL) {
+    R_LOG_ERROR ("Failed to associate handle %p with loop %p port (%lu)",
+        handle, loop, (unsigned long) GetLastError ());
+    return FALSE;
+  }
+  return TRUE;
+}
+
+void
+r_ev_loop_iocp_submit (REvLoop * loop)
+{
+  loop->iocp_inflight++;
+}
+
+void
+r_ev_loop_iocp_unsubmit (REvLoop * loop)
+{
+  if (R_LIKELY (loop->iocp_inflight > 0))
+    loop->iocp_inflight--;
+}
+#endif
+
 static rsize
 r_ev_loop_outstanding_events (REvLoop * loop)
 {
@@ -631,6 +738,9 @@ r_ev_loop_outstanding_events (REvLoop * loop)
     r_cbqueue_size (&loop->bcbs) +
     loop->tqitems +
     r_clock_timeout_count (loop->clock) +
+#ifdef USE_IOCP
+    loop->iocp_inflight +
+#endif
     r_queue_size (&loop->active);
 }
 
@@ -826,6 +936,10 @@ r_ev_loop_wakeup (REvLoop * loop)
     R_LOG_DEBUG ("loop %p wakeup!", loop);
   else
     R_LOG_ERROR ("Wakeup signalling failed for loop %p", loop);
+#elif defined (USE_IOCP)
+  if (!PostQueuedCompletionStatus (loop->handle, 0, R_EV_IOCP_WAKEUP_KEY, NULL))
+    R_LOG_ERROR ("Wakeup signalling failed for loop %p (%lu)",
+        loop, (unsigned long) GetLastError ());
 #else
 #error No wakeup mechanism
 #endif

--- a/rlib/ev/revtcp.c
+++ b/rlib/ev/revtcp.c
@@ -17,6 +17,8 @@
  */
 
 #include "config.h"
+/* Before rsocket-private.h / rev-private.h: orders <winsock2.h> first. */
+#include "rev-iocp-private.h"
 #include "rev-private.h"
 #include "../net/rsocket-private.h"
 #include "../net/rnet-private.h"
@@ -48,6 +50,17 @@ r_ev_tcp_send_ctx_free (rpointer data)
   r_free (ctx);
 }
 
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+/* One pre-posted AcceptEx slot: its overlapped op, the socket the incoming
+ * connection is accepted into, and the address output buffer AcceptEx fills
+ * (room for the local + remote address, each sockaddr_storage + 16 bytes as
+ * AcceptEx requires). */
+typedef struct {
+  REvIOCPOp op;
+  RSocket * sock;
+  ruint8 addr[2 * (sizeof (struct sockaddr_storage) + 16)];
+} REvTCPAccept;
+#endif
 
 struct REvTCP {
   REvIO evio;
@@ -72,12 +85,57 @@ struct REvTCP {
   RTask * recv_task;
 
   RQueue qsend;
+
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+  /* Completion (proactor) backend: an op is posted, its completion delivers
+   * the result. Each in-flight op holds one ref on this REvTCP. */
+  REvIOCPOp iocp_recv;
+  RBuffer * iocp_recv_buf;     /* buffer backing the in-flight WSARecv */
+  RMemMapInfo iocp_recv_map;
+  rboolean iocp_recv_active;   /* receiving (recv_start, not yet stopped) */
+  rboolean iocp_recv_task;     /* deliver received buffers via a task group */
+
+  REvIOCPOp iocp_send;
+  RMemMapInfo iocp_send_map;
+  rboolean iocp_send_active;   /* a WSASend is in flight for the queue head */
+
+  REvIOCPOp iocp_connect;
+  rpointer connect_data;       /* user data for the connected callback */
+  RDestroyNotify connect_datanotify;
+  RDestroyNotify recv_datanotify;
+
+  rpointer accept_data;        /* user data for the connection callback */
+  RDestroyNotify accept_datanotify;
+  REvTCPAccept * iocp_accept;  /* array of pre-posted AcceptEx slots */
+  ruint iocp_naccept;
+#endif
 };
 
 static void
 r_ev_tcp_free (REvTCP * evtcp)
 {
   r_queue_clear (&evtcp->qsend, r_ev_tcp_send_ctx_free);
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+  /* No ops can be in flight here: each holds a ref, so the last unref (which
+   * brought us here) cannot run while one is outstanding. Release whatever
+   * the completion paths did not get to free. */
+  if (evtcp->iocp_recv_buf != NULL)
+    r_buffer_unref (evtcp->iocp_recv_buf);
+  if (evtcp->iocp_accept != NULL) {
+    ruint i;
+    for (i = 0; i < evtcp->iocp_naccept; i++) {
+      if (evtcp->iocp_accept[i].sock != NULL)
+        r_socket_unref (evtcp->iocp_accept[i].sock);
+    }
+    r_free (evtcp->iocp_accept);
+  }
+  /* The recv / connection user data outlived every op that referenced it
+   * (each held a ref); release it now that the socket is gone. */
+  if (evtcp->recv_datanotify != NULL)
+    evtcp->recv_datanotify (evtcp->recv_data);
+  if (evtcp->accept_datanotify != NULL)
+    evtcp->accept_datanotify (evtcp->accept_data);
+#endif
   if (evtcp->error_datanotify != NULL)
     evtcp->error_datanotify (evtcp->error_data);
   r_socket_unref (evtcp->socket);
@@ -95,6 +153,15 @@ r_ev_tcp_new_with_socket (RSocket * socket, REvLoop * loop)
         (RDestroyNotify)r_ev_tcp_free);
     ret->socket = socket;
     r_queue_init (&ret->qsend);
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+    /* Bind the socket to the loop's completion port so its overlapped ops
+     * complete on this loop. */
+    if (R_UNLIKELY (!r_ev_loop_iocp_associate (loop, (RIOHandle) socket->handle))) {
+      r_ev_io_clear (&ret->evio);
+      r_free (ret);
+      ret = NULL;
+    }
+#endif
   }
 
   return ret;
@@ -129,11 +196,432 @@ r_ev_tcp_new_bind (const RSocketAddress * addr, REvLoop * loop)
   return ret;
 }
 
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+/* ---- IOCP (completion / proactor) TCP path -------------------------------
+ * Each posted overlapped op holds one ref on its REvTCP and one in-flight
+ * count on the loop; its completion (success, EOS, error, or aborted close)
+ * drops both. Re-arming ops (recv / accept) post afresh before dropping the
+ * completing op's ref, so a continuously busy socket holds exactly one. */
+
+#define R_EV_TCP_IOCP_SOCKET(evtcp)                                           \
+  R_IO_HANDLE_TO_SOCKET_HANDLE ((evtcp)->socket->handle)
+#define R_EV_TCP_IOCP_NACCEPT       4
+#define R_EV_TCP_IOCP_ADDRLEN       ((DWORD) (sizeof (struct sockaddr_storage) + 16))
+
+static LPFN_CONNECTEX r__ev_tcp_connectex = NULL;
+static LPFN_ACCEPTEX  r__ev_tcp_acceptex  = NULL;
+
+static rpointer
+r_ev_tcp_iocp_load_ext (RSocket * socket, GUID guid)
+{
+  rpointer fn = NULL;
+  DWORD bytes = 0;
+
+  if (WSAIoctl (R_IO_HANDLE_TO_SOCKET_HANDLE (socket->handle),
+        SIO_GET_EXTENSION_FUNCTION_POINTER, &guid, (DWORD) sizeof (guid),
+        &fn, (DWORD) sizeof (fn), &bytes, NULL, NULL) != 0)
+    return NULL;
+  return fn;
+}
+
+static LPFN_CONNECTEX
+r_ev_tcp_iocp_connectex (RSocket * socket)
+{
+  if (r__ev_tcp_connectex == NULL) {
+    GUID guid = WSAID_CONNECTEX;
+    r__ev_tcp_connectex = (LPFN_CONNECTEX) r_ev_tcp_iocp_load_ext (socket, guid);
+  }
+  return r__ev_tcp_connectex;
+}
+
+static LPFN_ACCEPTEX
+r_ev_tcp_iocp_acceptex (RSocket * socket)
+{
+  if (r__ev_tcp_acceptex == NULL) {
+    GUID guid = WSAID_ACCEPTEX;
+    r__ev_tcp_acceptex = (LPFN_ACCEPTEX) r_ev_tcp_iocp_load_ext (socket, guid);
+  }
+  return r__ev_tcp_acceptex;
+}
+
+static RSocketStatus
+r_ev_tcp_iocp_status (DWORD err)
+{
+  switch (err) {
+    case 0:                       return R_SOCKET_OK;
+    case ERROR_OPERATION_ABORTED: return R_SOCKET_CANCELED;
+    case WSAECONNRESET:           return R_SOCKET_CONN_RESET;
+    case WSAECONNABORTED:         return R_SOCKET_CONN_ABORTED;
+    case WSAECONNREFUSED:         return R_SOCKET_CONN_REFUSED;
+    case WSAENOTCONN:             return R_SOCKET_NOT_CONNECTED;
+    default:                      return R_SOCKET_ERROR;
+  }
+}
+
+/* Authoritative result of a completed op: 0 on success (with @bytes set), else
+ * the WSA error. */
+static DWORD
+r_ev_tcp_iocp_result (REvTCP * evtcp, REvIOCPOp * op, rsize * bytes)
+{
+  DWORD transferred = 0, flags = 0;
+
+  if (WSAGetOverlappedResult (R_EV_TCP_IOCP_SOCKET (evtcp), &op->overlapped,
+        &transferred, FALSE, &flags)) {
+    if (bytes != NULL)
+      *bytes = (rsize) transferred;
+    return 0;
+  }
+  if (bytes != NULL)
+    *bytes = 0;
+  return (DWORD) WSAGetLastError ();
+}
+
+static rboolean r_ev_tcp_iocp_post_recv (REvTCP * evtcp);
+static rboolean r_ev_tcp_iocp_post_send (REvTCP * evtcp);
+static rboolean r_ev_tcp_iocp_post_accept (REvTCP * ltcp, REvTCPAccept * a);
+
+static void
+r_ev_tcp_iocp_recv_teardown (REvTCP * evtcp, RSocketStatus res)
+{
+  evtcp->iocp_recv_active = FALSE;
+  if (res != R_SOCKET_OK && evtcp->error != NULL)
+    evtcp->error (evtcp->error_data, evtcp, res);
+  else
+    evtcp->recv (evtcp->recv_data, NULL, evtcp);
+}
+
+/* Task-group delivery (r_ev_tcp_task_recv_start): the received buffer is
+ * processed off the loop thread. The task carries a ref on the buffer and the
+ * evtcp, both released (on the task thread) when the context is freed. No loop
+ * 'done' callback is used, so the task is not an outstanding loop event -- the
+ * re-armed WSARecv keeps the loop alive, and r_ev_tcp_recv_stop waits on the
+ * last task. Each task chains on the previous, so they run in order. */
+typedef struct {
+  REvTCP * evtcp;
+  RBuffer * buf;
+} REvTCPRecvTaskCtx;
+
+static void
+r_ev_tcp_iocp_recv_task (rpointer data, RTaskQueue * queue, RTask * task)
+{
+  REvTCPRecvTaskCtx * ctx = data;
+  (void) queue;
+  (void) task;
+  ctx->evtcp->recv (ctx->evtcp->recv_data, ctx->buf, ctx->evtcp);
+}
+
+static void
+r_ev_tcp_iocp_recv_task_free (rpointer data)
+{
+  REvTCPRecvTaskCtx * ctx = data;
+  r_buffer_unref (ctx->buf);
+  r_ev_tcp_unref (ctx->evtcp);
+  r_free (ctx);
+}
+
+static void
+r_ev_tcp_iocp_recv_deliver (REvTCP * evtcp, RBuffer * buf)
+{
+  REvTCPRecvTaskCtx * ctx;
+  RTask * task;
+
+  if (!evtcp->iocp_recv_task) {
+    evtcp->recv (evtcp->recv_data, buf, evtcp);
+    r_buffer_unref (buf);
+    return;
+  }
+
+  /* Populate the context before queuing: the task may start on another thread
+   * the instant it is added. */
+  if ((ctx = r_mem_new (REvTCPRecvTaskCtx)) != NULL) {
+    ctx->evtcp = r_ev_tcp_ref (evtcp);
+    ctx->buf = buf;   /* ownership transferred to the task */
+    if ((task = r_ev_loop_add_task_full (evtcp->evio.loop, evtcp->taskgroup,
+            r_ev_tcp_iocp_recv_task, NULL, ctx, r_ev_tcp_iocp_recv_task_free,
+            evtcp->recv_task, NULL)) != NULL) {
+      if (evtcp->recv_task != NULL)
+        r_task_unref (evtcp->recv_task);
+      evtcp->recv_task = task;
+      return;
+    }
+    /* Queuing failed: undo without releasing buf (delivered inline below). */
+    r_ev_tcp_unref (ctx->evtcp);
+    r_free (ctx);
+  }
+
+  /* Could not offload: process inline rather than drop the data. */
+  evtcp->recv (evtcp->recv_data, buf, evtcp);
+  r_buffer_unref (buf);
+}
+
+static void
+r_ev_tcp_iocp_recv_complete (REvIOCPOp * op, REvLoop * loop, rsize bytes)
+{
+  REvTCP * evtcp = op->data;
+  RBuffer * buf = evtcp->iocp_recv_buf;
+  rsize got = 0;
+  DWORD err;
+  (void) loop;
+  (void) bytes;
+
+  err = r_ev_tcp_iocp_result (evtcp, op, &got);
+  r_buffer_unmap (buf, &evtcp->iocp_recv_map);
+  evtcp->iocp_recv_buf = NULL;
+
+  if (err != 0) {
+    R_LOG_DEBUG ("loop %p evio "R_EV_IO_FORMAT" recv err %lu",
+        evtcp->evio.loop, R_EV_IO_ARGS (evtcp), (unsigned long) err);
+    r_buffer_unref (buf);
+    if (err != ERROR_OPERATION_ABORTED)
+      r_ev_tcp_iocp_recv_teardown (evtcp, r_ev_tcp_iocp_status (err));
+  } else if (got == 0) {
+    R_LOG_DEBUG ("loop %p evio "R_EV_IO_FORMAT" EOS",
+        evtcp->evio.loop, R_EV_IO_ARGS (evtcp));
+    r_buffer_unref (buf);
+    r_ev_tcp_iocp_recv_teardown (evtcp, R_SOCKET_OK);
+  } else {
+    r_buffer_set_size (buf, got);
+    r_ev_tcp_iocp_recv_deliver (evtcp, buf);
+    if (evtcp->iocp_recv_active && !r_socket_is_closed (evtcp->socket))
+      r_ev_tcp_iocp_post_recv (evtcp);
+  }
+
+  r_ev_tcp_unref (evtcp);
+}
+
+static rboolean
+r_ev_tcp_iocp_post_recv (REvTCP * evtcp)
+{
+  RBuffer * buf;
+  DWORD flags = 0;
+  int res;
+
+  if ((buf = evtcp->alloc (evtcp->recv_data, evtcp)) == NULL)
+    return FALSE;
+  if (!r_buffer_map (buf, &evtcp->iocp_recv_map, R_MEM_MAP_WRITE)) {
+    r_buffer_unref (buf);
+    return FALSE;
+  }
+  evtcp->iocp_recv_buf = buf;
+
+  r_ev_iocp_op_init (&evtcp->iocp_recv, r_ev_tcp_iocp_recv_complete, evtcp);
+  evtcp->iocp_recv.wbuf.buf = (CHAR *) evtcp->iocp_recv_map.data;
+  evtcp->iocp_recv.wbuf.len = (ULONG) evtcp->iocp_recv_map.size;
+  r_ev_tcp_ref (evtcp);
+  r_ev_loop_iocp_submit (evtcp->evio.loop);
+  res = WSARecv (R_EV_TCP_IOCP_SOCKET (evtcp), &evtcp->iocp_recv.wbuf, 1, NULL, &flags,
+      &evtcp->iocp_recv.overlapped, NULL);
+  if (res == 0 || WSAGetLastError () == WSA_IO_PENDING)
+    return TRUE;
+
+  R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT" WSARecv failed %d",
+      evtcp->evio.loop, R_EV_IO_ARGS (evtcp), WSAGetLastError ());
+  r_ev_loop_iocp_unsubmit (evtcp->evio.loop);
+  r_buffer_unmap (buf, &evtcp->iocp_recv_map);
+  r_buffer_unref (buf);
+  evtcp->iocp_recv_buf = NULL;
+  r_ev_tcp_unref (evtcp);
+  return FALSE;
+}
+
+static void
+r_ev_tcp_iocp_send_complete (REvIOCPOp * op, REvLoop * loop, rsize bytes)
+{
+  REvTCP * evtcp = op->data;
+  REvTCPSendCtx * ctx = r_queue_peek (&evtcp->qsend);
+  DWORD err;
+  (void) loop;
+  (void) bytes;
+
+  evtcp->iocp_send_active = FALSE;
+  err = r_ev_tcp_iocp_result (evtcp, op, NULL);
+  if (ctx != NULL)
+    r_buffer_unmap (ctx->buf, &evtcp->iocp_send_map);
+
+  if (err == 0 && ctx != NULL) {
+    r_queue_pop (&evtcp->qsend);
+    if (ctx->done != NULL)
+      ctx->done (ctx->data, ctx->buf, evtcp);
+    r_ev_tcp_send_ctx_clear (ctx);
+    r_free (ctx);
+    if (!r_socket_is_closed (evtcp->socket))
+      r_ev_tcp_iocp_post_send (evtcp);
+  } else if (err != 0 && err != ERROR_OPERATION_ABORTED) {
+    R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT" send err %lu",
+        evtcp->evio.loop, R_EV_IO_ARGS (evtcp), (unsigned long) err);
+    if (evtcp->error != NULL)
+      evtcp->error (evtcp->error_data, evtcp, r_ev_tcp_iocp_status (err));
+  }
+
+  r_ev_tcp_unref (evtcp);
+}
+
+static rboolean
+r_ev_tcp_iocp_post_send (REvTCP * evtcp)
+{
+  REvTCPSendCtx * ctx;
+  int res;
+
+  if ((ctx = r_queue_peek (&evtcp->qsend)) == NULL)
+    return TRUE;
+  if (!r_buffer_map (ctx->buf, &evtcp->iocp_send_map, R_MEM_MAP_READ))
+    return FALSE;
+
+  r_ev_iocp_op_init (&evtcp->iocp_send, r_ev_tcp_iocp_send_complete, evtcp);
+  evtcp->iocp_send.wbuf.buf = (CHAR *) evtcp->iocp_send_map.data;
+  evtcp->iocp_send.wbuf.len = (ULONG) evtcp->iocp_send_map.size;
+  evtcp->iocp_send_active = TRUE;
+  r_ev_tcp_ref (evtcp);
+  r_ev_loop_iocp_submit (evtcp->evio.loop);
+  res = WSASend (R_EV_TCP_IOCP_SOCKET (evtcp), &evtcp->iocp_send.wbuf, 1, NULL, 0,
+      &evtcp->iocp_send.overlapped, NULL);
+  if (res == 0 || WSAGetLastError () == WSA_IO_PENDING)
+    return TRUE;
+
+  R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT" WSASend failed %d",
+      evtcp->evio.loop, R_EV_IO_ARGS (evtcp), WSAGetLastError ());
+  r_ev_loop_iocp_unsubmit (evtcp->evio.loop);
+  r_buffer_unmap (ctx->buf, &evtcp->iocp_send_map);
+  evtcp->iocp_send_active = FALSE;
+  r_ev_tcp_unref (evtcp);
+  return FALSE;
+}
+
+static void
+r_ev_tcp_iocp_accept_complete (REvIOCPOp * op, REvLoop * loop, rsize bytes)
+{
+  REvTCP * ltcp = op->data;
+  REvTCPAccept * a = CONTAINING_RECORD (op, REvTCPAccept, op);
+  RSocket * s = a->sock;
+  DWORD err;
+  (void) loop;
+  (void) bytes;
+
+  a->sock = NULL;
+  err = r_ev_tcp_iocp_result (ltcp, op, NULL);
+
+  if (err == 0) {
+    REvTCP * newtcp;
+    SOCKET ls = R_EV_TCP_IOCP_SOCKET (ltcp);
+
+    /* Inherit the listening socket's properties on the accepted socket. */
+    setsockopt (R_IO_HANDLE_TO_SOCKET_HANDLE (s->handle), SOL_SOCKET,
+        SO_UPDATE_ACCEPT_CONTEXT, (const char *) &ls, (int) sizeof (ls));
+
+    if ((newtcp = r_ev_tcp_new_with_socket (s, ltcp->evio.loop)) != NULL) {
+      R_LOG_DEBUG ("loop %p evio "R_EV_IO_FORMAT" accept "R_EV_IO_FORMAT,
+          ltcp->evio.loop, R_EV_IO_ARGS (ltcp), R_EV_IO_ARGS (newtcp));
+      ltcp->connection (ltcp->accept_data, newtcp, ltcp);
+      r_ev_tcp_unref (newtcp);
+    } else {
+      r_socket_unref (s);
+    }
+    if (!r_socket_is_closed (ltcp->socket))
+      r_ev_tcp_iocp_post_accept (ltcp, a);
+  } else {
+    r_socket_unref (s);
+    if (err != ERROR_OPERATION_ABORTED && !r_socket_is_closed (ltcp->socket))
+      r_ev_tcp_iocp_post_accept (ltcp, a);
+  }
+
+  r_ev_tcp_unref (ltcp);
+}
+
+static rboolean
+r_ev_tcp_iocp_post_accept (REvTCP * ltcp, REvTCPAccept * a)
+{
+  RSocket * s;
+  DWORD recvd = 0;
+
+  if ((s = r_socket_new (r_socket_get_family (ltcp->socket),
+          R_SOCKET_TYPE_STREAM, R_SOCKET_PROTOCOL_TCP)) == NULL)
+    return FALSE;
+  a->sock = s;
+
+  r_ev_iocp_op_init (&a->op, r_ev_tcp_iocp_accept_complete, ltcp);
+  r_ev_tcp_ref (ltcp);
+  r_ev_loop_iocp_submit (ltcp->evio.loop);
+  if (r__ev_tcp_acceptex (R_EV_TCP_IOCP_SOCKET (ltcp),
+        R_IO_HANDLE_TO_SOCKET_HANDLE (s->handle), a->addr, 0,
+        R_EV_TCP_IOCP_ADDRLEN, R_EV_TCP_IOCP_ADDRLEN, &recvd, &a->op.overlapped)
+      || WSAGetLastError () == WSA_IO_PENDING)
+    return TRUE;
+
+  R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT" AcceptEx failed %d",
+      ltcp->evio.loop, R_EV_IO_ARGS (ltcp), WSAGetLastError ());
+  r_ev_loop_iocp_unsubmit (ltcp->evio.loop);
+  r_socket_unref (s);
+  a->sock = NULL;
+  r_ev_tcp_unref (ltcp);
+  return FALSE;
+}
+
+/* ConnectEx requires a bound socket; bind to the wildcard address (best
+ * effort: an already-bound socket simply keeps its binding). */
+static void
+r_ev_tcp_iocp_bind_any (REvTCP * evtcp)
+{
+  RSocketAddress * any;
+
+  if (r_socket_get_family (evtcp->socket) == R_SOCKET_FAMILY_IPV6) {
+    ruint8 zero[16] = { 0 };
+    any = r_socket_address_ipv6_new_from_bytes (zero, 0);
+  } else {
+    any = r_socket_address_ipv4_new_uint32 (0, 0);
+  }
+  if (any != NULL) {
+    r_socket_bind (evtcp->socket, any, FALSE);
+    r_socket_address_unref (any);
+  }
+}
+
+static void
+r_ev_tcp_iocp_connect_complete (REvIOCPOp * op, REvLoop * loop, rsize bytes)
+{
+  REvTCP * evtcp = op->data;
+  DWORD err;
+  (void) loop;
+  (void) bytes;
+
+  err = r_ev_tcp_iocp_result (evtcp, op, NULL);
+  if (err == 0) {
+    setsockopt (R_EV_TCP_IOCP_SOCKET (evtcp), SOL_SOCKET,
+        SO_UPDATE_CONNECT_CONTEXT, NULL, 0);
+  }
+  R_LOG_DEBUG ("loop %p evio "R_EV_IO_FORMAT" connect err %lu",
+      evtcp->evio.loop, R_EV_IO_ARGS (evtcp), (unsigned long) err);
+  evtcp->connected (evtcp->connect_data, evtcp,
+      err == 0 ? R_SOCKET_OK : r_ev_tcp_iocp_status (err));
+
+  if (evtcp->connect_datanotify != NULL) {
+    evtcp->connect_datanotify (evtcp->connect_data);
+    evtcp->connect_datanotify = NULL;
+  }
+  r_ev_tcp_unref (evtcp);
+}
+#endif /* R_OS_WIN32 && !R_EV_USE_RPOLL */
+
 rboolean
 r_ev_tcp_close (REvTCP * evtcp, REvIOFunc close_cb, rpointer data, RDestroyNotify datanotify)
 {
   R_LOG_DEBUG ("loop %p evio "R_EV_IO_FORMAT,
       evtcp->evio.loop, R_EV_IO_ARGS (evtcp));
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+  /* Cancel every in-flight overlapped op on the socket; each completes with
+   * ERROR_OPERATION_ABORTED, drops its ref, and the socket is finally closed
+   * when the last ref is released in r_ev_tcp_free -> r_socket_unref. */
+  evtcp->iocp_recv_active = FALSE;
+  CancelIoEx ((HANDLE) evtcp->socket->handle, NULL);
+  /* Task delivery: drain the last dispatched buffer's task, as recv_stop does
+   * -- otherwise closing during task-mode recv leaks the recv_task ref. */
+  if (evtcp->recv_task != NULL) {
+    r_task_wait (evtcp->recv_task);
+    r_task_unref (evtcp->recv_task);
+    evtcp->recv_task = NULL;
+  }
+  evtcp->evio.flags |= R_EV_IO_CLOSED;
+  return r_ev_io_close ((REvIO *)evtcp, close_cb, data, datanotify);
+#else
   r_ev_tcp_recv_stop (evtcp);
 
   if (evtcp->send_iocb_ctx != NULL) {
@@ -152,6 +640,7 @@ r_ev_tcp_close (REvTCP * evtcp, REvIOFunc close_cb, rpointer data, RDestroyNotif
   /* Mark as closed, but close is actually happening in r_socket_free -> FIXME? */
   evtcp->evio.flags |= R_EV_IO_CLOSED;
   return r_ev_io_close ((REvIO *)evtcp, close_cb, data, datanotify);
+#endif
 }
 
 RSocket *
@@ -231,6 +720,48 @@ r_ev_tcp_connect (REvTCP * evtcp, const RSocketAddress * address,
   if (R_UNLIKELY (evtcp == NULL)) return R_SOCKET_INVAL;
   if (R_UNLIKELY (connected == NULL)) return R_SOCKET_INVAL;
 
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+  {
+    LPFN_CONNECTEX connectex;
+
+    if (R_UNLIKELY (address == NULL)) return R_SOCKET_INVAL;
+    if ((connectex = r_ev_tcp_iocp_connectex (evtcp->socket)) == NULL)
+      return R_SOCKET_NOT_SUPPORTED;
+
+    r_ev_tcp_iocp_bind_any (evtcp);
+
+    evtcp->connected = connected;
+    evtcp->connect_data = data;
+    evtcp->connect_datanotify = datanotify;
+    r_ev_iocp_op_init (&evtcp->iocp_connect, r_ev_tcp_iocp_connect_complete, evtcp);
+    r_ev_tcp_ref (evtcp);
+    r_ev_loop_iocp_submit (evtcp->evio.loop);
+    R_LOG_DEBUG ("loop %p evio "R_EV_IO_FORMAT, evtcp->evio.loop, R_EV_IO_ARGS (evtcp));
+    if (connectex (R_EV_TCP_IOCP_SOCKET (evtcp),
+          (const struct sockaddr *) &address->addr, address->addrlen,
+          NULL, 0, NULL, &evtcp->iocp_connect.overlapped) ||
+        WSAGetLastError () == WSA_IO_PENDING)
+      /* Connection is in progress; completes asynchronously via @connected,
+       * matching the readiness backend's non-blocking connect contract. */
+      return R_SOCKET_WOULD_BLOCK;
+
+    /* Capture the error before logging: a log call can clobber the thread
+     * last-error, and the status below must reflect ConnectEx, not the log. */
+    {
+      DWORD err = (DWORD) WSAGetLastError ();
+      R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT" ConnectEx failed %lu",
+          evtcp->evio.loop, R_EV_IO_ARGS (evtcp), (unsigned long) err);
+      ret = r_ev_tcp_iocp_status (err);
+    }
+    r_ev_loop_iocp_unsubmit (evtcp->evio.loop);
+    evtcp->connected = NULL;
+    evtcp->connect_datanotify = NULL;
+    if (datanotify != NULL)
+      datanotify (data);
+    r_ev_tcp_unref (evtcp);
+    return ret;
+  }
+#else
   if ((ret = r_socket_connect (evtcp->socket, address)) >= R_SOCKET_OK) {
     evtcp->connected = connected;
     R_LOG_DEBUG ("loop %p evio "R_EV_IO_FORMAT, evtcp->evio.loop, R_EV_IO_ARGS (evtcp));
@@ -248,6 +779,7 @@ r_ev_tcp_connect (REvTCP * evtcp, const RSocketAddress * address,
   }
 
   return ret;
+#endif
 }
 
 static void
@@ -279,6 +811,26 @@ r_ev_tcp_listen (REvTCP * evtcp, ruint8 backlog,
   if (R_UNLIKELY (evtcp->connect_iocb_ctx != NULL)) return R_SOCKET_INVALID_OP;
   if (R_UNLIKELY (evtcp->listen_iocb_ctx != NULL)) return R_SOCKET_INVALID_OP;
 
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+  if (R_UNLIKELY (evtcp->iocp_accept != NULL)) return R_SOCKET_INVALID_OP;
+  if (r_ev_tcp_iocp_acceptex (evtcp->socket) == NULL) return R_SOCKET_NOT_SUPPORTED;
+
+  if ((ret = r_socket_listen_full (evtcp->socket, backlog)) >= R_SOCKET_OK) {
+    ruint i;
+
+    evtcp->connection = connection;
+    evtcp->accept_data = data;
+    evtcp->accept_datanotify = datanotify;
+    evtcp->iocp_accept = r_mem_new0_n (REvTCPAccept, R_EV_TCP_IOCP_NACCEPT);
+    evtcp->iocp_naccept = R_EV_TCP_IOCP_NACCEPT;
+    R_LOG_DEBUG ("loop %p evio "R_EV_IO_FORMAT,
+        evtcp->evio.loop, R_EV_IO_ARGS (evtcp));
+    for (i = 0; i < evtcp->iocp_naccept; i++)
+      r_ev_tcp_iocp_post_accept (evtcp, &evtcp->iocp_accept[i]);
+  }
+
+  return ret;
+#else
   if ((ret = r_socket_listen_full (evtcp->socket, backlog)) >= R_SOCKET_OK) {
     evtcp->connection = connection;
     R_LOG_DEBUG ("loop %p evio "R_EV_IO_FORMAT,
@@ -297,6 +849,7 @@ r_ev_tcp_listen (REvTCP * evtcp, ruint8 backlog,
   }
 
   return ret;
+#endif
 }
 
 #define R_EV_TCP_BUFFER_SIZE        4096
@@ -507,6 +1060,27 @@ r_ev_tcp_recv_start (REvTCP * evtcp,
   if (R_UNLIKELY (recv == NULL)) return FALSE;
   if (R_UNLIKELY (evtcp->recv_iocb_ctx != NULL)) return FALSE;
 
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+  if (R_UNLIKELY (evtcp->iocp_recv_active)) return FALSE;
+  if (alloc == NULL)
+    alloc = r_ev_tcp_buffer_alloc_default;
+  if (evtcp->recv_datanotify != NULL)
+    evtcp->recv_datanotify (evtcp->recv_data);
+  evtcp->alloc = alloc;
+  evtcp->recv = recv;
+  evtcp->recv_data = data;
+  evtcp->recv_datanotify = datanotify;
+  evtcp->iocp_recv_active = TRUE;
+  if (R_UNLIKELY (!r_ev_tcp_iocp_post_recv (evtcp))) {
+    evtcp->iocp_recv_active = FALSE;
+    evtcp->recv = NULL;
+    evtcp->recv_datanotify = NULL;
+    if (datanotify != NULL)
+      datanotify (data);
+    return FALSE;
+  }
+  return TRUE;
+#else
   if ((evtcp->recv_iocb_ctx = r_ev_io_start (&evtcp->evio, R_EV_IO_READABLE,
       r_ev_tcp_iocb, data, datanotify))) {
     if (alloc == NULL)
@@ -519,6 +1093,7 @@ r_ev_tcp_recv_start (REvTCP * evtcp,
   }
 
   return FALSE;
+#endif
 }
 
 rboolean
@@ -530,6 +1105,30 @@ r_ev_tcp_task_recv_start (REvTCP * evtcp, ruint taskgroup,
   if (R_UNLIKELY (evtcp->recv_iocb_ctx != NULL)) return FALSE;
   if (R_UNLIKELY (!r_ev_io_validate_taskgroup (&evtcp->evio, taskgroup))) return FALSE;
 
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+  if (R_UNLIKELY (evtcp->iocp_recv_active)) return FALSE;
+  if (alloc == NULL)
+    alloc = r_ev_tcp_buffer_alloc_default;
+  if (evtcp->recv_datanotify != NULL)
+    evtcp->recv_datanotify (evtcp->recv_data);
+  evtcp->taskgroup = taskgroup;
+  evtcp->alloc = alloc;
+  evtcp->recv = recv;
+  evtcp->recv_data = data;
+  evtcp->recv_datanotify = datanotify;
+  evtcp->iocp_recv_active = TRUE;
+  evtcp->iocp_recv_task = TRUE;
+  if (R_UNLIKELY (!r_ev_tcp_iocp_post_recv (evtcp))) {
+    evtcp->iocp_recv_active = FALSE;
+    evtcp->iocp_recv_task = FALSE;
+    evtcp->recv = NULL;
+    evtcp->recv_datanotify = NULL;
+    if (datanotify != NULL)
+      datanotify (data);
+    return FALSE;
+  }
+  return TRUE;
+#else
   if ((evtcp->recv_iocb_ctx = r_ev_io_start (&evtcp->evio, R_EV_IO_READABLE,
       r_ev_tcp_task_iocb, data, datanotify))) {
     if (alloc == NULL)
@@ -545,11 +1144,28 @@ r_ev_tcp_task_recv_start (REvTCP * evtcp, ruint taskgroup,
   }
 
   return FALSE;
+#endif
 }
 
 rboolean
 r_ev_tcp_recv_stop (REvTCP * evtcp)
 {
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+  /* Stop re-arming and cancel any in-flight WSARecv; its completion arrives
+   * with ERROR_OPERATION_ABORTED and simply drops the op ref. The recv user
+   * data is released when the evtcp is freed (any pending completion may still
+   * reference it). */
+  evtcp->iocp_recv_active = FALSE;
+  if (evtcp->iocp_recv_buf != NULL)
+    CancelIoEx ((HANDLE) evtcp->socket->handle, &evtcp->iocp_recv.overlapped);
+  /* Task delivery: wait for the last dispatched buffer to be processed. */
+  if (evtcp->recv_task != NULL) {
+    r_task_wait (evtcp->recv_task);
+    r_task_unref (evtcp->recv_task);
+    evtcp->recv_task = NULL;
+  }
+  return TRUE;
+#else
   rboolean ret;
 
   ret = r_ev_io_stop (&evtcp->evio, evtcp->recv_iocb_ctx);
@@ -561,6 +1177,7 @@ r_ev_tcp_recv_stop (REvTCP * evtcp)
   }
 
   return ret;
+#endif
 }
 
 void
@@ -593,8 +1210,13 @@ r_ev_tcp_send (REvTCP * evtcp, RBuffer * buf,
     R_LOG_TRACE ("loop %p evio "R_EV_IO_FORMAT" buf %p",
         evtcp->evio.loop, R_EV_IO_ARGS (evtcp), buf);
     if (r_queue_size (&evtcp->qsend) == 1) {
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+      /* Post the head; subsequent sends drain in order as each completes. */
+      ret = r_ev_tcp_iocp_post_send (evtcp);
+#else
       ret = r_ev_loop_add_callback (evtcp->evio.loop, TRUE,
           r_ev_tcp_send_iocb_ev, r_ev_tcp_ref (evtcp), r_ev_tcp_unref);
+#endif
     }
   }
 

--- a/rlib/ev/revudp.c
+++ b/rlib/ev/revudp.c
@@ -17,6 +17,8 @@
  */
 
 #include "config.h"
+/* Before rsocket-private.h / rev-private.h: orders <winsock2.h> first. */
+#include "rev-iocp-private.h"
 #include "rev-private.h"
 #include "../net/rsocket-private.h"
 #include "../net/rnet-private.h"
@@ -69,12 +71,39 @@ struct REvUDP {
   RTask * recv_task;
 
   RQueue qsend;
+
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+  /* Completion (proactor) backend: overlapped WSARecvFrom per datagram (the
+   * socket is associated with the port lazily, on recv_start). See revtcp.c for
+   * the ref/lifetime model. */
+  REvIOCPOp iocp_recv;
+  RBuffer * iocp_recv_buf;     /* buffer backing the in-flight WSARecvFrom */
+  RMemMapInfo iocp_recv_map;
+  struct sockaddr_storage iocp_recv_addr;  /* sender address WSARecvFrom fills */
+  INT iocp_recv_addrlen;
+  DWORD iocp_recv_flags;
+  rboolean iocp_recv_active;
+  rboolean iocp_recv_task;
+  RDestroyNotify recv_datanotify;
+
+  REvIOCPOp iocp_send;
+  RMemMapInfo iocp_send_map;
+  rboolean iocp_send_active;
+  rboolean iocp_associated;    /* bound to the completion port (on recv_start) */
+#endif
 };
 
 static void
 r_ev_udp_free (REvUDP * evudp)
 {
   r_queue_clear (&evudp->qsend, r_ev_udp_send_ctx_free);
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+  /* No op can be in flight (each holds a ref); release leftovers. */
+  if (evudp->iocp_recv_buf != NULL)
+    r_buffer_unref (evudp->iocp_recv_buf);
+  if (evudp->recv_datanotify != NULL)
+    evudp->recv_datanotify (evudp->recv_data);
+#endif
   if (evudp->error_datanotify != NULL)
     evudp->error_datanotify (evudp->error_data);
   r_socket_unref (evudp->socket);
@@ -95,6 +124,10 @@ r_ev_udp_new (RSocketFamily family, REvLoop * loop)
       ret->family = family;
       ret->socket = socket;
       r_queue_init (&ret->qsend);
+      /* The socket is associated with the completion port lazily, on
+       * recv_start: a send-only socket stays unassociated so it can send
+       * synchronously (an overlapped send from a port-associated socket does
+       * not deliver a loopback datagram to a peer on the same port). */
     } else {
       r_socket_unref (socket);
     }
@@ -261,6 +294,254 @@ r_ev_udp_task_iocb (rpointer data, REvIOEvents events, REvIO * evio)
   if (events & R_EV_IO_ERROR) r_ev_udp_error_iocb ((REvUDP *)evio);
 }
 
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+/* ---- IOCP (completion / proactor) UDP path -------------------------------
+ * Overlapped WSARecvFrom per datagram (re-armed on completion) and WSASendTo
+ * for the ordered send queue; the ref / lifetime model is the same as
+ * revtcp.c. */
+#define R_EV_UDP_IOCP_SOCKET(evudp)  R_IO_HANDLE_TO_SOCKET_HANDLE ((evudp)->socket->handle)
+
+static rboolean r_ev_udp_iocp_post_recv (REvUDP * evudp);
+static rboolean r_ev_udp_iocp_post_send (REvUDP * evudp);
+
+static RSocketStatus
+r_ev_udp_iocp_status (DWORD err)
+{
+  switch (err) {
+    case 0:                       return R_SOCKET_OK;
+    case ERROR_OPERATION_ABORTED: return R_SOCKET_CANCELED;
+    case WSAECONNRESET:           return R_SOCKET_CONN_RESET;
+    case WSAECONNREFUSED:         return R_SOCKET_CONN_REFUSED;
+    case WSAEMSGSIZE:             return R_SOCKET_MSG_SIZE;
+    default:                      return R_SOCKET_ERROR;
+  }
+}
+
+static DWORD
+r_ev_udp_iocp_result (REvUDP * evudp, REvIOCPOp * op, rsize * bytes)
+{
+  DWORD transferred = 0, flags = 0;
+
+  if (WSAGetOverlappedResult (R_EV_UDP_IOCP_SOCKET (evudp), &op->overlapped,
+        &transferred, FALSE, &flags)) {
+    if (bytes != NULL)
+      *bytes = (rsize) transferred;
+    return 0;
+  }
+  if (bytes != NULL)
+    *bytes = 0;
+  return (DWORD) WSAGetLastError ();
+}
+
+/* Task-group delivery: hand the datagram to the task group; the buffer, sender
+ * address and the evudp ref are released when the task context is freed. */
+typedef struct {
+  REvUDP * evudp;
+  RBuffer * buf;
+  RSocketAddress * addr;
+} REvUDPRecvTaskCtx;
+
+static void
+r_ev_udp_iocp_recv_task (rpointer data, RTaskQueue * queue, RTask * task)
+{
+  REvUDPRecvTaskCtx * ctx = data;
+  (void) queue;
+  (void) task;
+  ctx->evudp->recv (ctx->evudp->recv_data, ctx->buf, ctx->addr, ctx->evudp);
+}
+
+static void
+r_ev_udp_iocp_recv_task_free (rpointer data)
+{
+  REvUDPRecvTaskCtx * ctx = data;
+  r_socket_address_unref (ctx->addr);
+  r_buffer_unref (ctx->buf);
+  r_ev_udp_unref (ctx->evudp);
+  r_free (ctx);
+}
+
+static void
+r_ev_udp_iocp_recv_deliver (REvUDP * evudp, RBuffer * buf, RSocketAddress * addr)
+{
+  REvUDPRecvTaskCtx * ctx;
+  RTask * task;
+
+  if (!evudp->iocp_recv_task) {
+    evudp->recv (evudp->recv_data, buf, addr, evudp);
+    r_socket_address_unref (addr);
+    r_buffer_unref (buf);
+    return;
+  }
+
+  if ((ctx = r_mem_new (REvUDPRecvTaskCtx)) != NULL) {
+    ctx->evudp = r_ev_udp_ref (evudp);
+    ctx->buf = buf;     /* ownership transferred to the task */
+    ctx->addr = addr;
+    if ((task = r_ev_loop_add_task_full (evudp->evio.loop, evudp->taskgroup,
+            r_ev_udp_iocp_recv_task, NULL, ctx, r_ev_udp_iocp_recv_task_free,
+            evudp->recv_task, NULL)) != NULL) {
+      if (evudp->recv_task != NULL)
+        r_task_unref (evudp->recv_task);
+      evudp->recv_task = task;
+      return;
+    }
+    /* Queuing failed: undo without releasing buf/addr (delivered inline). */
+    r_ev_udp_unref (ctx->evudp);
+    r_free (ctx);
+  }
+
+  evudp->recv (evudp->recv_data, buf, addr, evudp);
+  r_socket_address_unref (addr);
+  r_buffer_unref (buf);
+}
+
+static void
+r_ev_udp_iocp_recv_complete (REvIOCPOp * op, REvLoop * loop, rsize bytes)
+{
+  REvUDP * evudp = op->data;
+  RBuffer * buf = evudp->iocp_recv_buf;
+  rsize got = 0;
+  DWORD err;
+  (void) loop;
+  (void) bytes;
+
+  err = r_ev_udp_iocp_result (evudp, op, &got);
+  r_buffer_unmap (buf, &evudp->iocp_recv_map);
+  evudp->iocp_recv_buf = NULL;
+
+  if (err == 0) {
+    /* A zero-length datagram is valid: deliver an empty buffer, not EOS. */
+    RSocketAddress * addr = r_socket_address_new_from_native (
+        &evudp->iocp_recv_addr, (rsize) evudp->iocp_recv_addrlen);
+    r_buffer_set_size (buf, got);
+    r_ev_udp_iocp_recv_deliver (evudp, buf, addr);
+    if (evudp->iocp_recv_active && !r_socket_is_closed (evudp->socket))
+      r_ev_udp_iocp_post_recv (evudp);
+  } else {
+    r_buffer_unref (buf);
+    if (err != ERROR_OPERATION_ABORTED) {
+      R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT" recv err %lu",
+          evudp->evio.loop, R_EV_IO_ARGS (evudp), (unsigned long) err);
+      if (evudp->error != NULL)
+        evudp->error (evudp->error_data, evudp, r_ev_udp_iocp_status (err));
+      /* The socket stays usable on a datagram error; keep receiving. */
+      if (evudp->iocp_recv_active && !r_socket_is_closed (evudp->socket))
+        r_ev_udp_iocp_post_recv (evudp);
+    }
+  }
+
+  r_ev_udp_unref (evudp);
+}
+
+static rboolean
+r_ev_udp_iocp_post_recv (REvUDP * evudp)
+{
+  RBuffer * buf;
+  int res;
+
+  if (!evudp->iocp_associated) {
+    if (!r_ev_loop_iocp_associate (evudp->evio.loop, (RIOHandle) evudp->socket->handle))
+      return FALSE;
+    evudp->iocp_associated = TRUE;
+  }
+
+  if ((buf = evudp->alloc (evudp->recv_data, evudp)) == NULL)
+    return FALSE;
+  if (!r_buffer_map (buf, &evudp->iocp_recv_map, R_MEM_MAP_WRITE)) {
+    r_buffer_unref (buf);
+    return FALSE;
+  }
+  evudp->iocp_recv_buf = buf;
+  evudp->iocp_recv_flags = 0;
+  evudp->iocp_recv_addrlen = (INT) sizeof (evudp->iocp_recv_addr);
+
+  r_ev_iocp_op_init (&evudp->iocp_recv, r_ev_udp_iocp_recv_complete, evudp);
+  evudp->iocp_recv.wbuf.buf = (CHAR *) evudp->iocp_recv_map.data;
+  evudp->iocp_recv.wbuf.len = (ULONG) evudp->iocp_recv_map.size;
+  r_ev_udp_ref (evudp);
+  r_ev_loop_iocp_submit (evudp->evio.loop);
+  res = WSARecvFrom (R_EV_UDP_IOCP_SOCKET (evudp), &evudp->iocp_recv.wbuf, 1, NULL,
+      &evudp->iocp_recv_flags, (struct sockaddr *) &evudp->iocp_recv_addr,
+      &evudp->iocp_recv_addrlen, &evudp->iocp_recv.overlapped, NULL);
+  if (res == 0 || WSAGetLastError () == WSA_IO_PENDING)
+    return TRUE;
+
+  R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT" WSARecvFrom failed %d",
+      evudp->evio.loop, R_EV_IO_ARGS (evudp), WSAGetLastError ());
+  r_ev_loop_iocp_unsubmit (evudp->evio.loop);
+  r_buffer_unmap (buf, &evudp->iocp_recv_map);
+  r_buffer_unref (buf);
+  evudp->iocp_recv_buf = NULL;
+  r_ev_udp_unref (evudp);
+  return FALSE;
+}
+
+static void
+r_ev_udp_iocp_send_complete (REvIOCPOp * op, REvLoop * loop, rsize bytes)
+{
+  REvUDP * evudp = op->data;
+  REvUDPSendCtx * ctx = r_queue_peek (&evudp->qsend);
+  DWORD err;
+  (void) loop;
+  (void) bytes;
+
+  evudp->iocp_send_active = FALSE;
+  err = r_ev_udp_iocp_result (evudp, op, NULL);
+  if (ctx != NULL) {
+    r_buffer_unmap (ctx->buf, &evudp->iocp_send_map);
+    r_queue_pop (&evudp->qsend);
+    if (err == 0) {
+      if (ctx->done != NULL)
+        ctx->done (ctx->data, ctx->buf, ctx->addr, evudp);
+    } else if (err != ERROR_OPERATION_ABORTED) {
+      R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT" send err %lu",
+          evudp->evio.loop, R_EV_IO_ARGS (evudp), (unsigned long) err);
+      if (evudp->error != NULL)
+        evudp->error (evudp->error_data, evudp, r_ev_udp_iocp_status (err));
+    }
+    r_ev_udp_send_ctx_clear (ctx);
+    r_free (ctx);
+    if (!r_socket_is_closed (evudp->socket))
+      r_ev_udp_iocp_post_send (evudp);
+  }
+
+  r_ev_udp_unref (evudp);
+}
+
+static rboolean
+r_ev_udp_iocp_post_send (REvUDP * evudp)
+{
+  REvUDPSendCtx * ctx;
+  int res;
+
+  if ((ctx = r_queue_peek (&evudp->qsend)) == NULL)
+    return TRUE;
+  if (!r_buffer_map (ctx->buf, &evudp->iocp_send_map, R_MEM_MAP_READ))
+    return FALSE;
+
+  r_ev_iocp_op_init (&evudp->iocp_send, r_ev_udp_iocp_send_complete, evudp);
+  evudp->iocp_send.wbuf.buf = (CHAR *) evudp->iocp_send_map.data;
+  evudp->iocp_send.wbuf.len = (ULONG) evudp->iocp_send_map.size;
+  evudp->iocp_send_active = TRUE;
+  r_ev_udp_ref (evudp);
+  r_ev_loop_iocp_submit (evudp->evio.loop);
+  res = WSASendTo (R_EV_UDP_IOCP_SOCKET (evudp), &evudp->iocp_send.wbuf, 1, NULL, 0,
+      (const struct sockaddr *) &ctx->addr->addr, (int) ctx->addr->addrlen,
+      &evudp->iocp_send.overlapped, NULL);
+  if (res == 0 || WSAGetLastError () == WSA_IO_PENDING)
+    return TRUE;
+
+  R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT" WSASendTo failed %d",
+      evudp->evio.loop, R_EV_IO_ARGS (evudp), WSAGetLastError ());
+  r_ev_loop_iocp_unsubmit (evudp->evio.loop);
+  r_buffer_unmap (ctx->buf, &evudp->iocp_send_map);
+  evudp->iocp_send_active = FALSE;
+  r_ev_udp_unref (evudp);
+  return FALSE;
+}
+
+#endif /* R_OS_WIN32 && !R_EV_USE_RPOLL */
+
 rboolean
 r_ev_udp_recv_start (REvUDP * evudp,
     REvUDPBufferAllocFunc alloc, REvUDPBufferFunc recv,
@@ -269,6 +550,27 @@ r_ev_udp_recv_start (REvUDP * evudp,
   if (R_UNLIKELY (recv == NULL)) return FALSE;
   if (R_UNLIKELY (evudp->recv_iocb_ctx != NULL)) return FALSE;
 
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+  if (R_UNLIKELY (evudp->iocp_recv_active)) return FALSE;
+  if (alloc == NULL)
+    alloc = r_ev_udp_buffer_alloc_default;
+  if (evudp->recv_datanotify != NULL)
+    evudp->recv_datanotify (evudp->recv_data);
+  evudp->alloc = alloc;
+  evudp->recv = recv;
+  evudp->recv_data = data;
+  evudp->recv_datanotify = datanotify;
+  evudp->iocp_recv_active = TRUE;
+  if (R_UNLIKELY (!r_ev_udp_iocp_post_recv (evudp))) {
+    evudp->iocp_recv_active = FALSE;
+    evudp->recv = NULL;
+    evudp->recv_datanotify = NULL;
+    if (datanotify != NULL)
+      datanotify (data);
+    return FALSE;
+  }
+  return TRUE;
+#else
   if ((evudp->recv_iocb_ctx = r_ev_io_start (&evudp->evio, R_EV_IO_READABLE,
       r_ev_udp_iocb, data, datanotify))) {
     if (alloc == NULL)
@@ -281,6 +583,7 @@ r_ev_udp_recv_start (REvUDP * evudp,
   }
 
   return FALSE;
+#endif
 }
 
 rboolean
@@ -292,6 +595,30 @@ r_ev_udp_task_recv_start (REvUDP * evudp, ruint taskgroup,
   if (R_UNLIKELY (evudp->recv_iocb_ctx != NULL)) return FALSE;
   if (R_UNLIKELY (!r_ev_io_validate_taskgroup (&evudp->evio, taskgroup))) return FALSE;
 
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+  if (R_UNLIKELY (evudp->iocp_recv_active)) return FALSE;
+  if (alloc == NULL)
+    alloc = r_ev_udp_buffer_alloc_default;
+  if (evudp->recv_datanotify != NULL)
+    evudp->recv_datanotify (evudp->recv_data);
+  evudp->taskgroup = taskgroup;
+  evudp->alloc = alloc;
+  evudp->recv = recv;
+  evudp->recv_data = data;
+  evudp->recv_datanotify = datanotify;
+  evudp->iocp_recv_active = TRUE;
+  evudp->iocp_recv_task = TRUE;
+  if (R_UNLIKELY (!r_ev_udp_iocp_post_recv (evudp))) {
+    evudp->iocp_recv_active = FALSE;
+    evudp->iocp_recv_task = FALSE;
+    evudp->recv = NULL;
+    evudp->recv_datanotify = NULL;
+    if (datanotify != NULL)
+      datanotify (data);
+    return FALSE;
+  }
+  return TRUE;
+#else
   if ((evudp->recv_iocb_ctx = r_ev_io_start (&evudp->evio, R_EV_IO_READABLE,
       r_ev_udp_task_iocb, data, datanotify))) {
     if (alloc == NULL)
@@ -307,11 +634,25 @@ r_ev_udp_task_recv_start (REvUDP * evudp, ruint taskgroup,
   }
 
   return FALSE;
+#endif
 }
 
 rboolean
 r_ev_udp_recv_stop (REvUDP * evudp)
 {
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+  /* Stop re-arming and cancel any in-flight WSARecvFrom; its completion
+   * arrives with ERROR_OPERATION_ABORTED and drops the op ref. */
+  evudp->iocp_recv_active = FALSE;
+  if (evudp->iocp_recv_buf != NULL)
+    CancelIoEx ((HANDLE) evudp->socket->handle, &evudp->iocp_recv.overlapped);
+  if (evudp->recv_task != NULL) {
+    r_task_wait (evudp->recv_task);
+    r_task_unref (evudp->recv_task);
+    evudp->recv_task = NULL;
+  }
+  return TRUE;
+#else
   rboolean ret;
 
   ret = r_ev_io_stop (&evudp->evio, evudp->recv_iocb_ctx);
@@ -322,6 +663,7 @@ r_ev_udp_recv_stop (REvUDP * evudp)
   }
 
   return ret;
+#endif
 }
 
 void
@@ -354,8 +696,20 @@ r_ev_udp_send (REvUDP * evudp, RBuffer * buf,
     r_queue_push (&evudp->qsend, ctx);
 
     if (r_queue_size (&evudp->qsend) == 1) {
+#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
+      /* An unassociated (send-only) socket sends synchronously -- it delivers a
+       * loopback datagram like a plain socket. A receiving socket is associated
+       * with the port, where a synchronous send is not usable, so it sends with
+       * an overlapped op. */
+      if (evudp->iocp_associated)
+        ret = r_ev_udp_iocp_post_send (evudp);
+      else
+        ret = r_ev_loop_add_callback (evudp->evio.loop, TRUE,
+            r_ev_udp_send_iocb_ev, r_ev_udp_ref (evudp), r_ev_udp_unref);
+#else
       ret = r_ev_loop_add_callback (evudp->evio.loop, TRUE,
           r_ev_udp_send_iocb_ev, r_ev_udp_ref (evudp), r_ev_udp_unref);
+#endif
     }
   }
 

--- a/rlib/net/riosocket.c
+++ b/rlib/net/riosocket.c
@@ -58,6 +58,11 @@ r_socket_err_to_socket_status (int err)
 #endif
     case EOPNOTSUPP:
       return R_SOCKET_INVALID_OP;
+#ifdef WSAEMSGSIZE
+    case WSAEMSGSIZE:
+#endif
+    case EMSGSIZE:
+      return R_SOCKET_MSG_SIZE;
     case 0:
       return R_SOCKET_OK;
     default:
@@ -76,7 +81,11 @@ r_io_socket (RSocketFamily family, RSocketType type, RSocketProtocol proto)
 {
   RIOHandle ret;
 #ifdef HAVE_WINSOCK2
-  ret = R_SOCKET_HANDLE_TO_IO_HANDLE (WSASocketW (family, type, proto, NULL, 0, 0));
+  /* WSA_FLAG_OVERLAPPED keeps the socket usable with the default IOCP backend's
+   * overlapped ops; it is harmless for the rpoll (WSAEventSelect) opt-out path,
+   * which issues non-overlapped WSARecv/WSASend regardless. */
+  ret = R_SOCKET_HANDLE_TO_IO_HANDLE (WSASocketW (family, type, proto, NULL, 0,
+        WSA_FLAG_OVERLAPPED));
 #elif defined (HAVE_POSIX_SOCKETS)
 #ifdef SOCK_CLOEXEC
   if ((ret = socket (family, type | SOCK_CLOEXEC, proto)) != R_IO_HANDLE_INVALID ||

--- a/rlib/rconfig.h.meson
+++ b/rlib/rconfig.h.meson
@@ -48,6 +48,11 @@
 #mesondefine R_OS_DARWIN
 #mesondefine R_OS_RTEMS
 
+/* Event-loop backend: defined when built with -Drpoll to force the readiness/
+ * poll backend (overriding epoll/kqueue/IOCP); otherwise the backend is chosen
+ * automatically (IOCP on Windows). */
+#mesondefine R_EV_USE_RPOLL
+
 
 typedef signed char             rint8;
 typedef signed @RINT16_TYPE@    rint16;

--- a/test/revtcp.c
+++ b/test/revtcp.c
@@ -30,8 +30,17 @@ data_received (rpointer data, RBuffer * buf, REvTCP * evtcp)
   *b = r_buffer_ref (buf);
 }
 
-/* The recv-error tests below are gated off on Windows (see their guard). */
-#ifndef R_OS_WIN32
+static void
+data_counted (rpointer data, RBuffer * buf, REvTCP * evtcp)
+{
+  (void) evtcp;
+  if (buf != NULL)
+    *((rsize *)data) += r_buffer_get_size (buf);
+}
+
+/* The recv-error tests below need a backend that observes an abortive peer
+ * close; the rpoll readiness backend cannot, so they are gated off there. */
+#ifndef R_EV_USE_RPOLL
 static void
 error_received (rpointer data, REvTCP * evtcp, RSocketStatus error)
 {
@@ -110,14 +119,68 @@ RTEST (revtcp, listen_connect_accept_send_recv, RTEST_FAST | RTEST_SYSTEM)
 }
 RTEST_END;
 
+/* Queue several sends back-to-back and confirm every byte arrives, exercising
+ * the ordered send queue (a completion backend posts one send at a time and
+ * re-arms the next from each completion) and repeated receive completions. */
+RTEST (revtcp, queued_send_recv, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RSocketAddress * addr;
+  REvTCP * server, * servcli = NULL, * client;
+  rboolean conn = FALSE;
+  rsize received = 0;
+  ruint8 chunk[1024];
+  ruint i;
+  const ruint nsends = 8;
+
+  r_memset (chunk, 0x5a, sizeof (chunk));
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((client = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpptr ((server = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x6364)), !=, NULL);
+  r_assert_cmpint (r_ev_tcp_bind (server, addr, TRUE), ==, R_SOCKET_OK);
+  r_assert_cmpint (r_ev_tcp_listen (server, 10, new_connection_ready, &servcli, NULL), ==, R_SOCKET_OK);
+  r_assert_cmpint (r_ev_tcp_connect (client, addr, client_connected, &conn, NULL), ==, R_SOCKET_WOULD_BLOCK);
+  r_socket_address_unref (addr);
+
+  while (servcli == NULL)
+    r_assert_cmpuint (r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE), >, 0);
+  r_assert (conn);
+  r_assert (r_ev_tcp_close (server, NULL, NULL, NULL));
+  r_ev_tcp_unref (server);
+
+  r_assert (r_ev_tcp_recv_start (servcli, NULL, data_counted, &received, NULL));
+  for (i = 0; i < nsends; i++)
+    r_assert (r_ev_tcp_send_dup (client, chunk, sizeof (chunk), NULL, NULL, NULL));
+
+  while (received < (rsize)nsends * sizeof (chunk))
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_NOWAIT);
+  r_assert_cmpuint (received, ==, (rsize)nsends * sizeof (chunk));
+  r_assert (r_ev_tcp_recv_stop (servcli));
+
+  r_assert (r_ev_tcp_close (client, NULL, NULL, NULL));
+  r_assert (r_ev_tcp_close (servcli, NULL, NULL, NULL));
+  r_assert_cmpuint (r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP), ==, 0);
+
+  r_ev_tcp_unref (client);
+  r_ev_tcp_unref (servcli);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
 /* These two exercise an abortive close (peer RST) and assert the client
- * observes it promptly. On Windows that is not reliably possible in a readiness
- * reactor: an abortive RST on a loopback socket is, intermittently, not
- * surfaced by the stack (recv keeps returning WOULDBLOCK) until a multi-second
- * TCP abort timeout -- documented Winsock behaviour that libuv et al. avoid
- * only via IOCP (pre-posted overlapped reads). Gated off on Windows until the
- * Win32 backend gains an IOCP read path. */
-#ifndef R_OS_WIN32
+ * observes it promptly. The rpoll readiness backend cannot do this reliably:
+ * an abortive RST on a loopback socket is, intermittently, not surfaced by the
+ * Windows stack (recv keeps returning WOULDBLOCK) until a multi-second TCP
+ * abort timeout. A completion backend (IOCP, the Windows default) pre-posts
+ * overlapped reads and observes it promptly, so these run everywhere except a
+ * forced rpoll build. */
+#ifndef R_EV_USE_RPOLL
 RTEST (revtcp, recv_error_handler, RTEST_FAST | RTEST_SYSTEM)
 {
   REvLoop * loop;
@@ -228,7 +291,7 @@ RTEST (revtcp, recv_error_no_handler, RTEST_FAST | RTEST_SYSTEM)
   r_ev_loop_unref (loop);
 }
 RTEST_END;
-#endif /* !R_OS_WIN32 */
+#endif /* !R_EV_USE_RPOLL */
 
 /* The error handler's data is released (via datanotify) both when it is
  * replaced and when the socket is freed. */

--- a/test/revudp.c
+++ b/test/revudp.c
@@ -3,6 +3,9 @@
 typedef struct {
   RList * buffers;
   RList * addrs;
+  rauint recvd;       /* bumped last in buffer_recv; lets a waiter on another
+                         thread observe delivery and synchronize-with the
+                         writes above (task_recv delivers off the loop thread). */
 } REvUDPTestRecvCtx;
 
 static void
@@ -14,6 +17,7 @@ buffer_recv (rpointer user, RBuffer * buf, RSocketAddress * addr, REvUDP * evudp
 
   ctx->buffers = r_list_append (ctx->buffers, r_buffer_ref (buf));
   ctx->addrs = r_list_append (ctx->addrs, r_socket_address_ref (addr));
+  r_atomic_uint_fetch_add (&ctx->recvd, 1);
 }
 
 static void
@@ -67,6 +71,10 @@ RTEST (revudp, bind_recv, RTEST_FAST | RTEST_SYSTEM)
 
   r_socket_address_unref (addr);
   r_ev_udp_unref (evudp);
+  /* Drain the cancelled in-flight recv: a completion backend reaps its aborted
+   * completion here, releasing the socket so it cannot linger bound to the port
+   * into the next test. No-op on a readiness backend (nothing outstanding). */
+  r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
   r_ev_loop_unref (loop);
 }
 RTEST_END;
@@ -98,7 +106,13 @@ RTEST (revudp, send_recv, RTEST_FAST | RTEST_SYSTEM)
   r_assert_cmpptr ((udp2 = r_ev_udp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
   r_assert (r_ev_udp_send_take (udp2, r_memdup (sendbuf, 512), 512, addr, buffer_send_done, &sentbuf, NULL));
 
-  r_assert_cmpuint (r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE), ==, 1);
+  /* Drive the loop until the datagram round-trips. A completion (proactor)
+   * backend delivers the send and recv completions independently with no
+   * ordering guarantee, so this may span more than one iteration. NOWAIT (don't
+   * block): a blocking run-once after the datagram is delivered would wait
+   * forever for a second one. */
+  while (sentbuf == NULL || ctx.buffers == NULL)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_NOWAIT);
 
   r_assert (r_ev_udp_recv_stop (udp1));
 
@@ -116,6 +130,55 @@ RTEST (revudp, send_recv, RTEST_FAST | RTEST_SYSTEM)
   r_socket_address_unref (addr);
   r_ev_udp_unref (udp1);
   r_ev_udp_unref (udp2);
+  /* Drain the cancelled in-flight recv (see bind_recv). */
+  r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+/* Several datagrams in flight at once, exercising the re-armed receive (a
+ * completion backend posts the next WSARecvFrom from each completion). */
+RTEST (revudp, send_recv_multi, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RSocketAddress * addr;
+  REvUDP * udp1, * udp2;
+  REvUDPTestRecvCtx ctx;
+  ruint8 sendbuf[512];
+  ruint i;
+  const ruint ndatagrams = 4;
+
+  r_memclear (&ctx, sizeof (REvUDPTestRecvCtx));
+  r_memset (sendbuf, 0x37, 512);
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((udp1 = r_ev_udp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x4242)), !=, NULL);
+  r_assert (r_ev_udp_bind (udp1, addr, TRUE));
+  r_assert (r_ev_udp_recv_start (udp1, NULL, buffer_recv, &ctx, NULL));
+
+  r_assert_cmpptr ((udp2 = r_ev_udp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  for (i = 0; i < ndatagrams; i++)
+    r_assert (r_ev_udp_send_take (udp2, r_memdup (sendbuf, 512), 512, addr, NULL, NULL, NULL));
+
+  while (r_atomic_uint_load (&ctx.recvd) < ndatagrams)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_NOWAIT);
+
+  r_assert (r_ev_udp_recv_stop (udp1));
+  r_assert_cmpuint (r_list_len (ctx.buffers), ==, ndatagrams);
+  r_assert_cmpuint (r_list_len (ctx.addrs), ==, ndatagrams);
+  r_assert_cmpbufmem (ctx.buffers->data, 0, -1, ==, sendbuf, 512);
+
+  r_list_destroy_full (ctx.buffers, r_buffer_unref);
+  r_list_destroy_full (ctx.addrs, r_socket_address_unref);
+  r_socket_address_unref (addr);
+  r_ev_udp_unref (udp1);
+  r_ev_udp_unref (udp2);
+  r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
   r_ev_loop_unref (loop);
 }
 RTEST_END;
@@ -149,7 +212,12 @@ RTEST (revudp, task_recv, RTEST_FAST | RTEST_SYSTEM)
   r_assert_cmpptr ((udp2 = r_ev_udp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
   r_assert (r_ev_udp_send_take (udp2, r_memdup (sendbuf, 512), 512, addr, buffer_send_done, &sentbuf, NULL));
 
-  r_assert_cmpuint (r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE), ==, 1);
+  /* Drive the loop until the datagram round-trips (see the note in send_recv).
+   * The recv is delivered on a task-group thread, so wait on the atomic counter
+   * rather than reading the lists directly -- it both signals delivery and
+   * synchronizes-with the worker's writes to ctx. */
+  while (sentbuf == NULL || r_atomic_uint_load (&ctx.recvd) == 0)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_NOWAIT);
 
   r_assert (r_ev_udp_recv_stop (udp1));
 
@@ -167,6 +235,8 @@ RTEST (revudp, task_recv, RTEST_FAST | RTEST_SYSTEM)
   r_socket_address_unref (addr);
   r_ev_udp_unref (udp1);
   r_ev_udp_unref (udp2);
+  /* Drain the cancelled in-flight recv (see bind_recv). */
+  r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
   r_task_queue_unref (tq);
   r_ev_loop_unref (loop);
 }
@@ -204,7 +274,7 @@ RTEST (revudp, send_error_handler, RTEST_FAST | RTEST_SYSTEM)
   for (i = 0; i < 8 && err == R_SOCKET_OK; i++)
     r_ev_loop_run (loop, R_EV_LOOP_RUN_NOWAIT);
 
-  r_assert_cmpint (err, !=, R_SOCKET_OK);
+  r_assert_cmpint (err, ==, R_SOCKET_MSG_SIZE);
 
   r_socket_address_unref (addr);
   r_ev_udp_unref (evudp);


### PR DESCRIPTION
Give Windows a completion-port (proactor) event-loop backend under the existing `REvLoop` abstraction, alongside the epoll (Linux) and kqueue (macOS/BSD) reactors, and make it the **Windows default**. Part of #34.

## IOCP by default; rpoll as the opt-out

On Windows the loop now uses IOCP unflagged. `-Drpoll=enabled` forces the `WSAEventSelect`/poll readiness backend instead — on any platform, overriding epoll/kqueue/IOCP — for parity testing and as an escape hatch. The selected backend is recorded as `R_EV_USE_RPOLL` in the public `rconfig.h`.

This is the motivation for the backend: a readiness reactor cannot reliably observe an abortive peer close (RST) on Windows, which previously forced gating the `revtcp/recv_error_*` tests off Windows. A completion backend pre-posts overlapped reads and observes it promptly, so those tests now run on the Windows default and gate off only under `-Drpoll`.

## What it covers

- **Loop core:** the completion port, a `GetQueuedCompletionStatusEx` wait that blocks once then drains every remaining ready completion (so a loopback recv that completes just after its triggering send is not held for the next iteration), recovers each in-flight op from its `OVERLAPPED`, a `PostQueuedCompletionStatus` wakeup, and in-flight-op accounting that keeps the loop alive while ops are outstanding.
- **Sockets:** created with `WSA_FLAG_OVERLAPPED` and associated with the loop's port.
- **TCP (`r_evtcp`):** `ConnectEx`, a pool of pre-posted `AcceptEx`, `WSARecv`, and an ordered `WSASend` queue, with `CancelIoEx`-on-close lifetime — each in-flight op holds one ref on its `REvTCP`, released when its completion is dispatched.
- **UDP (`r_evudp`):** a re-armed overlapped `WSARecvFrom` delivers each datagram; the send queue drains synchronously. The socket is associated with the port lazily on `recv_start`, so a send-only socket stays unassociated and a loopback datagram reaches a peer on the same port.
- **Resolve (`r_evresolve`):** already runs on the task queue, so it works with no backend-specific code.

The readiness backends are untouched; all completion-path code is gated on the IOCP backend being active (Windows, no `-Drpoll`).

## CI

The default `Windows / MSVC` job now exercises IOCP (and the recv-error tests it enables); a second `Windows rpoll` job builds with `-Drpoll` so the readiness opt-out keeps building and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)