### PR TITLE
revloop: prune a dead handle the rpoll backend reports (win32)

### DIFF
--- a/rlib/ev/revloop.c
+++ b/rlib/ev/revloop.c
@@ -592,7 +592,9 @@ r_ev_loop_io_wait (REvLoop * loop, RClockTime deadline)
       REvIOEvents rev;
       RIOHandle handle;
     } dispatch[R_EV_LOOP_MAX_EVENTS];
+    RIOHandle dead[R_EV_LOOP_MAX_EVENTS];
     int ndispatch = 0;
+    int ndead = 0;
     int j;
 
     R_LOG_DEBUG ("r_poll for loop %p with %d events", loop, ret);
@@ -612,9 +614,15 @@ r_ev_loop_io_wait (REvLoop * loop, RClockTime deadline)
         continue;
 
       evio = r_poll_set_get_user (&loop->pollset, handle);
-      if (R_UNLIKELY (evio == NULL)) {
-        R_LOG_WARNING ("loop %p: r_poll reported events on stale handle "
-            "%"R_IO_HANDLE_FMT" (no evio); skipping", loop, handle);
+      if (R_UNLIKELY (evio == NULL || R_EV_IO_IS_CLOSED (evio))) {
+        /* The handle has gone invalid -- e.g. a closed socket whose arming
+         * fell back to a bare wait, which then fails WaitForMultipleObjectsEx
+         * on every call. Drop it from the set (after dispatch, so the set is
+         * not mutated mid-scan) or the loop spins on it. */
+        R_LOG_DEBUG ("loop %p: pruning dead handle %"R_IO_HANDLE_FMT" from pollset",
+            loop, handle);
+        if (ndead < R_EV_LOOP_MAX_EVENTS)
+          dead[ndead++] = handle;
         continue;
       }
 
@@ -630,6 +638,9 @@ r_ev_loop_io_wait (REvLoop * loop, RClockTime deadline)
           (ruint)dispatch[j].rev);
       r_ev_io_invoke_iocb (dispatch[j].evio, dispatch[j].rev);
     }
+
+    for (j = 0; j < ndead; j++)
+      r_poll_set_remove (&loop->pollset, dead[j]);
   } else {
     R_LOG_ERROR ("r_poll for loop %p failed with error %d", loop, ret);
   }


### PR DESCRIPTION
Follow-up to #302. The Windows `rpoll` spin on `/rhttpclient/server_stop_during_request` still recurred after #302 — on the **release** build last night.

## Why #302 wasn't enough

#302 made `r_poll` report an invalid bare handle as `R_IO_ERR` so the loop could tear it down. But the loop dispatched that error to the handle's `evio`, and when the `evio` was **already closed** (the force-close had already run by the time `r_poll` observed the dead handle), the dispatch was a no-op — nothing re-closed or re-enqueued the entry, it stayed in the pollset, and the next `WaitForMultipleObjectsEx` failed again. So the spin persisted in exactly the case where the close won the race.

## Fix

In the loop's dispatch scan, treat a reported handle whose `evio` is gone (`NULL`) or already `R_EV_IO_CLOSED` as **dead** and remove it from the pollset (after dispatching, so the set isn't mutated mid-scan). A dead handle can then never survive more than one `r_poll`, regardless of whether the close beat the poll. Together with #302's report, this covers every `WAIT_FAILED`-spin variant (only an invalid *bare* handle fails the whole wait, and #302 now reports it).

## Validation

Windows-only behaviour (the Linux `-Drpoll` build uses `select`/`poll`), so validated through CI:
- **No-fix + a 200× force-close stress → Windows rpoll hangs** (the spin), proven on #303.
- **This fix + the same stress → Windows rpoll passes** (no hang).
- Linux `-Drpoll` full suite, mingw cross (`-Werror`), and epoll all green; the prune path runs in the Linux rpoll build too.

Honest caveat: the stress reliably reproduces the *not-yet-closed* variant; the rarer *already-closed* variant that bit release is timing-dependent and can't be forced on demand in CI — but it is exactly what this prune covers by construction (it removes the entry whether or not the evio is already closed). Recommend merging and watching master/nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)