### PR TITLE
net/http: add an HTTP client (RHttpClient) (#261)

### DIFF
--- a/include/rlib/net/rhttpclient.h
+++ b/include/rlib/net/rhttpclient.h
@@ -1,0 +1,141 @@
+/* RLIB - Convenience library for useful things
+ * Copyright (C) 2017 Haakon Sporsheim <haakon.sporsheim@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ * See the COPYING file at the root of the source repository.
+ */
+#ifndef __R_NET_HTTP_CLIENT_H__
+#define __R_NET_HTTP_CLIENT_H__
+
+#if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
+#error "#include <rlib.h> only please."
+#endif
+
+/**
+ * @file rlib/net/rhttpclient.h
+ * @brief Event-loop-driven HTTP client: connect, send a request and
+ * deliver the parsed response.
+ */
+
+#include <rlib/rtypes.h>
+#include <rlib/rref.h>
+
+#include <rlib/net/proto/rhttp.h>
+#include <rlib/ev/revloop.h>
+
+#include <rlib/net/rsocketaddress.h>
+
+/**
+ * @defgroup r_http_client HTTP client
+ * @ingroup r_net
+ *
+ * @brief Refcounted HTTP client that runs on an @c REvLoop: it connects
+ * to a peer, sends an @ref RHttpRequest and delivers the parsed
+ * @ref RHttpResponse.
+ *
+ * @ref r_http_client_send is asynchronous: the result arrives via a
+ * callback on the loop thread. For blocking use without managing a loop,
+ * see @ref RHttpClientSync, which owns a private loop and an @ref RHttpClient.
+ *
+ * Scope is plaintext HTTP/1.1 to an explicit @ref RSocketAddress, with
+ * response bodies framed by @c Content-Length or by connection close.
+ * Built on the @ref r_http_proto wire codec and @ref r_evtcp.
+ *
+ * @{
+ */
+
+R_BEGIN_DECLS
+
+/** @brief Opaque, refcounted HTTP client. */
+typedef struct RHttpClient RHttpClient;
+
+/** @brief Outcome of an HTTP request attempt. */
+typedef enum {
+  R_HTTP_CLIENT_OK = 0,         /**< Response received and parsed. */
+  R_HTTP_CLIENT_CONNECT_FAILED, /**< Could not connect to the peer. */
+  R_HTTP_CLIENT_SEND_FAILED,    /**< Could not send the request. */
+  R_HTTP_CLIENT_RECV_FAILED,    /**< Transport error, or closed before the body completed. */
+  R_HTTP_CLIENT_PARSE_FAILED,   /**< Malformed response, or unsupported framing (chunked / tunnel). */
+} RHttpClientResult;
+
+/**
+ * @brief Deliver the outcome of @ref r_http_client_send.
+ * @param data   User pointer passed to @ref r_http_client_send.
+ * @param res    The parsed response, non-@c NULL only when @p result is
+ *               @ref R_HTTP_CLIENT_OK. Borrowed; @ref r_http_response_ref to keep it.
+ * @param result The request outcome.
+ * @param client The client that issued the request.
+ */
+typedef void (*RHttpClientResponseFunc) (rpointer data,
+    RHttpResponse * res, RHttpClientResult result, RHttpClient * client);
+
+/** @brief Create an HTTP client on event loop @p loop (@c NULL for the default loop). */
+R_API RHttpClient * r_http_client_new (REvLoop * loop);
+/** @brief Take a reference (alias for @ref r_ref_ref). */
+#define r_http_client_ref   r_ref_ref
+/** @brief Drop a reference (alias for @ref r_ref_unref). */
+#define r_http_client_unref r_ref_unref
+
+/**
+ * @brief Asynchronously send @p req to @p addr and deliver the response.
+ * @param client The client.
+ * @param req    The request to send.
+ * @param addr   Peer address to connect to.
+ * @param cb     Invoked with the outcome on the loop thread.
+ * @param data   User pointer passed to @p cb.
+ * @param notify Destroy notify for @p data.
+ * @return @c TRUE if the request was started, in which case @p cb delivers the
+ *         outcome and @p notify is called once the request finishes. On
+ *         @c FALSE the request could not be started and the caller retains
+ *         ownership of @p data (@p notify is not called).
+ */
+R_API rboolean r_http_client_send (RHttpClient * client, RHttpRequest * req,
+    const RSocketAddress * addr,
+    RHttpClientResponseFunc cb, rpointer data, RDestroyNotify notify);
+
+
+/**
+ * @brief Opaque, refcounted blocking HTTP client.
+ *
+ * A self-contained synchronous client: it owns a private @ref REvLoop and an
+ * @ref RHttpClient, and @ref r_http_client_sync_request runs that loop until
+ * the response is in. Callers never deal with an event loop. For overlapping
+ * or non-blocking requests, use @ref RHttpClient directly on your own loop.
+ */
+typedef struct RHttpClientSync RHttpClientSync;
+
+/** @brief Create a blocking HTTP client (owns a private event loop). */
+R_API RHttpClientSync * r_http_client_sync_new (void);
+/** @brief Take a reference (alias for @ref r_ref_ref). */
+#define r_http_client_sync_ref   r_ref_ref
+/** @brief Drop a reference (alias for @ref r_ref_unref). */
+#define r_http_client_sync_unref r_ref_unref
+
+/**
+ * @brief Send @p req to @p addr and block until the response arrives.
+ * @param client The blocking client.
+ * @param req    The request to send.
+ * @param addr   Peer address to connect to.
+ * @param result If non-@c NULL, receives the request outcome.
+ * @return The response (caller @ref r_http_response_unref's it) on success,
+ *         or @c NULL on failure.
+ */
+R_API RHttpResponse * r_http_client_sync_request (RHttpClientSync * client,
+    RHttpRequest * req, const RSocketAddress * addr, RHttpClientResult * result);
+
+R_END_DECLS
+
+/** @} */
+
+#endif /* __R_NET_HTTP_CLIENT_H__ */

--- a/include/rlib/rnet.h
+++ b/include/rlib/rnet.h
@@ -47,6 +47,7 @@
 #include <rlib/net/rsocket.h>
 #include <rlib/net/rsocketaddress.h>
 #include <rlib/net/rresolve.h>
+#include <rlib/net/rhttpclient.h>
 #include <rlib/net/rhttpserver.h>
 #include <rlib/net/rsrtp.h>
 #include <rlib/net/rtlsclient.h>

--- a/rlib/meson.build
+++ b/rlib/meson.build
@@ -104,6 +104,7 @@ rlib_sources = [
   'net/proto/rsdp.c',
   'net/proto/rstun.c',
   'net/proto/rtls.c',
+  'net/rhttpclient.c',
   'net/rhttpserver.c',
   'net/rnet.c',
   'net/rresolve.c',

--- a/rlib/net/rhttpclient.c
+++ b/rlib/net/rhttpclient.c
@@ -1,0 +1,415 @@
+/* RLIB - Convenience library for useful things
+ * Copyright (C) 2017 Haakon Sporsheim <haakon.sporsheim@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ * See the COPYING file at the root of the source repository.
+ */
+
+#include "config.h"
+#include "../rlib-private.h"
+#include <rlib/net/rhttpclient.h>
+
+#include <rlib/ev/revtcp.h>
+
+#include <rlib/data/rptrarray.h>
+
+#include <rlib/rmem.h>
+
+/* Cap unparsed response-header bytes so a peer that never sends the
+ * terminating CRLFCRLF can't grow the input buffer without bound. */
+#define R_HTTP_CLIENT_MAX_HEADER  (64 * 1024)
+
+struct RHttpClient {
+  RRef ref;
+
+  REvLoop * loop;
+  RPtrArray * reqs;
+};
+
+typedef struct {
+  RRef ref;
+  RHttpClient * client;
+  REvTCP * evtcp;
+
+  RHttpRequest * req;
+  RBuffer * inbuf;
+
+  RHttpResponse * res;
+  rssize bodysize;
+  RHttpBodyParseType bodytype;
+
+  RHttpClientResponseFunc cb;
+  rpointer data;
+  RDestroyNotify notify;
+
+  rboolean finished;
+} RHttpClientReqCtx;
+
+#define R_LOG_CAT_DEFAULT &httpclicat
+R_LOG_CATEGORY_DEFINE_STATIC (httpclicat, "httpclient", "RLib HTTP client",
+    R_CLR_FG_WHITE | R_CLR_BG_BLUE | R_CLR_FMT_BOLD);
+
+void
+r_http_client_init (void)
+{
+  r_log_category_register (&httpclicat);
+}
+
+
+static void
+r_http_client_req_ctx_free (RHttpClientReqCtx * ctx)
+{
+  if (ctx->notify != NULL)
+    ctx->notify (ctx->data);
+  if (ctx->res != NULL)
+    r_http_response_unref (ctx->res);
+  if (ctx->inbuf != NULL)
+    r_buffer_unref (ctx->inbuf);
+  if (ctx->req != NULL)
+    r_http_request_unref (ctx->req);
+  if (ctx->evtcp != NULL)
+    r_ev_tcp_unref (ctx->evtcp);
+
+  r_http_client_unref (ctx->client);
+  r_free (ctx);
+}
+
+static void
+r_http_client_req_do_close (rpointer data, REvLoop * loop)
+{
+  RHttpClientReqCtx * ctx = data;
+  (void) loop;
+
+  r_ev_tcp_close (ctx->evtcp, NULL, NULL, NULL);
+}
+
+/* Deliver the outcome once and tear the request down. Idempotent: a
+ * receive-path error and a later error event can both land here.
+ *
+ * @defer is TRUE when called from inside a connect/recv callback, where
+ * closing the socket synchronously would free the io-watch entry the loop is
+ * still iterating; the close is then deferred to a loop callback. It is FALSE
+ * only for a synchronous connect failure raised from r_http_client_send (not a
+ * loop callback, and the failed socket has no active watch), where deferring
+ * would strand the close if the caller never runs the loop again. */
+static void
+r_http_client_req_teardown (RHttpClientReqCtx * ctx, RHttpClientResult result,
+    rboolean defer)
+{
+  if (ctx->finished)
+    return;
+  ctx->finished = TRUE;
+
+  /* Keep ctx alive across the callback and the array removal below (the
+   * array holds the only other reference). */
+  r_ref_ref (ctx);
+
+  R_LOG_TRACE ("%p: request %p finished (%d)", ctx->client, ctx, (int) result);
+  if (ctx->cb != NULL)
+    ctx->cb (ctx->data, result == R_HTTP_CLIENT_OK ? ctx->res : NULL,
+        result, ctx->client);
+
+  if (defer)
+    r_ev_loop_add_callback (ctx->client->loop, FALSE,
+        r_http_client_req_do_close, r_ref_ref (ctx), r_ref_unref);
+  else
+    r_ev_tcp_close (ctx->evtcp, NULL, NULL, NULL);
+  r_ptr_array_remove_first_fast (ctx->client->reqs, ctx);
+
+  r_ref_unref (ctx);
+}
+
+#define r_http_client_req_finish(ctx, result) \
+  r_http_client_req_teardown (ctx, result, TRUE)
+
+static void
+r_http_client_req_recv (rpointer data, RBuffer * buf, REvTCP * evtcp)
+{
+  RHttpClientReqCtx * ctx = data;
+  (void) evtcp;
+
+  /* The recv watch stays armed until the deferred close runs, so a late
+   * event after the request finished must be ignored. */
+  if (ctx->finished)
+    return;
+
+  if (buf == NULL) {
+    /* End-of-stream: a CLOSE-framed body ends here; anything else mid-body
+     * is a truncated response. */
+    if (ctx->res != NULL && ctx->bodytype == R_HTTP_BODY_PARSE_CLOSE) {
+      if (ctx->inbuf != NULL)
+        r_http_response_set_body_buffer (ctx->res, ctx->inbuf);
+      r_http_client_req_finish (ctx, R_HTTP_CLIENT_OK);
+    } else {
+      r_http_client_req_finish (ctx, R_HTTP_CLIENT_RECV_FAILED);
+    }
+    return;
+  }
+
+  if (ctx->inbuf == NULL)
+    ctx->inbuf = r_buffer_ref (buf);
+  else
+    r_buffer_append_mem_from_buffer (ctx->inbuf, buf);
+
+  /* Parse the status line + headers once enough bytes have arrived. */
+  if (ctx->res == NULL) {
+    RHttpError err;
+    RBuffer * remainder = NULL;
+
+    ctx->res = r_http_response_new_from_buffer (ctx->req, ctx->inbuf, &err, &remainder);
+    if (ctx->res != NULL) {
+      ctx->bodysize = r_http_response_calc_body_size (ctx->res, &ctx->bodytype);
+    } else if (err == R_HTTP_BUF_TOO_SMALL) {
+      if (r_buffer_get_size (ctx->inbuf) > R_HTTP_CLIENT_MAX_HEADER) {
+        r_buffer_unref (ctx->inbuf);
+        ctx->inbuf = remainder;
+        r_http_client_req_finish (ctx, R_HTTP_CLIENT_PARSE_FAILED);
+        return;
+      }
+      /* Wait for more header bytes (remainder re-holds the pending data). */
+    } else {
+      r_buffer_unref (ctx->inbuf);
+      ctx->inbuf = remainder;
+      r_http_client_req_finish (ctx, R_HTTP_CLIENT_PARSE_FAILED);
+      return;
+    }
+
+    /* On success remainder is the post-header bytes; on BUF_TOO_SMALL it
+     * re-holds the pending data. Either way it becomes the new inbuf. */
+    r_buffer_unref (ctx->inbuf);
+    ctx->inbuf = remainder;
+
+    if (ctx->res == NULL)
+      return;
+  }
+
+  /* Headers parsed; collect the body per its framing. */
+  switch (ctx->bodytype) {
+    case R_HTTP_BODY_PARSE_SIZED:
+      if (ctx->bodysize <= 0) {
+        r_http_client_req_finish (ctx, R_HTTP_CLIENT_OK);
+      } else if (ctx->inbuf != NULL &&
+          r_buffer_get_size (ctx->inbuf) >= (rsize) ctx->bodysize) {
+        RBuffer * body = r_buffer_view (ctx->inbuf, 0, (rsize) ctx->bodysize);
+        r_http_response_set_body_buffer (ctx->res, body);
+        r_buffer_unref (body);
+        r_http_client_req_finish (ctx, R_HTTP_CLIENT_OK);
+      }
+      /* else wait for more body bytes */
+      break;
+    case R_HTTP_BODY_PARSE_CLOSE:
+      /* Body runs until the connection closes; handled on end-of-stream. */
+      break;
+    default:
+      /* Chunked / tunnel framing isn't implemented yet. */
+      R_LOG_DEBUG ("%p: request %p unsupported body framing %d",
+          ctx->client, ctx, (int) ctx->bodytype);
+      r_http_client_req_finish (ctx, R_HTTP_CLIENT_PARSE_FAILED);
+      break;
+  }
+}
+
+static void
+r_http_client_req_connected (rpointer data, REvTCP * evtcp, int status)
+{
+  RHttpClientReqCtx * ctx = data;
+  RBuffer * buf;
+  (void) evtcp;
+
+  if (status != 0) {
+    R_LOG_DEBUG ("%p: request %p connect failed (%d)", ctx->client, ctx, status);
+    r_http_client_req_finish (ctx, R_HTTP_CLIENT_CONNECT_FAILED);
+    return;
+  }
+
+  if ((buf = r_http_msg_get_buffer ((RHttpMsg *) ctx->req)) == NULL) {
+    r_http_client_req_finish (ctx, R_HTTP_CLIENT_SEND_FAILED);
+    return;
+  }
+  r_ev_tcp_send_and_forget (ctx->evtcp, buf);
+  r_buffer_unref (buf);
+
+  if (!r_ev_tcp_recv_start (ctx->evtcp, NULL, r_http_client_req_recv, ctx, NULL))
+    r_http_client_req_finish (ctx, R_HTTP_CLIENT_RECV_FAILED);
+}
+
+static void
+r_http_client_req_error (rpointer data, REvTCP * evtcp, RSocketStatus error)
+{
+  RHttpClientReqCtx * ctx = data;
+  (void) evtcp;
+
+  R_LOG_DEBUG ("%p: request %p socket error (%d)", ctx->client, ctx, (int) error);
+  r_http_client_req_finish (ctx, R_HTTP_CLIENT_RECV_FAILED);
+}
+
+rboolean
+r_http_client_send (RHttpClient * client, RHttpRequest * req,
+    const RSocketAddress * addr,
+    RHttpClientResponseFunc cb, rpointer data, RDestroyNotify notify)
+{
+  RHttpClientReqCtx * ctx;
+
+  if (R_UNLIKELY (client == NULL || req == NULL || addr == NULL || cb == NULL))
+    return FALSE;
+
+  if ((ctx = r_mem_new0 (RHttpClientReqCtx)) == NULL)
+    return FALSE;
+  r_ref_init (ctx, r_http_client_req_ctx_free);
+  ctx->client = r_http_client_ref (client);
+  ctx->req = r_http_request_ref (req);
+  ctx->bodytype = R_HTTP_BODY_PARSE_SIZED;
+
+  /* Set cb/data/notify only once the request is committed (TRUE return):
+   * a FALSE return must not invoke notify -- the caller keeps ownership. */
+  if ((ctx->evtcp = r_ev_tcp_new (r_socket_address_get_family (addr),
+          client->loop)) == NULL) {
+    r_ref_unref (ctx);
+    return FALSE;
+  }
+  ctx->cb = cb;
+  ctx->data = data;
+  ctx->notify = notify;
+
+  /* The array owns the request context; the in-flight callbacks borrow it. */
+  r_ptr_array_add (client->reqs, ctx, r_ref_unref);
+  r_ev_tcp_set_error_handler (ctx->evtcp, r_http_client_req_error, ctx, NULL);
+
+  R_LOG_TRACE ("%p: request %p started", client, ctx);
+  if (r_ev_tcp_connect (ctx->evtcp, addr,
+        r_http_client_req_connected, ctx, NULL) < R_SOCKET_OK)
+    r_http_client_req_teardown (ctx, R_HTTP_CLIENT_CONNECT_FAILED, FALSE);
+
+  return TRUE;
+}
+
+
+
+static void
+r_http_client_free (RHttpClient * client)
+{
+  /* A request context holds a reference on the client, so the client can
+   * only be freed once every request has finished and left client->reqs. */
+  r_ptr_array_unref (client->reqs);
+  r_ev_loop_unref (client->loop);
+  r_free (client);
+}
+
+RHttpClient *
+r_http_client_new (REvLoop * loop)
+{
+  RHttpClient * ret;
+
+  loop = (loop != NULL) ? r_ev_loop_ref (loop) : r_ev_loop_default ();
+  if (R_UNLIKELY (loop == NULL)) return NULL;
+
+  if ((ret = r_mem_new (RHttpClient)) != NULL) {
+    r_ref_init (ret, r_http_client_free);
+
+    ret->loop = loop;
+    ret->reqs = r_ptr_array_new ();
+
+    R_LOG_INFO ("New HTTP client %p", ret);
+  } else {
+    r_ev_loop_unref (loop);
+  }
+
+  return ret;
+}
+
+
+struct RHttpClientSync {
+  RRef ref;
+  REvLoop * loop;
+  RHttpClient * client;
+};
+
+typedef struct {
+  RHttpResponse * res;
+  RHttpClientResult result;
+  rboolean done;
+  REvLoop * loop;
+} RHttpClientSyncState;
+
+static void
+r_http_client_sync_free (RHttpClientSync * sync)
+{
+  if (sync->client != NULL)
+    r_http_client_unref (sync->client);
+  r_ev_loop_unref (sync->loop);
+  r_free (sync);
+}
+
+RHttpClientSync *
+r_http_client_sync_new (void)
+{
+  RHttpClientSync * ret;
+  REvLoop * loop;
+
+  /* A private loop (real system clock) the blocking request drives itself, so
+   * the caller never manages an event loop. */
+  if ((loop = r_ev_loop_new_full (NULL, NULL)) == NULL)
+    return NULL;
+
+  if ((ret = r_mem_new0 (RHttpClientSync)) != NULL) {
+    r_ref_init (ret, r_http_client_sync_free);
+    ret->loop = loop;
+    if (R_UNLIKELY ((ret->client = r_http_client_new (loop)) == NULL)) {
+      r_ref_unref (ret);
+      return NULL;
+    }
+    R_LOG_INFO ("New blocking HTTP client %p", ret);
+  } else {
+    r_ev_loop_unref (loop);
+  }
+
+  return ret;
+}
+
+static void
+r_http_client_sync_cb (rpointer data, RHttpResponse * res,
+    RHttpClientResult result, RHttpClient * client)
+{
+  RHttpClientSyncState * state = data;
+  (void) client;
+
+  state->result = result;
+  state->res = (res != NULL) ? r_http_response_ref (res) : NULL;
+  state->done = TRUE;
+  /* Break out of the r_ev_loop_run below now that the exchange is complete. */
+  r_ev_loop_stop (state->loop);
+}
+
+RHttpResponse *
+r_http_client_sync_request (RHttpClientSync * sync, RHttpRequest * req,
+    const RSocketAddress * addr, RHttpClientResult * result)
+{
+  RHttpClientSyncState state = { NULL, R_HTTP_CLIENT_CONNECT_FAILED, FALSE,
+      sync != NULL ? sync->loop : NULL };
+
+  if (R_UNLIKELY (sync == NULL) ||
+      !r_http_client_send (sync->client, req, addr,
+          r_http_client_sync_cb, &state, NULL)) {
+    if (result != NULL)
+      *result = R_HTTP_CLIENT_CONNECT_FAILED;
+    return NULL;
+  }
+
+  while (!state.done)
+    r_ev_loop_run (sync->loop, R_EV_LOOP_RUN_LOOP);
+
+  if (result != NULL)
+    *result = state.result;
+  return state.res;
+}

--- a/rlib/net/rhttpserver.c
+++ b/rlib/net/rhttpserver.c
@@ -488,7 +488,12 @@ r_http_server_tcp_connection_ready (rpointer data,
         server, R_EV_IO_ARGS (newtcp), R_EV_IO_ARGS (listening));
 
     if (r_ev_tcp_recv_start (newtcp, NULL, r_http_client_ctx_tcp_recv, ctx, NULL)) {
-      r_ptr_array_add (server->clients, r_ref_ref (ctx), r_ref_unref);
+      /* Transfer the context's reference to the clients array; the recv
+       * callback borrows it. Keeping a second ref here would leak the ctx
+       * (and thus never close the accepted socket) once it leaves the array. */
+      r_ptr_array_add (server->clients, ctx, r_ref_unref);
+    } else {
+      r_ref_unref (ctx);
     }
   } else {
     R_LOG_WARNING ("%p: New connection "R_EV_IO_FORMAT" on "R_EV_IO_FORMAT
@@ -564,7 +569,11 @@ r_http_server_close_client_ctx (rpointer data, rpointer user)
   RHttpServerStopCtx * ctx = user;
   R_LOG_DEBUG ("%p: Force close client socket "R_EV_IO_FORMAT,
       ctx->server, R_EV_IO_ARGS (cli->evtcp));
-  r_http_client_ctx_close (cli, r_ref_ref (ctx), r_ref_unref);
+  /* Close only; the array removal (and the context's last unref) is done by
+   * the r_ptr_array_remove_all_full walk that invoked this. Calling
+   * r_http_client_ctx_close here would remove the entry mid-walk and drop the
+   * reference twice. */
+  r_ev_tcp_close (cli->evtcp, NULL, r_ref_ref (ctx), r_ref_unref);
 }
 
 rsize

--- a/rlib/rlib-private.h
+++ b/rlib/rlib-private.h
@@ -34,6 +34,7 @@ R_API_HIDDEN void r_ev_loop_deinit (void);
 R_API_HIDDEN void r_log_init (void);
 R_API_HIDDEN void r_log_deinit (void);
 
+R_API_HIDDEN void r_http_client_init (void);
 R_API_HIDDEN void r_http_server_init (void);
 
 R_API_HIDDEN void r_mem_allocator_init (void);

--- a/rlib/rlibinit.c
+++ b/rlib/rlibinit.c
@@ -42,6 +42,7 @@ R_INITIALIZER (rlib_init)
 
   r_ref__init ();
   r_ev_loop_init ();
+  r_http_client_init ();
   r_http_server_init ();
   r_mem_allocator_init ();
   r_module_init ();

--- a/test/meson.build
+++ b/test/meson.build
@@ -50,6 +50,7 @@ rlibtest_sources = [
   'rhashset.c',
   'rhashtable.c',
   'rhttp.c',
+  'rhttpclient.c',
   'rhttpserver.c',
   'rhzrptr.c',
   'rjson.c',

--- a/test/rhttpclient.c
+++ b/test/rhttpclient.c
@@ -1,0 +1,601 @@
+#include <rlib/rnet.h>
+#include <rlib/rev.h>
+
+/* Each test uses a distinct port: on Windows rtest runs single-process, so a
+ * shared port can collide with a previous test's not-yet-torn-down socket. */
+#define R_TEST_HTTP_CLIENT_BODY   "hello from rlib"
+
+typedef struct {
+  RHttpResponse * res;
+  RHttpClientResult result;
+  rboolean done;
+  REvLoop * loop;
+} RTestHttpSyncState;
+
+static void
+r_test_http_send_cb (rpointer data, RHttpResponse * res,
+    RHttpClientResult result, RHttpClient * client)
+{
+  RTestHttpSyncState * st = data;
+  (void) client;
+  st->result = result;
+  st->res = (res != NULL) ? r_http_response_ref (res) : NULL;
+  st->done = TRUE;
+  r_ev_loop_stop (st->loop);
+}
+
+/* Issue an async request and drive @loop until it completes. The in-process
+ * tests put server and client on one shared loop, so a blocking
+ * RHttpClientSync (which owns a private loop) can't drive the server here. */
+static RHttpResponse *
+r_test_http_send (REvLoop * loop, RHttpClient * client, RHttpRequest * req,
+    const RSocketAddress * addr, RHttpClientResult * result)
+{
+  RTestHttpSyncState st = { NULL, R_HTTP_CLIENT_CONNECT_FAILED, FALSE, loop };
+
+  if (!r_http_client_send (client, req, addr, r_test_http_send_cb, &st, NULL)) {
+    if (result != NULL)
+      *result = R_HTTP_CLIENT_CONNECT_FAILED;
+    return NULL;
+  }
+  while (!st.done)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
+  if (result != NULL)
+    *result = st.result;
+  return st.res;
+}
+
+static RHttpResponse *
+r_test_http_client_handler (rpointer data, RHttpRequest * req,
+    RSocketAddress * addr, RHttpServer * server)
+{
+  RHttpResponse * res;
+
+  (void) addr;
+  (void) server;
+
+  if ((res = r_http_response_new (req, (RHttpStatus) RPOINTER_TO_UINT (data),
+          NULL, NULL, NULL)) != NULL) {
+    RBuffer * buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS (R_TEST_HTTP_CLIENT_BODY));
+    if (buf != NULL) {
+      r_http_response_set_body_buffer_full (res, buf, "text/plain", -1, TRUE);
+      r_buffer_unref (buf);
+    }
+  }
+
+  return res;
+}
+
+/* Build a listening server with a handler at @p path returning @p status
+ * (with a body); the address to connect to is returned in *out. */
+static RHttpServer *
+r_test_http_client_server (REvLoop * loop, ruint16 port, const rchar * path,
+    RHttpStatus status, RSocketAddress ** out)
+{
+  RHttpServer * srv;
+  RSocketAddress * addr;
+
+  if ((srv = r_http_server_new (loop)) == NULL)
+    return NULL;
+
+  r_assert (r_http_server_set_handler (srv, path, -1,
+        r_test_http_client_handler, RUINT_TO_POINTER (status), NULL));
+
+  addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, port);
+  r_assert_cmpptr (addr, !=, NULL);
+  r_assert (r_http_server_listen (srv, addr));
+
+  *out = addr;
+  return srv;
+}
+
+static void
+r_test_http_client_teardown (REvLoop * loop, RHttpClient * client,
+    RHttpServer * srv)
+{
+  /* Stop the server and drain the loop so every socket close completes. */
+  if (client != NULL)
+    r_http_client_unref (client);
+  if (srv != NULL) {
+    r_http_server_stop (srv, NULL, NULL, NULL);
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
+    r_http_server_unref (srv);
+  }
+}
+
+RTEST (rhttpclient, request_get, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RHttpServer * srv;
+  RHttpClient * client;
+  RHttpRequest * req;
+  RHttpResponse * res;
+  RSocketAddress * addr;
+  RHttpClientResult result;
+  rchar * body;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((srv = r_test_http_client_server (loop, 47654, "/",
+          R_HTTP_STATUS_OK, &addr)), !=, NULL);
+  r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
+
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+          "http://127.0.0.1/", NULL, NULL)), !=, NULL);
+  r_assert (r_http_request_add_header (req, "Host", -1, "127.0.0.1", -1));
+
+  res = r_test_http_send (loop, client, req, addr, &result);
+  r_http_request_unref (req);
+
+  r_assert_cmpint (result, ==, R_HTTP_CLIENT_OK);
+  r_assert_cmpptr (res, !=, NULL);
+  r_assert_cmpint (r_http_response_get_status (res), ==, R_HTTP_STATUS_OK);
+  r_assert_cmpstr ((body = r_http_response_get_body (res, NULL)), ==,
+      R_TEST_HTTP_CLIENT_BODY);
+  r_free (body);
+  r_http_response_unref (res);
+
+  r_socket_address_unref (addr);
+  r_test_http_client_teardown (loop, client, srv);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+RTEST (rhttpclient, request_not_found, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RHttpServer * srv;
+  RHttpClient * client;
+  RHttpRequest * req;
+  RHttpResponse * res;
+  RSocketAddress * addr;
+  RHttpClientResult result;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  /* Handler is registered at "/specific"; request an unrelated path so no
+   * handler (nor any parent with one) matches -> 404. */
+  r_assert_cmpptr ((srv = r_test_http_client_server (loop, 47655, "/specific",
+          R_HTTP_STATUS_OK, &addr)), !=, NULL);
+  r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
+
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+          "http://127.0.0.1/other", NULL, NULL)), !=, NULL);
+  r_assert (r_http_request_add_header (req, "Host", -1, "127.0.0.1", -1));
+
+  res = r_test_http_send (loop, client, req, addr, &result);
+  r_http_request_unref (req);
+
+  r_assert_cmpint (result, ==, R_HTTP_CLIENT_OK);
+  r_assert_cmpptr (res, !=, NULL);
+  r_assert_cmpint (r_http_response_get_status (res), ==, R_HTTP_STATUS_NOT_FOUND);
+  r_http_response_unref (res);
+
+  r_socket_address_unref (addr);
+  r_test_http_client_teardown (loop, client, srv);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+RTEST (rhttpclient, connect_refused, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RHttpClient * client;
+  RHttpRequest * req;
+  RHttpResponse * res;
+  RSocketAddress * addr;
+  RHttpClientResult result;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
+
+  /* No listener on this port -> the connection is refused. */
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1,
+          47656)), !=, NULL);
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+          "http://127.0.0.1/", NULL, NULL)), !=, NULL);
+
+  res = r_test_http_send (loop, client, req, addr, &result);
+  r_http_request_unref (req);
+
+  r_assert_cmpint (result, ==, R_HTTP_CLIENT_CONNECT_FAILED);
+  r_assert_cmpptr (res, ==, NULL);
+
+  r_socket_address_unref (addr);
+  r_test_http_client_teardown (loop, client, NULL);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+#define R_TEST_HTTP_CLIENT_BIG    (300 * 1024)
+
+static RHttpResponse *
+r_test_http_client_big_handler (rpointer data, RHttpRequest * req,
+    RSocketAddress * addr, RHttpServer * server)
+{
+  RHttpResponse * res;
+
+  (void) data;
+  (void) addr;
+  (void) server;
+
+  if ((res = r_http_response_new (req, R_HTTP_STATUS_OK, NULL, NULL, NULL)) != NULL) {
+    ruint8 * mem = r_malloc (R_TEST_HTTP_CLIENT_BIG);
+    RBuffer * buf;
+    rsize i;
+    for (i = 0; i < R_TEST_HTTP_CLIENT_BIG; i++)
+      mem[i] = (ruint8) (i & 0xff);
+    if ((buf = r_buffer_new_take (mem, R_TEST_HTTP_CLIENT_BIG)) != NULL) {
+      r_http_response_set_body_buffer_full (res, buf,
+          "application/octet-stream", -1, TRUE);
+      r_buffer_unref (buf);
+    } else {
+      r_free (mem);
+    }
+  }
+
+  return res;
+}
+
+/* A body larger than a single TCP segment forces the response across several
+ * recv callbacks, exercising the incremental accumulate + Content-Length
+ * (SIZED) "wait for more body" path. */
+RTEST (rhttpclient, request_large_body, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RHttpServer * srv;
+  RHttpClient * client;
+  RHttpRequest * req;
+  RHttpResponse * res;
+  RSocketAddress * addr;
+  RHttpClientResult result;
+  rchar * body;
+  rsize bsize, i;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((srv = r_http_server_new (loop)), !=, NULL);
+  r_assert (r_http_server_set_handler (srv, "/", -1,
+        r_test_http_client_big_handler, NULL, NULL));
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1,
+          47657)), !=, NULL);
+  r_assert (r_http_server_listen (srv, addr));
+
+  r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+          "http://127.0.0.1/", NULL, NULL)), !=, NULL);
+  r_assert (r_http_request_add_header (req, "Host", -1, "127.0.0.1", -1));
+
+  res = r_test_http_send (loop, client, req, addr, &result);
+  r_http_request_unref (req);
+
+  r_assert_cmpint (result, ==, R_HTTP_CLIENT_OK);
+  r_assert_cmpptr (res, !=, NULL);
+  r_assert_cmpint (r_http_response_get_status (res), ==, R_HTTP_STATUS_OK);
+  r_assert_cmpptr ((body = r_http_response_get_body (res, &bsize)), !=, NULL);
+  r_assert_cmpuint (bsize, ==, R_TEST_HTTP_CLIENT_BIG);
+  for (i = 0; i < bsize; i++)
+    r_assert_cmpuint ((ruint8) body[i], ==, (ruint8) (i & 0xff));
+  r_free (body);
+  r_http_response_unref (res);
+
+  r_socket_address_unref (addr);
+  r_test_http_client_teardown (loop, client, srv);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+/* A HEAD response has no body regardless of Content-Length; the client must
+ * complete on the headers alone (SIZED with size 0). */
+RTEST (rhttpclient, request_head, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RHttpServer * srv;
+  RHttpClient * client;
+  RHttpRequest * req;
+  RHttpResponse * res;
+  RSocketAddress * addr;
+  RHttpClientResult result;
+  rchar * body;
+  rsize bsize;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((srv = r_test_http_client_server (loop, 47658, "/",
+          R_HTTP_STATUS_OK, &addr)), !=, NULL);
+  r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
+
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_HEAD,
+          "http://127.0.0.1/", NULL, NULL)), !=, NULL);
+  r_assert (r_http_request_add_header (req, "Host", -1, "127.0.0.1", -1));
+
+  res = r_test_http_send (loop, client, req, addr, &result);
+  r_http_request_unref (req);
+
+  r_assert_cmpint (result, ==, R_HTTP_CLIENT_OK);
+  r_assert_cmpptr (res, !=, NULL);
+  r_assert_cmpint (r_http_response_get_status (res), ==, R_HTTP_STATUS_OK);
+  body = r_http_response_get_body (res, &bsize);
+  r_assert_cmpuint (bsize, ==, 0);
+  r_free (body);
+  r_http_response_unref (res);
+
+  r_socket_address_unref (addr);
+  r_test_http_client_teardown (loop, client, srv);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+static RHttpResponse *
+r_test_http_client_stop_handler (rpointer data, RHttpRequest * req,
+    RSocketAddress * addr, RHttpServer * server)
+{
+  (void) data;
+  (void) addr;
+
+  /* Stop the server while this connection is still active: exercises the
+   * close-with-in-flight-connection teardown path in r_http_server_stop. */
+  r_http_server_stop (server, NULL, NULL, NULL);
+  return r_http_response_new (req, R_HTTP_STATUS_OK, NULL, NULL, NULL);
+}
+
+RTEST (rhttpclient, server_stop_during_request, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RHttpServer * srv;
+  RHttpClient * client;
+  RHttpRequest * req;
+  RHttpResponse * res;
+  RSocketAddress * addr;
+  RHttpClientResult result;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((srv = r_http_server_new (loop)), !=, NULL);
+  r_assert (r_http_server_set_handler (srv, "/", -1,
+        r_test_http_client_stop_handler, NULL, NULL));
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1,
+          47659)), !=, NULL);
+  r_assert (r_http_server_listen (srv, addr));
+
+  r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+          "http://127.0.0.1/", NULL, NULL)), !=, NULL);
+
+  /* The point is that stopping mid-request neither hangs nor corrupts memory
+   * (the latter caught under the sanitizer job); the exact outcome races the
+   * force-close, so accept a delivered response or a transport error. */
+  res = r_test_http_send (loop, client, req, addr, &result);
+  r_http_request_unref (req);
+  r_assert (result == R_HTTP_CLIENT_OK || result == R_HTTP_CLIENT_RECV_FAILED);
+  if (res != NULL)
+    r_http_response_unref (res);
+
+  r_socket_address_unref (addr);
+  r_http_client_unref (client);
+  r_http_server_unref (srv);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+/* A minimal raw-TCP "server" that sends a fixed byte blob and closes, used to
+ * feed the client responses RHttpServer cannot itself produce. */
+typedef struct {
+  REvTCP * listen;
+  REvTCP * conn;
+  const rchar * blob;
+  rsize blen;
+} RTestRawServer;
+
+static void
+r_test_raw_sent (rpointer data, RBuffer * buf, REvTCP * evtcp)
+{
+  (void) data;
+  (void) buf;
+  /* Close after the blob is written so a client still waiting sees EOS. */
+  r_ev_tcp_close (evtcp, NULL, NULL, NULL);
+}
+
+static void
+r_test_raw_conn_ready (rpointer data, REvTCP * newtcp, REvTCP * listening)
+{
+  RTestRawServer * s = data;
+  (void) listening;
+  s->conn = r_ev_tcp_ref (newtcp);
+  r_ev_tcp_send_dup (newtcp, s->blob, s->blen, r_test_raw_sent, NULL, NULL);
+}
+
+static RTestRawServer *
+r_test_raw_server_new (REvLoop * loop, ruint16 port, const rchar * blob,
+    rsize blen, RSocketAddress ** out)
+{
+  RTestRawServer * s = r_mem_new0 (RTestRawServer);
+
+  *out = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, port);
+  r_assert_cmpptr (*out, !=, NULL);
+  s->blob = blob;
+  s->blen = blen;
+  r_assert_cmpptr ((s->listen = r_ev_tcp_new_bind (*out, loop)), !=, NULL);
+  r_assert_cmpint (r_ev_tcp_listen (s->listen, R_SOCKET_DEFAULT_BACKLOG,
+        r_test_raw_conn_ready, s, NULL), >=, R_SOCKET_OK);
+  return s;
+}
+
+static void
+r_test_raw_server_free (RTestRawServer * s)
+{
+  if (s->conn != NULL) {
+    r_ev_tcp_close (s->conn, NULL, NULL, NULL);
+    r_ev_tcp_unref (s->conn);
+  }
+  r_ev_tcp_close (s->listen, NULL, NULL, NULL);
+  r_ev_tcp_unref (s->listen);
+  r_free (s);
+}
+
+static RHttpClientResult
+r_test_http_client_raw (ruint16 port, const rchar * blob)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RTestRawServer * raw;
+  RHttpClient * client;
+  RHttpRequest * req;
+  RHttpResponse * res;
+  RSocketAddress * addr;
+  RHttpClientResult result;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  raw = r_test_raw_server_new (loop, port, blob, r_strlen (blob), &addr);
+  r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+          "http://127.0.0.1/", NULL, NULL)), !=, NULL);
+
+  res = r_test_http_send (loop, client, req, addr, &result);
+  r_http_request_unref (req);
+  if (res != NULL)
+    r_http_response_unref (res);
+
+  r_socket_address_unref (addr);
+  r_http_client_unref (client);
+  r_test_raw_server_free (raw);
+  r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
+  r_ev_loop_unref (loop);
+  return result;
+}
+
+/* A chunked response is valid HTTP but the client does not decode chunked
+ * framing yet, so it reports a parse failure rather than hanging. */
+RTEST (rhttpclient, response_chunked_unsupported, RTEST_FAST | RTEST_SYSTEM)
+{
+  r_assert_cmpint (r_test_http_client_raw (47660,
+        "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+        "3\r\nabc\r\n0\r\n\r\n"), ==, R_HTTP_CLIENT_PARSE_FAILED);
+}
+RTEST_END;
+
+/* A response that is not valid HTTP is a parse failure. */
+RTEST (rhttpclient, response_malformed, RTEST_FAST | RTEST_SYSTEM)
+{
+  r_assert_cmpint (r_test_http_client_raw (47661,
+        "totally not a http response\r\n\r\n"), ==, R_HTTP_CLIENT_PARSE_FAILED);
+}
+RTEST_END;
+
+/* A blocking-socket HTTP responder run on its own thread so a blocking
+ * RHttpClientSync (which drives its own private loop) has a peer to talk to:
+ * accept one connection, read the request, send a fixed response, close. */
+static rpointer
+r_test_http_blocking_responder (rpointer data)
+{
+  RSocket * listen = data;
+  RSocket * conn;
+  static const rchar resp[] =
+      "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi";
+
+  if ((conn = r_socket_accept (listen, NULL)) != NULL) {
+    ruint8 buf[1024];
+    rsize n = 0;
+    r_socket_set_blocking (conn, TRUE);
+    /* A small GET arrives in one segment; drain it before replying. */
+    r_socket_receive (conn, buf, sizeof (buf), &n);
+    r_socket_send (conn, (const ruint8 *) resp, sizeof (resp) - 1, &n);
+    r_socket_close (conn);
+    r_socket_unref (conn);
+  }
+
+  return NULL;
+}
+
+RTEST (rhttpclientsync, request, RTEST_FAST | RTEST_SYSTEM)
+{
+  RSocket * listen;
+  RSocketAddress * addr;
+  RThread * thread;
+  RHttpClientSync * sync;
+  RHttpRequest * req;
+  RHttpResponse * res;
+  RHttpClientResult result;
+  rchar * body;
+
+  r_assert_cmpptr ((listen = r_socket_new (R_SOCKET_FAMILY_IPV4,
+          R_SOCKET_TYPE_STREAM, R_SOCKET_PROTOCOL_TCP)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1,
+          47662)), !=, NULL);
+  r_assert_cmpint (r_socket_bind (listen, addr, TRUE), ==, R_SOCKET_OK);
+  r_assert_cmpint (r_socket_listen (listen), ==, R_SOCKET_OK);
+  /* Block in accept until the client connects (the thread starts first). */
+  r_assert (r_socket_set_blocking (listen, TRUE));
+  r_assert_cmpptr ((thread = r_thread_new (NULL,
+          r_test_http_blocking_responder, listen)), !=, NULL);
+
+  r_assert_cmpptr ((sync = r_http_client_sync_new ()), !=, NULL);
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+          "http://127.0.0.1/", NULL, NULL)), !=, NULL);
+  r_assert (r_http_request_add_header (req, "Host", -1, "127.0.0.1", -1));
+
+  res = r_http_client_sync_request (sync, req, addr, &result);
+  r_http_request_unref (req);
+
+  r_assert_cmpint (result, ==, R_HTTP_CLIENT_OK);
+  r_assert_cmpptr (res, !=, NULL);
+  r_assert_cmpint (r_http_response_get_status (res), ==, R_HTTP_STATUS_OK);
+  r_assert_cmpstr ((body = r_http_response_get_body (res, NULL)), ==, "hi");
+  r_free (body);
+  r_http_response_unref (res);
+
+  r_thread_join (thread);
+  r_thread_unref (thread);
+  r_http_client_sync_unref (sync);
+  r_socket_close (listen);
+  r_socket_unref (listen);
+  r_socket_address_unref (addr);
+}
+RTEST_END;
+
+RTEST (rhttpclientsync, connect_refused, RTEST_FAST | RTEST_SYSTEM)
+{
+  RHttpClientSync * sync;
+  RHttpRequest * req;
+  RHttpResponse * res;
+  RSocketAddress * addr;
+  RHttpClientResult result;
+
+  r_assert_cmpptr ((sync = r_http_client_sync_new ()), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1,
+          47663)), !=, NULL);
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+          "http://127.0.0.1/", NULL, NULL)), !=, NULL);
+
+  res = r_http_client_sync_request (sync, req, addr, &result);
+  r_http_request_unref (req);
+
+  r_assert_cmpint (result, ==, R_HTTP_CLIENT_CONNECT_FAILED);
+  r_assert_cmpptr (res, ==, NULL);
+
+  r_socket_address_unref (addr);
+  r_http_client_sync_unref (sync);
+}
+RTEST_END;


