### PR TITLE
rhttpclient: HTTP/1.1 keep-alive connection reuse

### DIFF
--- a/include/rlib/net/proto/rhttp.h
+++ b/include/rlib/net/proto/rhttp.h
@@ -192,6 +192,17 @@ R_API rboolean r_http_msg_has_header_of_value (RHttpMsg * msg,
 /** @brief Return the value of header @p field (newly allocated), or @c NULL. */
 R_API rchar * r_http_msg_get_header (RHttpMsg * msg, const rchar * field, rssize size);
 /**
+ * @brief @c TRUE if this message permits HTTP/1.1 keep-alive.
+ *
+ * From the message's own @c Connection header and HTTP version: explicit
+ * @c close is @c FALSE, explicit @c keep-alive is @c TRUE, otherwise persistence
+ * is the HTTP/1.1 default. Connection reuse needs both the response and its
+ * originating request to agree, and ignores body framing (a @ref
+ * R_HTTP_BODY_PARSE_CLOSE body still requires the connection to close) -- the
+ * caller combines those.
+ */
+R_API rboolean r_http_msg_is_keepalive (RHttpMsg * msg);
+/**
  * @brief Per-header callback for @ref r_http_msg_foreach_header.
  * @param data  User pointer passed to @ref r_http_msg_foreach_header.
  * @param name  Header name, @p nsize bytes — points into the message, not NUL-terminated.
@@ -255,6 +266,8 @@ R_API RUri * r_http_request_get_uri (RHttpRequest * req);
   r_http_msg_has_header_of_value ((RHttpMsg *)req, key, ksize, val, vsize)
 /** @brief @ref r_http_msg_get_header on a request. */
 #define r_http_request_get_header(req, field, size) r_http_msg_get_header ((RHttpMsg *)req, field, size)
+/** @brief @ref r_http_msg_is_keepalive on a request. */
+#define r_http_request_is_keepalive(req) r_http_msg_is_keepalive ((RHttpMsg *)req)
 /** @brief @ref r_http_msg_foreach_header on a request. */
 #define r_http_request_foreach_header(req, func, data) r_http_msg_foreach_header ((RHttpMsg *)req, func, data)
 /** @brief @ref r_http_msg_add_header on a request. */
@@ -301,6 +314,8 @@ R_API rchar * r_http_response_get_phrase (const RHttpResponse * res) R_ATTR_MALL
 /** @brief Return the request this response was built for (caller owns the
  *  reference; @ref r_http_request_unref when done), or @c NULL if none. */
 R_API RHttpRequest * r_http_response_get_request (RHttpResponse * res);
+/** @brief @ref r_http_msg_is_keepalive on a response. */
+#define r_http_response_is_keepalive(res) r_http_msg_is_keepalive ((RHttpMsg *)res)
 /** @brief @ref r_http_msg_has_header on a response. */
 #define r_http_response_has_header(res, field, size) r_http_msg_has_header ((RHttpMsg *)res, field, size)
 /** @brief @ref r_http_msg_has_header_of_value on a response. */

--- a/include/rlib/net/rhttpclient.h
+++ b/include/rlib/net/rhttpclient.h
@@ -51,8 +51,9 @@
  * Scope is plaintext HTTP/1.1, either to an explicit @ref RSocketAddress or
  * to the host/port derived from the request URI (@ref r_http_client_request),
  * with response bodies framed by @c Content-Length, chunked transfer-encoding
- * or connection close. Built on the @ref r_http_proto wire codec and
- * @ref r_evtcp.
+ * or connection close. Persistent connections are reused via a small per-client
+ * pool (@ref r_http_client_set_keepalive). Built on the @ref r_http_proto wire
+ * codec and @ref r_evtcp.
  *
  * @{
  */
@@ -89,6 +90,28 @@ R_API RHttpClient * r_http_client_new (REvLoop * loop);
 #define r_http_client_ref   r_ref_ref
 /** @brief Drop a reference (alias for @ref r_ref_unref). */
 #define r_http_client_unref r_ref_unref
+
+/**
+ * @brief Enable or disable HTTP/1.1 keep-alive connection reuse (default on).
+ *
+ * When enabled, a connection left open by a self-delimited, persistent response
+ * is parked in a per-client pool and reused by the next request to the same
+ * destination. A caller can still force a single request to close by setting a
+ * @c Connection: close header on it.
+ */
+R_API void r_http_client_set_keepalive (RHttpClient * client, rboolean enabled);
+/** @brief Whether keep-alive connection reuse is enabled (see @ref r_http_client_set_keepalive). */
+R_API rboolean r_http_client_get_keepalive (RHttpClient * client);
+/**
+ * @brief Set how long an idle pooled connection is kept before eviction.
+ * @param client  The client.
+ * @param timeout Idle lifetime (e.g. @c 30 * @c R_SECOND); @c 0 disables the
+ *                timer so connections live until the peer closes them or the
+ *                client is destroyed. Default is 60 seconds.
+ */
+R_API void r_http_client_set_idle_timeout (RHttpClient * client, RClockTimeDiff timeout);
+/** @brief The idle-connection timeout (see @ref r_http_client_set_idle_timeout). */
+R_API RClockTimeDiff r_http_client_get_idle_timeout (RHttpClient * client);
 
 /**
  * @brief Asynchronously send @p req to @p addr and deliver the response.
@@ -148,6 +171,15 @@ R_API RHttpClientSync * r_http_client_sync_new (void);
 #define r_http_client_sync_ref   r_ref_ref
 /** @brief Drop a reference (alias for @ref r_ref_unref). */
 #define r_http_client_sync_unref r_ref_unref
+
+/** @brief @ref r_http_client_set_keepalive on the underlying client. */
+R_API void r_http_client_sync_set_keepalive (RHttpClientSync * client, rboolean enabled);
+/** @brief @ref r_http_client_get_keepalive on the underlying client. */
+R_API rboolean r_http_client_sync_get_keepalive (RHttpClientSync * client);
+/** @brief @ref r_http_client_set_idle_timeout on the underlying client. */
+R_API void r_http_client_sync_set_idle_timeout (RHttpClientSync * client, RClockTimeDiff timeout);
+/** @brief @ref r_http_client_get_idle_timeout on the underlying client. */
+R_API RClockTimeDiff r_http_client_sync_get_idle_timeout (RHttpClientSync * client);
 
 /**
  * @brief Send @p req to @p addr and block until the response arrives.

--- a/rlib/net/proto/rhttp.c
+++ b/rlib/net/proto/rhttp.c
@@ -1018,6 +1018,49 @@ r_http_response_get_request (RHttpResponse * res)
   return NULL;
 }
 
+/* TRUE if the message start line is HTTP/1.1. The version is the field that
+ * begins with "HTTP/": the first of a response status line ("HTTP/1.1 200 OK"),
+ * the third of a request line ("GET / HTTP/1.1"). Anything else (1.0, 0.9,
+ * malformed) is treated as not 1.1. */
+static rboolean
+r_http_msg_is_http_1_1 (RHttpMsg * msg)
+{
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  rboolean ret = FALSE;
+
+  if (r_buffer_map (msg->start, &info, R_MEM_MAP_READ)) {
+    RStrMatchResult * sres;
+
+    if ((sres = r_http_parse_start_line (info.data, info.size)) != NULL) {
+      ruint v = (sres->token[0].chunk.size >= 5 &&
+          r_strncmp (sres->token[0].chunk.str, "HTTP/", 5) == 0) ? 0 : 4;
+      ret = sres->token[v].chunk.size == 8 &&
+          r_strncmp (sres->token[v].chunk.str, "HTTP/1.1", 8) == 0;
+      r_free (sres);
+    }
+
+    r_buffer_unmap (msg->start, &info);
+  }
+
+  return ret;
+}
+
+rboolean
+r_http_msg_is_keepalive (RHttpMsg * msg)
+{
+  if (R_UNLIKELY (msg == NULL)) return FALSE;
+
+  /* An explicit directive wins; absent that, only HTTP/1.1 persists by default.
+   * Connection reuse needs both sides to agree (a response and its originating
+   * request), which the caller checks. */
+  if (r_http_msg_has_header_of_value (msg, "Connection", -1, "close", -1))
+    return FALSE;
+  if (r_http_msg_has_header_of_value (msg, "Connection", -1, "keep-alive", -1))
+    return TRUE;
+
+  return r_http_msg_is_http_1_1 (msg);
+}
+
 RHttpError
 r_http_response_set_body_buffer_full (RHttpResponse * res, RBuffer * buf,
     const rchar * contenttype, rssize size, rboolean contentlen)

--- a/rlib/net/rhttpclient.c
+++ b/rlib/net/rhttpclient.c
@@ -23,27 +23,38 @@
 #include <rlib/ev/revtcp.h>
 #include <rlib/ev/revresolve.h>
 
+#include <rlib/net/rsocket.h>
 #include <rlib/data/rptrarray.h>
 
 #include <rlib/ruri.h>
 #include <rlib/rmem.h>
 #include <rlib/rstr.h>
+#include <rlib/rtime.h>
 
 /* Cap unparsed response-header bytes so a peer that never sends the
  * terminating CRLFCRLF can't grow the input buffer without bound. */
 #define R_HTTP_CLIENT_MAX_HEADER  (64 * 1024)
 
+/* Default idle-connection timeout before a pooled connection is evicted. */
+#define R_HTTP_CLIENT_IDLE_TIMEOUT  (60 * R_SECOND)
+
+typedef struct RHttpClientConn RHttpClientConn;
+typedef struct RHttpClientReqCtx RHttpClientReqCtx;
+
 struct RHttpClient {
   RRef ref;
 
   REvLoop * loop;
-  RPtrArray * reqs;
+  RPtrArray * reqs;     /* in-flight request contexts */
+  RPtrArray * idle;     /* idle RHttpClientConn, scanned by destination addr */
+  rboolean keepalive;
+  RClockTimeDiff idle_timeout;
 };
 
-typedef struct {
+struct RHttpClientReqCtx {
   RRef ref;
   RHttpClient * client;
-  REvTCP * evtcp;
+  RHttpClientConn * conn;   /* serving connection; holds a ref while in use */
 
   RHttpRequest * req;
   RBuffer * inbuf;
@@ -56,8 +67,29 @@ typedef struct {
   rpointer data;
   RDestroyNotify notify;
 
+  RSocketAddress * dest;  /* connect target; keys reuse and drives the retry */
+  rboolean reused;        /* running on a pooled connection */
+  rboolean retried;       /* a stale-connection retry has already happened */
   rboolean finished;
-} RHttpClientReqCtx;
+};
+
+/* A client connection. It owns the socket and keeps its recv watch armed for
+ * its whole life, so reuse needs no re-arming. While serving a request conn->req
+ * is set; when idle it is NULL and the connection sits in client->idle awaiting
+ * reuse, watched only so a peer close evicts it. */
+struct RHttpClientConn {
+  RRef ref;
+  RHttpClient * client;       /* borrowed */
+  REvTCP * evtcp;
+  RSocketAddress * addr;      /* destination key */
+  RHttpClientReqCtx * req;    /* current request, or NULL when idle */
+  RClockEntry * timer;        /* idle-eviction timer, set only when idle */
+  rboolean recving;           /* recv watch armed */
+  rboolean closing;
+};
+
+#define r_http_client_conn_ref   r_ref_ref
+#define r_http_client_conn_unref r_ref_unref
 
 #define R_LOG_CAT_DEFAULT &httpclicat
 R_LOG_CATEGORY_DEFINE_STATIC (httpclicat, "httpclient", "RLib HTTP client",
@@ -68,6 +100,17 @@ r_http_client_init (void)
 {
   r_log_category_register (&httpclicat);
 }
+
+
+/* Forward declarations (the request and connection flows are mutually
+ * recursive: connect -> send -> recv -> complete, with reuse and retry). */
+static void r_http_client_req_complete (RHttpClientReqCtx * ctx,
+    RHttpClientResult result, rboolean defer);
+static void r_http_client_req_fail (RHttpClientReqCtx * ctx,
+    RHttpClientResult result, rboolean defer);
+static void r_http_client_req_connect (RHttpClientReqCtx * ctx, rboolean defer);
+static void r_http_client_req_send (RHttpClientReqCtx * ctx, rboolean defer);
+static void r_http_client_conn_evict (RHttpClientConn * conn);
 
 
 static void
@@ -81,42 +124,238 @@ r_http_client_req_ctx_free (RHttpClientReqCtx * ctx)
     r_buffer_unref (ctx->inbuf);
   if (ctx->req != NULL)
     r_http_request_unref (ctx->req);
-  if (ctx->evtcp != NULL)
-    r_ev_tcp_unref (ctx->evtcp);
+  /* Normally cleared at completion; only set here on an abnormal teardown
+   * (e.g. the loop torn down mid-connect). Detach and drop our connection ref
+   * (conn_free closes the socket). */
+  if (ctx->conn != NULL) {
+    ctx->conn->req = NULL;
+    r_http_client_conn_unref (ctx->conn);
+  }
+  if (ctx->dest != NULL)
+    r_socket_address_unref (ctx->dest);
 
   r_http_client_unref (ctx->client);
   r_free (ctx);
 }
 
-static void
-r_http_client_req_do_close (rpointer data, REvLoop * loop)
-{
-  RHttpClientReqCtx * ctx = data;
-  (void) loop;
+/* --- connection lifecycle ------------------------------------------------- */
 
-  r_ev_tcp_close (ctx->evtcp, NULL, NULL, NULL);
+static void
+r_http_client_conn_free (RHttpClientConn * conn)
+{
+  if (conn->timer != NULL)
+    r_ev_loop_cancel_timer (conn->client->loop, conn->timer);
+  if (conn->evtcp != NULL) {
+    /* When closed via conn_close the close is already done/scheduled
+     * (closing == TRUE); otherwise (pool torn down with the client) close it
+     * here, synchronously -- we are not inside an io callback. */
+    if (!conn->closing)
+      r_ev_tcp_close (conn->evtcp, NULL, NULL, NULL);
+    r_ev_tcp_unref (conn->evtcp);
+  }
+  if (conn->addr != NULL)
+    r_socket_address_unref (conn->addr);
+  r_free (conn);
 }
 
-/* Deliver the outcome once and tear the request down. Idempotent: a
- * receive-path error and a later error event can both land here.
- *
- * @defer is TRUE when called from inside a connect/recv callback, where
- * closing the socket synchronously would free the io-watch entry the loop is
- * still iterating; the close is then deferred to a loop callback. It is FALSE
- * only for a synchronous connect failure raised from
- * r_http_client_request_to_addr (not a loop callback, and the failed socket has
- * no active watch), where deferring would strand the close if the caller never
- * runs the loop again. */
 static void
-r_http_client_req_teardown (RHttpClientReqCtx * ctx, RHttpClientResult result,
+r_http_client_conn_do_close (rpointer data, REvLoop * loop)
+{
+  RHttpClientConn * conn = data;
+  (void) loop;
+
+  r_ev_tcp_close (conn->evtcp, NULL, NULL, NULL);
+}
+
+/* Close conn's socket. Idempotent. @defer is TRUE when called from inside one
+ * of the socket's own callbacks, where closing synchronously would free the
+ * io-watch the loop is still iterating. Does not touch refs or pool membership. */
+static void
+r_http_client_conn_close (RHttpClientConn * conn, rboolean defer)
+{
+  if (conn->closing)
+    return;
+  conn->closing = TRUE;
+
+  if (conn->timer != NULL) {
+    r_ev_loop_cancel_timer (conn->client->loop, conn->timer);
+    conn->timer = NULL;
+  }
+  if (conn->evtcp != NULL) {
+    if (defer)
+      r_ev_loop_add_callback (conn->client->loop, FALSE,
+          r_http_client_conn_do_close, r_http_client_conn_ref (conn),
+          r_http_client_conn_unref);
+    else
+      r_ev_tcp_close (conn->evtcp, NULL, NULL, NULL);
+  }
+}
+
+/* Drop an idle connection from the pool and close it (deferred -- this runs
+ * from the idle recv/error/timer callbacks). Idempotent. */
+static void
+r_http_client_conn_evict (RHttpClientConn * conn)
+{
+  if (conn->closing)
+    return;
+
+  /* Hold a ref across the pool removal, which drops the array's ref. */
+  r_http_client_conn_ref (conn);
+  r_http_client_conn_close (conn, TRUE);
+  r_ptr_array_remove_first_fast (conn->client->idle, conn);
+  r_http_client_conn_unref (conn);
+}
+
+static void
+r_http_client_conn_idle_timeout (rpointer data, REvLoop * loop)
+{
+  RHttpClientConn * conn = data;
+  (void) loop;
+
+  conn->timer = NULL;   /* the entry fired; evict must not cancel it */
+  R_LOG_TRACE ("%p: idle connection %p timed out", conn->client, conn);
+  r_http_client_conn_evict (conn);
+}
+
+/* Receive on a connection. Routed to the current request, or -- when the
+ * connection is idle in the pool -- treated as a peer close that evicts it. */
+static void r_http_client_req_recv_data (RHttpClientReqCtx * ctx, RBuffer * buf);
+
+static void
+r_http_client_conn_recv (rpointer data, RBuffer * buf, REvTCP * evtcp)
+{
+  RHttpClientConn * conn = data;
+  (void) evtcp;
+
+  if (conn->req == NULL || conn->req->finished) {
+    /* Bytes or EOF on a parked connection: the peer is done with it. */
+    r_http_client_conn_evict (conn);
+    return;
+  }
+  r_http_client_req_recv_data (conn->req, buf);
+}
+
+static void
+r_http_client_conn_error (rpointer data, REvTCP * evtcp, RSocketStatus error)
+{
+  RHttpClientConn * conn = data;
+  (void) evtcp;
+
+  R_LOG_DEBUG ("%p: connection %p socket error (%d)", conn->client, conn,
+      (int) error);
+  if (conn->req == NULL)
+    r_http_client_conn_evict (conn);
+  else
+    r_http_client_req_fail (conn->req, R_HTTP_CLIENT_RECV_FAILED, TRUE);
+}
+
+static void
+r_http_client_conn_connected (rpointer data, REvTCP * evtcp, int status)
+{
+  RHttpClientConn * conn = data;
+  (void) evtcp;
+
+  if (conn->req == NULL)        /* request gone (e.g. torn down); drop conn */
+    return;
+  if (status != 0) {
+    R_LOG_DEBUG ("%p: request %p connect failed (%d)", conn->client, conn->req,
+        status);
+    r_http_client_req_fail (conn->req, R_HTTP_CLIENT_CONNECT_FAILED, TRUE);
+    return;
+  }
+
+  r_http_client_req_send (conn->req, TRUE);
+}
+
+static RHttpClientConn *
+r_http_client_conn_new (RHttpClient * client, RSocketAddress * addr)
+{
+  RHttpClientConn * conn;
+
+  if ((conn = r_mem_new0 (RHttpClientConn)) == NULL)
+    return NULL;
+  r_ref_init (conn, r_http_client_conn_free);
+  conn->client = client;
+  conn->addr = r_socket_address_ref (addr);
+  if ((conn->evtcp = r_ev_tcp_new (r_socket_address_get_family (addr),
+          client->loop)) == NULL) {
+    r_http_client_conn_unref (conn);
+    return NULL;
+  }
+  r_ev_tcp_set_error_handler (conn->evtcp, r_http_client_conn_error, conn, NULL);
+  return conn;
+}
+
+/* Take a live pooled connection to @addr out of the pool for reuse, or NULL.
+ * The returned connection carries the reference the pool held. */
+static RHttpClientConn *
+r_http_client_pool_acquire (RHttpClient * client, const RSocketAddress * addr)
+{
+  rsize i = 0;
+
+  while (i < r_ptr_array_size (client->idle)) {
+    RHttpClientConn * conn = r_ptr_array_get (client->idle, i);
+
+    if (conn->closing || !r_socket_address_is_equal (conn->addr, addr)) {
+      i++;
+      continue;
+    }
+    if (!r_socket_is_alive (r_ev_tcp_get_socket (conn->evtcp))) {
+      r_http_client_conn_evict (conn);   /* dead; drop and re-check this slot */
+      continue;
+    }
+
+    r_http_client_conn_ref (conn);       /* keep across the pool removal */
+    if (conn->timer != NULL) {
+      r_ev_loop_cancel_timer (client->loop, conn->timer);
+      conn->timer = NULL;
+    }
+    r_ptr_array_remove_first_fast (client->idle, conn);
+    return conn;                         /* ref transfers to the caller */
+  }
+
+  return NULL;
+}
+
+/* --- request flow --------------------------------------------------------- */
+
+/* TRUE if conn may be parked for reuse after this exchange. */
+static rboolean
+r_http_client_req_reusable (RHttpClientReqCtx * ctx, RHttpClientConn * conn)
+{
+  rsize leftover;
+
+  if (!ctx->client->keepalive || conn->closing || conn->evtcp == NULL)
+    return FALSE;
+  if (ctx->res == NULL)
+    return FALSE;
+  /* Only fixed-length bodies are pooled: the chunked decoder doesn't report
+   * how many bytes it consumed, so the post-body boundary is unknown. */
+  if (ctx->bodytype != R_HTTP_BODY_PARSE_SIZED)
+    return FALSE;
+  /* Both sides must agree to persist. */
+  if (!r_http_response_is_keepalive (ctx->res) ||
+      !r_http_request_is_keepalive (ctx->req))
+    return FALSE;
+  /* Unconsumed bytes past the body would corrupt the next response. */
+  leftover = (ctx->inbuf != NULL ? r_buffer_get_size (ctx->inbuf) : 0) -
+      (ctx->bodysize > 0 ? (rsize) ctx->bodysize : 0);
+  return leftover == 0;
+}
+
+/* Deliver the outcome once, then either park the connection for reuse (on a
+ * successful, reusable exchange) or close it, and tear the request down. */
+static void
+r_http_client_req_complete (RHttpClientReqCtx * ctx, RHttpClientResult result,
     rboolean defer)
 {
+  RHttpClientConn * conn;
+
   if (ctx->finished)
     return;
   ctx->finished = TRUE;
 
-  /* Keep ctx alive across the callback and the array removal below (the
-   * array holds the only other reference). */
+  /* Keep ctx alive across the callback and the array removal below. */
   r_ref_ref (ctx);
 
   R_LOG_TRACE ("%p: request %p finished (%d)", ctx->client, ctx, (int) result);
@@ -124,43 +363,75 @@ r_http_client_req_teardown (RHttpClientReqCtx * ctx, RHttpClientResult result,
     ctx->cb (ctx->data, result == R_HTTP_CLIENT_OK ? ctx->res : NULL,
         result, ctx->client);
 
-  /* evtcp is NULL when the request fails during DNS resolution, before a
-   * socket is created; there is then nothing to close. */
-  if (ctx->evtcp != NULL) {
-    if (defer)
-      r_ev_loop_add_callback (ctx->client->loop, FALSE,
-          r_http_client_req_do_close, r_ref_ref (ctx), r_ref_unref);
-    else
-      r_ev_tcp_close (ctx->evtcp, NULL, NULL, NULL);
+  /* Detach the connection (a safe pointer flip -- the recv watch stays armed)
+   * and decide its fate. conn is NULL if the request failed before connecting. */
+  conn = ctx->conn;
+  ctx->conn = NULL;
+  if (conn != NULL) {
+    conn->req = NULL;
+    if (result == R_HTTP_CLIENT_OK && r_http_client_req_reusable (ctx, conn)) {
+      if (ctx->client->idle_timeout > 0)
+        r_ev_loop_add_callback_later (ctx->client->loop, &conn->timer,
+            ctx->client->idle_timeout, r_http_client_conn_idle_timeout, conn,
+            NULL);
+      R_LOG_TRACE ("%p: parking idle connection %p", ctx->client, conn);
+      r_ptr_array_add (ctx->client->idle, conn, r_http_client_conn_unref);
+    } else {
+      r_http_client_conn_close (conn, defer);
+      r_http_client_conn_unref (conn);
+    }
   }
-  r_ptr_array_remove_first_fast (ctx->client->reqs, ctx);
 
+  r_ptr_array_remove_first_fast (ctx->client->reqs, ctx);
   r_ref_unref (ctx);
 }
 
-#define r_http_client_req_finish(ctx, result) \
-  r_http_client_req_teardown (ctx, result, TRUE)
-
+/* Deliver a failure, but first transparently retry once if it happened on a
+ * pooled connection before any response arrived -- the request almost
+ * certainly never reached the server, so reconnect and resend. */
 static void
-r_http_client_req_recv (rpointer data, RBuffer * buf, REvTCP * evtcp)
+r_http_client_req_fail (RHttpClientReqCtx * ctx, RHttpClientResult result,
+    rboolean defer)
 {
-  RHttpClientReqCtx * ctx = data;
-  (void) evtcp;
-
-  /* The recv watch stays armed until the deferred close runs, so a late
-   * event after the request finished must be ignored. */
   if (ctx->finished)
     return;
 
+  if (ctx->reused && !ctx->retried && ctx->res == NULL) {
+    RHttpClientConn * conn = ctx->conn;
+
+    ctx->retried = TRUE;
+    ctx->reused = FALSE;
+    ctx->conn = NULL;
+    if (conn != NULL) {
+      conn->req = NULL;
+      r_http_client_conn_close (conn, defer);
+      r_http_client_conn_unref (conn);
+    }
+    if (ctx->inbuf != NULL) {
+      r_buffer_unref (ctx->inbuf);
+      ctx->inbuf = NULL;
+    }
+    R_LOG_DEBUG ("%p: request %p retrying on a fresh connection", ctx->client, ctx);
+    r_http_client_req_connect (ctx, defer);
+    return;
+  }
+
+  r_http_client_req_complete (ctx, result, defer);
+}
+
+static void
+r_http_client_req_recv_data (RHttpClientReqCtx * ctx, RBuffer * buf)
+{
   if (buf == NULL) {
-    /* End-of-stream: a CLOSE-framed body ends here; anything else mid-body
-     * is a truncated response. */
+    /* End-of-stream: a CLOSE-framed body ends here; anything else mid-body is a
+     * truncated response (and, on a reused connection with nothing received
+     * yet, a candidate for the stale-connection retry). */
     if (ctx->res != NULL && ctx->bodytype == R_HTTP_BODY_PARSE_CLOSE) {
       if (ctx->inbuf != NULL)
         r_http_response_set_body_buffer (ctx->res, ctx->inbuf);
-      r_http_client_req_finish (ctx, R_HTTP_CLIENT_OK);
+      r_http_client_req_complete (ctx, R_HTTP_CLIENT_OK, TRUE);
     } else {
-      r_http_client_req_finish (ctx, R_HTTP_CLIENT_RECV_FAILED);
+      r_http_client_req_fail (ctx, R_HTTP_CLIENT_RECV_FAILED, TRUE);
     }
     return;
   }
@@ -182,14 +453,14 @@ r_http_client_req_recv (rpointer data, RBuffer * buf, REvTCP * evtcp)
       if (r_buffer_get_size (ctx->inbuf) > R_HTTP_CLIENT_MAX_HEADER) {
         r_buffer_unref (ctx->inbuf);
         ctx->inbuf = remainder;
-        r_http_client_req_finish (ctx, R_HTTP_CLIENT_PARSE_FAILED);
+        r_http_client_req_complete (ctx, R_HTTP_CLIENT_PARSE_FAILED, TRUE);
         return;
       }
       /* Wait for more header bytes (remainder re-holds the pending data). */
     } else {
       r_buffer_unref (ctx->inbuf);
       ctx->inbuf = remainder;
-      r_http_client_req_finish (ctx, R_HTTP_CLIENT_PARSE_FAILED);
+      r_http_client_req_complete (ctx, R_HTTP_CLIENT_PARSE_FAILED, TRUE);
       return;
     }
 
@@ -206,13 +477,13 @@ r_http_client_req_recv (rpointer data, RBuffer * buf, REvTCP * evtcp)
   switch (ctx->bodytype) {
     case R_HTTP_BODY_PARSE_SIZED:
       if (ctx->bodysize <= 0) {
-        r_http_client_req_finish (ctx, R_HTTP_CLIENT_OK);
+        r_http_client_req_complete (ctx, R_HTTP_CLIENT_OK, TRUE);
       } else if (ctx->inbuf != NULL &&
           r_buffer_get_size (ctx->inbuf) >= (rsize) ctx->bodysize) {
         RBuffer * body = r_buffer_view (ctx->inbuf, 0, (rsize) ctx->bodysize);
         r_http_response_set_body_buffer (ctx->res, body);
         r_buffer_unref (body);
-        r_http_client_req_finish (ctx, R_HTTP_CLIENT_OK);
+        r_http_client_req_complete (ctx, R_HTTP_CLIENT_OK, TRUE);
       }
       /* else wait for more body bytes */
       break;
@@ -226,9 +497,9 @@ r_http_client_req_recv (rpointer data, RBuffer * buf, REvTCP * evtcp)
       if (err == R_HTTP_OK) {
         r_http_response_set_body_buffer (ctx->res, body);
         r_buffer_unref (body);
-        r_http_client_req_finish (ctx, R_HTTP_CLIENT_OK);
+        r_http_client_req_complete (ctx, R_HTTP_CLIENT_OK, TRUE);
       } else if (err != R_HTTP_BUF_TOO_SMALL) {
-        r_http_client_req_finish (ctx, R_HTTP_CLIENT_PARSE_FAILED);
+        r_http_client_req_complete (ctx, R_HTTP_CLIENT_PARSE_FAILED, TRUE);
       }
       /* else wait for more chunk bytes */
       break;
@@ -237,43 +508,98 @@ r_http_client_req_recv (rpointer data, RBuffer * buf, REvTCP * evtcp)
       /* Tunnel framing (after CONNECT) isn't implemented. */
       R_LOG_DEBUG ("%p: request %p unsupported body framing %d",
           ctx->client, ctx, (int) ctx->bodytype);
-      r_http_client_req_finish (ctx, R_HTTP_CLIENT_PARSE_FAILED);
+      r_http_client_req_complete (ctx, R_HTTP_CLIENT_PARSE_FAILED, TRUE);
       break;
   }
 }
 
+/* Serialize and send the request on ctx's connection, arming its recv watch
+ * once. Used by both a fresh connect and a reused pooled connection. */
 static void
-r_http_client_req_connected (rpointer data, REvTCP * evtcp, int status)
+r_http_client_req_send (RHttpClientReqCtx * ctx, rboolean defer)
 {
-  RHttpClientReqCtx * ctx = data;
+  RHttpClientConn * conn = ctx->conn;
   RBuffer * buf;
-  (void) evtcp;
 
-  if (status != 0) {
-    R_LOG_DEBUG ("%p: request %p connect failed (%d)", ctx->client, ctx, status);
-    r_http_client_req_finish (ctx, R_HTTP_CLIENT_CONNECT_FAILED);
-    return;
-  }
+  /* Advertise keep-alive so the peer persists the connection (our server, and
+   * RFC 7230 strictly, treat 1.1 as persistent, but an explicit header is the
+   * interoperable signal). Idempotent across a retry's re-send. */
+  if (ctx->client->keepalive &&
+      !r_http_request_has_header (ctx->req, "Connection", -1))
+    r_http_request_add_header (ctx->req, "Connection", -1, "keep-alive", -1);
 
   if ((buf = r_http_msg_get_buffer ((RHttpMsg *) ctx->req)) == NULL) {
-    r_http_client_req_finish (ctx, R_HTTP_CLIENT_SEND_FAILED);
+    r_http_client_req_fail (ctx, R_HTTP_CLIENT_SEND_FAILED, defer);
     return;
   }
-  r_ev_tcp_send_and_forget (ctx->evtcp, buf);
+  r_ev_tcp_send_and_forget (conn->evtcp, buf);
   r_buffer_unref (buf);
 
-  if (!r_ev_tcp_recv_start (ctx->evtcp, NULL, r_http_client_req_recv, ctx, NULL))
-    r_http_client_req_finish (ctx, R_HTTP_CLIENT_RECV_FAILED);
+  /* The recv watch is bound to the connection for its whole life; a reused
+   * connection already has it armed. */
+  if (!conn->recving) {
+    if (!r_ev_tcp_recv_start (conn->evtcp, NULL, r_http_client_conn_recv,
+            conn, NULL)) {
+      r_http_client_req_fail (ctx, R_HTTP_CLIENT_RECV_FAILED, defer);
+      return;
+    }
+    conn->recving = TRUE;
+  }
 }
 
+/* Open a fresh connection to ctx->dest and send once connected. */
 static void
-r_http_client_req_error (rpointer data, REvTCP * evtcp, RSocketStatus error)
+r_http_client_req_connect (RHttpClientReqCtx * ctx, rboolean defer)
 {
-  RHttpClientReqCtx * ctx = data;
-  (void) evtcp;
+  RHttpClientConn * conn;
 
-  R_LOG_DEBUG ("%p: request %p socket error (%d)", ctx->client, ctx, (int) error);
-  r_http_client_req_finish (ctx, R_HTTP_CLIENT_RECV_FAILED);
+  ctx->reused = FALSE;
+  if ((conn = r_http_client_conn_new (ctx->client, ctx->dest)) == NULL) {
+    r_http_client_req_complete (ctx, R_HTTP_CLIENT_CONNECT_FAILED, defer);
+    return;
+  }
+  ctx->conn = conn;     /* ctx owns the new connection's reference */
+  conn->req = ctx;
+  if (r_ev_tcp_connect (conn->evtcp, ctx->dest,
+        r_http_client_conn_connected, conn, NULL) < R_SOCKET_OK)
+    r_http_client_req_complete (ctx, R_HTTP_CLIENT_CONNECT_FAILED, defer);
+}
+
+/* Reuse a pooled connection to ctx->dest if one is idle, else connect fresh. */
+static void
+r_http_client_req_dispatch (RHttpClientReqCtx * ctx, rboolean defer)
+{
+  RHttpClientConn * conn = r_http_client_pool_acquire (ctx->client, ctx->dest);
+
+  if (conn != NULL) {
+    ctx->conn = conn;   /* acquire transferred the pool's reference to us */
+    ctx->reused = TRUE;
+    conn->req = ctx;
+    R_LOG_TRACE ("%p: request %p reusing pooled connection %p", ctx->client,
+        ctx, conn);
+    r_http_client_req_send (ctx, defer);
+    return;
+  }
+
+  r_http_client_req_connect (ctx, defer);
+}
+
+static RHttpClientReqCtx *
+r_http_client_req_ctx_new (RHttpClient * client, RHttpRequest * req,
+    RHttpClientResponseFunc cb, rpointer data, RDestroyNotify notify)
+{
+  RHttpClientReqCtx * ctx;
+
+  if ((ctx = r_mem_new0 (RHttpClientReqCtx)) == NULL)
+    return NULL;
+  r_ref_init (ctx, r_http_client_req_ctx_free);
+  ctx->client = r_http_client_ref (client);
+  ctx->req = r_http_request_ref (req);
+  ctx->bodytype = R_HTTP_BODY_PARSE_SIZED;
+  ctx->cb = cb;
+  ctx->data = data;
+  ctx->notify = notify;
+  return ctx;
 }
 
 rboolean
@@ -286,39 +612,26 @@ r_http_client_request_to_addr (RHttpClient * client, RHttpRequest * req,
   if (R_UNLIKELY (client == NULL || req == NULL || addr == NULL || cb == NULL))
     return FALSE;
 
-  if ((ctx = r_mem_new0 (RHttpClientReqCtx)) == NULL)
+  if ((ctx = r_http_client_req_ctx_new (client, req, cb, data, notify)) == NULL)
     return FALSE;
-  r_ref_init (ctx, r_http_client_req_ctx_free);
-  ctx->client = r_http_client_ref (client);
-  ctx->req = r_http_request_ref (req);
-  ctx->bodytype = R_HTTP_BODY_PARSE_SIZED;
-
-  /* Set cb/data/notify only once the request is committed (TRUE return):
-   * a FALSE return must not invoke notify -- the caller keeps ownership. */
-  if ((ctx->evtcp = r_ev_tcp_new (r_socket_address_get_family (addr),
-          client->loop)) == NULL) {
+  if ((ctx->dest = r_socket_address_copy (addr)) == NULL) {
+    ctx->cb = NULL;     /* not committed: notify must not run */
+    ctx->notify = NULL;
     r_ref_unref (ctx);
     return FALSE;
   }
-  ctx->cb = cb;
-  ctx->data = data;
-  ctx->notify = notify;
 
-  /* The array owns the request context; the in-flight callbacks borrow it. */
+  /* Committed: the array owns ctx and every outcome is delivered via cb. */
   r_ptr_array_add (client->reqs, ctx, r_ref_unref);
-  r_ev_tcp_set_error_handler (ctx->evtcp, r_http_client_req_error, ctx, NULL);
-
   R_LOG_TRACE ("%p: request %p started", client, ctx);
-  if (r_ev_tcp_connect (ctx->evtcp, addr,
-        r_http_client_req_connected, ctx, NULL) < R_SOCKET_OK)
-    r_http_client_req_teardown (ctx, R_HTTP_CLIENT_CONNECT_FAILED, FALSE);
+  r_http_client_req_dispatch (ctx, FALSE);
 
   return TRUE;
 }
 
-/* DNS resolution completed: connect to the first resolved address. ctx is
- * borrowed -- it stays alive in client->reqs for the duration of the
- * resolution (nothing else can tear it down before this fires). */
+/* DNS resolution completed: reuse a pooled connection for, or connect to, the
+ * first resolved address. ctx is borrowed -- it stays alive in client->reqs
+ * for the duration of the resolution (nothing else can tear it down first). */
 static void
 r_http_client_req_resolved (rpointer data, RResolvedAddr * addr,
     RResolveResult res)
@@ -330,19 +643,15 @@ r_http_client_req_resolved (rpointer data, RResolvedAddr * addr,
 
   if (res != R_RESOLVE_OK || addr == NULL || addr->addr == NULL) {
     R_LOG_DEBUG ("%p: request %p resolve failed (%d)", ctx->client, ctx, (int) res);
-    r_http_client_req_finish (ctx, R_HTTP_CLIENT_RESOLVE_FAILED);
+    r_http_client_req_complete (ctx, R_HTTP_CLIENT_RESOLVE_FAILED, TRUE);
     return;
   }
 
-  if ((ctx->evtcp = r_ev_tcp_new (r_socket_address_get_family (addr->addr),
-          ctx->client->loop)) == NULL) {
-    r_http_client_req_finish (ctx, R_HTTP_CLIENT_CONNECT_FAILED);
+  if ((ctx->dest = r_socket_address_copy (addr->addr)) == NULL) {
+    r_http_client_req_complete (ctx, R_HTTP_CLIENT_RESOLVE_FAILED, TRUE);
     return;
   }
-  r_ev_tcp_set_error_handler (ctx->evtcp, r_http_client_req_error, ctx, NULL);
-  if (r_ev_tcp_connect (ctx->evtcp, addr->addr,
-        r_http_client_req_connected, ctx, NULL) < R_SOCKET_OK)
-    r_http_client_req_finish (ctx, R_HTTP_CLIENT_CONNECT_FAILED);
+  r_http_client_req_dispatch (ctx, TRUE);
 }
 
 rboolean
@@ -378,19 +687,12 @@ r_http_client_request (RHttpClient * client, RHttpRequest * req,
   }
   r_snprintf (service, sizeof (service), "%u", (ruint) port);
 
-  if ((ctx = r_mem_new0 (RHttpClientReqCtx)) == NULL) {
+  if ((ctx = r_http_client_req_ctx_new (client, req, cb, data, notify)) == NULL) {
     r_free (host);
     return FALSE;
   }
-  r_ref_init (ctx, r_http_client_req_ctx_free);
-  ctx->client = r_http_client_ref (client);
-  ctx->req = r_http_request_ref (req);
-  ctx->bodytype = R_HTTP_BODY_PARSE_SIZED;
 
   /* Committed: the array owns ctx and every outcome is delivered via cb. */
-  ctx->cb = cb;
-  ctx->data = data;
-  ctx->notify = notify;
   r_ptr_array_add (client->reqs, ctx, r_ref_unref);
 
   R_LOG_TRACE ("%p: request %p resolving %s:%s", client, ctx, host, service);
@@ -398,7 +700,7 @@ r_http_client_request (RHttpClient * client, RHttpRequest * req,
       r_http_client_req_resolved, ctx, NULL);
   r_free (host);
   if (R_UNLIKELY (resolve == NULL)) {
-    r_http_client_req_teardown (ctx, R_HTTP_CLIENT_RESOLVE_FAILED, FALSE);
+    r_http_client_req_complete (ctx, R_HTTP_CLIENT_RESOLVE_FAILED, FALSE);
     return TRUE;
   }
   /* The queued task keeps the resolve alive until the callback fires; we
@@ -413,8 +715,11 @@ r_http_client_request (RHttpClient * client, RHttpRequest * req,
 static void
 r_http_client_free (RHttpClient * client)
 {
-  /* A request context holds a reference on the client, so the client can
-   * only be freed once every request has finished and left client->reqs. */
+  /* A request context holds a reference on the client, so the client can only
+   * be freed once every request has finished and left client->reqs. Pooled
+   * connections are owned by client->idle; unref'ing it closes each one
+   * (conn_free, synchronous close -- we are not inside an io callback here). */
+  r_ptr_array_unref (client->idle);
   r_ptr_array_unref (client->reqs);
   r_ev_loop_unref (client->loop);
   r_free (client);
@@ -433,6 +738,9 @@ r_http_client_new (REvLoop * loop)
 
     ret->loop = loop;
     ret->reqs = r_ptr_array_new ();
+    ret->idle = r_ptr_array_new ();
+    ret->keepalive = TRUE;
+    ret->idle_timeout = R_HTTP_CLIENT_IDLE_TIMEOUT;
 
     R_LOG_INFO ("New HTTP client %p", ret);
   } else {
@@ -440,6 +748,32 @@ r_http_client_new (REvLoop * loop)
   }
 
   return ret;
+}
+
+void
+r_http_client_set_keepalive (RHttpClient * client, rboolean enabled)
+{
+  if (R_UNLIKELY (client == NULL)) return;
+  client->keepalive = enabled;
+}
+
+rboolean
+r_http_client_get_keepalive (RHttpClient * client)
+{
+  return client != NULL ? client->keepalive : FALSE;
+}
+
+void
+r_http_client_set_idle_timeout (RHttpClient * client, RClockTimeDiff timeout)
+{
+  if (R_UNLIKELY (client == NULL)) return;
+  client->idle_timeout = timeout;
+}
+
+RClockTimeDiff
+r_http_client_get_idle_timeout (RHttpClient * client)
+{
+  return client != NULL ? client->idle_timeout : 0;
 }
 
 
@@ -453,7 +787,6 @@ typedef struct {
   RHttpResponse * res;
   RHttpClientResult result;
   rboolean done;
-  REvLoop * loop;
 } RHttpClientSyncState;
 
 static void
@@ -491,6 +824,32 @@ r_http_client_sync_new (void)
   return ret;
 }
 
+void
+r_http_client_sync_set_keepalive (RHttpClientSync * sync, rboolean enabled)
+{
+  if (R_UNLIKELY (sync == NULL)) return;
+  r_http_client_set_keepalive (sync->client, enabled);
+}
+
+rboolean
+r_http_client_sync_get_keepalive (RHttpClientSync * sync)
+{
+  return sync != NULL ? r_http_client_get_keepalive (sync->client) : FALSE;
+}
+
+void
+r_http_client_sync_set_idle_timeout (RHttpClientSync * sync, RClockTimeDiff timeout)
+{
+  if (R_UNLIKELY (sync == NULL)) return;
+  r_http_client_set_idle_timeout (sync->client, timeout);
+}
+
+RClockTimeDiff
+r_http_client_sync_get_idle_timeout (RHttpClientSync * sync)
+{
+  return sync != NULL ? r_http_client_get_idle_timeout (sync->client) : 0;
+}
+
 static void
 r_http_client_sync_cb (rpointer data, RHttpResponse * res,
     RHttpClientResult result, RHttpClient * client)
@@ -501,16 +860,13 @@ r_http_client_sync_cb (rpointer data, RHttpResponse * res,
   state->result = result;
   state->res = (res != NULL) ? r_http_response_ref (res) : NULL;
   state->done = TRUE;
-  /* Break out of the r_ev_loop_run below now that the exchange is complete. */
-  r_ev_loop_stop (state->loop);
 }
 
 RHttpResponse *
 r_http_client_sync_request_to_addr (RHttpClientSync * sync, RHttpRequest * req,
     const RSocketAddress * addr, RHttpClientResult * result)
 {
-  RHttpClientSyncState state = { NULL, R_HTTP_CLIENT_CONNECT_FAILED, FALSE,
-      sync != NULL ? sync->loop : NULL };
+  RHttpClientSyncState state = { NULL, R_HTTP_CLIENT_CONNECT_FAILED, FALSE };
 
   if (R_UNLIKELY (sync == NULL) ||
       !r_http_client_request_to_addr (sync->client, req, addr,
@@ -520,8 +876,11 @@ r_http_client_sync_request_to_addr (RHttpClientSync * sync, RHttpRequest * req,
     return NULL;
   }
 
+  /* Drive the private loop a round at a time until the exchange completes; the
+   * loop is not "stopped" (that is sticky), so it stays reusable for the next
+   * request on this client. */
   while (!state.done)
-    r_ev_loop_run (sync->loop, R_EV_LOOP_RUN_LOOP);
+    r_ev_loop_run (sync->loop, R_EV_LOOP_RUN_ONCE);
 
   if (result != NULL)
     *result = state.result;
@@ -532,8 +891,7 @@ RHttpResponse *
 r_http_client_sync_request (RHttpClientSync * sync, RHttpRequest * req,
     RHttpClientResult * result)
 {
-  RHttpClientSyncState state = { NULL, R_HTTP_CLIENT_RESOLVE_FAILED, FALSE,
-      sync != NULL ? sync->loop : NULL };
+  RHttpClientSyncState state = { NULL, R_HTTP_CLIENT_RESOLVE_FAILED, FALSE };
 
   if (R_UNLIKELY (sync == NULL) ||
       !r_http_client_request (sync->client, req,
@@ -544,7 +902,7 @@ r_http_client_sync_request (RHttpClientSync * sync, RHttpRequest * req,
   }
 
   while (!state.done)
-    r_ev_loop_run (sync->loop, R_EV_LOOP_RUN_LOOP);
+    r_ev_loop_run (sync->loop, R_EV_LOOP_RUN_ONCE);
 
   if (result != NULL)
     *result = state.result;

--- a/rlib/net/rhttpserver.c
+++ b/rlib/net/rhttpserver.c
@@ -27,6 +27,7 @@
 #include <rlib/data/rptrarray.h>
 
 #include <rlib/rmem.h>
+#include <rlib/rstr.h>
 
 struct RHttpServer {
   RRef ref;
@@ -118,6 +119,22 @@ r_http_client_ctx_tcp_response_ready (rpointer data, RHttpResponse * res,
 {
   RHttpClientCtx * ctx = data;
   RBuffer * buf;
+
+  /* A response on a kept-alive connection must be self-delimiting or the client
+   * cannot tell where it ends (it would wait for a close that never comes).
+   * Frame any response that is neither chunked nor already length-delimited --
+   * notably the bodyless auto-error responses built above. */
+  if (ctx->keepalive &&
+      !r_http_response_has_header (res, "Content-Length", -1) &&
+      !r_http_response_has_header (res, "Transfer-Encoding", -1)) {
+    RBuffer * body = r_http_response_get_body_buffer (res);
+    rchar len[16];
+
+    r_sprintf (len, "%"RSIZE_FMT, body != NULL ? r_buffer_get_size (body) : 0);
+    r_http_response_set_header (res, "Content-Length", -1, len, -1);
+    if (body != NULL)
+      r_buffer_unref (body);
+  }
 
   if ((buf = r_http_response_get_buffer (res)) != NULL) {
     R_LOG_TRACE ("%p: Buffer %p on "R_EV_IO_FORMAT" [%s]",

--- a/test/rhttp.c
+++ b/test/rhttp.c
@@ -570,3 +570,59 @@ RTEST (rhttp, chunked_decode_malformed, RTEST_FAST)
   r_buffer_unref (buf);
 }
 RTEST_END;
+
+static rboolean
+r_test_response_blob_keepalive (const rchar * blob)
+{
+  RHttpResponse * res;
+  RBuffer * buf;
+  rboolean ret;
+
+  r_assert_cmpptr ((buf = r_buffer_new_dup (blob, r_strlen (blob))), !=, NULL);
+  r_assert_cmpptr ((res = r_http_response_new_from_buffer (NULL, buf, NULL, NULL)), !=, NULL);
+  ret = r_http_response_is_keepalive (res);
+  r_http_response_unref (res);
+  r_buffer_unref (buf);
+  return ret;
+}
+
+RTEST (rhttp, msg_is_keepalive, RTEST_FAST)
+{
+  RHttpRequest * req, * reqclose, * reqka;
+
+  /* Response side (version is the first start-line field). */
+  /* HTTP/1.1 is persistent by default. */
+  r_assert (r_test_response_blob_keepalive (
+        "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"));
+  /* Explicit keep-alive persists. */
+  r_assert (r_test_response_blob_keepalive (
+        "HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nContent-Length: 0\r\n\r\n"));
+  /* Explicit close wins. */
+  r_assert (!r_test_response_blob_keepalive (
+        "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"));
+  /* HTTP/1.0 is not persistent by default. */
+  r_assert (!r_test_response_blob_keepalive (
+        "HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n"));
+  /* HTTP/1.0 with explicit keep-alive persists. */
+  r_assert (r_test_response_blob_keepalive (
+        "HTTP/1.0 200 OK\r\nConnection: keep-alive\r\nContent-Length: 0\r\n\r\n"));
+
+  /* Request side (version is the third start-line field). */
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+          "http://127.0.0.1/", NULL, NULL)), !=, NULL);
+  r_assert_cmpptr ((reqclose = r_http_request_new (R_HTTP_METHOD_GET,
+          "http://127.0.0.1/", NULL, NULL)), !=, NULL);
+  r_assert (r_http_request_add_header (reqclose, "Connection", -1, "close", -1));
+  r_assert_cmpptr ((reqka = r_http_request_new (R_HTTP_METHOD_GET,
+          "http://127.0.0.1/", NULL, NULL)), !=, NULL);
+  r_assert (r_http_request_add_header (reqka, "Connection", -1, "keep-alive", -1));
+
+  r_assert (r_http_request_is_keepalive (req));        /* HTTP/1.1 default */
+  r_assert (!r_http_request_is_keepalive (reqclose));
+  r_assert (r_http_request_is_keepalive (reqka));
+
+  r_http_request_unref (req);
+  r_http_request_unref (reqclose);
+  r_http_request_unref (reqka);
+}
+RTEST_END;

--- a/test/rhttpclient.c
+++ b/test/rhttpclient.c
@@ -9,7 +9,6 @@ typedef struct {
   RHttpResponse * res;
   RHttpClientResult result;
   rboolean done;
-  REvLoop * loop;
 } RTestHttpSyncState;
 
 static void
@@ -21,7 +20,6 @@ r_test_http_send_cb (rpointer data, RHttpResponse * res,
   st->result = result;
   st->res = (res != NULL) ? r_http_response_ref (res) : NULL;
   st->done = TRUE;
-  r_ev_loop_stop (st->loop);
 }
 
 /* Issue an async request and drive @loop until it completes. The in-process
@@ -31,15 +29,17 @@ static RHttpResponse *
 r_test_http_send (REvLoop * loop, RHttpClient * client, RHttpRequest * req,
     const RSocketAddress * addr, RHttpClientResult * result)
 {
-  RTestHttpSyncState st = { NULL, R_HTTP_CLIENT_CONNECT_FAILED, FALSE, loop };
+  RTestHttpSyncState st = { NULL, R_HTTP_CLIENT_CONNECT_FAILED, FALSE };
 
   if (!r_http_client_request_to_addr (client, req, addr, r_test_http_send_cb, &st, NULL)) {
     if (result != NULL)
       *result = R_HTTP_CLIENT_CONNECT_FAILED;
     return NULL;
   }
+  /* RUN_ONCE (not RUN_LOOP+stop): stopping is sticky, so the loop stays
+   * reusable for a follow-up request on the same loop. */
   while (!st.done)
-    r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE);
   if (result != NULL)
     *result = st.result;
   return st.res;
@@ -50,15 +50,17 @@ static RHttpResponse *
 r_test_http_send_uri (REvLoop * loop, RHttpClient * client, RHttpRequest * req,
     RHttpClientResult * result)
 {
-  RTestHttpSyncState st = { NULL, R_HTTP_CLIENT_RESOLVE_FAILED, FALSE, loop };
+  RTestHttpSyncState st = { NULL, R_HTTP_CLIENT_RESOLVE_FAILED, FALSE };
 
   if (!r_http_client_request (client, req, r_test_http_send_cb, &st, NULL)) {
     if (result != NULL)
       *result = R_HTTP_CLIENT_RESOLVE_FAILED;
     return NULL;
   }
+  /* RUN_ONCE (not RUN_LOOP+stop): stopping is sticky, so the loop stays
+   * reusable for a follow-up request on the same loop. */
   while (!st.done)
-    r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE);
   if (result != NULL)
     *result = st.result;
   return st.res;
@@ -740,5 +742,217 @@ RTEST (rhttpclientsync, connect_refused, RTEST_FAST | RTEST_SYSTEM)
 
   r_socket_address_unref (addr);
   r_http_client_sync_unref (sync);
+}
+RTEST_END;
+
+/* A keep-alive-capable raw responder: accept connections and serve a fixed
+ * response per request on each, until @max_requests have been served. Counts
+ * accepted connections and served requests so a test can prove reuse (one
+ * connection, many requests) or a reconnect (a new connection). With
+ * @close_each it closes the connection after every response, so a pooled
+ * connection the client tries to reuse is already dead. */
+typedef struct {
+  RSocket * listen;
+  int max_requests;
+  rboolean close_each;
+  int connections;
+  int requests;
+} RTestKaServer;
+
+static rpointer
+r_test_ka_responder (rpointer data)
+{
+  RTestKaServer * s = data;
+  static const rchar resp[] = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi";
+
+  while (s->requests < s->max_requests) {
+    RSocket * conn;
+    if ((conn = r_socket_accept (s->listen, NULL)) == NULL)
+      break;
+    s->connections++;
+    r_socket_set_blocking (conn, TRUE);
+    for (;;) {
+      ruint8 buf[2048];
+      rsize n = 0;
+      if (r_socket_receive (conn, buf, sizeof (buf), &n) != R_SOCKET_OK || n == 0)
+        break;                              /* peer closed / error */
+      r_socket_send (conn, (const ruint8 *) resp, sizeof (resp) - 1, &n);
+      s->requests++;
+      if (s->close_each || s->requests >= s->max_requests)
+        break;
+    }
+    r_socket_close (conn);
+    r_socket_unref (conn);
+  }
+
+  return NULL;
+}
+
+static RThread *
+r_test_ka_start (RTestKaServer * s, ruint16 port, RSocketAddress ** out)
+{
+  RSocketAddress * addr;
+
+  r_assert_cmpptr ((s->listen = r_socket_new (R_SOCKET_FAMILY_IPV4,
+          R_SOCKET_TYPE_STREAM, R_SOCKET_PROTOCOL_TCP)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1,
+          port)), !=, NULL);
+  r_assert_cmpint (r_socket_bind (s->listen, addr, TRUE), ==, R_SOCKET_OK);
+  r_assert_cmpint (r_socket_listen (s->listen), ==, R_SOCKET_OK);
+  r_assert (r_socket_set_blocking (s->listen, TRUE));
+  *out = addr;
+  return r_thread_new (NULL, r_test_ka_responder, s);
+}
+
+static void
+r_test_ka_request (RHttpClientSync * sync, const RSocketAddress * addr)
+{
+  RHttpRequest * req;
+  RHttpResponse * res;
+  RHttpClientResult result;
+  rchar * body;
+
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+          "http://127.0.0.1/", NULL, NULL)), !=, NULL);
+  res = r_http_client_sync_request_to_addr (sync, req, addr, &result);
+  r_http_request_unref (req);
+  r_assert_cmpint (result, ==, R_HTTP_CLIENT_OK);
+  r_assert_cmpptr (res, !=, NULL);
+  r_assert_cmpstr ((body = r_http_response_get_body (res, NULL)), ==, "hi");
+  r_free (body);
+  r_http_response_unref (res);
+}
+
+/* Two requests to one destination reuse a single pooled connection. */
+RTEST (rhttpclientsync, keepalive_reuse, RTEST_FAST | RTEST_SYSTEM)
+{
+  RTestKaServer s = { NULL, 2, FALSE, 0, 0 };
+  RThread * thread;
+  RSocketAddress * addr;
+  RHttpClientSync * sync;
+
+  thread = r_test_ka_start (&s, 47667, &addr);
+  r_assert_cmpptr ((sync = r_http_client_sync_new ()), !=, NULL);
+
+  r_test_ka_request (sync, addr);
+  r_test_ka_request (sync, addr);
+
+  r_thread_join (thread);
+  r_thread_unref (thread);
+  r_assert_cmpint (s.requests, ==, 2);
+  r_assert_cmpint (s.connections, ==, 1);   /* both served on one connection */
+
+  r_http_client_sync_unref (sync);
+  r_socket_close (s.listen);
+  r_socket_unref (s.listen);
+  r_socket_address_unref (addr);
+}
+RTEST_END;
+
+/* With keep-alive disabled each request opens (and closes) its own connection. */
+RTEST (rhttpclientsync, keepalive_disabled, RTEST_FAST | RTEST_SYSTEM)
+{
+  RTestKaServer s = { NULL, 2, FALSE, 0, 0 };
+  RThread * thread;
+  RSocketAddress * addr;
+  RHttpClientSync * sync;
+
+  thread = r_test_ka_start (&s, 47670, &addr);
+  r_assert_cmpptr ((sync = r_http_client_sync_new ()), !=, NULL);
+  r_assert (r_http_client_sync_get_keepalive (sync));   /* on by default */
+  r_http_client_sync_set_keepalive (sync, FALSE);
+  r_assert (!r_http_client_sync_get_keepalive (sync));
+
+  r_test_ka_request (sync, addr);
+  r_test_ka_request (sync, addr);
+
+  r_thread_join (thread);
+  r_thread_unref (thread);
+  r_assert_cmpint (s.requests, ==, 2);
+  r_assert_cmpint (s.connections, ==, 2);   /* not pooled: a connection each */
+
+  r_http_client_sync_unref (sync);
+  r_socket_close (s.listen);
+  r_socket_unref (s.listen);
+  r_socket_address_unref (addr);
+}
+RTEST_END;
+
+/* When a pooled connection has been closed by the peer, the next request
+ * transparently reconnects and still succeeds. */
+RTEST (rhttpclientsync, keepalive_retry_stale, RTEST_FAST | RTEST_SYSTEM)
+{
+  RTestKaServer s = { NULL, 2, TRUE, 0, 0 };   /* close after each response */
+  RThread * thread;
+  RSocketAddress * addr;
+  RHttpClientSync * sync;
+
+  thread = r_test_ka_start (&s, 47668, &addr);
+  r_assert_cmpptr ((sync = r_http_client_sync_new ()), !=, NULL);
+
+  r_test_ka_request (sync, addr);   /* pools the connection */
+  r_test_ka_request (sync, addr);   /* reuses it, finds it dead, retries */
+
+  r_thread_join (thread);
+  r_thread_unref (thread);
+  r_assert_cmpint (s.requests, ==, 2);
+  r_assert_cmpint (s.connections, ==, 2);   /* second request reconnected */
+
+  r_http_client_sync_unref (sync);
+  r_socket_close (s.listen);
+  r_socket_unref (s.listen);
+  r_socket_address_unref (addr);
+}
+RTEST_END;
+
+/* An idle pooled connection is evicted once its timeout elapses, so a later
+ * request opens a fresh connection. */
+RTEST (rhttpclient, keepalive_idle_timeout, RTEST_FAST | RTEST_SYSTEM)
+{
+  RTestKaServer s = { NULL, 2, FALSE, 0, 0 };
+  RThread * thread;
+  RSocketAddress * addr;
+  REvLoop * loop;
+  RClock * clock;
+  RHttpClient * client;
+  RHttpRequest * req;
+  RHttpResponse * res;
+  RHttpClientResult result;
+  int i;
+
+  thread = r_test_ka_start (&s, 47669, &addr);
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
+  r_http_client_set_idle_timeout (client, 5 * R_SECOND);
+
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+          "http://127.0.0.1/", NULL, NULL)), !=, NULL);
+  res = r_test_http_send (loop, client, req, addr, &result);
+  r_http_request_unref (req);
+  r_assert_cmpint (result, ==, R_HTTP_CLIENT_OK);
+  r_http_response_unref (res);
+
+  /* Advance past the idle timeout and pump the loop so the timer fires, the
+   * connection is evicted and the deferred close runs. */
+  r_test_clock_update_time (clock, 100 * R_SECOND);
+  for (i = 0; i < 8; i++)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_NOWAIT);
+
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+          "http://127.0.0.1/", NULL, NULL)), !=, NULL);
+  res = r_test_http_send (loop, client, req, addr, &result);
+  r_http_request_unref (req);
+  r_assert_cmpint (result, ==, R_HTTP_CLIENT_OK);
+  r_http_response_unref (res);
+
+  r_thread_join (thread);
+  r_thread_unref (thread);
+  r_assert_cmpint (s.connections, ==, 2);   /* eviction forced a reconnect */
+
+  r_clock_unref (clock);
+  r_http_client_unref (client);
+  r_ev_loop_unref (loop);
+  r_socket_address_unref (addr);
 }
 RTEST_END;


