### PR TITLE
rpoll: never wait on a socket handle directly (win32)

### DIFF
--- a/rlib/rpoll.c
+++ b/rlib/rpoll.c
@@ -94,6 +94,14 @@ r_poll (RPoll * handles, ruint count, RClockTime timeout)
  * through it. */
 #define R_POLL_WIN32_MAX_WAIT_MS    1000
 
+/* Sentinel RPoll.wsaevent for a socket that could not be associated with a
+ * WSAEVENT -- WSAEventSelect failed for a reason other than "not a socket",
+ * i.e. the socket was already closed/closing. Such an entry must never be
+ * waited on as a raw handle: a socket is not a waitable object, so the wait
+ * fails (ACCESS_DENIED / INVALID_HANDLE) on every call forever. r_poll reports
+ * it as an error instead, so the loop prunes it. */
+#define R_POLL_WSAEVENT_DEAD        ((rpointer) ~(rsize) 0)
+
 /* Map the requested R_IO_* readiness to the FD_* network events a socket is
  * associated with through WSAEventSelect. FD_CLOSE is folded into readability
  * so a peer reset / EOF wakes the read watcher (recv then reports the error). */
@@ -131,29 +139,40 @@ r_poll (RPoll * handles, ruint count, RClockTime timeout)
   else
     t = (DWORD) MIN (R_TIME_AS_MSECONDS (timeout) + 1, R_POLL_WIN32_MAX_WAIT_MS);
 
-  /* Wait on the per-socket WSAEVENT (socket readiness) or, for a non-socket
-   * handle such as the loop wakeup, on the handle itself. WSAEVENTs stay valid
-   * even after their socket is closed, so a closed-but-not-yet-pruned socket
-   * can no longer fail the whole wait the way a bare socket handle did. */
-  for (i = 0; i < count; i++) {
-    handles[i].revents = 0;
-    waits[i] = (handles[i].wsaevent != NULL) ?
-        (HANDLE)handles[i].wsaevent : (HANDLE)handles[i].handle;
+  /* Build the wait set from the waitable entries only: a per-socket WSAEVENT
+   * (socket readiness), or a genuine non-socket handle such as the loop wakeup
+   * (waited on directly). A dead-socket entry is reported as an error and left
+   * out -- waiting on a raw socket handle fails the whole call forever. A
+   * WSAEVENT stays valid even after its socket is closed, so a closed-but-not-
+   * yet-pruned socket no longer fails the wait. */
+  {
+    ruint nwait = 0;
+    for (i = 0; i < count; i++) {
+      handles[i].revents = 0;
+      if (handles[i].wsaevent == R_POLL_WSAEVENT_DEAD) {
+        handles[i].revents = R_IO_ERR;
+        ret++;
+        continue;
+      }
+      waits[nwait++] = (handles[i].wsaevent != NULL) ?
+          (HANDLE)handles[i].wsaevent : (HANDLE)handles[i].handle;
+    }
+
+    /* With a dead entry to report, don't block -- return so the loop prunes it
+     * this turn (still harvest any concurrent real readiness). */
+    if (nwait > 0) {
+      res = WaitForMultipleObjectsEx ((DWORD)nwait, waits, FALSE,
+          ret > 0 ? 0 : t, FALSE);
+      if (R_UNLIKELY (res == WAIT_FAILED))
+        R_LOG_WARNING ("WaitForMultipleObjectsEx failed (%lu); probing handles",
+            (unsigned long) GetLastError ());
+    }
   }
 
-  res = WaitForMultipleObjectsEx ((DWORD)count, waits, FALSE, t, FALSE);
-  /* Read actual readiness from every entry for every result: a normal wake, a
-   * WAIT_TIMEOUT (re-enumerate to pick up an event recorded but not signalled,
-   * see the cap above), or WAIT_FAILED (a single bad bare handle -- a socket
-   * whose arming fell back to a direct wait, closed before it was pruned --
-   * fails the whole call; the probe below reports it as an error so the loop
-   * tears it down, rather than re-failing every call and spinning). */
-  if (R_UNLIKELY (res == WAIT_FAILED))
-    R_LOG_WARNING ("WaitForMultipleObjectsEx failed (%lu); probing handles",
-        (unsigned long) GetLastError ());
-
   for (i = 0; i < count; i++) {
-    if (handles[i].wsaevent != NULL) {
+    if (handles[i].wsaevent == R_POLL_WSAEVENT_DEAD) {
+      continue;   /* already reported as an error above */
+    } else if (handles[i].wsaevent != NULL) {
       WSANETWORKEVENTS ne;
       rushort rev = 0;
 
@@ -176,16 +195,17 @@ r_poll (RPoll * handles, ruint count, RClockTime timeout)
         ret++;
       }
     } else {
-      /* Bare handle (the loop wakeup, or a socket whose arming fell back to a
-       * direct wait). WAIT_OBJECT_0 -> ready; WAIT_FAILED -> the handle is
-       * invalid (closed before it was pruned), so report an error and let the
-       * loop tear it down -- otherwise that handle fails the whole wait on
-       * every call and the loop spins. WAIT_TIMEOUT -> not ready. */
+      /* A genuine non-socket handle (the loop wakeup). WAIT_OBJECT_0 -> ready;
+       * WAIT_TIMEOUT -> not ready; WAIT_FAILED -> defensively report an error so
+       * an unexpectedly-invalid handle is torn down rather than spun on. */
       DWORD w = WaitForSingleObject ((HANDLE)handles[i].handle, 0);
       if (w == WAIT_OBJECT_0) {
         handles[i].revents = handles[i].events;
         ret++;
       } else if (w == WAIT_FAILED) {
+        /* Not a waitable handle after all; mark it dead so it is excluded from
+         * the next wait (and reported now) rather than failing every call. */
+        handles[i].wsaevent = R_POLL_WSAEVENT_DEAD;
         handles[i].revents = R_IO_ERR;
         ret++;
       }
@@ -272,20 +292,28 @@ r_poll_entry_arm (RPoll * p)
   if ((ev = WSACreateEvent ()) == WSA_INVALID_EVENT)
     return;
 
-  /* A non-socket handle (the loop wakeup) fails with WSAENOTSOCK and keeps
-   * wsaevent == NULL, so it is waited on directly. */
   if (WSAEventSelect ((SOCKET)(ruintptr)p->handle, ev,
-        r_poll_win32_fd_events (p->events)) == 0)
+        r_poll_win32_fd_events (p->events)) == 0) {
     p->wsaevent = ev;
-  else
+  } else {
+    /* WSAEventSelect fails both for the loop wakeup (a real, waitable handle)
+     * and for an already closed/closing socket -- both report WSAENOTSOCK, so
+     * the error code can't tell them apart. Distinguish by whether the handle
+     * is waitable at all: a socket (open or closed) is not a waitable object,
+     * so WaitForSingleObject fails on it. Mark such an entry dead so r_poll
+     * never waits on the raw socket; only a genuinely waitable non-socket
+     * handle (the wakeup) keeps the bare direct-wait path. */
     WSACloseEvent (ev);
+    if (WaitForSingleObject ((HANDLE)(ruintptr)p->handle, 0) == WAIT_FAILED)
+      p->wsaevent = R_POLL_WSAEVENT_DEAD;
+  }
 }
 
 /* Re-issue the WSAEventSelect association after the watched events changed. */
 static void
 r_poll_entry_rearm (RPoll * p)
 {
-  if (p->wsaevent != NULL)
+  if (p->wsaevent != NULL && p->wsaevent != R_POLL_WSAEVENT_DEAD)
     WSAEventSelect ((SOCKET)(ruintptr)p->handle, (WSAEVENT)p->wsaevent,
         r_poll_win32_fd_events (p->events));
 }