### PR DESCRIPTION
Adds an HTTP client (#261). The client exists primarily to exercise `RHttpServer` end-to-end over a real socket, which the server's own tests never did (they inject via `r_http_server_process_request`) — and doing so uncovered real server bugs (below).

## Clients

- **`RHttpClient`** — the async client. Connects to a peer over `REvTCP` on a caller-supplied loop, sends an `RHttpRequest`, and delivers the parsed `RHttpResponse` via a callback, reusing the proto codec (`r_http_msg_get_buffer` / `r_http_response_new_from_buffer`).
- **`RHttpClientSync`** — the blocking client (libcurl easy/multi split). It owns a *private* event loop and an `RHttpClient` and runs that loop to completion, so a blocking caller never manages an event loop. This mirrors how mainstream sync bridges work (`asyncio.run`, tokio `block_on`, `reqwest::blocking` all own the loop) and avoids driving a shared/already-running loop.

Scope is plaintext HTTP/1.1 to an explicit `RSocketAddress`, with response bodies framed by `Content-Length` or by connection close. Chunked decoding, URI/DNS-based targeting, and keep-alive are follow-ups; an unsupported framing (chunked/tunnel) is reported as a parse failure rather than hanging.

A finished request defers its socket close to a loop callback, since closing inside the connect/recv callback would free the io-watch entry the loop is still iterating (a synchronous connect failure is torn down inline). On a `FALSE` send the caller keeps ownership of the callback data (the destroy notify is not called).

## Server bugs uncovered (separate commit)

Driving `RHttpServer` over a socket for the first time surfaced two reference-counting bugs in the accepted-connection path:

1. The connection context was added to the clients array with an extra reference that was never dropped, so the accepted socket never reached zero refs — and since `r_ev_tcp_close` defers the real close to the last unref, the server never closed a connection after responding (no FIN).
2. With that leak gone, `r_http_server_stop` double-freed: its removal walk both invoked a per-client close that removed the entry and then dropped the reference again itself.

Both are fixed in the `fix RHttpServer connection lifecycle` commit.

## Tests

`test/rhttpclient.c` drives the async client against `RHttpServer` over a real socket — GET with a body, a large body spanning multiple reads (the incremental accumulate path), HEAD, a routed 404 (connection-close framed), a refused connection, and a server stopped mid-request (regression for the double-free) — plus a raw-TCP server for responses `RHttpServer` cannot emit (chunked, malformed). `RHttpClientSync` is covered against a blocking-socket responder on a thread and a refused connection. Each test binds a distinct port: rtest is single-process on Windows, where a shared port collides with a previous test's socket.

Verified: Linux epoll + rpoll suites green; the full suite under ASan/LSan and TSan is clean; the mingw cross (werror) build is clean; doxygen reports no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)