### PR DESCRIPTION
`RHttpClient` opened a fresh TCP connection per request and closed it once the response completed. This adds HTTP/1.1 keep-alive: a connection left open by a persistent, self-delimited response is parked in a small per-client pool keyed by destination and reused by the next request there.

## Proto: `r_http_msg_is_keepalive`

A per-message predicate (own `Connection` header + HTTP version; explicit `close` → false, explicit `keep-alive` → true, else the HTTP/1.1 default), with `r_http_request_is_keepalive` / `r_http_response_is_keepalive` wrappers — same idiom as the `has_header` family. The version is found position-agnostically (the start-line field beginning with `HTTP/`), so the one base helper is correct for both request and response lines.

## Server: frame kept-alive responses

A response on a kept-alive connection must be self-delimiting or the client waits for a close that never comes. The server's bodyless auto-error responses (404/400/5xx) carried no `Content-Length` and relied on the close to bound them — a hang once the client requests keep-alive. They now get a `Content-Length` when kept alive.

## Client: connection pool

- A connection is owned by a persistent `RHttpClientConn` that keeps its recv watch armed for life, so reuse is a pointer flip rather than re-arming a recv watch from inside its own callback (which is unsafe — the proto layer's own EOF teardown defers the io-stop for the same reason).
- Parked connections are watched only so a peer close evicts them, and an idle timer evicts them after a timeout (default 60s).
- **Transparent one-shot retry**: a pooled connection the peer closed can't be detected until reused, so a request that fails on a reused connection before any response arrives silently reconnects and retries once. This keeps keep-alive-by-default from turning a server's idle-close into a spurious failure.
- Pooled only when both response and request permit keep-alive and the response is `Content-Length` framed (the chunked decoder doesn't report consumed length, so the post-body boundary is unknown — chunked pooling is a follow-up).
- Tunable via `r_http_client_set_keepalive` / `r_http_client_set_idle_timeout` (+ getters), forwarded by `r_http_client_sync_*` for the blocking client.

## Drive-by fix

The blocking client drove its private loop with `RUN_LOOP` + `r_ev_loop_stop`. `r_ev_loop_stop` is sticky (by design — see `revloop/stop`), so that loop couldn't be re-run for a second request. Switched the sync client (and the async test helper) to `RUN_ONCE`; the loop's stop semantics are untouched.

## Tests

`r_http_msg_is_keepalive` (request + response sides), connection reuse (one connection serves two requests), keep-alive disabled (a connection each), stale-connection retry, and idle-timeout eviction.

Verified: epoll + rpoll full suite, ASan/UBSan full suite, mingw werror, doxygen — all clean.

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)