### PR TITLE
rhttpclient: decode chunked response bodies

### DIFF
--- a/include/rlib/net/proto/rhttp.h
+++ b/include/rlib/net/proto/rhttp.h
@@ -173,6 +173,17 @@ R_API rchar * r_http_msg_get_body (RHttpMsg * msg, rsize * size) R_ATTR_MALLOC;
 R_API RBuffer * r_http_msg_get_body_buffer (RHttpMsg * msg) R_ATTR_WARN_UNUSED_RESULT;
 /** @brief Set the message body from an @ref RBuffer. */
 R_API RHttpError r_http_msg_set_body_buffer (RHttpMsg * msg, RBuffer * buf);
+/**
+ * @brief Decode a chunked (Transfer-Encoding: chunked) body from @p buf.
+ * @param buf The accumulated chunked bytes (the body, starting at the first
+ *            chunk-size line).
+ * @param out On @c R_HTTP_OK receives the decoded body (zero-copy views into
+ *            @p buf; caller @ref r_buffer_unref's it). @c NULL otherwise.
+ * @return @c R_HTTP_OK when the terminating zero-size chunk has arrived,
+ *         @c R_HTTP_BUF_TOO_SMALL when more bytes are needed, or a decode
+ *         error for a malformed stream.
+ */
+R_API RHttpError r_http_chunked_decode (RBuffer * buf, RBuffer ** out) R_ATTR_WARN_UNUSED_RESULT;
 /** @brief @c TRUE if a header named @p field is present (@p size or @c -1). */
 R_API rboolean r_http_msg_has_header (RHttpMsg * msg, const rchar * field, rssize size);
 /** @brief @c TRUE if header @p key is present with value @p val. */

--- a/rlib/net/proto/rhttp.c
+++ b/rlib/net/proto/rhttp.c
@@ -502,6 +502,94 @@ r_http_msg_set_header (RHttpMsg * msg, const rchar * field, rssize fsize,
   return r_http_msg_add_header (msg, field, fsize, value, vsize);
 }
 
+RHttpError
+r_http_chunked_decode (RBuffer * buf, RBuffer ** out)
+{
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  RHttpError err = R_HTTP_BUF_TOO_SMALL;
+  RBuffer * body = NULL;
+
+  if (R_UNLIKELY (buf == NULL || out == NULL)) return R_HTTP_INVAL;
+  if (!r_buffer_map (buf, &info, R_MEM_MAP_READ)) return R_HTTP_INVAL;
+
+  if ((body = r_buffer_new ()) != NULL) {
+    const rchar * data = (const rchar *) info.data, * end = data + info.size;
+    const rchar * p = data;
+
+    for (;;) {
+      ruint64 csize = 0;
+      const rchar * q;
+      rssize crlf;
+
+      /* chunk-size line: hex size, optional ";ext", terminated by CRLF.
+       * Parse the hex digits directly: r_str_to_uint64 mishandles a leading
+       * zero in base 16, which is exactly the terminating "0" chunk. */
+      if ((crlf = r_str_idx_of_str (p, (rsize) (end - p), "\r\n", 2)) < 0)
+        break;                                  /* size line incomplete */
+      if (!r_ascii_isxdigit (*p)) {             /* need at least one hex digit */
+        err = R_HTTP_DECODE_ERROR;
+        break;
+      }
+      for (q = p; q < p + crlf && r_ascii_isxdigit (*q); q++) {
+        ruint d = r_ascii_isdigit (*q) ? (ruint) (*q - '0') :
+            (r_ascii_isupper (*q) ? (ruint) (*q - 'A' + 10) :
+                                    (ruint) (*q - 'a' + 10));
+        if (csize > (RUINT64_MAX - d) / 16) {   /* overflow */
+          err = R_HTTP_DECODE_ERROR;
+          break;
+        }
+        csize = csize * 16 + d;
+      }
+      if (err == R_HTTP_DECODE_ERROR)
+        break;
+      p += crlf + 2;
+
+      if (csize == 0) {
+        /* last chunk; consume any trailers up to the terminating empty line. */
+        for (;;) {
+          if ((crlf = r_str_idx_of_str (p, (rsize) (end - p), "\r\n", 2)) < 0) {
+            err = R_HTTP_BUF_TOO_SMALL;
+            break;
+          }
+          p += crlf + 2;
+          if (crlf == 0) {                      /* empty line: complete */
+            err = R_HTTP_OK;
+            break;
+          }
+        }
+        break;
+      }
+
+      /* need the chunk data plus its trailing CRLF. */
+      if ((ruint64) (end - p) < csize + 2) {
+        err = R_HTTP_BUF_TOO_SMALL;
+        break;
+      }
+      if (!r_buffer_append_view (body, buf, (rsize) (p - data), (rssize) csize)) {
+        err = R_HTTP_INVAL;
+        break;
+      }
+      p += csize;
+      if (p[0] != '\r' || p[1] != '\n') {
+        err = R_HTTP_DECODE_ERROR;
+        break;
+      }
+      p += 2;
+    }
+  }
+
+  r_buffer_unmap (buf, &info);
+
+  if (err == R_HTTP_OK) {
+    *out = body;
+  } else {
+    if (body != NULL)
+      r_buffer_unref (body);
+    *out = NULL;
+  }
+  return err;
+}
+
 
 
 static RBuffer *

