### PR TITLE
TEMP: rpoll bare-handle spin repro (do not merge)

### DIFF
--- a/rlib/rpoll.c
+++ b/rlib/rpoll.c
@@ -146,8 +146,8 @@ r_poll (RPoll * handles, ruint count, RClockTime timeout)
    * WAIT_TIMEOUT (re-enumerate to pick up an event recorded but not signalled,
    * see the cap above), or WAIT_FAILED (a single bad bare handle -- a socket
    * whose arming fell back to a direct wait, closed before it was pruned --
-   * fails the whole call; the probe below skips it and the loop prunes it next
-   * turn instead of stalling). */
+   * fails the whole call; the probe below reports it as an error so the loop
+   * tears it down, rather than re-failing every call and spinning). */
   if (R_UNLIKELY (res == WAIT_FAILED))
     R_LOG_WARNING ("WaitForMultipleObjectsEx failed (%lu); probing handles",
         (unsigned long) GetLastError ());
@@ -175,9 +175,20 @@ r_poll (RPoll * handles, ruint count, RClockTime timeout)
         handles[i].revents = rev;
         ret++;
       }
-    } else if (WaitForSingleObject ((HANDLE)handles[i].handle, 0) == WAIT_OBJECT_0) {
-      handles[i].revents = handles[i].events;
-      ret++;
+    } else {
+      /* Bare handle (the loop wakeup, or a socket whose arming fell back to a
+       * direct wait). WAIT_OBJECT_0 -> ready; WAIT_FAILED -> the handle is
+       * invalid (closed before it was pruned), so report an error and let the
+       * loop tear it down -- otherwise that handle fails the whole wait on
+       * every call and the loop spins. WAIT_TIMEOUT -> not ready. */
+      DWORD w = WaitForSingleObject ((HANDLE)handles[i].handle, 0);
+      if (w == WAIT_OBJECT_0) {
+        handles[i].revents = handles[i].events;
+        ret++;
+      } else if (w == WAIT_FAILED) {
+        handles[i].revents = R_IO_ERR;
+        ret++;
+      }
     }
   }
 

--- a/test/rhttpclient.c
+++ b/test/rhttpclient.c
@@ -988,3 +988,51 @@ RTEST (rhttpclient, keepalive_idle_timeout, RTEST_FAST | RTEST_SYSTEM)
   r_socket_address_unref (addr);
 }
 RTEST_END;
+
+/* TEMPORARY (rpoll bare-handle spin repro): hammer the mid-request force-close
+ * many times so the Windows rpoll race that strands a closed bare handle in the
+ * wait set is virtually certain to hit within one run. Without the fix this
+ * hangs (the loop spins on WaitForMultipleObjectsEx WAIT_FAILED); with it the
+ * handle is pruned and the test completes. */
+RTEST (rhttpclient, server_stop_stress_repro, RTEST_FAST | RTEST_SYSTEM)
+{
+  ruint iter;
+
+  for (iter = 0; iter < 200; iter++) {
+    REvLoop * loop;
+    RClock * clock;
+    RHttpServer * srv;
+    RHttpClient * client;
+    RHttpRequest * req;
+    RHttpResponse * res;
+    RSocketAddress * addr;
+    RHttpClientResult result;
+
+    r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+    r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+    r_clock_unref (clock);
+
+    r_assert_cmpptr ((srv = r_http_server_new (loop)), !=, NULL);
+    r_assert (r_http_server_set_handler (srv, "/", -1,
+          r_test_http_client_stop_handler, NULL, NULL));
+    r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1,
+            (ruint16) (47900 + iter))), !=, NULL);
+    r_assert (r_http_server_listen (srv, addr));
+
+    r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
+    r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+            "http://127.0.0.1/", NULL, NULL)), !=, NULL);
+
+    res = r_test_http_send (loop, client, req, addr, &result);
+    r_http_request_unref (req);
+    (void) result;   /* any outcome is fine; we only exercise the close path */
+    if (res != NULL)
+      r_http_response_unref (res);
+
+    r_socket_address_unref (addr);
+    r_http_client_unref (client);
+    r_http_server_unref (srv);
+    r_ev_loop_unref (loop);
+  }
+}
+RTEST_END;


### PR DESCRIPTION
Temporary: stress-reproduces the Windows rpoll bare-handle spin (PR #302) on the unfixed backend to validate the fix. Will be closed, not merged.