### PR TITLE
rhttpclient: pool chunked keep-alive responses

### DIFF
--- a/include/rlib/net/proto/rhttp.h
+++ b/include/rlib/net/proto/rhttp.h
@@ -179,11 +179,15 @@ R_API RHttpError r_http_msg_set_body_buffer (RHttpMsg * msg, RBuffer * buf);
  *            chunk-size line).
  * @param out On @c R_HTTP_OK receives the decoded body (zero-copy views into
  *            @p buf; caller @ref r_buffer_unref's it). @c NULL otherwise.
+ * @param consumed If non-@c NULL, on @c R_HTTP_OK receives the number of bytes
+ *            consumed from @p buf (through the terminating chunk and trailers);
+ *            any remainder belongs to the next message.
  * @return @c R_HTTP_OK when the terminating zero-size chunk has arrived,
  *         @c R_HTTP_BUF_TOO_SMALL when more bytes are needed, or a decode
  *         error for a malformed stream.
  */
-R_API RHttpError r_http_chunked_decode (RBuffer * buf, RBuffer ** out) R_ATTR_WARN_UNUSED_RESULT;
+R_API RHttpError r_http_chunked_decode (RBuffer * buf, RBuffer ** out,
+    rsize * consumed) R_ATTR_WARN_UNUSED_RESULT;
 /** @brief @c TRUE if a header named @p field is present (@p size or @c -1). */
 R_API rboolean r_http_msg_has_header (RHttpMsg * msg, const rchar * field, rssize size);
 /** @brief @c TRUE if header @p key is present with value @p val. */

--- a/rlib/net/proto/rhttp.c
+++ b/rlib/net/proto/rhttp.c
@@ -503,11 +503,12 @@ r_http_msg_set_header (RHttpMsg * msg, const rchar * field, rssize fsize,
 }
 
 RHttpError
-r_http_chunked_decode (RBuffer * buf, RBuffer ** out)
+r_http_chunked_decode (RBuffer * buf, RBuffer ** out, rsize * consumed)
 {
   RMemMapInfo info = R_MEM_MAP_INFO_INIT;
   RHttpError err = R_HTTP_BUF_TOO_SMALL;
   RBuffer * body = NULL;
+  rsize used = 0;
 
   if (R_UNLIKELY (buf == NULL || out == NULL)) return R_HTTP_INVAL;
   if (!r_buffer_map (buf, &info, R_MEM_MAP_READ)) return R_HTTP_INVAL;
@@ -554,6 +555,7 @@ r_http_chunked_decode (RBuffer * buf, RBuffer ** out)
           p += crlf + 2;
           if (crlf == 0) {                      /* empty line: complete */
             err = R_HTTP_OK;
+            used = (rsize) (p - data);
             break;
           }
         }
@@ -582,6 +584,8 @@ r_http_chunked_decode (RBuffer * buf, RBuffer ** out)
 
   if (err == R_HTTP_OK) {
     *out = body;
+    if (consumed != NULL)
+      *consumed = used;
   } else {
     if (body != NULL)
       r_buffer_unref (body);

--- a/rlib/net/rhttpclient.c
+++ b/rlib/net/rhttpclient.c
@@ -61,6 +61,7 @@ struct RHttpClientReqCtx {
 
   RHttpResponse * res;
   rssize bodysize;
+  rsize bodyconsumed;       /* inbuf bytes the chunked decoder used (CHUNKED) */
   RHttpBodyParseType bodytype;
 
   RHttpClientResponseFunc cb;
@@ -329,17 +330,21 @@ r_http_client_req_reusable (RHttpClientReqCtx * ctx, RHttpClientConn * conn)
     return FALSE;
   if (ctx->res == NULL)
     return FALSE;
-  /* Only fixed-length bodies are pooled: the chunked decoder doesn't report
-   * how many bytes it consumed, so the post-body boundary is unknown. */
-  if (ctx->bodytype != R_HTTP_BODY_PARSE_SIZED)
+  /* Only self-delimited bodies are poolable (a read-until-close body needs the
+   * connection to close). */
+  if (ctx->bodytype != R_HTTP_BODY_PARSE_SIZED &&
+      ctx->bodytype != R_HTTP_BODY_PARSE_CHUNKED)
     return FALSE;
   /* Both sides must agree to persist. */
   if (!r_http_response_is_keepalive (ctx->res) ||
       !r_http_request_is_keepalive (ctx->req))
     return FALSE;
-  /* Unconsumed bytes past the body would corrupt the next response. */
+  /* Unconsumed bytes past the body would corrupt the next response. The body
+   * consumed inbuf's leading bodysize bytes (SIZED) or bodyconsumed bytes as
+   * reported by the chunked decoder (CHUNKED). */
   leftover = (ctx->inbuf != NULL ? r_buffer_get_size (ctx->inbuf) : 0) -
-      (ctx->bodysize > 0 ? (rsize) ctx->bodysize : 0);
+      (ctx->bodytype == R_HTTP_BODY_PARSE_CHUNKED ? ctx->bodyconsumed :
+          (ctx->bodysize > 0 ? (rsize) ctx->bodysize : 0));
   return leftover == 0;
 }
 
@@ -493,7 +498,8 @@ r_http_client_req_recv_data (RHttpClientReqCtx * ctx, RBuffer * buf)
     case R_HTTP_BODY_PARSE_CHUNKED: {
       RBuffer * body = NULL;
       RHttpError err = (ctx->inbuf != NULL) ?
-          r_http_chunked_decode (ctx->inbuf, &body) : R_HTTP_BUF_TOO_SMALL;
+          r_http_chunked_decode (ctx->inbuf, &body, &ctx->bodyconsumed) :
+          R_HTTP_BUF_TOO_SMALL;
       if (err == R_HTTP_OK) {
         r_http_response_set_body_buffer (ctx->res, body);
         r_buffer_unref (body);

--- a/test/rhttp.c
+++ b/test/rhttp.c
@@ -497,6 +497,7 @@ RTEST_END;
 RTEST (rhttp, chunked_decode, RTEST_FAST)
 {
   RBuffer * buf, * out;
+  rsize consumed = 0;
   static const rchar chunked[] =
       "4\r\nWiki\r\n"
       "5\r\npedia\r\n"
@@ -504,9 +505,28 @@ RTEST (rhttp, chunked_decode, RTEST_FAST)
       "0\r\n\r\n";
 
   r_assert_cmpptr ((buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS (chunked))), !=, NULL);
-  r_assert_cmpint (r_http_chunked_decode (buf, &out), ==, R_HTTP_OK);
+  r_assert_cmpint (r_http_chunked_decode (buf, &out, &consumed), ==, R_HTTP_OK);
   r_assert_cmpptr (out, !=, NULL);
   r_assert_cmpbufsstr (out, 0, -1, ==, "Wikipedia in\r\n\r\nchunks.");
+  /* No trailing bytes: the whole buffer was consumed. */
+  r_assert_cmpuint (consumed, ==, sizeof (chunked) - 1);
+  r_buffer_unref (out);
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
+RTEST (rhttp, chunked_decode_trailing_bytes, RTEST_FAST)
+{
+  RBuffer * buf, * out;
+  rsize consumed = 0;
+  /* A complete chunked body immediately followed by the next message. */
+  static const rchar chunked[] = "3\r\nabc\r\n0\r\n\r\nGET / HTTP/1.1\r\n";
+
+  r_assert_cmpptr ((buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS (chunked))), !=, NULL);
+  r_assert_cmpint (r_http_chunked_decode (buf, &out, &consumed), ==, R_HTTP_OK);
+  r_assert_cmpbufsstr (out, 0, -1, ==, "abc");
+  /* consumed stops at the terminating chunk; the rest is the next message. */
+  r_assert_cmpuint (consumed, ==, r_strlen ("3\r\nabc\r\n0\r\n\r\n"));
   r_buffer_unref (out);
   r_buffer_unref (buf);
 }
@@ -522,7 +542,7 @@ RTEST (rhttp, chunked_decode_chunk_ext_and_trailer, RTEST_FAST)
       "\r\n";
 
   r_assert_cmpptr ((buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS (chunked))), !=, NULL);
-  r_assert_cmpint (r_http_chunked_decode (buf, &out), ==, R_HTTP_OK);
+  r_assert_cmpint (r_http_chunked_decode (buf, &out, NULL), ==, R_HTTP_OK);
   r_assert_cmpbufsstr (out, 0, -1, ==, "hello");
   r_buffer_unref (out);
   r_buffer_unref (buf);
@@ -535,19 +555,19 @@ RTEST (rhttp, chunked_decode_incomplete, RTEST_FAST)
 
   /* Size line not yet terminated. */
   r_assert_cmpptr ((buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS ("4"))), !=, NULL);
-  r_assert_cmpint (r_http_chunked_decode (buf, &out), ==, R_HTTP_BUF_TOO_SMALL);
+  r_assert_cmpint (r_http_chunked_decode (buf, &out, NULL), ==, R_HTTP_BUF_TOO_SMALL);
   r_assert_cmpptr (out, ==, NULL);
   r_buffer_unref (buf);
 
   /* Chunk data shorter than the announced size. */
   r_assert_cmpptr ((buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS ("4\r\nWi"))), !=, NULL);