@@ -293,11 +321,11 @@ r_poll_entry_rearm (RPoll * p)
 static void
 r_poll_entry_disarm (RPoll * p)
 {
-  if (p->wsaevent != NULL) {
+  if (p->wsaevent != NULL && p->wsaevent != R_POLL_WSAEVENT_DEAD) {
     WSAEventSelect ((SOCKET)(ruintptr)p->handle, NULL, 0);
     WSACloseEvent ((WSAEVENT)p->wsaevent);
-    p->wsaevent = NULL;
   }
+  p->wsaevent = NULL;
 }
 
 #define R_POLL_ENTRY_ARM(p)         r_poll_entry_arm (p)


### PR DESCRIPTION
Third and (validated) final fix for the Windows `rpoll` spin on `/rhttpclient/server_stop_during_request`. After #302 and #304 it still recurred on the **release** build — `WaitForMultipleObjectsEx` failing every call with `ACCESS_DENIED (5)`/`INVALID_HANDLE (6)`, busy-spinning to the watchdog.

## Root cause

`r_poll_entry_arm` fell back to a bare *direct* wait whenever `WSAEventSelect` failed, assuming only the non-socket loop wakeup fails it. But an already closed/closing socket — produced by the mid-request force-close race — fails `WSAEventSelect` with the **same `WSAENOTSOCK`**, and a socket is not a waitable object, so its raw handle in `WaitForMultipleObjectsEx` fails the whole call forever. (#302/#304 addressed downstream symptoms; this is the source, and the `ACCESS_DENIED` code is the tell — a socket handle was in the wait set.)

## Fix

Distinguish the wakeup from a socket by **waitability** (`WaitForSingleObject`), not the WSA error code: an entry whose handle isn't waitable is marked dead, so `r_poll` leaves it out of the wait set and reports `R_IO_ERR` (the loop prunes it via #304). Only a genuinely waitable non-socket handle keeps the bare path. `r_poll` also marks a bare handle dead if it ever fails the wait, so a bad handle can never fail the wait twice.

## Validation (A/B on the *release* build, under stress)

A 200× mid-request force-close stress reliably reproduces it. On the Windows rpoll **release** job:
- **without this fix → both rpoll jobs FAILED** (spin/hang),
- **with this fix → both rpoll jobs PASSED.**

Linux `-Drpoll` full suite, mingw cross (`-Werror`), and epoll all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)