### PR TITLE
rhttpclient: add URI-targeted request API

### DIFF
--- a/include/rlib/net/rhttpclient.h
+++ b/include/rlib/net/rhttpclient.h
@@ -44,13 +44,15 @@
  * to a peer, sends an @ref RHttpRequest and delivers the parsed
  * @ref RHttpResponse.
  *
- * @ref r_http_client_send is asynchronous: the result arrives via a
+ * @ref r_http_client_request_to_addr is asynchronous: the result arrives via a
  * callback on the loop thread. For blocking use without managing a loop,
  * see @ref RHttpClientSync, which owns a private loop and an @ref RHttpClient.
  *
- * Scope is plaintext HTTP/1.1 to an explicit @ref RSocketAddress, with
- * response bodies framed by @c Content-Length or by connection close.
- * Built on the @ref r_http_proto wire codec and @ref r_evtcp.
+ * Scope is plaintext HTTP/1.1, either to an explicit @ref RSocketAddress or
+ * to the host/port derived from the request URI (@ref r_http_client_request),
+ * with response bodies framed by @c Content-Length, chunked transfer-encoding
+ * or connection close. Built on the @ref r_http_proto wire codec and
+ * @ref r_evtcp.
  *
  * @{
  */
@@ -63,6 +65,7 @@ typedef struct RHttpClient RHttpClient;
 /** @brief Outcome of an HTTP request attempt. */
 typedef enum {
   R_HTTP_CLIENT_OK = 0,         /**< Response received and parsed. */
+  R_HTTP_CLIENT_RESOLVE_FAILED, /**< Could not resolve the request URI's host. */
   R_HTTP_CLIENT_CONNECT_FAILED, /**< Could not connect to the peer. */
   R_HTTP_CLIENT_SEND_FAILED,    /**< Could not send the request. */
   R_HTTP_CLIENT_RECV_FAILED,    /**< Transport error, or closed before the body completed. */
@@ -70,8 +73,8 @@ typedef enum {
 } RHttpClientResult;
 
 /**
- * @brief Deliver the outcome of @ref r_http_client_send.
- * @param data   User pointer passed to @ref r_http_client_send.
+ * @brief Deliver the outcome of @ref r_http_client_request_to_addr.
+ * @param data   User pointer passed to @ref r_http_client_request_to_addr.
  * @param res    The parsed response, non-@c NULL only when @p result is
  *               @ref R_HTTP_CLIENT_OK. Borrowed; @ref r_http_response_ref to keep it.
  * @param result The request outcome.
@@ -100,8 +103,32 @@ R_API RHttpClient * r_http_client_new (REvLoop * loop);
  *         @c FALSE the request could not be started and the caller retains
  *         ownership of @p data (@p notify is not called).
  */
-R_API rboolean r_http_client_send (RHttpClient * client, RHttpRequest * req,
+R_API rboolean r_http_client_request_to_addr (RHttpClient * client, RHttpRequest * req,
     const RSocketAddress * addr,
+    RHttpClientResponseFunc cb, rpointer data, RDestroyNotify notify);
+
+/**
+ * @brief Asynchronously resolve @p req's URI, send it and deliver the response.
+ *
+ * Derives the host and port from the request URI (@ref r_http_request_get_uri),
+ * resolves them on the loop via the asynchronous resolver (never blocking the
+ * loop thread), then connects to the first resolved address. The port defaults
+ * to 80 for the @c http scheme when the URI omits it. Only plaintext targets
+ * are supported: a missing host, or a URI with no port and a non-@c http
+ * scheme, is rejected.
+ *
+ * @param client The client.
+ * @param req    The request to send; its URI selects the target.
+ * @param cb     Invoked with the outcome on the loop thread.
+ * @param data   User pointer passed to @p cb.
+ * @param notify Destroy notify for @p data.
+ * @return @c TRUE if the request was started, in which case @p cb delivers the
+ *         outcome (including @ref R_HTTP_CLIENT_RESOLVE_FAILED) and @p notify is
+ *         called once the request finishes. On @c FALSE the request could not
+ *         be started -- the URI lacked a usable host/port -- and the caller
+ *         retains ownership of @p data (@p notify is not called).
+ */
+R_API rboolean r_http_client_request (RHttpClient * client, RHttpRequest * req,
     RHttpClientResponseFunc cb, rpointer data, RDestroyNotify notify);
 
 
@@ -109,7 +136,7 @@ R_API rboolean r_http_client_send (RHttpClient * client, RHttpRequest * req,
  * @brief Opaque, refcounted blocking HTTP client.
  *
  * A self-contained synchronous client: it owns a private @ref REvLoop and an
- * @ref RHttpClient, and @ref r_http_client_sync_request runs that loop until
+ * @ref RHttpClient, and @ref r_http_client_sync_request_to_addr runs that loop until
  * the response is in. Callers never deal with an event loop. For overlapping
  * or non-blocking requests, use @ref RHttpClient directly on your own loop.
  */
@@ -131,8 +158,23 @@ R_API RHttpClientSync * r_http_client_sync_new (void);
  * @return The response (caller @ref r_http_response_unref's it) on success,
  *         or @c NULL on failure.
  */
-R_API RHttpResponse * r_http_client_sync_request (RHttpClientSync * client,
+R_API RHttpResponse * r_http_client_sync_request_to_addr (RHttpClientSync * client,
     RHttpRequest * req, const RSocketAddress * addr, RHttpClientResult * result);
+
+/**
+ * @brief Resolve @p req's URI, send it and block until the response arrives.
+ *
+ * The blocking counterpart of @ref r_http_client_request -- the destination
+ * is derived from the request URI, so the caller passes no address.
+ *
+ * @param client The blocking client.
+ * @param req    The request to send; its URI selects the target.
+ * @param result If non-@c NULL, receives the request outcome.
+ * @return The response (caller @ref r_http_response_unref's it) on success,
+ *         or @c NULL on failure.
+ */
+R_API RHttpResponse * r_http_client_sync_request (RHttpClientSync * client,
+    RHttpRequest * req, RHttpClientResult * result);
 
 R_END_DECLS
 

--- a/rlib/net/rhttpclient.c
+++ b/rlib/net/rhttpclient.c
@@ -21,10 +21,13 @@
 #include <rlib/net/rhttpclient.h>
 
 #include <rlib/ev/revtcp.h>
+#include <rlib/ev/revresolve.h>
 
 #include <rlib/data/rptrarray.h>
 
+#include <rlib/ruri.h>
 #include <rlib/rmem.h>
+#include <rlib/rstr.h>
 
 /* Cap unparsed response-header bytes so a peer that never sends the
  * terminating CRLFCRLF can't grow the input buffer without bound. */
@@ -100,9 +103,10 @@ r_http_client_req_do_close (rpointer data, REvLoop * loop)
  * @defer is TRUE when called from inside a connect/recv callback, where
  * closing the socket synchronously would free the io-watch entry the loop is
  * still iterating; the close is then deferred to a loop callback. It is FALSE
- * only for a synchronous connect failure raised from r_http_client_send (not a
- * loop callback, and the failed socket has no active watch), where deferring
- * would strand the close if the caller never runs the loop again. */
+ * only for a synchronous connect failure raised from
+ * r_http_client_request_to_addr (not a loop callback, and the failed socket has
+ * no active watch), where deferring would strand the close if the caller never
+ * runs the loop again. */
 static void
 r_http_client_req_teardown (RHttpClientReqCtx * ctx, RHttpClientResult result,
     rboolean defer)
@@ -120,11 +124,15 @@ r_http_client_req_teardown (RHttpClientReqCtx * ctx, RHttpClientResult result,
     ctx->cb (ctx->data, result == R_HTTP_CLIENT_OK ? ctx->res : NULL,
         result, ctx->client);
 
-  if (defer)
-    r_ev_loop_add_callback (ctx->client->loop, FALSE,
-        r_http_client_req_do_close, r_ref_ref (ctx), r_ref_unref);
-  else
-    r_ev_tcp_close (ctx->evtcp, NULL, NULL, NULL);
+  /* evtcp is NULL when the request fails during DNS resolution, before a
+   * socket is created; there is then nothing to close. */
+  if (ctx->evtcp != NULL) {
+    if (defer)
+      r_ev_loop_add_callback (ctx->client->loop, FALSE,
+          r_http_client_req_do_close, r_ref_ref (ctx), r_ref_unref);
+    else
+      r_ev_tcp_close (ctx->evtcp, NULL, NULL, NULL);
+  }
   r_ptr_array_remove_first_fast (ctx->client->reqs, ctx);
 
   r_ref_unref (ctx);
@@ -269,7 +277,7 @@ r_http_client_req_error (rpointer data, REvTCP * evtcp, RSocketStatus error)
 }
 
 rboolean
-r_http_client_send (RHttpClient * client, RHttpRequest * req,
+r_http_client_request_to_addr (RHttpClient * client, RHttpRequest * req,
     const RSocketAddress * addr,
     RHttpClientResponseFunc cb, rpointer data, RDestroyNotify notify)
 {
@@ -304,6 +312,98 @@ r_http_client_send (RHttpClient * client, RHttpRequest * req,
   if (r_ev_tcp_connect (ctx->evtcp, addr,
         r_http_client_req_connected, ctx, NULL) < R_SOCKET_OK)
     r_http_client_req_teardown (ctx, R_HTTP_CLIENT_CONNECT_FAILED, FALSE);
+
+  return TRUE;
+}
+
+/* DNS resolution completed: connect to the first resolved address. ctx is
+ * borrowed -- it stays alive in client->reqs for the duration of the
+ * resolution (nothing else can tear it down before this fires). */
+static void
+r_http_client_req_resolved (rpointer data, RResolvedAddr * addr,
+    RResolveResult res)
+{
+  RHttpClientReqCtx * ctx = data;
+
+  if (ctx->finished)
+    return;
+
+  if (res != R_RESOLVE_OK || addr == NULL || addr->addr == NULL) {
+    R_LOG_DEBUG ("%p: request %p resolve failed (%d)", ctx->client, ctx, (int) res);
+    r_http_client_req_finish (ctx, R_HTTP_CLIENT_RESOLVE_FAILED);
+    return;
+  }
+
+  if ((ctx->evtcp = r_ev_tcp_new (r_socket_address_get_family (addr->addr),
+          ctx->client->loop)) == NULL) {
+    r_http_client_req_finish (ctx, R_HTTP_CLIENT_CONNECT_FAILED);
+    return;
+  }
+  r_ev_tcp_set_error_handler (ctx->evtcp, r_http_client_req_error, ctx, NULL);
+  if (r_ev_tcp_connect (ctx->evtcp, addr->addr,
+        r_http_client_req_connected, ctx, NULL) < R_SOCKET_OK)
+    r_http_client_req_finish (ctx, R_HTTP_CLIENT_CONNECT_FAILED);
+}
+
+rboolean
+r_http_client_request (RHttpClient * client, RHttpRequest * req,
+    RHttpClientResponseFunc cb, rpointer data, RDestroyNotify notify)
+{
+  RHttpClientReqCtx * ctx;
+  RUri * uri;
+  rchar * host, * scheme;
+  ruint16 port;
+  rchar service[8];
+  RResolveHints hints = { R_SOCKET_FAMILY_NONE, R_SOCKET_TYPE_STREAM,
+      R_SOCKET_PROTOCOL_DEFAULT };
+  REvResolve * resolve;
+
+  if (R_UNLIKELY (client == NULL || req == NULL || cb == NULL))
+    return FALSE;
+  if (R_UNLIKELY ((uri = r_http_request_get_uri (req)) == NULL))
+    return FALSE;
+
+  host = r_uri_get_hostname (uri);
+  scheme = r_uri_get_scheme (uri);
+  port = r_uri_get_port (uri);
+  r_uri_unref (uri);
+
+  /* Fall back to the scheme's default port; only plaintext http is targeted. */
+  if (port == 0 && scheme != NULL && r_strcasecmp (scheme, "http") == 0)
+    port = 80;
+  r_free (scheme);
+  if (R_UNLIKELY (host == NULL || port == 0)) {
+    r_free (host);
+    return FALSE;
+  }
+  r_snprintf (service, sizeof (service), "%u", (ruint) port);
+
+  if ((ctx = r_mem_new0 (RHttpClientReqCtx)) == NULL) {
+    r_free (host);
+    return FALSE;
+  }
+  r_ref_init (ctx, r_http_client_req_ctx_free);
+  ctx->client = r_http_client_ref (client);
+  ctx->req = r_http_request_ref (req);
+  ctx->bodytype = R_HTTP_BODY_PARSE_SIZED;
+
+  /* Committed: the array owns ctx and every outcome is delivered via cb. */
+  ctx->cb = cb;
+  ctx->data = data;
+  ctx->notify = notify;
+  r_ptr_array_add (client->reqs, ctx, r_ref_unref);
+
+  R_LOG_TRACE ("%p: request %p resolving %s:%s", client, ctx, host, service);
+  resolve = r_ev_resolve_addr_new (host, service, 0, &hints, client->loop,
+      r_http_client_req_resolved, ctx, NULL);
+  r_free (host);
+  if (R_UNLIKELY (resolve == NULL)) {
+    r_http_client_req_teardown (ctx, R_HTTP_CLIENT_RESOLVE_FAILED, FALSE);
+    return TRUE;
+  }
+  /* The queued task keeps the resolve alive until the callback fires; we
+   * don't retain the handle (the request can't be cancelled mid-resolve). */
+  r_ev_resolve_unref (resolve);
 
   return TRUE;
 }
@@ -406,17 +506,40 @@ r_http_client_sync_cb (rpointer data, RHttpResponse * res,
 }
 
 RHttpResponse *
-r_http_client_sync_request (RHttpClientSync * sync, RHttpRequest * req,
+r_http_client_sync_request_to_addr (RHttpClientSync * sync, RHttpRequest * req,
     const RSocketAddress * addr, RHttpClientResult * result)
 {
   RHttpClientSyncState state = { NULL, R_HTTP_CLIENT_CONNECT_FAILED, FALSE,
       sync != NULL ? sync->loop : NULL };
 
   if (R_UNLIKELY (sync == NULL) ||
-      !r_http_client_send (sync->client, req, addr,
+      !r_http_client_request_to_addr (sync->client, req, addr,
           r_http_client_sync_cb, &state, NULL)) {
     if (result != NULL)
       *result = R_HTTP_CLIENT_CONNECT_FAILED;
+    return NULL;
+  }
+
+  while (!state.done)
+    r_ev_loop_run (sync->loop, R_EV_LOOP_RUN_LOOP);
+
+  if (result != NULL)
+    *result = state.result;
+  return state.res;
+}
+
+RHttpResponse *
+r_http_client_sync_request (RHttpClientSync * sync, RHttpRequest * req,
+    RHttpClientResult * result)
+{
+  RHttpClientSyncState state = { NULL, R_HTTP_CLIENT_RESOLVE_FAILED, FALSE,
+      sync != NULL ? sync->loop : NULL };
+
+  if (R_UNLIKELY (sync == NULL) ||
+      !r_http_client_request (sync->client, req,
+          r_http_client_sync_cb, &state, NULL)) {
+    if (result != NULL)
+      *result = R_HTTP_CLIENT_RESOLVE_FAILED;
     return NULL;
   }
 

--- a/test/rhttpclient.c
+++ b/test/rhttpclient.c
@@ -33,9 +33,28 @@ r_test_http_send (REvLoop * loop, RHttpClient * client, RHttpRequest * req,
 {
   RTestHttpSyncState st = { NULL, R_HTTP_CLIENT_CONNECT_FAILED, FALSE, loop };
 
-  if (!r_http_client_send (client, req, addr, r_test_http_send_cb, &st, NULL)) {
+  if (!r_http_client_request_to_addr (client, req, addr, r_test_http_send_cb, &st, NULL)) {
     if (result != NULL)
       *result = R_HTTP_CLIENT_CONNECT_FAILED;
+    return NULL;
+  }
+  while (!st.done)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
+  if (result != NULL)
+    *result = st.result;
+  return st.res;
+}
+
+/* As r_test_http_send, but targets the host/port derived from req's URI. */
+static RHttpResponse *
+r_test_http_send_uri (REvLoop * loop, RHttpClient * client, RHttpRequest * req,
+    RHttpClientResult * result)
+{
+  RTestHttpSyncState st = { NULL, R_HTTP_CLIENT_RESOLVE_FAILED, FALSE, loop };
+
+  if (!r_http_client_request (client, req, r_test_http_send_cb, &st, NULL)) {
+    if (result != NULL)
+      *result = R_HTTP_CLIENT_RESOLVE_FAILED;
     return NULL;
   }
   while (!st.done)
@@ -140,6 +159,73 @@ RTEST (rhttpclient, request_get, RTEST_FAST | RTEST_SYSTEM)
 
   r_socket_address_unref (addr);
   r_test_http_client_teardown (loop, client, srv);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+/* The target is derived from the request URI (host:port) and resolved on the
+ * loop; 127.0.0.1 resolves numerically without touching DNS. */
+RTEST (rhttpclient, request_get_uri, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RHttpServer * srv;
+  RHttpClient * client;
+  RHttpRequest * req;
+  RHttpResponse * res;
+  RSocketAddress * addr;
+  RHttpClientResult result;
+  rchar * body;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((srv = r_test_http_client_server (loop, 47664, "/",
+          R_HTTP_STATUS_OK, &addr)), !=, NULL);
+  r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
+
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+          "http://127.0.0.1:47664/", NULL, NULL)), !=, NULL);
+
+  res = r_test_http_send_uri (loop, client, req, &result);
+  r_http_request_unref (req);
+
+  r_assert_cmpint (result, ==, R_HTTP_CLIENT_OK);
+  r_assert_cmpptr (res, !=, NULL);
+  r_assert_cmpint (r_http_response_get_status (res), ==, R_HTTP_STATUS_OK);
+  r_assert_cmpstr ((body = r_http_response_get_body (res, NULL)), ==,
+      R_TEST_HTTP_CLIENT_BODY);
+  r_free (body);
+  r_http_response_unref (res);
+
+  r_socket_address_unref (addr);
+  r_test_http_client_teardown (loop, client, srv);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+/* A non-http scheme with no explicit port has no usable target: the request
+ * is rejected before it starts (FALSE), so notify is never called. */
+RTEST (rhttpclient, request_uri_unsupported, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RHttpClient * client;
+  RHttpRequest * req;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+          "https://127.0.0.1/", NULL, NULL)), !=, NULL);
+
+  r_assert (!r_http_client_request (client, req, r_test_http_send_cb, NULL, NULL));
+
+  r_http_request_unref (req);
+  r_http_client_unref (client);
   r_ev_loop_unref (loop);
 }
 RTEST_END;
@@ -568,7 +654,52 @@ RTEST (rhttpclientsync, request, RTEST_FAST | RTEST_SYSTEM)
           "http://127.0.0.1/", NULL, NULL)), !=, NULL);
   r_assert (r_http_request_add_header (req, "Host", -1, "127.0.0.1", -1));
 
-  res = r_http_client_sync_request (sync, req, addr, &result);
+  res = r_http_client_sync_request_to_addr (sync, req, addr, &result);
+  r_http_request_unref (req);
+
+  r_assert_cmpint (result, ==, R_HTTP_CLIENT_OK);
+  r_assert_cmpptr (res, !=, NULL);
+  r_assert_cmpint (r_http_response_get_status (res), ==, R_HTTP_STATUS_OK);
+  r_assert_cmpstr ((body = r_http_response_get_body (res, NULL)), ==, "hi");
+  r_free (body);
+  r_http_response_unref (res);
+
+  r_thread_join (thread);
+  r_thread_unref (thread);
+  r_http_client_sync_unref (sync);
+  r_socket_close (listen);
+  r_socket_unref (listen);
+  r_socket_address_unref (addr);
+}
+RTEST_END;
+
+/* The blocking client derives and resolves the target from the request URI. */
+RTEST (rhttpclientsync, request_uri, RTEST_FAST | RTEST_SYSTEM)
+{
+  RSocket * listen;
+  RSocketAddress * addr;
+  RThread * thread;
+  RHttpClientSync * sync;
+  RHttpRequest * req;
+  RHttpResponse * res;
+  RHttpClientResult result;
+  rchar * body;
+
+  r_assert_cmpptr ((listen = r_socket_new (R_SOCKET_FAMILY_IPV4,
+          R_SOCKET_TYPE_STREAM, R_SOCKET_PROTOCOL_TCP)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1,
+          47666)), !=, NULL);
+  r_assert_cmpint (r_socket_bind (listen, addr, TRUE), ==, R_SOCKET_OK);
+  r_assert_cmpint (r_socket_listen (listen), ==, R_SOCKET_OK);
+  r_assert (r_socket_set_blocking (listen, TRUE));
+  r_assert_cmpptr ((thread = r_thread_new (NULL,
+          r_test_http_blocking_responder, listen)), !=, NULL);
+
+  r_assert_cmpptr ((sync = r_http_client_sync_new ()), !=, NULL);
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+          "http://127.0.0.1:47666/", NULL, NULL)), !=, NULL);
+
+  res = r_http_client_sync_request (sync, req, &result);
   r_http_request_unref (req);
 
   r_assert_cmpint (result, ==, R_HTTP_CLIENT_OK);
@@ -601,7 +732,7 @@ RTEST (rhttpclientsync, connect_refused, RTEST_FAST | RTEST_SYSTEM)
   r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
           "http://127.0.0.1/", NULL, NULL)), !=, NULL);
 