--- a/rlib/net/rhttpclient.c
+++ b/rlib/net/rhttpclient.c
@@ -211,8 +211,22 @@ r_http_client_req_recv (rpointer data, RBuffer * buf, REvTCP * evtcp)
     case R_HTTP_BODY_PARSE_CLOSE:
       /* Body runs until the connection closes; handled on end-of-stream. */
       break;
+    case R_HTTP_BODY_PARSE_CHUNKED: {
+      RBuffer * body = NULL;
+      RHttpError err = (ctx->inbuf != NULL) ?
+          r_http_chunked_decode (ctx->inbuf, &body) : R_HTTP_BUF_TOO_SMALL;
+      if (err == R_HTTP_OK) {
+        r_http_response_set_body_buffer (ctx->res, body);
+        r_buffer_unref (body);
+        r_http_client_req_finish (ctx, R_HTTP_CLIENT_OK);
+      } else if (err != R_HTTP_BUF_TOO_SMALL) {
+        r_http_client_req_finish (ctx, R_HTTP_CLIENT_PARSE_FAILED);
+      }
+      /* else wait for more chunk bytes */
+      break;
+    }
     default:
-      /* Chunked / tunnel framing isn't implemented yet. */
+      /* Tunnel framing (after CONNECT) isn't implemented. */
       R_LOG_DEBUG ("%p: request %p unsupported body framing %d",
           ctx->client, ctx, (int) ctx->bodytype);
       r_http_client_req_finish (ctx, R_HTTP_CLIENT_PARSE_FAILED);

--- a/test/rhttp.c
+++ b/test/rhttp.c
@@ -493,3 +493,80 @@ RTEST (rhttp, set_body_no_duplicate_content_length, RTEST_FAST)
   r_http_response_unref (res);
 }
 RTEST_END;
+
+RTEST (rhttp, chunked_decode, RTEST_FAST)
+{
+  RBuffer * buf, * out;
+  static const rchar chunked[] =
+      "4\r\nWiki\r\n"
+      "5\r\npedia\r\n"
+      "E\r\n in\r\n\r\nchunks.\r\n"
+      "0\r\n\r\n";
+
+  r_assert_cmpptr ((buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS (chunked))), !=, NULL);
+  r_assert_cmpint (r_http_chunked_decode (buf, &out), ==, R_HTTP_OK);
+  r_assert_cmpptr (out, !=, NULL);
+  r_assert_cmpbufsstr (out, 0, -1, ==, "Wikipedia in\r\n\r\nchunks.");
+  r_buffer_unref (out);
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
+RTEST (rhttp, chunked_decode_chunk_ext_and_trailer, RTEST_FAST)
+{
+  RBuffer * buf, * out;
+  static const rchar chunked[] =
+      "5;name=value\r\nhello\r\n"
+      "0\r\n"
+      "X-Trailer: foo\r\n"
+      "\r\n";
+
+  r_assert_cmpptr ((buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS (chunked))), !=, NULL);
+  r_assert_cmpint (r_http_chunked_decode (buf, &out), ==, R_HTTP_OK);
+  r_assert_cmpbufsstr (out, 0, -1, ==, "hello");
+  r_buffer_unref (out);
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
+RTEST (rhttp, chunked_decode_incomplete, RTEST_FAST)
+{
+  RBuffer * buf, * out;
+
+  /* Size line not yet terminated. */
+  r_assert_cmpptr ((buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS ("4"))), !=, NULL);
+  r_assert_cmpint (r_http_chunked_decode (buf, &out), ==, R_HTTP_BUF_TOO_SMALL);
+  r_assert_cmpptr (out, ==, NULL);
+  r_buffer_unref (buf);
+
+  /* Chunk data shorter than the announced size. */
+  r_assert_cmpptr ((buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS ("4\r\nWi"))), !=, NULL);
+  r_assert_cmpint (r_http_chunked_decode (buf, &out), ==, R_HTTP_BUF_TOO_SMALL);
+  r_assert_cmpptr (out, ==, NULL);
+  r_buffer_unref (buf);
+
+  /* Last chunk seen but trailer block not terminated. */
+  r_assert_cmpptr ((buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS ("4\r\nWiki\r\n0\r\n"))), !=, NULL);
+  r_assert_cmpint (r_http_chunked_decode (buf, &out), ==, R_HTTP_BUF_TOO_SMALL);
+  r_assert_cmpptr (out, ==, NULL);
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
+RTEST (rhttp, chunked_decode_malformed, RTEST_FAST)
+{
+  RBuffer * buf, * out;
+
+  /* Non-hex chunk size. */
+  r_assert_cmpptr ((buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS ("zz\r\n"))), !=, NULL);
+  r_assert_cmpint (r_http_chunked_decode (buf, &out), ==, R_HTTP_DECODE_ERROR);
+  r_assert_cmpptr (out, ==, NULL);
+  r_buffer_unref (buf);
+
+  /* Chunk data not followed by CRLF. */
+  r_assert_cmpptr ((buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS ("4\r\nWikiXX0\r\n\r\n"))), !=, NULL);
+  r_assert_cmpint (r_http_chunked_decode (buf, &out), ==, R_HTTP_DECODE_ERROR);
+  r_assert_cmpptr (out, ==, NULL);
+  r_buffer_unref (buf);
+}
+RTEST_END;

