### PR TITLE
rmpint: fixed-size Comba multiply for 1024/2048-bit operands

### DIFF
--- a/rlib/data/rmpint.c
+++ b/rlib/data/rmpint.c
@@ -1193,6 +1193,42 @@ r_mpint_shr_digit (rmpint * dst, const rmpint * a, ruint16 d)
   return TRUE;
 }
 
+/* Fixed-size Comba (column/product-scanning) multiply of two @p n-digit
+ * operands into @p out[0 .. 2n-1]. Unlike the generic loop below it indexes the
+ * digit arrays directly -- no per-access bounds check and no per-column range
+ * recompute -- which is the win on the hot RSA sizes (n == 32 -> 1024-bit,
+ * n == 64 -> 2048-bit). @p out must not alias @p a or @p b.
+ *
+ * Each column sum is kept in a three-digit accumulator (c0,c1,c2): a single
+ * digit-product is at most (2^32-1)^2, split into low/high halves, and at most
+ * n of them accumulate per column (c2 <= n, far below 2^32), so nothing
+ * overflows. */
+static void
+r_mpint_mul_comba (rmpint_digit * out, const rmpint_digit * a,
+    const rmpint_digit * b, ruint n)
+{
+  const ruint dbits = sizeof (rmpint_digit) * 8;
+  rmpint_digit c0 = 0, c1 = 0, c2 = 0;
+  ruint k;
+
+  for (k = 0; k < 2 * n; k++) {
+    ruint i = (k + 1 > n) ? k + 1 - n : 0;
+    ruint imax = (k < n) ? k : n - 1;
+
+    for (; i <= imax; i++) {
+      rmpint_word uv = (rmpint_word)a[i] * b[k - i];
+      rmpint_word t = (rmpint_word)c0 + (rmpint_digit)uv;
+      c0 = (rmpint_digit)t;
+      t = (rmpint_word)c1 + (rmpint_digit)(uv >> dbits) + (rmpint_digit)(t >> dbits);
+      c1 = (rmpint_digit)t;
+      c2 += (rmpint_digit)(t >> dbits);
+    }
+
+    out[k] = c0;
+    c0 = c1; c1 = c2; c2 = 0;
+  }
+}
+
 /* Based on Paul G. Combas algorithm/method */
 rboolean
 r_mpint_mul (rmpint * dst, const rmpint * a, const rmpint * b)
@@ -1209,14 +1245,6 @@ r_mpint_mul (rmpint * dst, const rmpint * a, const rmpint * b)
   if (R_UNLIKELY (used < a->dig_used || used < b->dig_used))
     return FALSE;
 
