### PR TITLE
net/http: correct + complete the zero-copy header API (#290)

### DIFF
--- a/include/rlib/net/proto/rhttp.h
+++ b/include/rlib/net/proto/rhttp.h
@@ -199,6 +199,15 @@ R_API void r_http_msg_foreach_header (RHttpMsg * msg, RHttpHeaderFunc func, rpoi
 /** @brief Append a header @p field : @p value to the message. */
 R_API rboolean r_http_msg_add_header (RHttpMsg * msg,
     const rchar * field, rssize fsize, const rchar * value, rssize vsize);
+/**
+ * @brief Set header @p field to @p value, replacing any existing instances
+ * (the header is appended if it was not present).
+ */
+R_API rboolean r_http_msg_set_header (RHttpMsg * msg,
+    const rchar * field, rssize fsize, const rchar * value, rssize vsize);
+/** @brief Remove every instance of header @p field; @c TRUE if any was removed. */
+R_API rboolean r_http_msg_remove_header (RHttpMsg * msg,
+    const rchar * field, rssize fsize);
 
 /** @brief Opaque, refcounted HTTP request (an @ref RHttpMsg). */
 typedef struct RHttpRequest RHttpRequest;
@@ -239,6 +248,10 @@ R_API RUri * r_http_request_get_uri (RHttpRequest * req);
 #define r_http_request_foreach_header(req, func, data) r_http_msg_foreach_header ((RHttpMsg *)req, func, data)
 /** @brief @ref r_http_msg_add_header on a request. */
 #define r_http_request_add_header(req, field, fsize, value, vsize) r_http_msg_add_header ((RHttpMsg *)req, field, fsize, value, vsize)
+/** @brief @ref r_http_msg_set_header on a request. */
+#define r_http_request_set_header(req, field, fsize, value, vsize) r_http_msg_set_header ((RHttpMsg *)req, field, fsize, value, vsize)
+/** @brief @ref r_http_msg_remove_header on a request. */
+#define r_http_request_remove_header(req, field, fsize) r_http_msg_remove_header ((RHttpMsg *)req, field, fsize)
 /** @brief @ref r_http_msg_get_body on a request. */
 #define r_http_request_get_body(req, size) r_http_msg_get_body ((RHttpMsg *)req, size)
 /** @brief @ref r_http_msg_get_body_buffer on a request. */
@@ -288,6 +301,10 @@ R_API RHttpRequest * r_http_response_get_request (RHttpResponse * res);
 #define r_http_response_foreach_header(res, func, data) r_http_msg_foreach_header ((RHttpMsg *)res, func, data)
 /** @brief @ref r_http_msg_add_header on a response. */
 #define r_http_response_add_header(res, field, fsize, value, vsize) r_http_msg_add_header ((RHttpMsg *)res, field, fsize, value, vsize)
+/** @brief @ref r_http_msg_set_header on a response. */
+#define r_http_response_set_header(res, field, fsize, value, vsize) r_http_msg_set_header ((RHttpMsg *)res, field, fsize, value, vsize)
+/** @brief @ref r_http_msg_remove_header on a response. */
+#define r_http_response_remove_header(res, field, fsize) r_http_msg_remove_header ((RHttpMsg *)res, field, fsize)
 /** @brief @ref r_http_msg_get_body on a response. */
 #define r_http_response_get_body(res, size) r_http_msg_get_body ((RHttpMsg *)res, size)
 /** @brief @ref r_http_msg_get_body_buffer on a response. */

--- a/include/rlib/net/proto/rhttp.h
+++ b/include/rlib/net/proto/rhttp.h
@@ -180,6 +180,22 @@ R_API rboolean r_http_msg_has_header_of_value (RHttpMsg * msg,
     const rchar * key, rssize ksize, const rchar * val, rssize vsize);
 /** @brief Return the value of header @p field (newly allocated), or @c NULL. */
 R_API rchar * r_http_msg_get_header (RHttpMsg * msg, const rchar * field, rssize size);
+/**
+ * @brief Per-header callback for @ref r_http_msg_foreach_header.
+ * @param data  User pointer passed to @ref r_http_msg_foreach_header.
+ * @param name  Header name, @p nsize bytes — points into the message, not NUL-terminated.
+ * @param nsize Length of @p name.
+ * @param value Header value, @p vsize bytes — points into the message, not NUL-terminated.
+ * @param vsize Length of @p value.
+ * @return @c TRUE to continue iterating, @c FALSE to stop.
+ */
+typedef rboolean (*RHttpHeaderFunc) (rpointer data,
+    const rchar * name, rsize nsize, const rchar * value, rsize vsize);
+/**
+ * @brief Invoke @p func for each header in order (zero-copy: @p name / @p value
+ * point into the message). Handles repeated headers (e.g. @c Set-Cookie).
+ */
+R_API void r_http_msg_foreach_header (RHttpMsg * msg, RHttpHeaderFunc func, rpointer data);
 /** @brief Append a header @p field : @p value to the message. */
 R_API rboolean r_http_msg_add_header (RHttpMsg * msg,
     const rchar * field, rssize fsize, const rchar * value, rssize vsize);
@@ -219,6 +235,8 @@ R_API RUri * r_http_request_get_uri (RHttpRequest * req);
   r_http_msg_has_header_of_value ((RHttpMsg *)req, key, ksize, val, vsize)
 /** @brief @ref r_http_msg_get_header on a request. */
 #define r_http_request_get_header(req, field, size) r_http_msg_get_header ((RHttpMsg *)req, field, size)
+/** @brief @ref r_http_msg_foreach_header on a request. */
+#define r_http_request_foreach_header(req, func, data) r_http_msg_foreach_header ((RHttpMsg *)req, func, data)
 /** @brief @ref r_http_msg_add_header on a request. */
 #define r_http_request_add_header(req, field, fsize, value, vsize) r_http_msg_add_header ((RHttpMsg *)req, field, fsize, value, vsize)
 /** @brief @ref r_http_msg_get_body on a request. */
@@ -266,6 +284,8 @@ R_API RHttpRequest * r_http_response_get_request (RHttpResponse * res);
   r_http_msg_has_header_of_value ((RHttpMsg *)res, key, ksize, val, vsize)
 /** @brief @ref r_http_msg_get_header on a response. */
 #define r_http_response_get_header(res, field, size) r_http_msg_get_header ((RHttpMsg *)res, field, size)
+/** @brief @ref r_http_msg_foreach_header on a response. */
+#define r_http_response_foreach_header(res, func, data) r_http_msg_foreach_header ((RHttpMsg *)res, func, data)
 /** @brief @ref r_http_msg_add_header on a response. */
 #define r_http_response_add_header(res, field, fsize, value, vsize) r_http_msg_add_header ((RHttpMsg *)res, field, fsize, value, vsize)
 /** @brief @ref r_http_msg_get_body on a response. */

--- a/rlib/net/proto/rhttp.c
+++ b/rlib/net/proto/rhttp.c
@@ -440,6 +440,68 @@ r_http_msg_add_header (RHttpMsg * msg, const rchar * field, rssize fsize,
   return TRUE;
 }
 
+rboolean
+r_http_msg_remove_header (RHttpMsg * msg, const rchar * field, rssize fsize)
+{
+  RBuffer * empty;
+  rboolean removed = FALSE;
+
+  if (R_UNLIKELY (msg == NULL)) return FALSE;
+  if (R_UNLIKELY (field == NULL)) return FALSE;
+  if (fsize < 0) fsize = r_strlen (field);
+  if (R_UNLIKELY (fsize == 0)) return FALSE;
+  if (R_UNLIKELY (msg->hdr == NULL)) return FALSE;
+  if ((empty = r_buffer_new ()) == NULL) return FALSE;
+
+  /* Splice out each matching line so the other headers keep their exact
+   * bytes; re-scan after each removal since offsets shift. */
+  for (;;) {
+    RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+    rsize off = 0, len = 0;
+    rboolean found = FALSE;
+    RBuffer * next;
+
+    if (r_buffer_map (msg->hdr, &info, R_MEM_MAP_READ)) {
+      const rchar * data = (const rchar *) info.data, * end = data + info.size;
+      const rchar * p = data, * name, * value;
+      rsize nsize, vsize;
+      while (r_http_header_next (&p, end, &name, &nsize, &value, &vsize)) {
+        if (nsize == (rsize) fsize && r_strncasecmp (name, field, nsize) == 0) {
+          off = (rsize) (name - data);
+          len = (rsize) (p - name);     /* the line, including its CRLF */
+          found = TRUE;
+          break;
+        }
+      }
+      r_buffer_unmap (msg->hdr, &info);
+    }
+
+    if (!found)
+      break;
+    if ((next = r_buffer_replace_byte_range (msg->hdr, off, (rssize) len, empty)) == NULL)
+      break;
+    r_buffer_unref (msg->hdr);
+    msg->hdr = next;
+    removed = TRUE;
+  }
+
+  r_buffer_unref (empty);
+  return removed;
+}
+
+rboolean
+r_http_msg_set_header (RHttpMsg * msg, const rchar * field, rssize fsize,
+    const rchar * value, rssize vsize)
+{
+  if (R_UNLIKELY (msg == NULL)) return FALSE;
+  if (R_UNLIKELY (field == NULL)) return FALSE;
+  if (R_UNLIKELY (value == NULL)) return FALSE;
+
+  /* Replace any existing instances, then append once. */
+  r_http_msg_remove_header (msg, field, fsize);
+  return r_http_msg_add_header (msg, field, fsize, value, vsize);
+}
+
 
 
 static RBuffer *
@@ -876,11 +938,11 @@ r_http_response_set_body_buffer_full (RHttpResponse * res, RBuffer * buf,
 
   if ((ret = r_http_response_set_body_buffer (res, buf)) == R_HTTP_OK) {
     if (contenttype != NULL)
-      r_http_response_add_header (res, "Content-Type", -1, contenttype, size);
+      r_http_response_set_header (res, "Content-Type", -1, contenttype, size);
     if (contentlen) {
       rchar len[16];
       r_sprintf (len, "%"RSIZE_FMT, r_buffer_get_size (buf));
-      r_http_response_add_header (res, "Content-Length", -1, len, -1);
+      r_http_response_set_header (res, "Content-Length", -1, len, -1);
     }
   }
 

--- a/rlib/net/proto/rhttp.c
+++ b/rlib/net/proto/rhttp.c
@@ -239,6 +239,46 @@ r_http_msg_set_body_buffer (RHttpMsg * msg, RBuffer * buf)
   return R_HTTP_OK;
 }
 
+/* Zero-copy header scanner: advance *pp to the next "Name: value" line in the
+ * raw header block [*pp, end) and return its name/value as slices into the
+ * buffer (OWS trimmed). Returns FALSE at the terminating empty line or end.
+ * Malformed lines (no colon) are skipped. This is the single line-anchored
+ * primitive all the header accessors build on -- no allocation, no copy. */
+static rboolean
+r_http_header_next (const rchar ** pp, const rchar * end,
+    const rchar ** name, rsize * nsize, const rchar ** value, rsize * vsize)
+{
+  while (*pp < end) {
+    const rchar * p = *pp, * eol, * v, * ve;
+    rssize idx;
+
+    idx = r_str_idx_of_str (p, (rsize) (end - p), "\r\n", 2);
+    eol = (idx < 0) ? end : p + idx;
+    *pp = (idx < 0) ? end : eol + 2;
+
+    if (eol == p)               /* empty line: end of the header block */
+      return FALSE;
+
+    if ((idx = r_str_idx_of_str (p, (rsize) (eol - p), ":", 1)) < 0)
+      continue;                 /* no colon: skip a malformed line */
+
+    *name = p;
+    *nsize = (rsize) idx;
+    while (*nsize > 0 && r_ascii_isspace (p[*nsize - 1]))
+      (*nsize)--;               /* trim trailing OWS before the colon */
+
+    v = p + idx + 1;
+    while (v < eol && (*v == ' ' || *v == '\t')) v++;
+    ve = eol;
+    while (ve > v && (ve[-1] == ' ' || ve[-1] == '\t')) ve--;
+    *value = v;
+    *vsize = (rsize) (ve - v);
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
 rboolean
 r_http_msg_has_header (RHttpMsg * msg, const rchar * field, rssize size)
 {
@@ -251,9 +291,15 @@ r_http_msg_has_header (RHttpMsg * msg, const rchar * field, rssize size)
   if (R_UNLIKELY (size == 0)) return FALSE;
 
   if (r_buffer_map (msg->hdr, &info, R_MEM_MAP_READ)) {
-    rssize idx;
-    if ((idx = r_str_idx_of_str_case ((rchar *)info.data, info.size, field, size)) >= 0)
-      ret = info.data[idx + (rsize)size] == ':';
+    const rchar * p = (const rchar *) info.data, * end = (const rchar *) info.data + info.size;
+    const rchar * name, * value;
+    rsize nsize, vsize;
+    while (r_http_header_next (&p, end, &name, &nsize, &value, &vsize)) {
+      if (nsize == (rsize) size && r_strncasecmp (name, field, nsize) == 0) {
+        ret = TRUE;
+        break;
+      }
+    }
     r_buffer_unmap (msg->hdr, &info);
   }
 
@@ -276,20 +322,17 @@ r_http_msg_has_header_of_value (RHttpMsg * msg,
   if (R_UNLIKELY (vsize == 0)) return FALSE;
 
   if (r_buffer_map (msg->hdr, &info, R_MEM_MAP_READ)) {
-    rsize off = 0;
-    rssize idx;
-    while (off < info.size &&
-        (idx = r_str_idx_of_str_case ((rchar *)info.data + off, info.size - off, key, ksize)) >= 0) {
-      off += idx + ksize + 1;
-      while (off < info.size && r_ascii_isspace (((rchar *)info.data)[off]))
-        off++;
-
-      if (off + vsize < info.size && r_strncasecmp ((rchar *)info.data + off, val, vsize) == 0) {
+    const rchar * p = (const rchar *) info.data, * end = (const rchar *) info.data + info.size;
+    const rchar * name, * value;
+    rsize nsize, vsz;
+    /* Match the value anywhere within a same-named header's value, so a
+     * comma list like "Connection: keep-alive, Upgrade" matches "keep-alive". */
+    while (r_http_header_next (&p, end, &name, &nsize, &value, &vsz)) {
+      if (nsize == (rsize) ksize && r_strncasecmp (name, key, nsize) == 0 &&
+          r_str_idx_of_str_case (value, vsz, val, vsize) >= 0) {
         ret = TRUE;
         break;
       }
-
-      off += vsize;
     }
     r_buffer_unmap (msg->hdr, &info);
   }
@@ -301,25 +344,20 @@ static const rchar *
 r_http_get_header (rconstpointer data, rsize size, const rchar * field, rssize fsize,
     rsize * out)
 {
-  const rchar * beg = data, * end = beg + size, * ret = NULL;
-  rssize idx;
+  const rchar * p = data, * end = (const rchar *) data + size;
+  const rchar * name, * value;
+  rsize nsize, vsize;
 
   if (fsize < 0) fsize = r_strlen (field);
-  if ((idx = r_str_idx_of_str_case (beg, size, field, fsize)) >= 0 &&
-      beg[idx + (rsize)fsize] == ':') {
-    const rchar * valbeg;
-
-    valbeg = r_str_lwstrip (beg + idx + 1 + (rsize)fsize);
-    if ((idx = r_str_idx_of_str (valbeg, RPOINTER_TO_SIZE (end - valbeg), "\r\n", 2)) >= 0) {
-      while (idx > 0 && r_ascii_isspace (valbeg[idx - 1]))
-        idx--;
+  while (r_http_header_next (&p, end, &name, &nsize, &value, &vsize)) {
+    if (nsize == (rsize) fsize && r_strncasecmp (name, field, nsize) == 0) {
       if (out != NULL)
-        *out = (rsize)idx;
-      ret = valbeg;
+        *out = vsize;
+      return value;
     }
   }
 
-  return ret;
+  return NULL;
 }
 
 rchar *
@@ -341,6 +379,26 @@ r_http_msg_get_header (RHttpMsg * msg, const rchar * field, rssize fsize)
   }
 
   return ret;
+}
+
+void
+r_http_msg_foreach_header (RHttpMsg * msg, RHttpHeaderFunc func, rpointer data)
+{
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+
+  if (R_UNLIKELY (msg == NULL)) return;
+  if (R_UNLIKELY (func == NULL)) return;
+
+  if (r_buffer_map (msg->hdr, &info, R_MEM_MAP_READ)) {
+    const rchar * p = (const rchar *) info.data, * end = (const rchar *) info.data + info.size;
+    const rchar * name, * value;
+    rsize nsize, vsize;
+    while (r_http_header_next (&p, end, &name, &nsize, &value, &vsize)) {
+      if (!func (data, name, nsize, value, vsize))
+        break;
+    }
+    r_buffer_unmap (msg->hdr, &info);
+  }
 }
 
 rboolean

--- a/test/rhttp.c
+++ b/test/rhttp.c
@@ -321,3 +321,89 @@ RTEST_END;
 
 /* TODO: Add tests for various request->reponse patterns! */
 
+
+static const rchar http_hdr_response[] =
+  "HTTP/1.1 200 OK\r\n"
+  "Content-Type: text/html\r\n"
+  "Content-Length: 5\r\n"
+  "Set-Cookie: a=1\r\n"
+  "Set-Cookie: b=2\r\n"
+  "Connection: keep-alive, Upgrade\r\n"
+  "\r\n"
+  "hello";
+
+RTEST (rhttp, header_lookup_anchored, RTEST_FAST)
+{
+  RHttpResponse * res;
+  RHttpError err;
+  RBuffer * buf;
+  rchar * tmp;
+
+  r_assert_cmpptr ((buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS (http_hdr_response))), !=, NULL);
+  r_assert_cmpptr ((res = r_http_response_new_from_buffer (NULL, buf, &err, NULL)), !=, NULL);
+  r_buffer_unref (buf);
+
+  /* Whole-name match (case-insensitive). */
+  r_assert_cmpstr ((tmp = r_http_response_get_header (res, "Content-Type", -1)), ==, "text/html"); r_free (tmp);
+  r_assert_cmpstr ((tmp = r_http_response_get_header (res, "content-length", -1)), ==, "5"); r_free (tmp);
+  r_assert (r_http_response_has_header (res, "Content-Length", -1));
+
+  /* A field name that is only a suffix of another header must NOT match. */
+  r_assert_cmpptr ((tmp = r_http_response_get_header (res, "Type", -1)), ==, NULL);
+  r_assert_cmpptr ((tmp = r_http_response_get_header (res, "Length", -1)), ==, NULL);
+  r_assert (!r_http_response_has_header (res, "Type", -1));
+  r_assert (!r_http_response_has_header (res, "Length", -1));
+
+  /* Value match within a comma list, case-insensitive. */
+  r_assert (r_http_response_has_header_of_value (res, "Connection", -1, "keep-alive", -1));
+  r_assert (r_http_response_has_header_of_value (res, "Connection", -1, "upgrade", -1));
+  r_assert (!r_http_response_has_header_of_value (res, "Connection", -1, "close", -1));
+
+  r_http_response_unref (res);
+}
+RTEST_END;
+
+typedef struct {
+  ruint count;
+  ruint cookies;
+  ruint stop_at;
+} RTestHdrCtx;
+
+static rboolean
+r_test_hdr_count (rpointer data, const rchar * name, rsize nsize,
+    const rchar * value, rsize vsize)
+{
+  RTestHdrCtx * ctx = data;
+  (void) value; (void) vsize;
+
+  ctx->count++;
+  if (nsize == 10 && r_strncasecmp (name, "Set-Cookie", 10) == 0)
+    ctx->cookies++;
+  return ctx->stop_at == 0 || ctx->count < ctx->stop_at;
+}
+
+RTEST (rhttp, header_foreach, RTEST_FAST)
+{
+  RHttpResponse * res;
+  RHttpError err;
+  RBuffer * buf;
+  RTestHdrCtx ctx = { 0, 0, 0 };
+
+  r_assert_cmpptr ((buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS (http_hdr_response))), !=, NULL);
+  r_assert_cmpptr ((res = r_http_response_new_from_buffer (NULL, buf, &err, NULL)), !=, NULL);
+  r_buffer_unref (buf);
+
+  /* Enumerate all headers in order, including the repeated Set-Cookie. */
+  r_http_response_foreach_header (res, r_test_hdr_count, &ctx);
+  r_assert_cmpuint (ctx.count, ==, 5);
+  r_assert_cmpuint (ctx.cookies, ==, 2);
+
+  /* Returning FALSE stops the walk. */
+  ctx.count = ctx.cookies = 0;
+  ctx.stop_at = 2;
+  r_http_response_foreach_header (res, r_test_hdr_count, &ctx);
+  r_assert_cmpuint (ctx.count, ==, 2);
+
+  r_http_response_unref (res);
+}
+RTEST_END;

--- a/test/rhttp.c
+++ b/test/rhttp.c
@@ -407,3 +407,89 @@ RTEST (rhttp, header_foreach, RTEST_FAST)
   r_http_response_unref (res);
 }
 RTEST_END;
+
+static rboolean
+r_test_hdr_count_named (rpointer data, const rchar * name, rsize nsize,
+    const rchar * value, rsize vsize)
+{
+  ruint * matches = ((rpointer *) data)[0];
+  const rchar * target = ((rpointer *) data)[1];
+  (void) value; (void) vsize;
+  if (nsize == r_strlen (target) && r_strncasecmp (name, target, nsize) == 0)
+    (*matches)++;
+  return TRUE;
+}
+
+
+static ruint
+r_test_count_header (RHttpResponse * res, const rchar * field)
+{
+  ruint matches = 0;
+  rpointer ctx[2];
+  ctx[0] = &matches;
+  ctx[1] = (rpointer) field;
+  r_http_response_foreach_header (res, r_test_hdr_count_named, ctx);
+  return matches;
+}
+
+RTEST (rhttp, header_set_remove, RTEST_FAST)
+{
+  RHttpResponse * res;
+  rchar * tmp;
+
+  r_assert_cmpptr ((res = r_http_response_new (NULL, R_HTTP_STATUS_OK,
+          NULL, NULL, NULL)), !=, NULL);
+
+  /* set replaces an existing header rather than duplicating it. */
+  r_assert (r_http_response_add_header (res, "X-Test", -1, "one", -1));
+  r_assert (r_http_response_set_header (res, "X-Test", -1, "two", -1));
+  r_assert_cmpuint (r_test_count_header (res, "X-Test"), ==, 1);
+  r_assert_cmpstr ((tmp = r_http_response_get_header (res, "X-Test", -1)), ==, "two");
+  r_free (tmp);
+
+  /* set on an absent header adds it. */
+  r_assert (r_http_response_set_header (res, "X-New", -1, "v", -1));
+  r_assert_cmpstr ((tmp = r_http_response_get_header (res, "X-New", -1)), ==, "v");
+  r_free (tmp);
+
+  /* remove drops every instance and reports whether anything was removed. */
+  r_assert (r_http_response_add_header (res, "X-Dup", -1, "a", -1));
+  r_assert (r_http_response_add_header (res, "X-Dup", -1, "b", -1));
+  r_assert_cmpuint (r_test_count_header (res, "X-Dup"), ==, 2);
+  r_assert (r_http_response_remove_header (res, "X-Dup", -1));
+  r_assert_cmpuint (r_test_count_header (res, "X-Dup"), ==, 0);
+  r_assert (!r_http_response_remove_header (res, "X-Dup", -1));
+
+  /* the untouched headers survive. */
+  r_assert_cmpuint (r_test_count_header (res, "X-Test"), ==, 1);
+  r_assert_cmpuint (r_test_count_header (res, "X-New"), ==, 1);
+
+  r_http_response_unref (res);
+}
+RTEST_END;
+
+RTEST (rhttp, set_body_no_duplicate_content_length, RTEST_FAST)
+{
+  RHttpResponse * res;
+  RBuffer * b1, * b2;
+  rchar * tmp;
+
+  r_assert_cmpptr ((res = r_http_response_new (NULL, R_HTTP_STATUS_OK,
+          NULL, NULL, NULL)), !=, NULL);
+  r_assert_cmpptr ((b1 = r_buffer_new_dup ("ab", 2)), !=, NULL);
+  r_assert_cmpptr ((b2 = r_buffer_new_dup ("xyz", 3)), !=, NULL);
+
+  /* Re-setting the body must overwrite Content-Length, not add a second. */
+  r_http_response_set_body_buffer_full (res, b1, "text/plain", -1, TRUE);
+  r_http_response_set_body_buffer_full (res, b2, "text/plain", -1, TRUE);
+
+  r_assert_cmpuint (r_test_count_header (res, "Content-Length"), ==, 1);
+  r_assert_cmpuint (r_test_count_header (res, "Content-Type"), ==, 1);
+  r_assert_cmpstr ((tmp = r_http_response_get_header (res, "Content-Length", -1)), ==, "3");
+  r_free (tmp);
+
+  r_buffer_unref (b1);
+  r_buffer_unref (b2);
+  r_http_response_unref (res);
+}
+RTEST_END;


### PR DESCRIPTION
The HTTP proto layer's header handling had a correctness bug and an incomplete writer. This fixes both while keeping the lightweight, zero-copy, scan-on-demand model — no per-message dictionary, caching, or copies.

## Read side — line-anchored + enumerable

The accessors scanned the raw header buffer with an unanchored substring search, so a field name matched anywhere, including as a suffix of another header: `get_header ("Type")` returned the `Content-Type` value and `has_header ("Length")` matched `Content-Length`. They were also first-match only.

- A single zero-copy line-walker (`r_http_header_next`) yields each header's name/value as `(ptr, len)` slices into the buffer.
- `get` / `has` / `has_of_value` reimplemented on it, so matching is line-anchored (whole field token up to `:`). Same public signatures.
- New `r_http_msg_foreach_header` for zero-copy enumeration and repeated headers (e.g. `Set-Cookie`).

## Write side — set / remove

The writer was append-only, so `set_body_buffer_full` appended a second `Content-Length` whenever a body was re-set.

- `r_http_msg_set_header` (replace any existing instances, then append) and `r_http_msg_remove_header` (splice out matching lines, leaving the other headers' bytes intact); `set_body_buffer_full` now uses `set`.

Request/response wrapper macros added for each new accessor.

## Tests
`test/rhttp.c` gains: anchored lookups (the `Type`/`Length` false matches are gone, positive lookups still work), enumeration + repeated `Set-Cookie`, early-stop, `set` replace/add, `remove` (all instances + return value), and no-duplicate-`Content-Length` on body re-set.

Verified: full http suite, ASan/LSan, Linux epoll + rpoll, mingw cross (werror) all clean; doxygen reports no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)