### PR TITLE
rpoll: report an invalid bare handle as an error (win32)

### DIFF
--- a/rlib/rpoll.c
+++ b/rlib/rpoll.c
@@ -146,8 +146,8 @@ r_poll (RPoll * handles, ruint count, RClockTime timeout)
    * WAIT_TIMEOUT (re-enumerate to pick up an event recorded but not signalled,
    * see the cap above), or WAIT_FAILED (a single bad bare handle -- a socket
    * whose arming fell back to a direct wait, closed before it was pruned --
-   * fails the whole call; the probe below skips it and the loop prunes it next
-   * turn instead of stalling). */
+   * fails the whole call; the probe below reports it as an error so the loop
+   * tears it down, rather than re-failing every call and spinning). */
   if (R_UNLIKELY (res == WAIT_FAILED))
     R_LOG_WARNING ("WaitForMultipleObjectsEx failed (%lu); probing handles",
         (unsigned long) GetLastError ());
@@ -175,9 +175,20 @@ r_poll (RPoll * handles, ruint count, RClockTime timeout)
         handles[i].revents = rev;
         ret++;
       }
-    } else if (WaitForSingleObject ((HANDLE)handles[i].handle, 0) == WAIT_OBJECT_0) {
-      handles[i].revents = handles[i].events;
-      ret++;
+    } else {
+      /* Bare handle (the loop wakeup, or a socket whose arming fell back to a
+       * direct wait). WAIT_OBJECT_0 -> ready; WAIT_FAILED -> the handle is
+       * invalid (closed before it was pruned), so report an error and let the
+       * loop tear it down -- otherwise that handle fails the whole wait on
+       * every call and the loop spins. WAIT_TIMEOUT -> not ready. */
+      DWORD w = WaitForSingleObject ((HANDLE)handles[i].handle, 0);
+      if (w == WAIT_OBJECT_0) {
+        handles[i].revents = handles[i].events;
+        ret++;
+      } else if (w == WAIT_FAILED) {
+        handles[i].revents = R_IO_ERR;
+        ret++;
+      }
     }
   }
 


### PR DESCRIPTION
## Symptom

Intermittent hang on the **Windows `rpoll`** CI jobs (e.g. run 27042491602): `/rhttpclient/server_stop_during_request` times out after ~36 s while the log fills with thousands of `r_poll() WaitForMultipleObjectsEx failed (6); probing handles` (`ERROR_INVALID_HANDLE`) in the same instant — a busy-spin. Only the rpoll backend is affected; IOCP and the POSIX backends are fine. It is a race, not deterministic (the same commit passes on rerun), so it slips through most runs.

## Root cause

In `rpoll.c`, a *bare* (non-`WSAEVENT`) handle in the wait set that has become invalid — a socket whose arming fell back to a direct wait, closed before it was pruned — makes `WaitForMultipleObjectsEx` fail the whole call and return immediately. The probe loop only computed readiness for `WSAEVENT` entries; the bad bare handle's branch (`WaitForSingleObject(...) == WAIT_OBJECT_0`) is simply false for an invalid handle, so it was never reported. The event loop therefore never tore the handle down, the next wait failed again, and the loop spun until the watchdog fired. The trigger is the mid-request force-close in `server_stop_during_request`, which can strand such a handle.

## Fix

Report a `WAIT_FAILED` bare handle as `R_IO_ERR` so the loop closes and prunes it, instead of dropping it and re-failing the wait every iteration. WAIT_TIMEOUT (valid, unsignalled) and WAIT_OBJECT_0 (ready) are unchanged, so the loop wakeup and other valid bare handles are unaffected.

## Validation

Windows-only code (the Linux "rpoll" build uses `select`/`poll`, a different branch), so it can't be exercised locally — compile-checked via the mingw cross build, and validated on the Windows rpoll CI here. Because the failure is intermittent I've also re-run the rpoll jobs to build confidence the spin no longer recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)