-  r_assert_cmpint (r_http_chunked_decode (buf, &out), ==, R_HTTP_BUF_TOO_SMALL);
+  r_assert_cmpint (r_http_chunked_decode (buf, &out, NULL), ==, R_HTTP_BUF_TOO_SMALL);
   r_assert_cmpptr (out, ==, NULL);
   r_buffer_unref (buf);
 
   /* Last chunk seen but trailer block not terminated. */
   r_assert_cmpptr ((buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS ("4\r\nWiki\r\n0\r\n"))), !=, NULL);
-  r_assert_cmpint (r_http_chunked_decode (buf, &out), ==, R_HTTP_BUF_TOO_SMALL);
+  r_assert_cmpint (r_http_chunked_decode (buf, &out, NULL), ==, R_HTTP_BUF_TOO_SMALL);
   r_assert_cmpptr (out, ==, NULL);
   r_buffer_unref (buf);
 }
@@ -559,13 +579,13 @@ RTEST (rhttp, chunked_decode_malformed, RTEST_FAST)
 
   /* Non-hex chunk size. */
   r_assert_cmpptr ((buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS ("zz\r\n"))), !=, NULL);
-  r_assert_cmpint (r_http_chunked_decode (buf, &out), ==, R_HTTP_DECODE_ERROR);
+  r_assert_cmpint (r_http_chunked_decode (buf, &out, NULL), ==, R_HTTP_DECODE_ERROR);
   r_assert_cmpptr (out, ==, NULL);
   r_buffer_unref (buf);
 
   /* Chunk data not followed by CRLF. */
   r_assert_cmpptr ((buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS ("4\r\nWikiXX0\r\n\r\n"))), !=, NULL);