-  /* FIXME: Add specific comba versions for 1024 and 2048 bits multiplications */
-#if 0
-  if (a->dig_used == 16 && b->dig_used == 16)
-    return r_mpint_mul_comba16 (dst, a, b);
-  if (a->dig_used == 32 && b->dig_used == 32)
-    return r_mpint_mul_comba32 (dst, a, b);
-#endif
-
   if (a == dst || b == dst) {
     /* dst aliases one of the operands; build the full product in a
      * fresh scratch first, then r_mpint_set into dst. The scratch
@@ -1231,7 +1259,11 @@ r_mpint_mul (rmpint * dst, const rmpint * a, const rmpint * b)
     out = dst;
   }
 
-  for (ix = 0, acc = 0; ix < used; ix++) {
+  /* Fixed-size fast path for the hot RSA operand sizes (1024 / 2048 bit). */
+  if (a->dig_used == b->dig_used &&
+      (a->dig_used == 32 || a->dig_used == 64)) {
+    r_mpint_mul_comba (out->data, a->data, b->data, a->dig_used);
+  } else for (ix = 0, acc = 0; ix < used; ix++) {
     ty = MIN (ix, b->dig_used - 1);
     tx = ix - ty;
 

--- a/test/rmpint.c
+++ b/test/rmpint.c
@@ -504,6 +504,71 @@ RTEST (rmpint, mul, RTEST_FAST)
 }
 RTEST_END;
 
+/* Independent schoolbook reference: sum_i (a * b_digit[i]) << i digits, built
+ * only from mul-by-digit / shift / add, none of which use the Comba path. */
+static void
+r_test_mpint_mul_ref (rmpint * ref, const rmpint * a, const rmpint * b)
+{
+  rmpint term = R_MPINT_INIT;
+  ruint16 i, nb = r_mpint_digits_used (b);
+
+  r_mpint_zero (ref);
+  for (i = 0; i < nb; i++) {
+    r_assert (r_mpint_mul_u32 (&term, a, r_mpint_get_digit (b, i)));
+    r_assert (r_mpint_shl_digit (&term, &term, i));
+    r_assert (r_mpint_add (ref, ref, &term));
+  }
+  r_mpint_clear (&term);
+}
+
+/* The 1024- and 2048-bit fixed-size Comba path must agree with the schoolbook
+ * reference for random full-size operands (and their squares). */
+RTEST (rmpint, mul_comba, RTEST_FAST)
+{
+  static const ruint16 ndig[] = { 32, 64 };   /* 1024-bit, 2048-bit */
+  rmpint a = R_MPINT_INIT, b = R_MPINT_INIT;
+  rmpint prod = R_MPINT_INIT, ref = R_MPINT_INIT;
+  RPrng * prng;
+  rsize ni;
+
+  r_assert_cmpptr ((prng = r_prng_new_mt ()), !=, NULL);
+
+  for (ni = 0; ni < R_N_ELEMENTS (ndig); ni++) {
+    ruint8 buf[64 * sizeof (rmpint_digit)];
+    rsize nbytes = ndig[ni] * sizeof (rmpint_digit);
+    int it;
+
+    for (it = 0; it < 64; it++) {
+      r_assert (r_prng_fill (prng, buf, nbytes));
+      buf[0] |= 0x80;                 /* force top digit non-zero -> dig_used == n */
+      r_mpint_init_binary (&a, buf, nbytes);
+      r_assert (r_prng_fill (prng, buf, nbytes));
+      buf[0] |= 0x80;
+      r_mpint_init_binary (&b, buf, nbytes);
+      r_assert_cmpuint (r_mpint_digits_used (&a), ==, ndig[ni]);
+      r_assert_cmpuint (r_mpint_digits_used (&b), ==, ndig[ni]);
+
+      /* a * b */
+      r_assert (r_mpint_mul (&prod, &a, &b));
+      r_test_mpint_mul_ref (&ref, &a, &b);
+      r_assert_cmpint (r_mpint_cmp (&prod, &ref), ==, 0);
+
+      /* a * a (squaring also takes the equal-size path) */
+      r_assert (r_mpint_mul (&prod, &a, &a));
+      r_test_mpint_mul_ref (&ref, &a, &a);
+      r_assert_cmpint (r_mpint_cmp (&prod, &ref), ==, 0);
+
+      r_mpint_clear (&a);
+      r_mpint_clear (&b);
+    }
+  }
+
+  r_mpint_clear (&prod);
+  r_mpint_clear (&ref);
+  r_prng_unref (prng);
+}
+RTEST_END;
+
 RTEST (rmpint, div, RTEST_FAST)
 {
   rmpint n = R_MPINT_INIT, d = R_MPINT_INIT, q = R_MPINT_INIT, r = R_MPINT_INIT, cmp;


### PR DESCRIPTION
`r_mpint_mul` is already column-scanning (Comba), but every digit access goes through the bounds-checked `r_mpint_get_digit` and each column recomputes its range via `MIN`. For the hot RSA operand sizes that per-access overhead is avoidable.

## Change

When both operands have exactly **32 digits (1024-bit)** or **64 digits (2048-bit)**, dispatch to a new `r_mpint_mul_comba` that indexes the digit arrays directly, with a three-digit column accumulator (`c0,c1,c2`) — no bounds check, no per-column range recompute. Replaces the long-dead `#if 0 comba16/comba32` sketch in `r_mpint_mul` (whose 16/32-digit sizes assumed 64-bit digits; the build uses 32-bit digits, so the RSA sizes are 32/64 digits).

(`rmpint_digit` is 32-bit / `rmpint_word` 64-bit, so a single product is ≤ (2³²−1)², split into halves, and ≤ n accumulate per column — `c2 ≤ n` ≪ 2³², nothing overflows. The half-word shift uses `sizeof(rmpint_digit)*8`, not a literal 32.)

## Benchmark (gcc -O2, x86-64)

| | before | after | speedup |
|---|---|---|---|
| 1024-bit mul | 697 ns/op | 542 ns/op | **1.29×** |
| 2048-bit mul | 2730 ns/op | 2156 ns/op | **1.27×** |

Measured by timing `r_mpint_mul` on full-size operands before/after; this directly speeds up RSA/DH/DSA modexp.

## Tests

New `rmpint/mul_comba`: validates the path against an **independent schoolbook reference** (built only from mul-by-digit + shift + add, none of which use Comba) for 64 random full-size operand pairs and their squares, at both sizes. The existing RSA/DH/DSA suites already exercise the path end-to-end through modexp.

Verified: epoll + rpoll full suite, ASan/UBSan, mingw cross (`-Werror`), doxygen — all clean.

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)