-  res = r_http_client_sync_request (sync, req, addr, &result);
+  res = r_http_client_sync_request_to_addr (sync, req, addr, &result);
   r_http_request_unref (req);
 
   r_assert_cmpint (result, ==, R_HTTP_CLIENT_CONNECT_FAILED);


### PR DESCRIPTION
`RHttpClient` (added in #261) only connected to an explicit `RSocketAddress`, leaving the caller to resolve the destination. This adds URI/DNS-based targeting and reorganises the naming so the ergonomic, resolve-from-URI calls are the primary, unsuffixed API.

## API

| | URI-resolving (primary) | explicit `RSocketAddress` |
|---|---|---|
| **async** | `r_http_client_request` | `r_http_client_request_to_addr` |
| **blocking** | `r_http_client_sync_request` | `r_http_client_sync_request_to_addr` |

The explicit-address functions from #261 (`r_http_client_send`, `r_http_client_sync_request`) are renamed with a `_to_addr` suffix; the clean names go to the new URI-targeted functions.

## Behaviour

`r_http_client_request` derives the host and port from the request URI (`r_http_request_get_uri`) and resolves them on the loop via the asynchronous resolver — never blocking the loop thread — then connects to the first resolved address. The port defaults to 80 for the `http` scheme when the URI omits it; only plaintext targets are supported (a missing host, or no port with a non-`http` scheme, is rejected before the request starts). Adds `R_HTTP_CLIENT_RESOLVE_FAILED`.

## Lifetime

The request context is borrowed by the resolve callback and kept alive by the in-flight array — nothing can tear it down mid-resolution (the ctx→client reference also blocks client teardown). The resolve handle is dropped immediately since the queued task owns it until the callback fires, so there is no reference cycle and no handle to store. The teardown path now tolerates a `NULL` socket, which is the state when a request fails during resolution before any connection.

## Tests

Async URI round-trip and blocking URI round-trip (both against a loopback server, using numeric `127.0.0.1` so no live DNS), plus the unsupported-scheme rejection (`FALSE`, `notify` not called). A real-DNS resolve-failure case is left out deliberately — it would be flaky in the CI sandbox, matching the existing `SKIP_RTEST(revresolve, live_addr)` convention.

Verified: epoll + rpoll full suite, ASan/UBSan, mingw werror, doxygen — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)