### PR TITLE
poll: handle Win32 wait-failure and grow-OOM edge results (#224)

### DIFF
--- a/rlib/rpoll.c
+++ b/rlib/rpoll.c
@@ -17,9 +17,11 @@
  */
 
 #include "config.h"
+#include "rlib-private.h"
 #include <rlib/rpoll.h>
 
 #include <rlib/rassert.h>
+#include <rlib/rlog.h>
 #include <rlib/rmem.h>
 #include <rlib/rtime.h>
 
@@ -37,6 +39,8 @@
 #include <windows.h>
 #endif
 #include <errno.h>
+
+#define R_LOG_CAT_DEFAULT &rlib_logcat
 
 #define R_POLL_SET_MIN_INCREASE     64
 
@@ -144,7 +148,9 @@ r_poll (RPoll * handles, ruint count, RClockTime timeout)
    * whose arming fell back to a direct wait, closed before it was pruned --
    * fails the whole call; the probe below skips it and the loop prunes it next
    * turn instead of stalling). */
-  (void) res;
+  if (R_UNLIKELY (res == WAIT_FAILED))
+    R_LOG_WARNING ("WaitForMultipleObjectsEx failed (%lu); probing handles",
+        (unsigned long) GetLastError ());
 
   for (i = 0; i < count; i++) {
     if (handles[i].wsaevent != NULL) {
@@ -363,14 +369,18 @@ r_poll_set_add (RPollSet * ps, RIOHandle handle, rushort events, rpointer user)
   if (R_UNLIKELY (handle == R_IO_HANDLE_INVALID)) return -1;
 
   if (ps->count >= ps->alloc) {
+    ruint nalloc = ps->alloc;
+    RPoll * nhandles;
     do {
-      ps->alloc += R_POLL_SET_MIN_INCREASE;
-    } while (ps->count >= ps->alloc);
-    ps->handles = r_realloc (ps->handles, sizeof (RPoll) * ps->alloc);
-    if (R_UNLIKELY (ps->handles == NULL)) {
-      /* FIXME: Error out properly */
+      nalloc += R_POLL_SET_MIN_INCREASE;
+    } while (ps->count >= nalloc);
+    /* realloc into a temporary so a failure leaves the set intact (the old
+     * buffer is still valid) rather than nulling ps->handles. */
+    if (R_UNLIKELY ((nhandles = r_realloc (ps->handles,
+              sizeof (RPoll) * nalloc)) == NULL))
       return -1;
-    }
+    ps->handles = nhandles;
+    ps->alloc = nalloc;
   }
 
   idx = ps->count++;

--- a/test/rpoll.c
+++ b/test/rpoll.c
@@ -177,3 +177,49 @@ RTEST (rpollset, add_grows_past_initial_alloc, RTEST_FAST)
 }
 RTEST_END;
 
+static rpointer
+r_test_pollset_fail_realloc (rpointer ptr, rsize size)
+{
+  (void) ptr;
+  (void) size;
+  return NULL;
+}
+
+RTEST (rpollset, add_grow_oom_keeps_set_intact, RTEST_FAST)
+{
+  RPollSet ps;
+  RMemVTable saved, hook;
+  ruint i, fill;
+
+  r_poll_set_init (&ps, 0);
+
+  /* Fill exactly to capacity so the next add must grow the buffer. */
+  fill = ps.alloc;
+  for (i = 1; i <= fill; i++)
+    r_assert_cmpint (r_poll_set_add (&ps, (RIOHandle)(rsize)i, 0,
+          (rpointer)(rsize)i), >=, 0);
+  r_assert_cmpuint (ps.count, ==, fill);
+  r_assert_cmpuint (ps.alloc, ==, fill);
+
+  /* Fail the grow's realloc: the add must report failure without
+   * corrupting the set -- count/alloc unchanged and the buffer not nulled. */
+  r_mem_get_vtable (&saved);
+  hook = saved;
+  hook.realloc = r_test_pollset_fail_realloc;
+  r_mem_set_vtable (&hook);
+
+  r_assert_cmpint (r_poll_set_add (&ps, (RIOHandle)(rsize)(fill + 1), 0,
+        (rpointer)(rsize)(fill + 1)), <, 0);
+
+  r_mem_set_vtable (&saved);
+
+  r_assert_cmpuint (ps.count, ==, fill);
+  r_assert_cmpuint (ps.alloc, ==, fill);
+  for (i = 1; i <= fill; i++)
+    r_assert_cmpptr (r_poll_set_get_user (&ps, (RIOHandle)(rsize)i),
+        ==, (rpointer)(rsize)i);
+
+  r_poll_set_clear (&ps);
+}
+RTEST_END;
+


### PR DESCRIPTION
Resolves the remaining items of #224. Most of the issue's original concerns — the `WAIT_IO_COMPLETION` and `WAIT_ABANDONED_0` asserts, and the `res`→`errno` mapping — were already addressed by the earlier Win32 readiness rework (`90e88c4`), which made `WaitForMultipleObjectsEx`'s result non-load-bearing (the loop probes each handle individually). Two loose ends remained:

## `WAIT_FAILED` was discarded silently

The result was thrown away with a bare `(void) res;`. The per-handle probe still recovers, but a genuine failure left no trace. Now it logs (capturing `GetLastError()` before anything clobbers it) via the shared internal logger, then still proceeds to probe — observable degradation rather than a silent one.

## `r_poll_set_add` corrupted the set on grow-OOM

The grow path assigned `r_realloc`'s result straight back into `ps->handles` and bumped `ps->alloc` *before* the call, so an OOM nulled the buffer while leaving `alloc` inflated — a corrupted poll set (the old `FIXME: Error out properly`). It now reallocs into a temporary and commits `handles`/`alloc` only on success; on failure the set is untouched and `-1` is returned.

## Tests

Adds `rpollset/add_grow_oom_keeps_set_intact`, which injects a failing `realloc` through the mem vtable and asserts the set is intact after the failed grow. It fails on the pre-fix code (`alloc` inflated, buffer nulled) and passes with the fix.

Linux epoll + rpoll suites green; the mingw cross job (werror) is the build that actually compiles the Win32 diagnostic path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)