### PR TITLE
ev: harden the IOCP send queue, buffer limits, and task-recv docs

### DIFF
--- a/include/rlib/ev/revtcp.h
+++ b/include/rlib/ev/revtcp.h
@@ -45,9 +45,12 @@
  * connect, listen / accept, and callback-based send / receive.
  *
  * Receiving uses a caller-supplied allocator callback (to provide the
- * @ref RBuffer each read fills) plus a receive callback; the
- * @c _task_recv_start variant hands received buffers to a task group
- * for off-thread processing. All callbacks fire on the loop thread.
+ * @ref RBuffer each read fills) plus a receive callback. Callbacks fire on
+ * the loop thread, except the @c _task_recv_start variant, which hands
+ * received buffers to a task group for off-thread processing. Because
+ * @ref r_ev_tcp_recv_stop / @ref r_ev_tcp_close drain the last such task
+ * from the loop thread, a task-group receive callback must not block on work
+ * that needs the loop thread.
  *
  * @{
  */

--- a/include/rlib/ev/revudp.h
+++ b/include/rlib/ev/revudp.h
@@ -45,8 +45,11 @@
  *
  * As with @ref r_evtcp, receiving pairs an allocator callback (to
  * supply each datagram's @ref RBuffer) with a receive callback that
- * also reports the sender address; the @c _task_recv_start variant
- * dispatches to a task group. Callbacks fire on the loop thread.
+ * also reports the sender address. Callbacks fire on the loop thread,
+ * except the @c _task_recv_start variant, which dispatches to a task
+ * group. Because @ref r_ev_udp_recv_stop drains the last such task from
+ * the loop thread, a task-group receive callback must not block on work
+ * that needs the loop thread.
  *
  * @{
  */

--- a/rlib/ev/rev-iocp-private.h
+++ b/rlib/ev/rev-iocp-private.h
@@ -73,6 +73,14 @@ r_ev_iocp_op_init (REvIOCPOp * op, REvIOCPOpFunc cb, rpointer data)
   op->data = data;
 }
 
+/* Cap a buffer length to what one WSABUF (32-bit ULONG) can describe. */
+static inline ULONG
+r_ev_iocp_wsabuf_len (rsize size)
+{
+  const rsize max = (rsize) 0xFFFFFFFFu;
+  return (ULONG) (size > max ? max : size);
+}
+
 /* Associate @handle (a socket) with the loop's completion port; completions
  * for overlapped ops on it are then delivered to r_ev_loop_io_wait. */
 R_API_HIDDEN rboolean r_ev_loop_iocp_associate (REvLoop * loop, RIOHandle handle);

--- a/rlib/ev/revtcp.c
+++ b/rlib/ev/revtcp.c
@@ -406,7 +406,7 @@ r_ev_tcp_iocp_post_recv (REvTCP * evtcp)
 
   r_ev_iocp_op_init (&evtcp->iocp_recv, r_ev_tcp_iocp_recv_complete, evtcp);
   evtcp->iocp_recv.wbuf.buf = (CHAR *) evtcp->iocp_recv_map.data;
-  evtcp->iocp_recv.wbuf.len = (ULONG) evtcp->iocp_recv_map.size;
+  evtcp->iocp_recv.wbuf.len = r_ev_iocp_wsabuf_len (evtcp->iocp_recv_map.size);
   r_ev_tcp_ref (evtcp);
   r_ev_loop_iocp_submit (evtcp->evio.loop);
   res = WSARecv (R_EV_TCP_IOCP_SOCKET (evtcp), &evtcp->iocp_recv.wbuf, 1, NULL, &flags,
@@ -444,8 +444,11 @@ r_ev_tcp_iocp_send_complete (REvIOCPOp * op, REvLoop * loop, rsize bytes)
       ctx->done (ctx->data, ctx->buf, evtcp);
     r_ev_tcp_send_ctx_clear (ctx);
     r_free (ctx);
-    if (!r_socket_is_closed (evtcp->socket))
-      r_ev_tcp_iocp_post_send (evtcp);
+    /* Re-arm the next queued send; if it cannot be posted (e.g. the buffer
+     * cannot be mapped), report rather than silently stalling the queue. */
+    if (!r_socket_is_closed (evtcp->socket) &&
+        !r_ev_tcp_iocp_post_send (evtcp) && evtcp->error != NULL)
+      evtcp->error (evtcp->error_data, evtcp, R_SOCKET_ERROR);
   } else if (err != 0 && err != ERROR_OPERATION_ABORTED) {
     R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT" send err %lu",
         evtcp->evio.loop, R_EV_IO_ARGS (evtcp), (unsigned long) err);
@@ -466,6 +469,11 @@ r_ev_tcp_iocp_post_send (REvTCP * evtcp)
     return TRUE;
   if (!r_buffer_map (ctx->buf, &evtcp->iocp_send_map, R_MEM_MAP_READ))
     return FALSE;
+  if (evtcp->iocp_send_map.size > (rsize) 0xFFFFFFFFu) {
+    /* Too large for a single WSABUF; the stream send queue does not chunk. */
+    r_buffer_unmap (ctx->buf, &evtcp->iocp_send_map);
+    return FALSE;
+  }
 
   r_ev_iocp_op_init (&evtcp->iocp_send, r_ev_tcp_iocp_send_complete, evtcp);
   evtcp->iocp_send.wbuf.buf = (CHAR *) evtcp->iocp_send_map.data;

--- a/rlib/ev/revudp.c
+++ b/rlib/ev/revudp.c
@@ -457,7 +457,7 @@ r_ev_udp_iocp_post_recv (REvUDP * evudp)
 
   r_ev_iocp_op_init (&evudp->iocp_recv, r_ev_udp_iocp_recv_complete, evudp);
   evudp->iocp_recv.wbuf.buf = (CHAR *) evudp->iocp_recv_map.data;
-  evudp->iocp_recv.wbuf.len = (ULONG) evudp->iocp_recv_map.size;
+  evudp->iocp_recv.wbuf.len = r_ev_iocp_wsabuf_len (evudp->iocp_recv_map.size);
   r_ev_udp_ref (evudp);
   r_ev_loop_iocp_submit (evudp->evio.loop);
   res = WSARecvFrom (R_EV_UDP_IOCP_SOCKET (evudp), &evudp->iocp_recv.wbuf, 1, NULL,
@@ -513,31 +513,59 @@ r_ev_udp_iocp_post_send (REvUDP * evudp)
 {
   REvUDPSendCtx * ctx;
   int res;
+  DWORD err;
 
-  if ((ctx = r_queue_peek (&evudp->qsend)) == NULL)
-    return TRUE;
-  if (!r_buffer_map (ctx->buf, &evudp->iocp_send_map, R_MEM_MAP_READ))
-    return FALSE;
+  /* Drive the send queue. A datagram that cannot be sent is dropped (after
+   * reporting) rather than left to stall the queue -- datagrams are
+   * independent, unlike a TCP stream. */
+  while ((ctx = r_queue_peek (&evudp->qsend)) != NULL) {
+    if (!r_buffer_map (ctx->buf, &evudp->iocp_send_map, R_MEM_MAP_READ)) {
+      if (evudp->error != NULL)
+        evudp->error (evudp->error_data, evudp, R_SOCKET_OOM);
+      r_queue_pop (&evudp->qsend);
+      r_ev_udp_send_ctx_clear (ctx);
+      r_free (ctx);
+      continue;
+    }
+    if (evudp->iocp_send_map.size > (rsize) 0xFFFFFFFFu) {
+      r_buffer_unmap (ctx->buf, &evudp->iocp_send_map);
+      if (evudp->error != NULL)
+        evudp->error (evudp->error_data, evudp, R_SOCKET_MSG_SIZE);
+      r_queue_pop (&evudp->qsend);
+      r_ev_udp_send_ctx_clear (ctx);
+      r_free (ctx);
+      continue;
+    }
 
-  r_ev_iocp_op_init (&evudp->iocp_send, r_ev_udp_iocp_send_complete, evudp);
-  evudp->iocp_send.wbuf.buf = (CHAR *) evudp->iocp_send_map.data;
-  evudp->iocp_send.wbuf.len = (ULONG) evudp->iocp_send_map.size;
-  evudp->iocp_send_active = TRUE;
-  r_ev_udp_ref (evudp);
-  r_ev_loop_iocp_submit (evudp->evio.loop);
-  res = WSASendTo (R_EV_UDP_IOCP_SOCKET (evudp), &evudp->iocp_send.wbuf, 1, NULL, 0,
-      (const struct sockaddr *) &ctx->addr->addr, (int) ctx->addr->addrlen,
-      &evudp->iocp_send.overlapped, NULL);
-  if (res == 0 || WSAGetLastError () == WSA_IO_PENDING)
-    return TRUE;
+    r_ev_iocp_op_init (&evudp->iocp_send, r_ev_udp_iocp_send_complete, evudp);
+    evudp->iocp_send.wbuf.buf = (CHAR *) evudp->iocp_send_map.data;
+    evudp->iocp_send.wbuf.len = (ULONG) evudp->iocp_send_map.size;
+    evudp->iocp_send_active = TRUE;
+    r_ev_udp_ref (evudp);
+    r_ev_loop_iocp_submit (evudp->evio.loop);
+    res = WSASendTo (R_EV_UDP_IOCP_SOCKET (evudp), &evudp->iocp_send.wbuf, 1, NULL, 0,
+        (const struct sockaddr *) &ctx->addr->addr, (int) ctx->addr->addrlen,
+        &evudp->iocp_send.overlapped, NULL);
+    if (res == 0 || WSAGetLastError () == WSA_IO_PENDING)
+      return TRUE;
 
-  R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT" WSASendTo failed %d",
-      evudp->evio.loop, R_EV_IO_ARGS (evudp), WSAGetLastError ());
-  r_ev_loop_iocp_unsubmit (evudp->evio.loop);
-  r_buffer_unmap (ctx->buf, &evudp->iocp_send_map);
-  evudp->iocp_send_active = FALSE;
-  r_ev_udp_unref (evudp);
-  return FALSE;
+    /* Synchronous failure: capture the error before logging (a log call can
+     * clobber the thread last-error), report, drop, and keep draining. */
+    err = (DWORD) WSAGetLastError ();
+    R_LOG_ERROR ("loop %p evio "R_EV_IO_FORMAT" WSASendTo failed %lu",
+        evudp->evio.loop, R_EV_IO_ARGS (evudp), (unsigned long) err);
+    r_ev_loop_iocp_unsubmit (evudp->evio.loop);
+    r_buffer_unmap (ctx->buf, &evudp->iocp_send_map);
+    evudp->iocp_send_active = FALSE;
+    if (evudp->error != NULL)
+      evudp->error (evudp->error_data, evudp, r_ev_udp_iocp_status (err));
+    r_queue_pop (&evudp->qsend);
+    r_ev_udp_send_ctx_clear (ctx);
+    r_free (ctx);
+    r_ev_udp_unref (evudp);
+  }
+
+  return TRUE;
 }
 
 #endif /* R_OS_WIN32 && !R_EV_USE_RPOLL */


### PR DESCRIPTION
Follow-ups from the #277 IOCP-backend review.

## Send queue no longer stalls on a per-op failure
A datagram or stream chunk that cannot be posted — its buffer cannot be mapped, or it exceeds the single-`WSABUF` length limit — previously left the send queue silently stuck. Now:
- **UDP** reports the failure via the error callback, drops the datagram, and keeps draining (datagrams are independent).
- **TCP** reports and leaves the queue for `close` to free (the stream is broken), matching the readiness backend.

## Overlapped buffer lengths capped
Receive `WSABUF.len` is capped to the 32-bit limit (receiving into a larger buffer just fills the first 4 GiB), and an oversized single send buffer is rejected rather than truncated via `ULONG` wraparound.

## Task-recv loop-thread constraint documented
`recv_stop` / `close` drain the last task-delivered buffer from the loop thread, so a task-group receive callback must not block on work that needs the loop thread. Documented on the revtcp / revudp receive docs (and corrected the prior "all callbacks fire on the loop thread", which the task variant does not).

Verified locally on the readiness backends (epoll default + forced `-Drpoll`); the IOCP-only paths are validated by the Windows CI jobs.

Closes #278
Closes #279
Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)