-  r_assert_cmpint (r_http_chunked_decode (buf, &out), ==, R_HTTP_DECODE_ERROR);
+  r_assert_cmpint (r_http_chunked_decode (buf, &out, NULL), ==, R_HTTP_DECODE_ERROR);
   r_assert_cmpptr (out, ==, NULL);
   r_buffer_unref (buf);
 }

--- a/test/rhttpclient.c
+++ b/test/rhttpclient.c
@@ -757,6 +757,7 @@ typedef struct {
   rboolean close_each;
   int connections;
   int requests;
+  rboolean chunked;       /* reply chunked instead of Content-Length */
 } RTestKaServer;
 
 static rpointer
@@ -764,6 +765,10 @@ r_test_ka_responder (rpointer data)
 {
   RTestKaServer * s = data;
   static const rchar resp[] = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi";
+  static const rchar chunkedresp[] =
+      "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n2\r\nhi\r\n0\r\n\r\n";
+  const rchar * r = s->chunked ? chunkedresp : resp;
+  rsize rlen = (s->chunked ? sizeof (chunkedresp) : sizeof (resp)) - 1;
 
   while (s->requests < s->max_requests) {
     RSocket * conn;
@@ -776,7 +781,7 @@ r_test_ka_responder (rpointer data)
       rsize n = 0;
       if (r_socket_receive (conn, buf, sizeof (buf), &n) != R_SOCKET_OK || n == 0)
         break;                              /* peer closed / error */
-      r_socket_send (conn, (const ruint8 *) resp, sizeof (resp) - 1, &n);
+      r_socket_send (conn, (const ruint8 *) r, rlen, &n);
       s->requests++;
       if (s->close_each || s->requests >= s->max_requests)
         break;
@@ -826,7 +831,7 @@ r_test_ka_request (RHttpClientSync * sync, const RSocketAddress * addr)
 /* Two requests to one destination reuse a single pooled connection. */
 RTEST (rhttpclientsync, keepalive_reuse, RTEST_FAST | RTEST_SYSTEM)
 {
-  RTestKaServer s = { NULL, 2, FALSE, 0, 0 };
+  RTestKaServer s = { NULL, 2, FALSE, 0, 0, FALSE };
   RThread * thread;
   RSocketAddress * addr;
   RHttpClientSync * sync;
@@ -849,10 +854,37 @@ RTEST (rhttpclientsync, keepalive_reuse, RTEST_FAST | RTEST_SYSTEM)
 }
 RTEST_END;
 
+/* A chunked (Transfer-Encoding) response is self-delimited, so its connection
+ * is pooled and reused like a Content-Length one. */
+RTEST (rhttpclientsync, keepalive_reuse_chunked, RTEST_FAST | RTEST_SYSTEM)
+{
+  RTestKaServer s = { NULL, 2, FALSE, 0, 0, TRUE };   /* chunked replies */
+  RThread * thread;
+  RSocketAddress * addr;
+  RHttpClientSync * sync;
+
+  thread = r_test_ka_start (&s, 47671, &addr);
+  r_assert_cmpptr ((sync = r_http_client_sync_new ()), !=, NULL);
+
+  r_test_ka_request (sync, addr);
+  r_test_ka_request (sync, addr);
+
+  r_thread_join (thread);
+  r_thread_unref (thread);
+  r_assert_cmpint (s.requests, ==, 2);
+  r_assert_cmpint (s.connections, ==, 1);   /* chunked response reused */
+
+  r_http_client_sync_unref (sync);
+  r_socket_close (s.listen);
+  r_socket_unref (s.listen);
+  r_socket_address_unref (addr);
+}
+RTEST_END;
+
 /* With keep-alive disabled each request opens (and closes) its own connection. */
 RTEST (rhttpclientsync, keepalive_disabled, RTEST_FAST | RTEST_SYSTEM)
 {
-  RTestKaServer s = { NULL, 2, FALSE, 0, 0 };
+  RTestKaServer s = { NULL, 2, FALSE, 0, 0, FALSE };
   RThread * thread;
   RSocketAddress * addr;
   RHttpClientSync * sync;
@@ -882,7 +914,7 @@ RTEST_END;
  * transparently reconnects and still succeeds. */
 RTEST (rhttpclientsync, keepalive_retry_stale, RTEST_FAST | RTEST_SYSTEM)
 {
-  RTestKaServer s = { NULL, 2, TRUE, 0, 0 };   /* close after each response */
+  RTestKaServer s = { NULL, 2, TRUE, 0, 0, FALSE };   /* close after each response */
   RThread * thread;
   RSocketAddress * addr;
   RHttpClientSync * sync;
@@ -909,7 +941,7 @@ RTEST_END;
  * request opens a fresh connection. */
 RTEST (rhttpclient, keepalive_idle_timeout, RTEST_FAST | RTEST_SYSTEM)
 {
-  RTestKaServer s = { NULL, 2, FALSE, 0, 0 };
+  RTestKaServer s = { NULL, 2, FALSE, 0, 0, FALSE };
   RThread * thread;
   RSocketAddress * addr;
   REvLoop * loop;


### PR DESCRIPTION
Keep-alive pooling (#288) was restricted to `Content-Length`-framed responses: the chunked decoder didn't report how many bytes it consumed, so the client couldn't tell where a chunked body ended or confirm no trailing bytes remained before parking the connection.

## Proto

`r_http_chunked_decode` gains a `rsize * consumed` out-param — on `R_HTTP_OK` it reports the bytes consumed through the terminating chunk and trailers; any remainder belongs to the next message. (`NULL` is accepted to ignore it.)

## Client

The reuse check now accepts `R_HTTP_BODY_PARSE_CHUNKED` alongside `SIZED`, using the decoder's `consumed` count (vs `Content-Length` for SIZED) as the body length in the no-leftover-bytes test. A chunked, persistent response's connection is now pooled and reused like a sized one.

## Tests

- Proto: `consumed` reported for a clean chunked body and for one immediately followed by the next message (`chunked_decode_trailing_bytes`).
- Client: `keepalive_reuse_chunked` — two requests answered with chunked responses are served on a single reused connection.

Verified: epoll + rpoll full suite, ASan/UBSan, mingw werror, doxygen — all clean. Rebased on current master (#299 merged).

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)