### PR TITLE
rstr: parse a leading zero as a digit in r_str_to_uint

### DIFF
--- a/rlib/net/proto/rhttp.c
+++ b/rlib/net/proto/rhttp.c
@@ -518,31 +518,19 @@ r_http_chunked_decode (RBuffer * buf, RBuffer ** out, rsize * consumed)
     const rchar * p = data;
 
     for (;;) {
-      ruint64 csize = 0;
-      const rchar * q;
+      ruint64 csize;
+      RStrParse parse;
       rssize crlf;
 
-      /* chunk-size line: hex size, optional ";ext", terminated by CRLF.
-       * Parse the hex digits directly: r_str_to_uint64 mishandles a leading
-       * zero in base 16, which is exactly the terminating "0" chunk. */
+      /* chunk-size line: hex size, optional ";ext", terminated by CRLF. The
+       * parse stops at the ';' or CR, so it never reads past the line. */
       if ((crlf = r_str_idx_of_str (p, (rsize) (end - p), "\r\n", 2)) < 0)
         break;                                  /* size line incomplete */
-      if (!r_ascii_isxdigit (*p)) {             /* need at least one hex digit */
+      csize = r_str_to_uint64 (p, NULL, 16, &parse);
+      if (parse != R_STR_PARSE_OK) {            /* no digits, or it overflowed */
         err = R_HTTP_DECODE_ERROR;
         break;
       }
-      for (q = p; q < p + crlf && r_ascii_isxdigit (*q); q++) {
-        ruint d = r_ascii_isdigit (*q) ? (ruint) (*q - '0') :
-            (r_ascii_isupper (*q) ? (ruint) (*q - 'A' + 10) :
-                                    (ruint) (*q - 'a' + 10));
-        if (csize > (RUINT64_MAX - d) / 16) {   /* overflow */
-          err = R_HTTP_DECODE_ERROR;
-          break;
-        }
-        csize = csize * 16 + d;
-      }
-      if (err == R_HTTP_DECODE_ERROR)
-        break;
       p += crlf + 2;
 
       if (csize == 0) {

--- a/rlib/rstr.c
+++ b/rlib/rstr.c
@@ -721,20 +721,26 @@ r_str_to_uint_parse (const rchar * str, const rchar ** endptr, ruint base,
     goto beach;
 
   ret = R_STR_PARSE_OK;
-  if (*ptr == '0') {
-    ptr++;
-    if ((base == 0 || base == 16) && (*ptr == 'X' || *ptr == 'x')) {
-      if (!r_ascii_isxdigit (ptr[1]))
-        goto beach;
-      base = 16;
-      ptr++;
-    } else if (base == 0) {
-      if (*ptr < '0' || *ptr > '7')
-        goto beach;
-      base = 8;
-    }
-  } else if (base == 0) {
+  /* Pick the base / skip an optional prefix without consuming a leading zero
+   * that is itself a digit (matches r_str_to_int_parse above). */
+  if (base == 0) {
     base = 10;
+    if (ptr[0] == '0') {
+      if (ptr[1] == 'X' || ptr[1] == 'x') {
+        if (r_ascii_isxdigit (ptr[2])) {
+          base = 16;
+          ptr += 2;
+        }
+      } else if (ptr[1] >= '0' && ptr[1] <= '7') {
+        base = 8;
+        ptr++;
+      }
+    }
+  } else if (base == 16) {
+    if (ptr[0] == '0' && (ptr[1] == 'X' || ptr[1] == 'x') &&
+        r_ascii_isxdigit (ptr[2])) {
+      ptr += 2;
+    }
   }
 
   for (start = ptr; *ptr != 0;) {
@@ -750,8 +756,10 @@ r_str_to_uint_parse (const rchar * str, const rchar ** endptr, ruint base,
       break;
 
     ptr++;
+    /* nv >= v (not > v) so a still-zero accumulator -- a leading zero -- isn't
+     * mistaken for overflow. */
     nv = v * base + c;
-    if (nv <= m && nv > v) {
+    if (nv <= m && nv >= v) {
       v = nv;
     } else {
       v = m;

--- a/test/rstr.c
+++ b/test/rstr.c
@@ -605,6 +605,65 @@ RTEST (rstr, to_int_base2, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rstr, to_int_leading_zero, RTEST_FAST)
+{
+  RStrParse res = R_STR_PARSE_OK;
+  const rchar * e;
+
+  /* A bare zero, and a zero accumulator extended by more zeros, must parse as
+   * 0 (not INVAL/RANGE) -- for every base. */
+  r_assert_cmpuint (r_str_to_uint64 ("0", &e, 16, &res), ==, 0);
+  r_assert_cmpint  (res, ==, R_STR_PARSE_OK);
+  r_assert_cmpstr  (e, ==, "");
+  r_assert_cmpuint (r_str_to_uint64 ("00", &e, 16, &res), ==, 0);
+  r_assert_cmpint  (res, ==, R_STR_PARSE_OK);
+  r_assert_cmpstr  (e, ==, "");
+  r_assert_cmpuint (r_str_to_uint64 ("0", &e, 10, &res), ==, 0);
+  r_assert_cmpint  (res, ==, R_STR_PARSE_OK);
+  r_assert_cmpstr  (e, ==, "");
+  r_assert_cmpuint (r_str_to_uint64 ("0", &e, 0, &res), ==, 0);
+  r_assert_cmpint  (res, ==, R_STR_PARSE_OK);
+  r_assert_cmpstr  (e, ==, "");
+  r_assert_cmpuint (r_str_to_uint64 ("000", &e, 0, &res), ==, 0);
+  r_assert_cmpint  (res, ==, R_STR_PARSE_OK);
+  r_assert_cmpstr  (e, ==, "");
+
+  /* Leading zeros before significant digits, and a value-zero followed by a
+   * non-digit. */
+  r_assert_cmpuint (r_str_to_uint64 ("007f", &e, 16, &res), ==, 0x7f);
+  r_assert_cmpint  (res, ==, R_STR_PARSE_OK);
+  r_assert_cmpstr  (e, ==, "");
+  r_assert_cmpuint (r_str_to_uint64 ("000123", &e, 10, &res), ==, 123);
+  r_assert_cmpint  (res, ==, R_STR_PARSE_OK);
+  r_assert_cmpstr  (e, ==, "");
+  r_assert_cmpuint (r_str_to_uint64 ("0;ext", &e, 16, &res), ==, 0);
+  r_assert_cmpint  (res, ==, R_STR_PARSE_OK);
+  r_assert_cmpstr  (e, ==, ";ext");
+
+  /* An explicit 0x prefix followed by a zero value. */
+  r_assert_cmpuint (r_str_to_uint64 ("0x0", &e, 16, &res), ==, 0);
+  r_assert_cmpint  (res, ==, R_STR_PARSE_OK);
+  r_assert_cmpstr  (e, ==, "");
+  r_assert_cmpuint (r_str_to_uint64 ("0x00ff", &e, 0, &res), ==, 0xff);
+  r_assert_cmpint  (res, ==, R_STR_PARSE_OK);
+  r_assert_cmpstr  (e, ==, "");
+
+  /* The signed parser agrees (including the negative zero spelling). */
+  r_assert_cmpint  (r_str_to_int64 ("0", &e, 16, &res), ==, 0);
+  r_assert_cmpint  (res, ==, R_STR_PARSE_OK);
+  r_assert_cmpstr  (e, ==, "");
+  r_assert_cmpint  (r_str_to_int64 ("00", &e, 16, &res), ==, 0);
+  r_assert_cmpint  (res, ==, R_STR_PARSE_OK);
+  r_assert_cmpstr  (e, ==, "");
+  r_assert_cmpint  (r_str_to_int64 ("-0", &e, 10, &res), ==, 0);
+  r_assert_cmpint  (res, ==, R_STR_PARSE_OK);
+  r_assert_cmpstr  (e, ==, "");
+  r_assert_cmpint  (r_str_to_int64 ("007f", &e, 16, &res), ==, 0x7f);
+  r_assert_cmpint  (res, ==, R_STR_PARSE_OK);
+  r_assert_cmpstr  (e, ==, "");
+}
+RTEST_END;
+
 RTEST (rstr, to_int_base_error, RTEST_FAST)
 {
   RStrParse res = R_STR_PARSE_OK;


### PR DESCRIPTION
`r_str_to_uint_parse` mishandled unsigned values whose digits begin with zero — for example, in base 16:

| input | base | before | correct |
|-------|------|--------|---------|
| `"0"` | 16 | `R_STR_PARSE_INVAL` | `0`, OK |
| `"00"` | 16 | `R_STR_PARSE_RANGE`, value `UINT64_MAX` | `0`, OK |
| `"0;ext"` | 16 | `R_STR_PARSE_INVAL` | `0`, OK, endptr `";ext"` |
| `"007f"` | 16 | `R_STR_PARSE_RANGE` | `0x7f`, OK |

Two root causes in the unsigned parser:
1. A lone/leading `0` was consumed for prefix detection (`0x`/octal) but, when no prefix followed, never counted as a digit — so a value of zero parsed as `INVAL`.
2. The overflow guard `nv > v` rejected a still-zero accumulator (`v == c == 0` gives `nv == 0`, not `> 0`), so leading zeros were misread as wraparound and clamped to the max with `RANGE`.

The signed `r_str_to_int_parse` was already correct (proper prefix detection + `nv >= v`). The fix makes the unsigned parser match it: detect the base / strip an optional `0x` prefix without swallowing a digit-zero, and guard overflow with `nv >= v`.

In base 16 this is exactly the case the chunked transfer-encoding decoder hit on the terminating `0` chunk (worked around inline in #286).

## Test

A new `rstr/to_int_leading_zero` test covering bare/leading zeros and value-zero-then-non-digit across bases 0/10/16, the `0x` prefix, and the signed parser for parity. **It was written first and shown to fail against the unfixed parser** (`r_str_to_uint64("0", 16)` → `INVAL`) before the fix.

Verified: epoll + rpoll full suite, ASan/UBSan, mingw werror, doxygen — all clean (no regressions across the many `r_str_to_uint` callers).

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)