### PR TITLE
file: symlink create/remove APIs + win32 detection (#214)

### DIFF
--- a/config.h.meson
+++ b/config.h.meson
@@ -47,6 +47,7 @@
 #mesondefine HAVE_STAT
 #mesondefine HAVE_FSTAT
 #mesondefine HAVE_LSTAT
+#mesondefine HAVE_SYMLINK
 #mesondefine HAVE_MKDIR
 #mesondefine HAVE_SYSCTLBYNAME
 #mesondefine HAVE_KQUEUE

--- a/include/rlib/file/rfs.h
+++ b/include/rlib/file/rfs.h
@@ -123,6 +123,25 @@ R_API rboolean r_fs_mkdir (const rchar * path, int mode);
 R_API rboolean r_fs_mkdir_full (const rchar * path, int mode);
 
 /**
+ * @brief Create a symbolic link at @p linkpath pointing to @p target.
+ * @param target   Path the link refers to (need not exist; may be relative).
+ * @param linkpath Path of the link to create.
+ * @return @c TRUE on success. On Windows this needs the
+ *         @c SeCreateSymbolicLinkPrivilege or developer mode and returns
+ *         @c FALSE when neither is available; the directory-vs-file link kind
+ *         is chosen from @p target's current type.
+ */
+R_API rboolean r_fs_symlink (const rchar * target, const rchar * linkpath);
+
+/**
+ * @brief Remove the symbolic link at @p path.
+ * @return @c TRUE on success. Returns @c FALSE if @p path is not a symbolic
+ *         link, so a regular file or directory is never deleted by mistake.
+ *         The link's target is left untouched.
+ */
+R_API rboolean r_fs_remove_symlink (const rchar * path);
+
+/**
  * @brief @c TRUE if @p path is absolute.
  *
  * Absolute means a leading separator (Unix) or a drive-letter +

--- a/meson.build
+++ b/meson.build
@@ -328,6 +328,7 @@ check_funcs = [
   [ 'lseek', 'unistd.h' ],
   [ 'lseek64', 'unistd.h' ],
   [ 'access', 'unistd.h' ],
+  [ 'symlink', 'unistd.h' ],
   [ 'pipe', 'unistd.h' ],
   [ 'pipe2', 'unistd.h' ],
   # sys/stat

--- a/rlib/file/rfs.c
+++ b/rlib/file/rfs.c
@@ -37,6 +37,10 @@
 #if defined (HAVE_WINDOWS_H)
 #include <rlib/charset/runicode.h>
 #include <windows.h>
+/* Older Windows SDKs predate the unprivileged-symlink flag (value from winnt.h). */
+#ifndef SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE
+#define SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE 0x2
+#endif
 #endif
 #include <errno.h>
 
@@ -293,6 +297,28 @@ r_fs_get_file_attributes (const rchar * path)
   return ret;
 }
 