--- a/test/rhttpclient.c
+++ b/test/rhttpclient.c
@@ -453,7 +453,8 @@ r_test_raw_server_free (RTestRawServer * s)
 }
 
 static RHttpClientResult
-r_test_http_client_raw (ruint16 port, const rchar * blob)
+r_test_http_client_raw_body (ruint16 port, const rchar * blob,
+    const rchar * expect_body)
 {
   REvLoop * loop;
   RClock * clock;
@@ -474,6 +475,11 @@ r_test_http_client_raw (ruint16 port, const rchar * blob)
           "http://127.0.0.1/", NULL, NULL)), !=, NULL);
 
   res = r_test_http_send (loop, client, req, addr, &result);
+  if (expect_body != NULL && result == R_HTTP_CLIENT_OK) {
+    const rchar * body;
+    r_assert_cmpptr (res, !=, NULL);
+    r_assert_cmpstr ((body = r_http_response_get_body (res, NULL)), ==, expect_body);
+  }
   r_http_request_unref (req);
   if (res != NULL)
     r_http_response_unref (res);
@@ -486,13 +492,19 @@ r_test_http_client_raw (ruint16 port, const rchar * blob)
   return result;
 }
 
-/* A chunked response is valid HTTP but the client does not decode chunked
- * framing yet, so it reports a parse failure rather than hanging. */
-RTEST (rhttpclient, response_chunked_unsupported, RTEST_FAST | RTEST_SYSTEM)
+static RHttpClientResult
+r_test_http_client_raw (ruint16 port, const rchar * blob)
 {
-  r_assert_cmpint (r_test_http_client_raw (47660,
+  return r_test_http_client_raw_body (port, blob, NULL);
+}
+
+/* A chunked response is decoded back into the reassembled body. */
+RTEST (rhttpclient, response_chunked, RTEST_FAST | RTEST_SYSTEM)
+{
+  r_assert_cmpint (r_test_http_client_raw_body (47660,
         "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
-        "3\r\nabc\r\n0\r\n\r\n"), ==, R_HTTP_CLIENT_PARSE_FAILED);
+        "4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n", "Wikipedia"),
+      ==, R_HTTP_CLIENT_OK);
 }
 RTEST_END;
 


### PR DESCRIPTION
Adds a chunked (`Transfer-Encoding: chunked`) decoder and wires it into the HTTP client's response path. Previously chunked responses fell through to `R_HTTP_CLIENT_PARSE_FAILED`.

## Decoder (`rhttp.c`)
`r_http_chunked_decode (buf, &out)` lives in the proto layer so the server can reuse it for chunked request bodies. It reassembles the body using zero-copy views over the source — no payload copying — keeping the light feel of the rest of the layer.

- `R_HTTP_OK` once the terminating zero-size chunk and its trailer block have arrived (`out` = decoded body, caller unrefs).
- `R_HTTP_BUF_TOO_SMALL` while more bytes are needed.
- `R_HTTP_DECODE_ERROR` for a malformed stream; `R_HTTP_INVAL` for null args.
- Tolerates chunk-extensions (`;ext`) and trailer lines.

The hex chunk size is parsed inline rather than via `r_str_to_uint64`, which mishandles a leading zero in base 16 — exactly the terminating `0` chunk (filed separately as #293).

## Client (`rhttpclient.c`)
The `R_HTTP_BODY_PARSE_CHUNKED` arm re-runs the decoder over the accumulated input as bytes arrive, finishing the request once the body is complete.

## Tests
Decoder unit tests (round-trip, chunk-ext + trailer, incomplete, malformed) plus an end-to-end client test over the raw-TCP server asserting the reassembled body.

Verified: epoll + rpoll full suite, ASan/UBSan, mingw werror, doxygen — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)