### PR TITLE
rhttpserver: persist HTTP/1.1 connections by default

### DIFF
--- a/rlib/net/rhttpserver.c
+++ b/rlib/net/rhttpserver.c
@@ -205,11 +205,9 @@ r_http_client_ctx_tcp_recv (rpointer data, RBuffer * buf, REvTCP * evtcp)
       buf = NULL;
       if ((ctx->req = r_http_request_new_from_buffer (ctx->inbuf, &err, &buf)) != NULL) {
         ctx->bodysize = r_http_request_calc_body_size (ctx->req, NULL);
-        if (r_http_request_has_header_of_value (ctx->req, "Connection", -1, "close", -1))
-          ctx->keepalive = FALSE;
-        else
-          ctx->keepalive = r_http_request_has_header_of_value (ctx->req,
-              "Connection", -1, "keep-alive", -1);
+        /* Persistent unless the request says otherwise: explicit close closes,
+         * explicit keep-alive persists, and HTTP/1.1 persists by default. */
+        ctx->keepalive = r_http_request_is_keepalive (ctx->req);
 
         R_LOG_TRACE ("%p: "R_EV_IO_FORMAT" request created %p [%s] waiting for body size %"RSSIZE_FMT,
             ctx->server, R_EV_IO_ARGS (evtcp), ctx->req, ctx->keepalive ? "keepalive" : "close", ctx->bodysize);

--- a/test/rhttpserver.c
+++ b/test/rhttpserver.c
@@ -1,4 +1,5 @@
 #include <rlib/rnet.h>
+#include <rlib/rev.h>
 
 static void
 r_test_http_server_stop (rpointer data, REvLoop * loop)
@@ -146,3 +147,84 @@ RTEST (rhttpserver, handle_GET, RTEST_FAST)
 }
 RTEST_END;
 
+
+/* A raw client that sends @p two bare HTTP/1.1 requests (no Connection header)
+ * on one socket, counting responses; the second only arrives if the server
+ * kept the connection alive. */
+typedef struct {
+  RSocketAddress * addr;
+  int responses;
+  rboolean done;
+} RTestPersistClient;
+
+static rpointer
+r_test_persist_client (rpointer data)
+{
+  RTestPersistClient * c = data;
+  static const rchar req[] = "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n";
+  RSocket * s;
+
+  if ((s = r_socket_new (R_SOCKET_FAMILY_IPV4, R_SOCKET_TYPE_STREAM,
+          R_SOCKET_PROTOCOL_TCP)) != NULL) {
+    r_socket_set_blocking (s, TRUE);
+    if (r_socket_connect (s, c->addr) == R_SOCKET_OK) {
+      int i;
+      for (i = 0; i < 2; i++) {
+        ruint8 buf[2048];
+        rsize n = 0;
+        if (r_socket_send (s, (const ruint8 *) req, sizeof (req) - 1, &n) != R_SOCKET_OK)
+          break;
+        if (r_socket_receive (s, buf, sizeof (buf), &n) != R_SOCKET_OK || n == 0)
+          break;                  /* connection closed -> not persistent */
+        c->responses++;
+      }
+    }
+    r_socket_close (s);
+    r_socket_unref (s);
+  }
+  c->done = TRUE;
+  return NULL;
+}
+
+/* An HTTP/1.1 request without a Connection header is persistent by default, so
+ * a second request is served on the same connection. */
+RTEST (rhttpserver, keepalive_default_http11, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RHttpServer * srv;
+  RSocketAddress * addr;
+  RThread * thread;
+  RTestPersistClient c = { NULL, 0, FALSE };
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((srv = r_http_server_new (loop)), !=, NULL);
+  r_assert (r_http_server_set_handler (srv, "/", -1,
+        r_test_http_simple_status_handler,
+        RUINT_TO_POINTER (R_HTTP_STATUS_OK), NULL));
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 4243)),
+      !=, NULL);
+  r_assert (r_http_server_listen (srv, addr));
+
+  c.addr = addr;
+  r_assert_cmpptr ((thread = r_thread_new (NULL, r_test_persist_client, &c)),
+      !=, NULL);
+
+  /* Drive the server until the raw client has finished both exchanges. */
+  while (!c.done)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_NOWAIT);
+
+  r_thread_join (thread);
+  r_thread_unref (thread);
+  r_assert_cmpint (c.responses, ==, 2);   /* connection persisted across requests */
+
+  r_http_server_stop (srv, NULL, NULL, NULL);
+  r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
+  r_http_server_unref (srv);
+  r_socket_address_unref (addr);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;


### PR DESCRIPTION
`RHttpServer` kept a connection alive only when the request carried an explicit `Connection: keep-alive` header, closing after an HTTP/1.1 request that omitted it. Per RFC 7230 §6.3 an HTTP/1.1 connection is persistent by default — it should stay open unless `Connection: close` is present.

Determine persistence with `r_http_msg_is_keepalive` (added with the client keep-alive work) via the `r_http_request_is_keepalive` wrapper — it encodes exactly that rule (explicit close → false, explicit keep-alive → true, else the HTTP/1.1 default), replacing the server's hand-rolled two-line check.

The kept-alive response framing added earlier (a `Content-Length` on any persistent response that lacks one) already covers the now-larger set of responses kept alive by this change, so bodyless auto-errors stay self-delimiting.

## Test

A wire-level test: a raw client sends two bare HTTP/1.1 requests (no `Connection` header) on one socket; the second is served only because the server now keeps the connection open. (Our own `RHttpClient` always sends `Connection: keep-alive`, so this is the first test exercising the 1.1 *default* over a real socket.)

Verified: epoll + rpoll full suite, ASan/UBSan, mingw werror, doxygen — all clean.

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)