+/* TRUE if upath is a symlink: a reparse point tagged IO_REPARSE_TAG_SYMLINK.
+ * The tag (dwReserved0) and the link's own attributes come from the find data,
+ * which -- unlike GetFileAttributes -- describes the link, not its target. When
+ * it is a symlink and is_dir is non-NULL, *is_dir reports a directory symlink. */
+static rboolean
+r_fs_win32_is_symlink (const runichar2 * upath, rboolean * is_dir)
+{
+  WIN32_FIND_DATAW fd;
+  HANDLE h;
+  rboolean ret = FALSE;
+
+  if ((h = FindFirstFileW (upath, &fd)) != INVALID_HANDLE_VALUE) {
+    ret = (fd.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0 &&
+        fd.dwReserved0 == IO_REPARSE_TAG_SYMLINK;
+    if (ret && is_dir != NULL)
+      *is_dir = (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+    FindClose (h);
+  }
+
+  return ret;
+}
+
 static DWORD
 r_fs_get_file_access (const rchar * path, DWORD req)
 {
@@ -412,9 +438,14 @@ rboolean
 r_fs_test_is_symlink (const rchar * path)
 {
 #if defined (R_OS_WIN32)
-  /* FIXME: Symlinks on windows? */
-  (void) path;
-  return FALSE;
+  runichar2 * upath;
+  rboolean ret = FALSE;
+
+  if ((upath = r_utf8_to_utf16_dup (path, -1, NULL, NULL, NULL)) != NULL) {
+    ret = r_fs_win32_is_symlink (upath, NULL);
+    r_free (upath);
+  }
+  return ret;
 #elif defined (HAVE_LSTAT)
   struct stat s;
   return (lstat (path, &s) == 0) && S_ISLNK (s.st_mode);
@@ -507,6 +538,75 @@ r_fs_mkdir_full (const rchar * path, int mode)
   r_free (parent);
 
   return ret ? r_fs_mkdir (path, mode) : FALSE;
+}
+
+rboolean
+r_fs_symlink (const rchar * target, const rchar * linkpath)
+{
+  if (R_UNLIKELY (target == NULL || linkpath == NULL))
+    return FALSE;
+
+#if defined (R_OS_WIN32)
+  {
+    runichar2 * wtarget, * wlink;
+    rboolean ret = FALSE;
+    /* Windows distinguishes file and directory symlinks at creation time. */
+    DWORD flags = r_fs_test_is_directory (target) ?
+        SYMBOLIC_LINK_FLAG_DIRECTORY : 0;
+
+    wtarget = r_utf8_to_utf16_dup (target, -1, NULL, NULL, NULL);
+    wlink = r_utf8_to_utf16_dup (linkpath, -1, NULL, NULL, NULL);
+    if (wtarget != NULL && wlink != NULL) {
+      /* Prefer the unprivileged (developer-mode) path; older Windows rejects
+       * the flag with ERROR_INVALID_PARAMETER, so retry without it. */
+      ret = CreateSymbolicLinkW (wlink, wtarget,
+          flags | SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE) != 0;
+      if (!ret && GetLastError () == ERROR_INVALID_PARAMETER)
+        ret = CreateSymbolicLinkW (wlink, wtarget, flags) != 0;
+    }
+
+    r_free (wtarget);
+    r_free (wlink);
+    return ret;
+  }
+#elif defined (HAVE_SYMLINK)
+  return symlink (target, linkpath) == 0;
+#else
+  return FALSE;
+#endif
+}
+
+rboolean
+r_fs_remove_symlink (const rchar * path)
+{
+  if (R_UNLIKELY (path == NULL))
+    return FALSE;
+
+#if defined (R_OS_WIN32)
+  {
+    runichar2 * upath;
+    rboolean is_dir = FALSE, ret = FALSE;
+
+    if ((upath = r_utf8_to_utf16_dup (path, -1, NULL, NULL, NULL)) != NULL) {
+      /* Remove only an actual symlink, and with the matching call: a directory
+       * symlink needs RemoveDirectoryW, a file symlink DeleteFileW. */
+      if (r_fs_win32_is_symlink (upath, &is_dir))
+        ret = is_dir ? (RemoveDirectoryW (upath) != 0) :
+            (DeleteFileW (upath) != 0);
+      r_free (upath);
+    }
+    return ret;
+  }
+#elif defined (HAVE_LSTAT)
+  /* unlink removes the link itself; the guard keeps us from deleting a real
+   * file or directory if the caller hands us a non-symlink path. */
+  if (!r_fs_test_is_symlink (path))
+    return FALSE;
+  return unlink (path) == 0;
+#else
+  (void) path;
+  return FALSE;
+#endif
 }
 
 rboolean

--- a/test/rfs.c
+++ b/test/rfs.c
@@ -146,3 +146,24 @@ RTEST (rfs, mkdir, RTEST_FAST | RTEST_SYSTEM)
 }
 RTEST_END;
 
+RTEST (rfs, is_symlink, RTEST_FAST | RTEST_SYSTEM)
+{
+  rchar * link;
+  r_assert_cmpptr ((link = r_fs_path_new_tmpfile ()), !=, NULL);
+
+  /* A path that does not exist is not a symlink. */
+  r_assert (!r_fs_test_is_symlink (link));
+
+  /* Positive check: detect a symlink we create. r_fs_symlink returns FALSE
+   * when the platform forbids it (e.g. unprivileged Windows), so the check is
+   * skipped, not failed, there. */
+  if (r_fs_symlink ("rlib-symlink-target", link)) {
+    r_assert (r_fs_test_is_symlink (link));
+    r_assert (r_fs_remove_symlink (link));
+    r_assert (!r_fs_test_is_symlink (link));
+  }
+
+  r_free (link);
+}
+RTEST_END;
+


### PR DESCRIPTION
Implements win32 symlink detection (#214) and fills the surrounding gap: `r_fs` could neither create nor remove symlinks, and `r_fs_test_is_symlink` returned `FALSE` unconditionally on win32 (detection only existed on the `HAVE_LSTAT` path).

## New API

- **`r_fs_symlink(target, linkpath)`** — create a symbolic link. POSIX `symlink()` (gated on a new `HAVE_SYMLINK` probe); win32 `CreateSymbolicLinkW`, choosing the directory-vs-file link kind from the target's type and preferring the unprivileged (developer-mode) flag with a fallback for older Windows that rejects it.
- **`r_fs_remove_symlink(path)`** — remove a symbolic link, and *only* a symlink, so a real file or directory is never deleted by mistake. POSIX `unlink` behind an is-symlink guard; win32 `DeleteFileW`/`RemoveDirectoryW` chosen by the link's kind.

## Detection

`r_fs_test_is_symlink` on win32: a symlink is a reparse point tagged `IO_REPARSE_TAG_SYMLINK`. That tag lives in the find data's `dwReserved0` (not exposed by `GetFileAttributes`) and is only meaningful when `FILE_ATTRIBUTE_REPARSE_POINT` is set. The `FindFirstFileW` probe is factored into one helper shared by the detect and remove paths.

## Test

`rfs/is_symlink` drives the link entirely through the `r_fs` API (no platform-specific test code): a non-existent path is not a symlink, and a created symlink is detected and then removed. The positive half is skipped — not failed — when the platform forbids symlink creation (unprivileged Windows); on POSIX it runs end-to-end (create → detect → remove).

Linux epoll + rpoll suites green; mingw cross (werror) builds clean. The win32 runtime is exercised by the MSVC CI jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)