### PR TITLE
binfmt/elf: expand the ELF parser API

### DIFF
--- a/include/rlib/binfmt/relf.h
+++ b/include/rlib/binfmt/relf.h
@@ -444,6 +444,57 @@ typedef struct {
   ruint64 entsize;
 } RElf64SHdr;
 
+/**
+ * @name Dynamic-table tags
+ *
+ * Values of @c d_tag in a @ref RElf32Dyn / @ref RElf64Dyn entry of the
+ * @c .dynamic (@c PT_DYNAMIC / @c SHT_DYNAMIC) table. Tags below
+ * @c R_ELF_DTYPE_NUM cover the base ABI (needed libraries, string / symbol
+ * tables, relocation tables, init / fini, run paths, ...); the @c LOOS ..
+ * @c HIPROC ranges are OS- and processor-specific. A @c d_tag of
+ * @c R_ELF_DTYPE_NULL terminates the table.
+ * @{
+ */
+#define R_ELF_DTYPE_NULL              0
+#define R_ELF_DTYPE_NEEDED            1
+#define R_ELF_DTYPE_PLTRELSZ          2
+#define R_ELF_DTYPE_PLTGOT            3
+#define R_ELF_DTYPE_HASH              4
+#define R_ELF_DTYPE_STRTAB            5
+#define R_ELF_DTYPE_SYMTAB            6
+#define R_ELF_DTYPE_RELA              7
+#define R_ELF_DTYPE_RELASZ            8
+#define R_ELF_DTYPE_RELAENT           9
+#define R_ELF_DTYPE_STRSZ             10
+#define R_ELF_DTYPE_SYMENT            11
+#define R_ELF_DTYPE_INIT              12
+#define R_ELF_DTYPE_FINI              13
+#define R_ELF_DTYPE_SONAME            14
+#define R_ELF_DTYPE_RPATH             15
+#define R_ELF_DTYPE_SYMBOLIC          16
+#define R_ELF_DTYPE_REL               17
+#define R_ELF_DTYPE_RELSZ             18
+#define R_ELF_DTYPE_RELENT            19
+#define R_ELF_DTYPE_PLTREL            20
+#define R_ELF_DTYPE_DEBUG             21
+#define R_ELF_DTYPE_TEXTREL           22
+#define R_ELF_DTYPE_JMPREL            23
+#define R_ELF_DTYPE_BIND_NOW          24
+#define R_ELF_DTYPE_INIT_ARRAY        25
+#define R_ELF_DTYPE_FINI_ARRAY        26
+#define R_ELF_DTYPE_INIT_ARRAYSZ      27
+#define R_ELF_DTYPE_FINI_ARRAYSZ      28
+#define R_ELF_DTYPE_RUNPATH           29
+#define R_ELF_DTYPE_FLAGS             30
+#define R_ELF_DTYPE_PREINIT_ARRAY     32
+#define R_ELF_DTYPE_PREINIT_ARRAYSZ   33
+#define R_ELF_DTYPE_NUM               34
+#define R_ELF_DTYPE_LOOS              0x6000000d
+#define R_ELF_DTYPE_HIOS              0x6ffff000
+#define R_ELF_DTYPE_LOPROC            0x70000000
+#define R_ELF_DTYPE_HIPROC            0x7fffffff
+/** @} */
+
 /* Dynamic symbol */
 /** @brief ELF32 dynamic-table entry (tag + value pair). */
 typedef struct {

--- a/include/rlib/binfmt/relfparser.h
+++ b/include/rlib/binfmt/relfparser.h
@@ -57,7 +57,6 @@
  * time, so all accessors below return native-order values regardless of the
  * file's e_ident[EI_DATA]. */
 /* FIXME: Go over ELF chapter 2 loading and dynamic linking */
-/*    * TODO: Improve Program header API */
 /*    * TODO: Add Note API */
 /*    * TODO: Add program loading and dynamic linking API? */
 
@@ -136,6 +135,21 @@ R_API rpointer r_elf_parser_get_prg_header_table (RElfParser * parser);
 R_API RElf32PHdr * r_elf_parser_get_phdr32 (RElfParser * parser, ruint16 idx);
 /** @brief Pointer to the @p idx -th ELF64 program header. */
 R_API RElf64PHdr * r_elf_parser_get_phdr64 (RElfParser * parser, ruint16 idx);
+/** @brief First ELF32 program header of the given @c p_type, or @c NULL. */
+R_API RElf32PHdr * r_elf_parser_find_phdr32_by_type (RElfParser * parser, ruint32 type);
+/** @brief First ELF64 program header of the given @c p_type, or @c NULL. */
+R_API RElf64PHdr * r_elf_parser_find_phdr64_by_type (RElfParser * parser, ruint32 type);
+/**
+ * @brief Slice the file-resident bytes of an ELF32 segment (@c p_filesz at
+ * @c p_offset) out of the image.
+ * @param parser  The parser.
+ * @param phdr    Program header naming the segment to slice.
+ * @param size    Out: segment file size in bytes. Pass @c NULL to discard.
+ * @return Pointer to the segment bytes, or @c NULL if out of bounds.
+ */
+R_API rpointer r_elf_parser_phdr32_get_data (RElfParser * parser, RElf32PHdr * phdr, rsize * size);
+/** @brief Slice the file-resident bytes of an ELF64 segment out of the image. */
+R_API rpointer r_elf_parser_phdr64_get_data (RElfParser * parser, RElf64PHdr * phdr, rsize * size);
 
 /** @brief Lowest @c PT_LOAD virtual address (image base) for an ELF32. */
 R_API ruint32 r_elf_parser_get_base_addr32 (RElfParser * parser);

--- a/include/rlib/binfmt/relfparser.h
+++ b/include/rlib/binfmt/relfparser.h
@@ -38,15 +38,19 @@
  * (@ref r_elf_parser_get_class returns @c R_ELF_CLASS32 or
  * @c R_ELF_CLASS64) or by passing the file through one of the
  * sized accessor families and observing @c NULL when the class
- * doesn't match.
+ * doesn't match. Non-native-endianness images are normalized to host
+ * byte order at parse time, and @ref r_elf_parser_load builds an
+ * in-memory, self-relocated image of a single object.
  */
 
 /**
  * @file rlib/binfmt/relfparser.h
  * @ingroup r_binfmt_elf
- * @brief ELF parser: opaque @c RElfParser handle plus 32 / 64-bit
- * accessors for the file header, program / section headers, string
- * and symbol tables, and RELA-style relocations.
+ * @brief ELF parser and image loader: an opaque @c RElfParser handle
+ * with 32 / 64-bit accessors for the file header, program / section
+ * headers, string and symbol tables, REL / RELA relocations, notes
+ * (@c SHT_NOTE / @c PT_NOTE) and the dynamic table, plus a single-object
+ * loader (@ref RElfImage) that maps and self-relocates a PT_LOAD image.
  */
 
 #include <rlib/binfmt/relf.h>
@@ -56,9 +60,10 @@
  * normalizes such an image to host byte order on a private copy at parse
  * time, so all accessors below return native-order values regardless of the
  * file's e_ident[EI_DATA]. */
-/* The dynamic table (.dynamic / PT_DYNAMIC) is parseable via the dyntbl API
- * below; actual program loading and dynamic linking (segment mapping,
- * relocation application, cross-object symbol resolution) is not provided. */
+/* The dynamic table (.dynamic / PT_DYNAMIC) is parseable via the dyntbl API,
+ * and r_elf_parser_load maps + self-relocates a single object into an image
+ * and resolves its defined symbols.  Recursive DT_NEEDED dependency loading
+ * and cross-object symbol binding are not provided. */
 
 
 R_BEGIN_DECLS
@@ -336,6 +341,7 @@ R_API RElf64Sym * r_elf_parser_rela64_get_sym (RElfParser * parser, RElf64SHdr *
 R_API ruint32 * r_elf_parser_rela32_get_dst (RElfParser * parser, RElf32SHdr * shdr, RElf32Rela * rela);
 /** @brief Pointer to the ELF64 location patched by a RELA entry. */
 R_API ruint64 * r_elf_parser_rela64_get_dst (RElfParser * parser, RElf64SHdr * shdr, RElf64Rela * rela);
+
 /* ELF Section Header / Program Header - note */
 /** @brief Number of note entries in an ELF32 NOTE section. */
 R_API ruint32 r_elf_parser_notetbl32_note_count (RElfParser * parser, RElf32SHdr * shdr);
@@ -398,6 +404,42 @@ R_API const rchar * r_elf_parser_dyn32_get_str (RElfParser * parser, RElf32SHdr 
 /** @brief Resolve the string a string-valued ELF64 dynamic entry points at, or @c NULL. */
 R_API const rchar * r_elf_parser_dyn64_get_str (RElfParser * parser, RElf64SHdr * shdr, RElf64Dyn * dyn);
 
+/* ELF image loader */
+/** @brief Opaque, refcounted in-memory image produced by @ref r_elf_parser_load. */
+typedef struct RElfImage RElfImage;
+/**
+ * @brief Load an object into a fresh in-memory image.
+ *
+ * Maps the object's @c PT_LOAD segments into a newly allocated buffer, zeroes
+ * the @c .bss tail, and applies the object's own relocations: @c RELATIVE,
+ * plus absolute / @c GLOB_DAT / @c JMP_SLOT against symbols defined in the
+ * object (x86-64 and i386 relocation types). It does @e not recursively load
+ * @c DT_NEEDED dependencies or bind symbols across objects; undefined external
+ * symbols are left zero.  Intended for native-endianness objects: a
+ * non-native image's code and data keep the file's byte order, so only
+ * RELA-style relocations (whose addends come from the normalized relocation
+ * entries) are meaningful across byte orders.
+ *
+ * @return A refcounted @ref RElfImage, or @c NULL. Loading is 64-bit only by
+ *   design: a 32-bit object parses fully, but its relocation slots cannot
+ *   hold a 64-bit host address, so it cannot be loaded in-process here.
+ */
+R_API RElfImage * r_elf_parser_load (RElfParser * parser);
+/** @brief Add a reference to a loaded image. */
+R_API RElfImage * r_elf_image_ref (RElfImage * img);
+/** @brief Drop a reference; frees the image (and its mapping) at zero. */
+R_API void r_elf_image_unref (RElfImage * img);
+/** @brief Base address of the loaded image in memory. */
+R_API rpointer r_elf_image_get_mem (RElfImage * img);
+/** @brief Size of the loaded image in bytes. */
+R_API rsize r_elf_image_get_size (RElfImage * img);
+/** @brief Runtime entry point within the image, or @c NULL if the object has none. */
+R_API rpointer r_elf_image_get_entry (RElfImage * img);
+/**
+ * @brief Address within the loaded image of the defined dynamic symbol named
+ * @p name, or @c NULL if absent or undefined.
+ */
+R_API rpointer r_elf_image_resolve (RElfImage * img, const rchar * name);
 
 /** @} */
 

--- a/include/rlib/binfmt/relfparser.h
+++ b/include/rlib/binfmt/relfparser.h
@@ -57,7 +57,6 @@
  * time, so all accessors below return native-order values regardless of the
  * file's e_ident[EI_DATA]. */
 /* FIXME: Go over ELF chapter 2 loading and dynamic linking */
-/*    * TODO: Add Note API */
 /*    * TODO: Add program loading and dynamic linking API? */
 
 
@@ -336,6 +335,42 @@ R_API RElf64Sym * r_elf_parser_rela64_get_sym (RElfParser * parser, RElf64SHdr *
 R_API ruint32 * r_elf_parser_rela32_get_dst (RElfParser * parser, RElf32SHdr * shdr, RElf32Rela * rela);
 /** @brief Pointer to the ELF64 location patched by a RELA entry. */
 R_API ruint64 * r_elf_parser_rela64_get_dst (RElfParser * parser, RElf64SHdr * shdr, RElf64Rela * rela);
+/* ELF Section Header / Program Header - note */
+/** @brief Number of note entries in an ELF32 NOTE section. */
+R_API ruint32 r_elf_parser_notetbl32_note_count (RElfParser * parser, RElf32SHdr * shdr);
+/** @brief Number of note entries in an ELF64 NOTE section. */
+R_API ruint64 r_elf_parser_notetbl64_note_count (RElfParser * parser, RElf64SHdr * shdr);
+/**
+ * @brief Note header at @p idx within an ELF32 NOTE section, or @c NULL.
+ *
+ * The entry's @c n_type identifies the payload; @ref r_elf_nhdr32_get_name
+ * and @ref r_elf_nhdr32_get_desc slice the name and descriptor that follow.
+ */
+R_API RElf32NHdr * r_elf_parser_notetbl32_get_note (RElfParser * parser, RElf32SHdr * shdr, ruint32 idx);
+/** @brief Note header at @p idx within an ELF64 NOTE section, or @c NULL. */
+R_API RElf64NHdr * r_elf_parser_notetbl64_get_note (RElfParser * parser, RElf64SHdr * shdr, ruint64 idx);
+/** @brief Number of note entries in an ELF32 PT_NOTE segment. */
+R_API ruint32 r_elf_parser_phdr32_note_count (RElfParser * parser, RElf32PHdr * phdr);
+/** @brief Number of note entries in an ELF64 PT_NOTE segment. */
+R_API ruint64 r_elf_parser_phdr64_note_count (RElfParser * parser, RElf64PHdr * phdr);
+/** @brief Note header at @p idx within an ELF32 PT_NOTE segment, or @c NULL. */
+R_API RElf32NHdr * r_elf_parser_phdr32_get_note (RElfParser * parser, RElf32PHdr * phdr, ruint32 idx);
+/** @brief Note header at @p idx within an ELF64 PT_NOTE segment, or @c NULL. */
+R_API RElf64NHdr * r_elf_parser_phdr64_get_note (RElfParser * parser, RElf64PHdr * phdr, ruint64 idx);
+/** @brief Name string of an ELF32 note (NUL-terminated), or @c NULL when empty. */
+R_API const rchar * r_elf_nhdr32_get_name (RElf32NHdr * nhdr);
+/** @brief Name string of an ELF64 note, or @c NULL when empty. */
+R_API const rchar * r_elf_nhdr64_get_name (RElf64NHdr * nhdr);
+/**
+ * @brief Descriptor payload of an ELF32 note.
+ * @param nhdr  The note header (as returned by a note accessor).
+ * @param size  Out: descriptor size in bytes. Pass @c NULL to discard.
+ * @return Pointer to the descriptor bytes, or @c NULL when empty.
+ */
+R_API rpointer r_elf_nhdr32_get_desc (RElf32NHdr * nhdr, rsize * size);
+/** @brief Descriptor payload of an ELF64 note. */
+R_API rpointer r_elf_nhdr64_get_desc (RElf64NHdr * nhdr, rsize * size);
+
 
 /** @} */
 

--- a/include/rlib/binfmt/relfparser.h
+++ b/include/rlib/binfmt/relfparser.h
@@ -52,8 +52,11 @@
 #include <rlib/binfmt/relf.h>
 
 
+/* Non-native-endianness ELF files are read transparently: the parser
+ * normalizes such an image to host byte order on a private copy at parse
+ * time, so all accessors below return native-order values regardless of the
+ * file's e_ident[EI_DATA]. */
 /* FIXME: Add Rel API */
-/* FIXME: Figure out how to read non-native endianess formats */
 /* FIXME: Add high level API: */
 /*    * TODO: Add find corresponding rel/rela section for text/data section */
 /* FIXME: Go over ELF chapter 2 loading and dynamic linking */

--- a/include/rlib/binfmt/relfparser.h
+++ b/include/rlib/binfmt/relfparser.h
@@ -56,9 +56,6 @@
  * normalizes such an image to host byte order on a private copy at parse
  * time, so all accessors below return native-order values regardless of the
  * file's e_ident[EI_DATA]. */
-/* FIXME: Add Rel API */
-/* FIXME: Add high level API: */
-/*    * TODO: Add find corresponding rel/rela section for text/data section */
 /* FIXME: Go over ELF chapter 2 loading and dynamic linking */
 /*    * TODO: Improve Program header API */
 /*    * TODO: Add Note API */
@@ -161,6 +158,14 @@ R_API RElf64SHdr * r_elf_parser_find_shdr64 (RElfParser * parser, const rchar * 
 R_API RElf32SHdr * r_elf_parser_find_shdr32_by_type (RElfParser * parser, ruint32 type);
 /** @brief First ELF64 section header of the given @c sh_type, or @c NULL. */
 R_API RElf64SHdr * r_elf_parser_find_shdr64_by_type (RElfParser * parser, ruint32 type);
+/**
+ * @brief The ELF32 REL or RELA section that relocates section @p secidx
+ * (i.e. its @c sh_info targets that section, as for @c .rel.text /
+ * @c .rela.text relocating @c .text), or @c NULL.
+ */
+R_API RElf32SHdr * r_elf_parser_find_reloc_shdr32 (RElfParser * parser, ruint32 secidx);
+/** @brief The ELF64 REL or RELA section that relocates section @p secidx, or @c NULL. */
+R_API RElf64SHdr * r_elf_parser_find_reloc_shdr64 (RElfParser * parser, ruint32 secidx);
 /** @brief Resolved section name for an ELF32 section header. */
 R_API rchar * r_elf_parser_shdr32_get_name (RElfParser * parser, RElf32SHdr * shdr);
 /** @brief Resolved section name for an ELF64 section header. */
@@ -252,14 +257,38 @@ R_API RElf64Sym * r_elf_parser_symtbl64_find_sym_by_name (RElfParser * parser,
     RElf64SHdr * shdr, const rchar * name, rssize size);
 
 /* ELF Section Header - relocation */
-/*R_API ruint32 r_elf_parser_reltbl32_rel_count (RElfParser * parser, RElf32SHdr * shdr);*/
-/*R_API ruint64 r_elf_parser_reltbl64_rel_count (RElfParser * parser, RElf64SHdr * shdr);*/
-/*R_API RElf32Rel * r_elf_parser_reltbl32_get_rel (RElfParser * parser, RElf32SHdr * shdr, ruint32 idx);*/
-/*R_API RElf64Rel * r_elf_parser_reltbl64_get_rel (RElfParser * parser, RElf64SHdr * shdr, ruint64 idx);*/
-/*R_API RElf32Sym * r_elf_parser_rel32_get_sym (RElfParser * parser, RElf32SHdr * shdr, RElf32Rel * rel, RElf32SHdr ** symtbl)*/;
-/*R_API RElf64Sym * r_elf_parser_rel64_get_sym (RElfParser * parser, RElf64SHdr * shdr, RElf64Rel * rel, RElf64SHdr ** symtbl)*/;
-/*R_API ruint32 * r_elf_parser_rel32_get_dst (RElfParser * parser, RElf32SHdr * shdr, RElf32Rel * rel)*/;
-/*R_API ruint64 * r_elf_parser_rel64_get_dst (RElfParser * parser, RElf64SHdr * shdr, RElf64Rel * rel)*/;
+/** @brief Number of relocations in an ELF32 REL section. */
+R_API ruint32 r_elf_parser_reltbl32_rel_count (RElfParser * parser, RElf32SHdr * shdr);
+/** @brief Number of relocations in an ELF64 REL section. */
+R_API ruint64 r_elf_parser_reltbl64_rel_count (RElfParser * parser, RElf64SHdr * shdr);
+/** @brief ELF32 relocation entry at @p idx within a REL section. */
+R_API RElf32Rel * r_elf_parser_reltbl32_get_rel (RElfParser * parser, RElf32SHdr * shdr, ruint32 idx);
+/** @brief ELF64 relocation entry at @p idx within a REL section. */
+R_API RElf64Rel * r_elf_parser_reltbl64_get_rel (RElfParser * parser, RElf64SHdr * shdr, ruint64 idx);
+/**
+ * @brief Symbol referred to by an ELF32 REL entry.
+ * @param parser  The parser.
+ * @param shdr    REL section containing @p rel.
+ * @param rel     The relocation entry.
+ * @param symtbl  Out: section header of the symbol table @p shdr is
+ *                linked to. Pass @c NULL to discard.
+ */
+R_API RElf32Sym * r_elf_parser_rel32_get_sym (RElfParser * parser, RElf32SHdr * shdr, RElf32Rel * rel, RElf32SHdr ** symtbl);
+/**
+ * @brief Symbol referred to by an ELF64 REL entry.
+ * @param parser  The parser.
+ * @param shdr    REL section containing @p rel.
+ * @param rel     The relocation entry.
+ * @param symtbl  Out: linked symbol-table section.
+ */
+R_API RElf64Sym * r_elf_parser_rel64_get_sym (RElfParser * parser, RElf64SHdr * shdr, RElf64Rel * rel, RElf64SHdr ** symtbl);
+/**
+ * @brief Pointer to the ELF32 location patched by a REL entry
+ * (i.e. the byte position the relocation rewrites).
+ */
+R_API ruint32 * r_elf_parser_rel32_get_dst (RElfParser * parser, RElf32SHdr * shdr, RElf32Rel * rel);
+/** @brief Pointer to the ELF64 location patched by a REL entry. */
+R_API ruint64 * r_elf_parser_rel64_get_dst (RElfParser * parser, RElf64SHdr * shdr, RElf64Rel * rel);
 
 /** @brief Number of relocations in an ELF32 RELA section. */
 R_API ruint32 r_elf_parser_relatbl32_rela_count (RElfParser * parser, RElf32SHdr * shdr);

--- a/include/rlib/binfmt/relfparser.h
+++ b/include/rlib/binfmt/relfparser.h
@@ -56,8 +56,9 @@
  * normalizes such an image to host byte order on a private copy at parse
  * time, so all accessors below return native-order values regardless of the
  * file's e_ident[EI_DATA]. */
-/* FIXME: Go over ELF chapter 2 loading and dynamic linking */
-/*    * TODO: Add program loading and dynamic linking API? */
+/* The dynamic table (.dynamic / PT_DYNAMIC) is parseable via the dyntbl API
+ * below; actual program loading and dynamic linking (segment mapping,
+ * relocation application, cross-object symbol resolution) is not provided. */
 
 
 R_BEGIN_DECLS
@@ -370,6 +371,32 @@ R_API const rchar * r_elf_nhdr64_get_name (RElf64NHdr * nhdr);
 R_API rpointer r_elf_nhdr32_get_desc (RElf32NHdr * nhdr, rsize * size);
 /** @brief Descriptor payload of an ELF64 note. */
 R_API rpointer r_elf_nhdr64_get_desc (RElf64NHdr * nhdr, rsize * size);
+
+/* ELF Section Header - dynamic */
+/** @brief Number of entries in an ELF32 DYNAMIC section. */
+R_API ruint32 r_elf_parser_dyntbl32_dyn_count (RElfParser * parser, RElf32SHdr * shdr);
+/** @brief Number of entries in an ELF64 DYNAMIC section. */
+R_API ruint64 r_elf_parser_dyntbl64_dyn_count (RElfParser * parser, RElf64SHdr * shdr);
+/** @brief ELF32 dynamic entry at @p idx within a DYNAMIC section, or @c NULL. */
+R_API RElf32Dyn * r_elf_parser_dyntbl32_get_dyn (RElfParser * parser, RElf32SHdr * shdr, ruint32 idx);
+/** @brief ELF64 dynamic entry at @p idx within a DYNAMIC section, or @c NULL. */
+R_API RElf64Dyn * r_elf_parser_dyntbl64_get_dyn (RElfParser * parser, RElf64SHdr * shdr, ruint64 idx);
+/**
+ * @brief First ELF32 dynamic entry with the given @c d_tag, or @c NULL.
+ *
+ * Scans up to the terminating @c R_ELF_DTYPE_NULL entry.
+ */
+R_API RElf32Dyn * r_elf_parser_dyntbl32_find_dyn_by_tag (RElfParser * parser, RElf32SHdr * shdr, rint32 tag);
+/** @brief First ELF64 dynamic entry with the given @c d_tag, or @c NULL. */
+R_API RElf64Dyn * r_elf_parser_dyntbl64_find_dyn_by_tag (RElfParser * parser, RElf64SHdr * shdr, rint64 tag);
+/**
+ * @brief Resolve the string a string-valued ELF32 dynamic entry points at
+ * (e.g. @c DT_SONAME, @c DT_NEEDED, @c DT_RPATH), via the string table the
+ * DYNAMIC section is linked to, or @c NULL.
+ */
+R_API const rchar * r_elf_parser_dyn32_get_str (RElfParser * parser, RElf32SHdr * shdr, RElf32Dyn * dyn);
+/** @brief Resolve the string a string-valued ELF64 dynamic entry points at, or @c NULL. */
+R_API const rchar * r_elf_parser_dyn64_get_str (RElfParser * parser, RElf64SHdr * shdr, RElf64Dyn * dyn);
 
 
 /** @} */

--- a/rlib/binfmt/relfparser.c
+++ b/rlib/binfmt/relfparser.c
@@ -1587,3 +1587,175 @@ r_elf_parser_rel64_get_dst (RElfParser * parser,
 
   return NULL;
 }
+
+/* Notes form a packed stream within a NOTE section: each entry is an
+ * RElf*NHdr (identical for 32/64-bit) followed by the name (namesz bytes) and
+ * descriptor (descsz bytes), each padded to a 4-byte boundary. */
+#define R_ELF_NOTE_ALIGN(x)  (((x) + 3) & ~(rsize)3)
+
+/* Walk the note stream in [data, data+size).  With out_count != NULL, count
+ * all well-formed notes; otherwise return the @p want-th note or NULL. */
+static rpointer
+r_elf_note_walk (ruint8 * data, rsize size, rsize want, rsize * out_count)
+{
+  rsize off = 0, idx = 0;
+
+  while (off + sizeof (RElf32NHdr) <= size) {
+    RElf32NHdr * n = (RElf32NHdr *)(data + off);
+    rsize esz = sizeof (RElf32NHdr) +
+        R_ELF_NOTE_ALIGN ((rsize) n->namesz) + R_ELF_NOTE_ALIGN ((rsize) n->descsz);
+    if (esz < sizeof (RElf32NHdr) || off + esz > size)
+      break;                                /* truncated or overflow */
+    if (out_count == NULL && idx == want)
+      return n;
+    off += esz;
+    idx++;
+  }
+
+  if (out_count != NULL)
+    *out_count = idx;
+  return NULL;
+}
+
+ruint32
+r_elf_parser_notetbl32_note_count (RElfParser * parser, RElf32SHdr * shdr)
+{
+  rsize size, count = 0;
+  ruint8 * data;
+
+  if (parser != NULL && shdr != NULL && shdr->type == R_ELF_STYPE_NOTE &&
+      (data = r_elf_parser_shdr32_get_data (parser, shdr, &size)) != NULL)
+    r_elf_note_walk (data, size, 0, &count);
+
+  return (ruint32) count;
+}
+
+ruint64
+r_elf_parser_notetbl64_note_count (RElfParser * parser, RElf64SHdr * shdr)
+{
+  rsize size, count = 0;
+  ruint8 * data;
+
+  if (parser != NULL && shdr != NULL && shdr->type == R_ELF_STYPE_NOTE &&
+      (data = r_elf_parser_shdr64_get_data (parser, shdr, &size)) != NULL)
+    r_elf_note_walk (data, size, 0, &count);
+
+  return count;
+}
+
+RElf32NHdr *
+r_elf_parser_notetbl32_get_note (RElfParser * parser, RElf32SHdr * shdr, ruint32 idx)
+{
+  rsize size;
+  ruint8 * data;
+
+  if (parser != NULL && shdr != NULL && shdr->type == R_ELF_STYPE_NOTE &&
+      (data = r_elf_parser_shdr32_get_data (parser, shdr, &size)) != NULL)
+    return (RElf32NHdr *) r_elf_note_walk (data, size, idx, NULL);
+
+  return NULL;
+}
+
+RElf64NHdr *
+r_elf_parser_notetbl64_get_note (RElfParser * parser, RElf64SHdr * shdr, ruint64 idx)
+{
+  rsize size;
+  ruint8 * data;
+
+  if (parser != NULL && shdr != NULL && shdr->type == R_ELF_STYPE_NOTE &&
+      (data = r_elf_parser_shdr64_get_data (parser, shdr, &size)) != NULL)
+    return (RElf64NHdr *) r_elf_note_walk (data, size, idx, NULL);
+
+  return NULL;
+}
+
+/* The name and descriptor follow the note header, the descriptor at a 4-byte
+ * offset past the name.  A note obtained from get_note has already been
+ * validated to fit its container, so these derive directly from the header. */
+const rchar *
+r_elf_nhdr32_get_name (RElf32NHdr * nhdr)
+{
+  if (nhdr != NULL && nhdr->namesz > 0)
+    return (const rchar *)(nhdr + 1);
+  return NULL;
+}
+
+const rchar *
+r_elf_nhdr64_get_name (RElf64NHdr * nhdr)
+{
+  if (nhdr != NULL && nhdr->namesz > 0)
+    return (const rchar *)(nhdr + 1);
+  return NULL;
+}
+
+rpointer
+r_elf_nhdr32_get_desc (RElf32NHdr * nhdr, rsize * size)
+{
+  if (size != NULL)
+    *size = (nhdr != NULL) ? nhdr->descsz : 0;
+  if (nhdr == NULL || nhdr->descsz == 0)
+    return NULL;
+  return (ruint8 *)(nhdr + 1) + R_ELF_NOTE_ALIGN ((rsize) nhdr->namesz);
+}
+
+rpointer
+r_elf_nhdr64_get_desc (RElf64NHdr * nhdr, rsize * size)
+{
+  if (size != NULL)
+    *size = (nhdr != NULL) ? nhdr->descsz : 0;
+  if (nhdr == NULL || nhdr->descsz == 0)
+    return NULL;
+  return (ruint8 *)(nhdr + 1) + R_ELF_NOTE_ALIGN ((rsize) nhdr->namesz);
+}
+
+ruint32
+r_elf_parser_phdr32_note_count (RElfParser * parser, RElf32PHdr * phdr)
+{
+  rsize size, count = 0;
+  ruint8 * data;
+
+  if (parser != NULL && phdr != NULL && phdr->type == R_ELF_PTYPE_NOTE &&
+      (data = r_elf_parser_phdr32_get_data (parser, phdr, &size)) != NULL)
+    r_elf_note_walk (data, size, 0, &count);
+
+  return (ruint32) count;
+}
+
+ruint64
+r_elf_parser_phdr64_note_count (RElfParser * parser, RElf64PHdr * phdr)
+{
+  rsize size, count = 0;
+  ruint8 * data;
+
+  if (parser != NULL && phdr != NULL && phdr->type == R_ELF_PTYPE_NOTE &&
+      (data = r_elf_parser_phdr64_get_data (parser, phdr, &size)) != NULL)
+    r_elf_note_walk (data, size, 0, &count);
+
+  return count;
+}
+
+RElf32NHdr *
+r_elf_parser_phdr32_get_note (RElfParser * parser, RElf32PHdr * phdr, ruint32 idx)
+{
+  rsize size;
+  ruint8 * data;
+
+  if (parser != NULL && phdr != NULL && phdr->type == R_ELF_PTYPE_NOTE &&
+      (data = r_elf_parser_phdr32_get_data (parser, phdr, &size)) != NULL)
+    return (RElf32NHdr *) r_elf_note_walk (data, size, idx, NULL);
+
+  return NULL;
+}
+
+RElf64NHdr *
+r_elf_parser_phdr64_get_note (RElfParser * parser, RElf64PHdr * phdr, ruint64 idx)
+{
+  rsize size;
+  ruint8 * data;
+
+  if (parser != NULL && phdr != NULL && phdr->type == R_ELF_PTYPE_NOTE &&
+      (data = r_elf_parser_phdr64_get_data (parser, phdr, &size)) != NULL)
+    return (RElf64NHdr *) r_elf_note_walk (data, size, idx, NULL);
+
+  return NULL;
+}

--- a/rlib/binfmt/relfparser.c
+++ b/rlib/binfmt/relfparser.c
@@ -1759,3 +1759,105 @@ r_elf_parser_phdr64_get_note (RElfParser * parser, RElf64PHdr * phdr, ruint64 id
 
   return NULL;
 }
+
+ruint32
+r_elf_parser_dyntbl32_dyn_count (RElfParser * parser, RElf32SHdr * shdr)
+{
+  if (parser != NULL && shdr != NULL && shdr->entsize >= sizeof (RElf32Dyn) &&
+      shdr->type == R_ELF_STYPE_DYNAMIC)
+    return shdr->size / shdr->entsize;
+
+  return 0;
+}
+
+ruint64
+r_elf_parser_dyntbl64_dyn_count (RElfParser * parser, RElf64SHdr * shdr)
+{
+  if (parser != NULL && shdr != NULL && shdr->entsize >= sizeof (RElf64Dyn) &&
+      shdr->type == R_ELF_STYPE_DYNAMIC)
+    return shdr->size / shdr->entsize;
+
+  return 0;
+}
+
+RElf32Dyn *
+r_elf_parser_dyntbl32_get_dyn (RElfParser * parser, RElf32SHdr * shdr, ruint32 idx)
+{
+  ruint32 count = r_elf_parser_dyntbl32_dyn_count (parser, shdr);
+  if (count > idx) {
+    ruint8 * mem = parser->mem;
+    return (RElf32Dyn *)(mem + shdr->offset + shdr->entsize * idx);
+  }
+
+  return NULL;
+}
+
+RElf64Dyn *
+r_elf_parser_dyntbl64_get_dyn (RElfParser * parser, RElf64SHdr * shdr, ruint64 idx)
+{
+  ruint64 count = r_elf_parser_dyntbl64_dyn_count (parser, shdr);
+  if (count > idx) {
+    ruint8 * mem = parser->mem;
+    return (RElf64Dyn *)(mem + shdr->offset + shdr->entsize * idx);
+  }
+
+  return NULL;
+}
+
+RElf32Dyn *
+r_elf_parser_dyntbl32_find_dyn_by_tag (RElfParser * parser, RElf32SHdr * shdr,
+    rint32 tag)
+{
+  ruint32 i, count = r_elf_parser_dyntbl32_dyn_count (parser, shdr);
+
+  for (i = 0; i < count; i++) {
+    RElf32Dyn * dyn = r_elf_parser_dyntbl32_get_dyn (parser, shdr, i);
+    if (dyn == NULL) break;
+    if (dyn->tag == tag) return dyn;
+    if (dyn->tag == R_ELF_DTYPE_NULL) break;     /* table is NULL-terminated */
+  }
+
+  return NULL;
+}
+
+RElf64Dyn *
+r_elf_parser_dyntbl64_find_dyn_by_tag (RElfParser * parser, RElf64SHdr * shdr,
+    rint64 tag)
+{
+  ruint64 i, count = r_elf_parser_dyntbl64_dyn_count (parser, shdr);
+
+  for (i = 0; i < count; i++) {
+    RElf64Dyn * dyn = r_elf_parser_dyntbl64_get_dyn (parser, shdr, i);
+    if (dyn == NULL) break;
+    if (dyn->tag == tag) return dyn;
+    if (dyn->tag == R_ELF_DTYPE_NULL) break;     /* table is NULL-terminated */
+  }
+
+  return NULL;
+}
+
+const rchar *
+r_elf_parser_dyn32_get_str (RElfParser * parser, RElf32SHdr * shdr, RElf32Dyn * dyn)
+{
+  RElf32SHdr * strtab;
+
+  if (parser != NULL && shdr != NULL && dyn != NULL &&
+      shdr->link != R_ELF_SHN_UNDEF &&
+      (strtab = r_elf_parser_get_shdr32 (parser, shdr->link)) != NULL)
+    return r_elf_parser_strtbl32_get_str (parser, strtab, dyn->un.ptr);
+
+  return NULL;
+}
+
+const rchar *
+r_elf_parser_dyn64_get_str (RElfParser * parser, RElf64SHdr * shdr, RElf64Dyn * dyn)
+{
+  RElf64SHdr * strtab;
+
+  if (parser != NULL && shdr != NULL && dyn != NULL &&
+      shdr->link != R_ELF_SHN_UNDEF &&
+      (strtab = r_elf_parser_get_shdr64 (parser, shdr->link)) != NULL)
+    return r_elf_parser_strtbl64_get_str (parser, strtab, dyn->un.ptr);
+
+  return NULL;
+}

--- a/rlib/binfmt/relfparser.c
+++ b/rlib/binfmt/relfparser.c
@@ -1463,7 +1463,6 @@ r_elf_parser_rela64_get_dst (RElfParser * parser,
   return NULL;
 }
 
-
 ruint32
 r_elf_parser_reltbl32_rel_count (RElfParser * parser, RElf32SHdr * shdr)
 {
@@ -1760,6 +1759,7 @@ r_elf_parser_phdr64_get_note (RElfParser * parser, RElf64PHdr * phdr, ruint64 id
   return NULL;
 }
 
+
 ruint32
 r_elf_parser_dyntbl32_dyn_count (RElfParser * parser, RElf32SHdr * shdr)
 {
@@ -1860,4 +1860,272 @@ r_elf_parser_dyn64_get_str (RElfParser * parser, RElf64SHdr * shdr, RElf64Dyn * 
     return r_elf_parser_strtbl64_get_str (parser, strtab, dyn->un.ptr);
 
   return NULL;
+}
+
+/* ------------------------------------------------------------------------- *
+ * Program image loader
+ *
+ * Maps an object's PT_LOAD segments into a freshly-allocated image, applies
+ * the object's own relocations (RELATIVE plus absolute / GLOB_DAT / JMP_SLOT
+ * against symbols defined in this object; x86-64 and i386 share these type
+ * numbers), and resolves defined symbols to their address in the image.  It
+ * does not recursively load DT_NEEDED dependencies or bind across objects.
+ * ------------------------------------------------------------------------- */
+
+struct RElfImage {
+  rauint refcount;
+  RElfParser * parser;
+  ruint8 * image;
+  rsize size;
+  ruint64 base;     /* lowest PT_LOAD p_vaddr (link base) */
+  ruint64 bias;     /* runtime address of @base: image - base */
+  ruint64 entry;    /* runtime entry point, or 0 */
+};
+
+/* Map a link-time vaddr to its location in the loaded image, NULL if the
+ * span [vaddr, vaddr+need) falls outside the image. */
+static rpointer
+r_elf_image_vaddr (RElfImage * img, ruint64 vaddr, rsize need)
+{
+  if (vaddr >= img->base && (vaddr - img->base) <= img->size &&
+      img->size - (vaddr - img->base) >= need)
+    return img->image + (vaddr - img->base);
+
+  return NULL;
+}
+
+/* Apply one relocation to the 64-bit image. @rela selects RELA (use @addend)
+ * vs REL (the addend is the slot's existing value). */
+static void
+r_elf_image_apply64 (RElfImage * img, ruint64 offset, ruint64 info,
+    rint64 addend, RElf64Sym * symtab, ruint64 symcount, rboolean rela)
+{
+  ruint32 type = R_ELF64_RELINFO_TYPE (info);
+  ruint64 symidx = R_ELF64_RELINFO_SYM (info);
+  ruint64 * slot = r_elf_image_vaddr (img, offset, sizeof (ruint64));
+  ruint64 symval = 0;
+
+  if (slot == NULL)
+    return;
+  if (symidx != 0 && symtab != NULL && symidx < symcount &&
+      symtab[symidx].shndx != R_ELF_SHN_UNDEF)
+    symval = (symtab[symidx].shndx == R_ELF_SHN_ABS)
+        ? symtab[symidx].value : img->bias + symtab[symidx].value;
+
+  switch (type) {
+    case R_ELF_RELTYPE_X86_64_RELATIVE:
+      *slot = img->bias + (rela ? (ruint64) addend : *slot);
+      break;
+    case R_ELF_RELTYPE_X86_64_64:
+      *slot = symval + (rela ? (ruint64) addend : *slot);
+      break;
+    case R_ELF_RELTYPE_X86_64_GLOB_DAT:
+    case R_ELF_RELTYPE_X86_64_JUMP_SLOT:
+      *slot = symval + (rela ? (ruint64) addend : 0);
+      break;
+    default:                                /* unsupported: leave untouched */
+      break;
+  }
+}
+
+static void
+r_elf_image_reloc64 (RElfImage * img)
+{
+  RElfParser * p = img->parser;
+  RElf64SHdr * dynsh = r_elf_parser_find_shdr64_by_type (p, R_ELF_STYPE_DYNAMIC);
+  RElf64SHdr * dynsym;
+  RElf64Sym * symtab = NULL;
+  ruint64 symcount = 0;
+  ruint64 rela_va = 0, rela_sz = 0, rela_ent = sizeof (RElf64Rela);
+  ruint64 rel_va = 0, rel_sz = 0, rel_ent = sizeof (RElf64Rel);
+  ruint64 jmp_va = 0, jmp_sz = 0, pltrel = 0;
+  ruint64 symtab_va = 0;
+  ruint64 i, n;
+
+  if (dynsh == NULL)
+    return;
+
+  n = r_elf_parser_dyntbl64_dyn_count (p, dynsh);
+  for (i = 0; i < n; i++) {
+    RElf64Dyn * d = r_elf_parser_dyntbl64_get_dyn (p, dynsh, i);
+    if (d == NULL || d->tag == R_ELF_DTYPE_NULL) break;
+    switch (d->tag) {
+      case R_ELF_DTYPE_RELA:     rela_va = d->un.ptr; break;
+      case R_ELF_DTYPE_RELASZ:   rela_sz = d->un.ptr; break;
+      case R_ELF_DTYPE_RELAENT:  rela_ent = d->un.ptr; break;
+      case R_ELF_DTYPE_REL:      rel_va = d->un.ptr; break;
+      case R_ELF_DTYPE_RELSZ:    rel_sz = d->un.ptr; break;
+      case R_ELF_DTYPE_RELENT:   rel_ent = d->un.ptr; break;
+      case R_ELF_DTYPE_JMPREL:   jmp_va = d->un.ptr; break;
+      case R_ELF_DTYPE_PLTRELSZ: jmp_sz = d->un.ptr; break;
+      case R_ELF_DTYPE_PLTREL:   pltrel = d->un.ptr; break;
+      case R_ELF_DTYPE_SYMTAB:   symtab_va = d->un.ptr; break;
+      default: break;
+    }
+  }
+
+  if (symtab_va != 0)
+    symtab = r_elf_image_vaddr (img, symtab_va, sizeof (RElf64Sym));
+  if ((dynsym = r_elf_parser_find_shdr64_by_type (p, R_ELF_STYPE_DYNSYM)) != NULL)
+    symcount = r_elf_parser_symtbl64_sym_count (p, dynsym);
+
+  if (rela_va != 0 && rela_ent != 0) {
+    for (i = 0, n = rela_sz / rela_ent; i < n; i++) {
+      RElf64Rela * r = r_elf_image_vaddr (img, rela_va + i * rela_ent,
+          sizeof (RElf64Rela));
+      if (r != NULL)
+        r_elf_image_apply64 (img, r->offset, r->info, r->addend,
+            symtab, symcount, TRUE);
+    }
+  }
+  if (rel_va != 0 && rel_ent != 0) {
+    for (i = 0, n = rel_sz / rel_ent; i < n; i++) {
+      RElf64Rel * r = r_elf_image_vaddr (img, rel_va + i * rel_ent,
+          sizeof (RElf64Rel));
+      if (r != NULL)
+        r_elf_image_apply64 (img, r->offset, r->info, 0, symtab, symcount, FALSE);
+    }
+  }
+  if (jmp_va != 0) {
+    rboolean rela = (pltrel == R_ELF_DTYPE_RELA);
+    ruint64 ent = rela ? rela_ent : rel_ent;
+    for (i = 0, n = ent ? jmp_sz / ent : 0; i < n; i++) {
+      rpointer rp = r_elf_image_vaddr (img, jmp_va + i * ent, ent);
+      if (rp == NULL) continue;
+      if (rela) {
+        RElf64Rela * r = rp;
+        r_elf_image_apply64 (img, r->offset, r->info, r->addend,
+            symtab, symcount, TRUE);
+      } else {
+        RElf64Rel * r = rp;
+        r_elf_image_apply64 (img, r->offset, r->info, 0, symtab, symcount, FALSE);
+      }
+    }
+  }
+}
+
+static RElfImage *
+r_elf_load64 (RElfParser * parser)
+{
+  RElf64EHdr * eh = r_elf_parser_get_ehdr64 (parser);
+  ruint16 i, ph = r_elf_parser_prg_header_count (parser);
+  ruint64 base = 0, end = 0;
+  rboolean have = FALSE;
+  RElfImage * img;
+  ruint8 * image;
+  rsize size;
+
+  for (i = 0; i < ph; i++) {
+    RElf64PHdr * p = r_elf_parser_get_phdr64 (parser, i);
+    if (p == NULL || p->type != R_ELF_PTYPE_LOAD) continue;
+    if (!have) {
+      base = p->vaddr; end = p->vaddr + p->memsz; have = TRUE;
+    } else {
+      if (p->vaddr < base) base = p->vaddr;
+      if (p->vaddr + p->memsz > end) end = p->vaddr + p->memsz;
+    }
+  }
+  if (!have || end <= base)
+    return NULL;
+
+  size = end - base;
+  if ((image = r_malloc0 (size)) == NULL)
+    return NULL;
+
+  for (i = 0; i < ph; i++) {
+    RElf64PHdr * p = r_elf_parser_get_phdr64 (parser, i);
+    if (p == NULL || p->type != R_ELF_PTYPE_LOAD || p->filesz == 0) continue;
+    if (p->offset > parser->size || parser->size - p->offset < p->filesz)
+      continue;
+    if (p->vaddr < base || (p->vaddr - base) > size ||
+        size - (p->vaddr - base) < p->filesz)
+      continue;
+    r_memcpy (image + (p->vaddr - base),
+        (ruint8 *)parser->mem + p->offset, p->filesz);
+  }
+
+  img = r_mem_new (RElfImage);
+  r_atomic_uint_store (&img->refcount, 1);
+  img->parser = r_elf_parser_ref (parser);
+  img->image = image;
+  img->size = size;
+  img->base = base;
+  img->bias = (ruint64)(ruintptr) image - base;
+  img->entry = (eh != NULL && eh->entry != 0) ? img->bias + eh->entry : 0;
+
+  r_elf_image_reloc64 (img);
+
+  return img;
+}
+
+RElfImage *
+r_elf_parser_load (RElfParser * parser)
+{
+  if (parser == NULL)
+    return NULL;
+
+  switch (r_elf_parser_get_class (parser)) {
+    case R_ELF_CLASS64: return r_elf_load64 (parser);
+    default:            return NULL;
+  }
+}
+
+static void
+r_elf_image_free (RElfImage * img)
+{
+  r_elf_parser_unref (img->parser);
+  r_free (img->image);
+  r_free (img);
+}
+
+RElfImage *
+r_elf_image_ref (RElfImage * img)
+{
+  r_atomic_uint_fetch_add (&img->refcount, 1);
+  return img;
+}
+
+void
+r_elf_image_unref (RElfImage * img)
+{
+  if (r_atomic_uint_fetch_sub (&img->refcount, 1) == 1)
+    r_elf_image_free (img);
+}
+
+rpointer
+r_elf_image_get_mem (RElfImage * img)
+{
+  return (img != NULL) ? img->image : NULL;
+}
+
+rsize
+r_elf_image_get_size (RElfImage * img)
+{
+  return (img != NULL) ? img->size : 0;
+}
+
+rpointer
+r_elf_image_get_entry (RElfImage * img)
+{
+  if (img == NULL || img->entry == 0)
+    return NULL;
+  return r_elf_image_vaddr (img, img->entry - img->bias, 0);
+}
+
+rpointer
+r_elf_image_resolve (RElfImage * img, const rchar * name)
+{
+  RElf64SHdr * dynsym;
+  RElf64Sym * sym;
+
+  if (img == NULL || name == NULL)
+    return NULL;
+  if ((dynsym = r_elf_parser_find_shdr64_by_type (img->parser,
+          R_ELF_STYPE_DYNSYM)) == NULL)
+    return NULL;
+  if ((sym = r_elf_parser_symtbl64_find_sym_by_name (img->parser, dynsym,
+          name, -1)) == NULL || sym->shndx == R_ELF_SHN_UNDEF)
+    return NULL;
+
+  return r_elf_image_vaddr (img, sym->value, 0);
 }

--- a/rlib/binfmt/relfparser.c
+++ b/rlib/binfmt/relfparser.c
@@ -706,14 +706,14 @@ static ruint16
 r_elf_parser_ehdr32_prg_header_count (RElfParser * parser)
 {
   RElf32EHdr * ehdr = r_elf_parser_get_ehdr32 (parser);
-  return ehdr->phnum;
+  return ehdr != NULL ? ehdr->phnum : 0;
 }
 
 static ruint16
 r_elf_parser_ehdr64_prg_header_count (RElfParser * parser)
 {
   RElf64EHdr * ehdr = r_elf_parser_get_ehdr64 (parser);
-  return ehdr->phnum;
+  return ehdr != NULL ? ehdr->phnum : 0;
 }
 
 ruint16
@@ -790,6 +790,70 @@ r_elf_parser_get_base_addr64 (RElfParser * parser)
   }
 
   return 0;
+}
+
+RElf32PHdr *
+r_elf_parser_find_phdr32_by_type (RElfParser * parser, ruint32 type)
+{
+  RElf32EHdr * ehdr;
+
+  if ((ehdr = r_elf_parser_get_ehdr32 (parser)) != NULL) {
+    ruint16 i;
+    for (i = 0; i < ehdr->phnum; i++) {
+      RElf32PHdr * hdr = r_elf_parser_get_phdr32 (parser, i);
+      if (hdr != NULL && hdr->type == type)
+        return hdr;
+    }
+  }
+
+  return NULL;
+}
+
+RElf64PHdr *
+r_elf_parser_find_phdr64_by_type (RElfParser * parser, ruint32 type)
+{
+  RElf64EHdr * ehdr;
+
+  if ((ehdr = r_elf_parser_get_ehdr64 (parser)) != NULL) {
+    ruint16 i;
+    for (i = 0; i < ehdr->phnum; i++) {
+      RElf64PHdr * hdr = r_elf_parser_get_phdr64 (parser, i);
+      if (hdr != NULL && hdr->type == type)
+        return hdr;
+    }
+  }
+
+  return NULL;
+}
+
+rpointer
+r_elf_parser_phdr32_get_data (RElfParser * parser, RElf32PHdr * phdr, rsize * size)
+{
+  if (parser != NULL && phdr != NULL && phdr->offset <= parser->size &&
+      parser->size - phdr->offset >= phdr->filesz) {
+    if (size != NULL)
+      *size = phdr->filesz;
+    return (ruint8 *)parser->mem + phdr->offset;
+  }
+
+  if (size != NULL)
+    *size = 0;
+  return NULL;
+}
+
+rpointer
+r_elf_parser_phdr64_get_data (RElfParser * parser, RElf64PHdr * phdr, rsize * size)
+{
+  if (parser != NULL && phdr != NULL && phdr->offset <= parser->size &&
+      parser->size - phdr->offset >= phdr->filesz) {
+    if (size != NULL)
+      *size = phdr->filesz;
+    return (ruint8 *)parser->mem + phdr->offset;
+  }
+
+  if (size != NULL)
+    *size = 0;
+  return NULL;
 }
 
 static ruint16

--- a/rlib/binfmt/relfparser.c
+++ b/rlib/binfmt/relfparser.c
@@ -934,6 +934,50 @@ r_elf_parser_find_shdr64_by_type (RElfParser * parser, ruint32 type)
   return NULL;
 }
 
+RElf32SHdr *
+r_elf_parser_find_reloc_shdr32 (RElfParser * parser, ruint32 secidx)
+{
+  RElf32EHdr * ehdr;
+
+  if (secidx != R_ELF_SHN_UNDEF &&
+      (ehdr = r_elf_parser_get_ehdr32 (parser)) != NULL) {
+    ruint16 i;
+    ruint8 * ptr = parser->mem;
+    ptr += ehdr->shoff;
+
+    for (i = 0; i < ehdr->shnum; i++) {
+      RElf32SHdr * shdr = (RElf32SHdr *)(ptr + ehdr->shentsize * i);
+      if ((shdr->type == R_ELF_STYPE_REL || shdr->type == R_ELF_STYPE_RELA) &&
+          shdr->info == secidx)
+        return shdr;
+    }
+  }
+
+  return NULL;
+}
+
+RElf64SHdr *
+r_elf_parser_find_reloc_shdr64 (RElfParser * parser, ruint32 secidx)
+{
+  RElf64EHdr * ehdr;
+
+  if (secidx != R_ELF_SHN_UNDEF &&
+      (ehdr = r_elf_parser_get_ehdr64 (parser)) != NULL) {
+    ruint16 i;
+    ruint8 * ptr = parser->mem;
+    ptr += ehdr->shoff;
+
+    for (i = 0; i < ehdr->shnum; i++) {
+      RElf64SHdr * shdr = (RElf64SHdr *)(ptr + ehdr->shentsize * i);
+      if ((shdr->type == R_ELF_STYPE_REL || shdr->type == R_ELF_STYPE_RELA) &&
+          shdr->info == secidx)
+        return shdr;
+    }
+  }
+
+  return NULL;
+}
+
 rchar *
 r_elf_parser_shdr32_get_name (RElfParser * parser, RElf32SHdr * shdr)
 {
@@ -1355,3 +1399,127 @@ r_elf_parser_rela64_get_dst (RElfParser * parser,
   return NULL;
 }
 
+
+ruint32
+r_elf_parser_reltbl32_rel_count (RElfParser * parser, RElf32SHdr * shdr)
+{
+  if (parser != NULL && shdr != NULL && shdr->entsize >= sizeof (RElf32Rel) &&
+      shdr->type == R_ELF_STYPE_REL)
+    return shdr->size / shdr->entsize;
+
+  return 0;
+}
+
+ruint64
+r_elf_parser_reltbl64_rel_count (RElfParser * parser, RElf64SHdr * shdr)
+{
+  if (parser != NULL && shdr != NULL && shdr->entsize >= sizeof (RElf64Rel) &&
+      shdr->type == R_ELF_STYPE_REL)
+    return shdr->size / shdr->entsize;
+
+  return 0;
+}
+
+RElf32Rel *
+r_elf_parser_reltbl32_get_rel (RElfParser * parser, RElf32SHdr * shdr, ruint32 idx)
+{
+  ruint32 count = r_elf_parser_reltbl32_rel_count (parser, shdr);
+  if (count > idx) {
+    ruint8 * mem = parser->mem;
+    return (RElf32Rel *)(mem + shdr->offset + shdr->entsize * idx);
+  }
+
+  return NULL;
+}
+
+RElf64Rel *
+r_elf_parser_reltbl64_get_rel (RElfParser * parser, RElf64SHdr * shdr, ruint64 idx)
+{
+  ruint64 count = r_elf_parser_reltbl64_rel_count (parser, shdr);
+  if (count > idx) {
+    ruint8 * mem = parser->mem;
+    return (RElf64Rel *)(mem + shdr->offset + shdr->entsize * idx);
+  }
+
+  return NULL;
+}
+
+RElf32Sym *
+r_elf_parser_rel32_get_sym (RElfParser * parser, RElf32SHdr * shdr,
+    RElf32Rel * rel, RElf32SHdr ** symtbl)
+{
+  RElf32SHdr * stbl;
+
+  if (shdr != NULL && shdr->link != R_ELF_SHN_UNDEF) {
+    if ((stbl = r_elf_parser_get_shdr32 (parser, shdr->link)) != NULL) {
+      ruint32 symidx;
+      if (symtbl != NULL)
+        *symtbl = stbl;
+
+      if (rel != NULL && (symidx = R_ELF32_RELINFO_SYM (rel->info)) > 0)
+        return r_elf_parser_symtbl32_get_sym (parser, stbl, symidx);
+    }
+  }
+
+  if (symtbl != NULL)
+    *symtbl = NULL;
+  return NULL;
+}
+
+RElf64Sym *
+r_elf_parser_rel64_get_sym (RElfParser * parser, RElf64SHdr * shdr,
+    RElf64Rel * rel, RElf64SHdr ** symtbl)
+{
+  RElf64SHdr * stbl;
+
+  if (shdr != NULL && shdr->link != R_ELF_SHN_UNDEF) {
+    if ((stbl = r_elf_parser_get_shdr64 (parser, shdr->link)) != NULL) {
+      ruint64 symidx;
+      if (symtbl != NULL)
+        *symtbl = stbl;
+
+      if (rel != NULL && (symidx = R_ELF64_RELINFO_SYM (rel->info)) > 0)
+        return r_elf_parser_symtbl64_get_sym (parser, stbl, symidx);
+    }
+  }
+
+  if (symtbl != NULL)
+    *symtbl = NULL;
+  return NULL;
+}
+
+ruint32 *
+r_elf_parser_rel32_get_dst (RElfParser * parser,
+    RElf32SHdr * shdr, RElf32Rel * rel)
+{
+  if (parser != NULL && shdr != NULL && rel != NULL) {
+    if (shdr->flags & R_ELF_SFLAGS_ALLOC) {
+      return RUINT_TO_POINTER (rel->offset);
+    } else {
+      if (shdr->info != R_ELF_SHN_UNDEF) {
+        return (ruint32 *)((ruint8 *)r_elf_parser_shdr32_get_data_by_idx (parser,
+              shdr->info, NULL) + rel->offset);
+      }
+    }
+  }
+
+  return NULL;
+}
+
+ruint64 *
+r_elf_parser_rel64_get_dst (RElfParser * parser,
+    RElf64SHdr * shdr, RElf64Rel * rel)
+{
+  if (parser != NULL && shdr != NULL && rel != NULL) {
+    if (shdr->flags & R_ELF_SFLAGS_ALLOC) {
+      return RUINT_TO_POINTER (rel->offset);
+    } else {
+      if (shdr->info != R_ELF_SHN_UNDEF) {
+        return (ruint64 *)((ruint8 *)r_elf_parser_shdr64_get_data_by_idx (parser,
+              shdr->info, NULL) + rel->offset);
+      }
+    }
+  }
+
+  return NULL;
+}

--- a/rlib/binfmt/relfparser.c
+++ b/rlib/binfmt/relfparser.c
@@ -31,9 +31,22 @@ struct RElfParser {
   rauint refcount;
   RMemFile * file;
   rpointer mem;
+  rboolean owns_mem;
   rsize size;
   int elfidx;
 };
+
+/* TRUE when the ELF's e_ident[EI_DATA] byte order differs from the host, so
+ * multi-byte fields must be swapped before they can be read natively. */
+static rboolean
+r_elf_data_needs_swap (ruint8 data)
+{
+#if R_BYTE_ORDER == R_BIG_ENDIAN
+  return data == R_ELF_DATA2LSB;
+#else
+  return data == R_ELF_DATA2MSB;
+#endif
+}
 
 rsize
 r_elf_calc_size (rpointer mem)
@@ -41,21 +54,38 @@ r_elf_calc_size (rpointer mem)
   ruint8 * ident = mem;
   if (ident[R_ELF_IDX_MAG0] == R_ELF_MAG0 && ident[R_ELF_IDX_MAG1] == R_ELF_MAG1 &&
       ident[R_ELF_IDX_MAG2] == R_ELF_MAG2 && ident[R_ELF_IDX_MAG3] == R_ELF_MAG3) {
+    rboolean swap = r_elf_data_needs_swap (ident[R_ELF_IDX_DATA]);
     rsize phend, shend;
 
     switch (ident[R_ELF_IDX_CLASS]) {
       case R_ELF_CLASS32:
         {
           RElf32EHdr * hdr = mem;
-          phend = hdr->phoff + hdr->phentsize * hdr->phnum;
-          shend = hdr->shoff + hdr->shentsize * hdr->shnum;
+          ruint32 phoff = hdr->phoff, shoff = hdr->shoff;
+          ruint16 phentsize = hdr->phentsize, phnum = hdr->phnum;
+          ruint16 shentsize = hdr->shentsize, shnum = hdr->shnum;
+          if (swap) {
+            phoff = RUINT32_BSWAP (phoff); shoff = RUINT32_BSWAP (shoff);
+            phentsize = RUINT16_BSWAP (phentsize); phnum = RUINT16_BSWAP (phnum);
+            shentsize = RUINT16_BSWAP (shentsize); shnum = RUINT16_BSWAP (shnum);
+          }
+          phend = phoff + (rsize)phentsize * phnum;
+          shend = shoff + (rsize)shentsize * shnum;
         }
         break;
       case R_ELF_CLASS64:
         {
           RElf64EHdr * hdr = mem;
-          phend = hdr->phoff + hdr->phentsize * hdr->phnum;
-          shend = hdr->shoff + hdr->shentsize * hdr->shnum;
+          ruint64 phoff = hdr->phoff, shoff = hdr->shoff;
+          ruint16 phentsize = hdr->phentsize, phnum = hdr->phnum;
+          ruint16 shentsize = hdr->shentsize, shnum = hdr->shnum;
+          if (swap) {
+            phoff = RUINT64_BSWAP (phoff); shoff = RUINT64_BSWAP (shoff);
+            phentsize = RUINT16_BSWAP (phentsize); phnum = RUINT16_BSWAP (phnum);
+            shentsize = RUINT16_BSWAP (shentsize); shnum = RUINT16_BSWAP (shnum);
+          }
+          phend = phoff + (rsize)phentsize * phnum;
+          shend = shoff + (rsize)shentsize * shnum;
         }
         break;
       case R_ELF_CLASSNONE:
@@ -129,6 +159,394 @@ _check_elf_header (rpointer mem, rsize size)
   return -1;
 }
 
+/* In-place byte-order swap of each multi-byte field of the fixed-layout ELF
+ * structures.  The 1-byte fields (ident[], st_info, st_other) are left as-is.
+ * Only called for non-native ELFs, on a private copy. */
+static void
+r_elf_swap_ehdr32 (RElf32EHdr * h)
+{
+  h->type      = RUINT16_BSWAP (h->type);
+  h->machine   = RUINT16_BSWAP (h->machine);
+  h->version   = RUINT32_BSWAP (h->version);
+  h->entry     = RUINT32_BSWAP (h->entry);
+  h->phoff     = RUINT32_BSWAP (h->phoff);
+  h->shoff     = RUINT32_BSWAP (h->shoff);
+  h->flags     = RUINT32_BSWAP (h->flags);
+  h->ehsize    = RUINT16_BSWAP (h->ehsize);
+  h->phentsize = RUINT16_BSWAP (h->phentsize);
+  h->phnum     = RUINT16_BSWAP (h->phnum);
+  h->shentsize = RUINT16_BSWAP (h->shentsize);
+  h->shnum     = RUINT16_BSWAP (h->shnum);
+  h->shstrndx  = RUINT16_BSWAP (h->shstrndx);
+}
+
+static void
+r_elf_swap_ehdr64 (RElf64EHdr * h)
+{
+  h->type      = RUINT16_BSWAP (h->type);
+  h->machine   = RUINT16_BSWAP (h->machine);
+  h->version   = RUINT32_BSWAP (h->version);
+  h->entry     = RUINT64_BSWAP (h->entry);
+  h->phoff     = RUINT64_BSWAP (h->phoff);
+  h->shoff     = RUINT64_BSWAP (h->shoff);
+  h->flags     = RUINT32_BSWAP (h->flags);
+  h->ehsize    = RUINT16_BSWAP (h->ehsize);
+  h->phentsize = RUINT16_BSWAP (h->phentsize);
+  h->phnum     = RUINT16_BSWAP (h->phnum);
+  h->shentsize = RUINT16_BSWAP (h->shentsize);
+  h->shnum     = RUINT16_BSWAP (h->shnum);
+  h->shstrndx  = RUINT16_BSWAP (h->shstrndx);
+}
+
+static void
+r_elf_swap_phdr32 (RElf32PHdr * h)
+{
+  h->type   = RUINT32_BSWAP (h->type);
+  h->offset = RUINT32_BSWAP (h->offset);
+  h->vaddr  = RUINT32_BSWAP (h->vaddr);
+  h->paddr  = RUINT32_BSWAP (h->paddr);
+  h->filesz = RUINT32_BSWAP (h->filesz);
+  h->memsz  = RUINT32_BSWAP (h->memsz);
+  h->flags  = RUINT32_BSWAP (h->flags);
+  h->align  = RUINT32_BSWAP (h->align);
+}
+
+static void
+r_elf_swap_phdr64 (RElf64PHdr * h)
+{
+  h->type   = RUINT32_BSWAP (h->type);
+  h->flags  = RUINT32_BSWAP (h->flags);
+  h->offset = RUINT64_BSWAP (h->offset);
+  h->vaddr  = RUINT64_BSWAP (h->vaddr);
+  h->paddr  = RUINT64_BSWAP (h->paddr);
+  h->filesz = RUINT64_BSWAP (h->filesz);
+  h->memsz  = RUINT64_BSWAP (h->memsz);
+  h->align  = RUINT64_BSWAP (h->align);
+}
+
+static void
+r_elf_swap_shdr32 (RElf32SHdr * h)
+{
+  h->name      = RUINT32_BSWAP (h->name);
+  h->type      = RUINT32_BSWAP (h->type);
+  h->flags     = RUINT32_BSWAP (h->flags);
+  h->addr      = RUINT32_BSWAP (h->addr);
+  h->offset    = RUINT32_BSWAP (h->offset);
+  h->size      = RUINT32_BSWAP (h->size);
+  h->link      = RUINT32_BSWAP (h->link);
+  h->info      = RUINT32_BSWAP (h->info);
+  h->addralign = RUINT32_BSWAP (h->addralign);
+  h->entsize   = RUINT32_BSWAP (h->entsize);
+}
+
+static void
+r_elf_swap_shdr64 (RElf64SHdr * h)
+{
+  h->name      = RUINT32_BSWAP (h->name);
+  h->type      = RUINT32_BSWAP (h->type);
+  h->flags     = RUINT64_BSWAP (h->flags);
+  h->addr      = RUINT64_BSWAP (h->addr);
+  h->offset    = RUINT64_BSWAP (h->offset);
+  h->size      = RUINT64_BSWAP (h->size);
+  h->link      = RUINT32_BSWAP (h->link);
+  h->info      = RUINT32_BSWAP (h->info);
+  h->addralign = RUINT64_BSWAP (h->addralign);
+  h->entsize   = RUINT64_BSWAP (h->entsize);
+}
+
+static void
+r_elf_swap_sym32 (RElf32Sym * s)
+{
+  s->name  = RUINT32_BSWAP (s->name);
+  s->value = RUINT32_BSWAP (s->value);
+  s->size  = RUINT32_BSWAP (s->size);
+  s->shndx = RUINT16_BSWAP (s->shndx);
+}
+
+static void
+r_elf_swap_sym64 (RElf64Sym * s)
+{
+  s->name  = RUINT32_BSWAP (s->name);
+  s->shndx = RUINT16_BSWAP (s->shndx);
+  s->value = RUINT64_BSWAP (s->value);
+  s->size  = RUINT64_BSWAP (s->size);
+}
+
+static void
+r_elf_swap_rel32 (RElf32Rel * r)
+{
+  r->offset = RUINT32_BSWAP (r->offset);
+  r->info   = RUINT32_BSWAP (r->info);
+}
+
+static void
+r_elf_swap_rel64 (RElf64Rel * r)
+{
+  r->offset = RUINT64_BSWAP (r->offset);
+  r->info   = RUINT64_BSWAP (r->info);
+}
+
+static void
+r_elf_swap_rela32 (RElf32Rela * r)
+{
+  r->offset = RUINT32_BSWAP (r->offset);
+  r->info   = RUINT32_BSWAP (r->info);
+  r->addend = (rint32) RUINT32_BSWAP ((ruint32) r->addend);
+}
+
+static void
+r_elf_swap_rela64 (RElf64Rela * r)
+{
+  r->offset = RUINT64_BSWAP (r->offset);
+  r->info   = RUINT64_BSWAP (r->info);
+  r->addend = (rint64) RUINT64_BSWAP ((ruint64) r->addend);
+}
+
+static void
+r_elf_swap_dyn32 (RElf32Dyn * d)
+{
+  d->tag    = (rint32) RUINT32_BSWAP ((ruint32) d->tag);
+  d->un.val = (rint32) RUINT32_BSWAP ((ruint32) d->un.val);
+}
+
+static void
+r_elf_swap_dyn64 (RElf64Dyn * d)
+{
+  d->tag    = (rint64) RUINT64_BSWAP ((ruint64) d->tag);
+  d->un.val = (rint64) RUINT64_BSWAP ((ruint64) d->un.val);
+}
+
+/* Swap the multi-byte header fields (namesz/descsz/type) of every note in a
+ * NOTE section's packed stream; the name/descriptor payloads are opaque bytes.
+ * Each field is swapped before its swapped value is used to advance, so the
+ * walk stays correct.  The Nhdr layout is identical for 32- and 64-bit. */
+static void
+r_elf_normalize_notes (ruint8 * data, rsize size)
+{
+  rsize off = 0;
+
+  while (off + sizeof (RElf32NHdr) <= size) {
+    RElf32NHdr * n = (RElf32NHdr *)(data + off);
+    rsize esz;
+    n->namesz = RUINT32_BSWAP (n->namesz);
+    n->descsz = RUINT32_BSWAP (n->descsz);
+    n->type   = RUINT32_BSWAP (n->type);
+    esz = sizeof (RElf32NHdr) +
+        (((rsize) n->namesz + 3) & ~(rsize)3) +
+        (((rsize) n->descsz + 3) & ~(rsize)3);
+    if (esz < sizeof (RElf32NHdr) || off + esz > size)
+      break;
+    off += esz;
+  }
+}
+
+/* Swap the per-entry contents of a section that holds fixed-layout entries
+ * (symbol / relocation tables) or a note stream.  Opaque sections (PROGBITS,
+ * STRTAB, ...) are left untouched.  The section header is already host order. */
+static void
+r_elf_normalize_section32 (ruint8 * base, rsize size, RElf32SHdr * sh)
+{
+  rsize off = sh->offset, sz = sh->size, es = sh->entsize, i, n;
+
+  if (off > size || size - off < sz)
+    return;
+
+  if (sh->type == R_ELF_STYPE_NOTE) {
+    r_elf_normalize_notes (base + off, sz);
+    return;
+  }
+
+  if (es == 0)
+    return;
+  n = sz / es;
+
+  switch (sh->type) {
+    case R_ELF_STYPE_SYMTAB:
+    case R_ELF_STYPE_DYNSYM:
+      for (i = 0; i < n; i++)
+        r_elf_swap_sym32 ((RElf32Sym *)(base + off + i * es));
+      break;
+    case R_ELF_STYPE_REL:
+      for (i = 0; i < n; i++)
+        r_elf_swap_rel32 ((RElf32Rel *)(base + off + i * es));
+      break;
+    case R_ELF_STYPE_RELA:
+      for (i = 0; i < n; i++)
+        r_elf_swap_rela32 ((RElf32Rela *)(base + off + i * es));
+      break;
+    case R_ELF_STYPE_DYNAMIC:
+      for (i = 0; i < n; i++)
+        r_elf_swap_dyn32 ((RElf32Dyn *)(base + off + i * es));
+      break;
+    default:
+      break;
+  }
+}
+
+static void
+r_elf_normalize_section64 (ruint8 * base, rsize size, RElf64SHdr * sh)
+{
+  rsize off = sh->offset, sz = sh->size, es = sh->entsize, i, n;
+
+  if (off > size || size - off < sz)
+    return;
+
+  if (sh->type == R_ELF_STYPE_NOTE) {
+    r_elf_normalize_notes (base + off, sz);
+    return;
+  }
+
+  if (es == 0)
+    return;
+  n = sz / es;
+
+  switch (sh->type) {
+    case R_ELF_STYPE_SYMTAB:
+    case R_ELF_STYPE_DYNSYM:
+      for (i = 0; i < n; i++)
+        r_elf_swap_sym64 ((RElf64Sym *)(base + off + i * es));
+      break;
+    case R_ELF_STYPE_REL:
+      for (i = 0; i < n; i++)
+        r_elf_swap_rel64 ((RElf64Rel *)(base + off + i * es));
+      break;
+    case R_ELF_STYPE_RELA:
+      for (i = 0; i < n; i++)
+        r_elf_swap_rela64 ((RElf64Rela *)(base + off + i * es));
+      break;
+    case R_ELF_STYPE_DYNAMIC:
+      for (i = 0; i < n; i++)
+        r_elf_swap_dyn64 ((RElf64Dyn *)(base + off + i * es));
+      break;
+    default:
+      break;
+  }
+}
+
+static void
+r_elf_normalize_tables32 (ruint8 * base, rsize size)
+{
+  RElf32EHdr * eh = (RElf32EHdr *) base;
+  ruint16 i;
+
+  for (i = 0; i < eh->phnum; i++)
+    r_elf_swap_phdr32 ((RElf32PHdr *)(base + eh->phoff + (rsize)i * eh->phentsize));
+
+  for (i = 0; i < eh->shnum; i++) {
+    RElf32SHdr * sh = (RElf32SHdr *)(base + eh->shoff + (rsize)i * eh->shentsize);
+    r_elf_swap_shdr32 (sh);
+    r_elf_normalize_section32 (base, size, sh);
+  }
+
+  /* A section-less image (e.g. a core dump) carries notes only in PT_NOTE
+   * segments; with sections present, those bytes alias a NOTE section already
+   * normalized above, so only swap segment notes when there are no sections. */
+  if (eh->shnum == 0) {
+    for (i = 0; i < eh->phnum; i++) {
+      RElf32PHdr * ph = (RElf32PHdr *)(base + eh->phoff + (rsize)i * eh->phentsize);
+      if (ph->type == R_ELF_PTYPE_NOTE && ph->offset <= size &&
+          size - ph->offset >= ph->filesz)
+        r_elf_normalize_notes (base + ph->offset, ph->filesz);
+    }
+  }
+}
+
+static void
+r_elf_normalize_tables64 (ruint8 * base, rsize size)
+{
+  RElf64EHdr * eh = (RElf64EHdr *) base;
+  ruint16 i;
+
+  for (i = 0; i < eh->phnum; i++)
+    r_elf_swap_phdr64 ((RElf64PHdr *)(base + eh->phoff + (rsize)i * eh->phentsize));
+
+  for (i = 0; i < eh->shnum; i++) {
+    RElf64SHdr * sh = (RElf64SHdr *)(base + eh->shoff + (rsize)i * eh->shentsize);
+    r_elf_swap_shdr64 (sh);
+    r_elf_normalize_section64 (base, size, sh);
+  }
+
+  /* A section-less image (e.g. a core dump) carries notes only in PT_NOTE
+   * segments; with sections present, those bytes alias a NOTE section already
+   * normalized above, so only swap segment notes when there are no sections. */
+  if (eh->shnum == 0) {
+    for (i = 0; i < eh->phnum; i++) {
+      RElf64PHdr * ph = (RElf64PHdr *)(base + eh->phoff + (rsize)i * eh->phentsize);
+      if (ph->type == R_ELF_PTYPE_NOTE && ph->offset <= size &&
+          size - ph->offset >= ph->filesz)
+        r_elf_normalize_notes (base + ph->offset, ph->filesz);
+    }
+  }
+}
+
+/* Swap a non-native ELF (already copied to private memory) to host order:
+ * header first, then validate, then the program/section tables and the
+ * fixed-layout entries they describe.  Returns the elf index or -1. */
+static int
+r_elf_normalize_copy (rpointer mem, rsize size)
+{
+  ruint8 * ident = mem;
+  int elfidx;
+
+  switch (ident[R_ELF_IDX_CLASS]) {
+    case R_ELF_CLASS32:
+      r_elf_swap_ehdr32 (mem);
+      break;
+    case R_ELF_CLASS64:
+      r_elf_swap_ehdr64 (mem);
+      break;
+    default:
+      return -1;
+  }
+
+  if ((elfidx = _check_elf_header (mem, size)) < 0)
+    return -1;
+
+  if (elfidx == RELF32_IDX)
+    r_elf_normalize_tables32 (mem, size);
+  else
+    r_elf_normalize_tables64 (mem, size);
+
+  return elfidx;
+}
+
+/* Validate the ELF at @mem and pick the memory the parser should read from.
+ * Native-endianness ELFs are used in place (no copy); non-native ones are
+ * copied to private, owned memory normalized to host order. */
+static int
+r_elf_parser_prepare (rpointer mem, rsize size, rpointer * out_mem,
+    rboolean * out_owns)
+{
+  ruint8 * ident = mem;
+
+  *out_mem = mem;
+  *out_owns = FALSE;
+
+  if (size < R_ELF_NIDENT || mem == NULL)
+    return -1;
+  if (!(ident[R_ELF_IDX_MAG0] == R_ELF_MAG0 && ident[R_ELF_IDX_MAG1] == R_ELF_MAG1 &&
+        ident[R_ELF_IDX_MAG2] == R_ELF_MAG2 && ident[R_ELF_IDX_MAG3] == R_ELF_MAG3))
+    return -1;
+
+  if (!r_elf_data_needs_swap (ident[R_ELF_IDX_DATA]))
+    return _check_elf_header (mem, size);
+
+  {
+    rpointer copy = r_memdup (mem, size);
+    int elfidx;
+
+    if (R_UNLIKELY (copy == NULL))
+      return -1;
+    if ((elfidx = r_elf_normalize_copy (copy, size)) < 0) {
+      r_free (copy);
+      return -1;
+    }
+    *out_mem = copy;
+    *out_owns = TRUE;
+    return elfidx;
+  }
+}
+
 static RElfParser *
 r_elf_parser_new_from_mem_file (RMemFile * file)
 {
@@ -138,14 +556,19 @@ r_elf_parser_new_from_mem_file (RMemFile * file)
   if (file != NULL) {
     rpointer mem = r_mem_file_get_mem (file);
     rsize size = r_mem_file_get_size (file);
+    rpointer pmem;
+    rboolean owns;
 
-    if ((elfidx = _check_elf_header (mem, size)) >= 0) {
+    if ((elfidx = r_elf_parser_prepare (mem, size, &pmem, &owns)) >= 0) {
       if (R_LIKELY (ret = r_mem_new (RElfParser))) {
         r_atomic_uint_store (&ret->refcount, 1);
-        ret->file = r_mem_file_ref (file);
-        ret->mem = mem;
+        ret->file = owns ? NULL : r_mem_file_ref (file);
+        ret->mem = pmem;
+        ret->owns_mem = owns;
         ret->size = size;
         ret->elfidx = elfidx;
+      } else if (owns) {
+        r_free (pmem);
       }
     }
   }
@@ -188,14 +611,19 @@ r_elf_parser_new_from_mem (rpointer mem, rsize size)
 {
   RElfParser * ret = NULL;
   int elfidx;
+  rpointer pmem;
+  rboolean owns;
 
-  if ((elfidx = _check_elf_header (mem, size)) >= 0) {
+  if ((elfidx = r_elf_parser_prepare (mem, size, &pmem, &owns)) >= 0) {
     if (R_LIKELY (ret = r_mem_new (RElfParser))) {
       r_atomic_uint_store (&ret->refcount, 1);
       ret->file = NULL;
-      ret->mem = mem;
+      ret->mem = pmem;
+      ret->owns_mem = owns;
       ret->size = size;
       ret->elfidx = elfidx;
+    } else if (owns) {
+      r_free (pmem);
     }
   }
 
@@ -205,6 +633,8 @@ r_elf_parser_new_from_mem (rpointer mem, rsize size)
 static void
 r_elf_parser_free (RElfParser * parser)
 {
+  if (parser->owns_mem)
+    r_free (parser->mem);
   if (parser->file != NULL)
     r_mem_file_unref (parser->file);
   r_free (parser);

--- a/test/relf.c
+++ b/test/relf.c
@@ -186,6 +186,19 @@ verify_min_elf64 (RElfParser * parser)
   r_assert_cmpuint (ph->type, ==, R_ELF_PTYPE_LOAD);
   r_assert_cmpuint (ph->vaddr, ==, 0x400000);
   r_assert_cmpuint (ph->align, ==, 0x1000);
+  r_assert_cmpptr (r_elf_parser_find_phdr64_by_type (parser, R_ELF_PTYPE_LOAD),
+      ==, ph);
+  r_assert_cmpptr (r_elf_parser_find_phdr64_by_type (parser, R_ELF_PTYPE_DYNAMIC),
+      ==, NULL);
+  r_assert_cmpptr (r_elf_parser_find_phdr32_by_type (parser, R_ELF_PTYPE_LOAD),
+      ==, NULL);
+  {
+    rsize psz = 0;
+    /* p_offset == 0, so the segment data starts at the ELF header. */
+    r_assert_cmpptr (r_elf_parser_phdr64_get_data (parser, ph, &psz), ==,
+        r_elf_parser_get_elf_header (parser));
+    r_assert_cmpuint (psz, ==, ph->filesz);
+  }
 
   r_assert_cmpptr ((sh = r_elf_parser_find_shdr64 (parser, ".text", -1)), !=, NULL);
   r_assert_cmpuint (sh->type, ==, R_ELF_STYPE_PROGBITS);
@@ -396,7 +409,6 @@ RTEST (relf, phdr, RTEST_FAST)
   r_assert_cmpptr ((parser =
         r_elf_parser_new_from_mem (elf_o, sizeof (elf_o))), !=, NULL);
 
-  /* FIXME: Add elfprg.inc and test properly */
   r_assert_cmpuint (r_elf_parser_prg_header_count (parser), ==, 0);
   r_assert_cmpptr (r_elf_parser_get_prg_header_table (parser), ==, NULL);
   r_assert_cmpptr (r_elf_parser_get_phdr32 (parser, 0), ==, NULL);

--- a/test/relf.c
+++ b/test/relf.c
@@ -450,6 +450,145 @@ build_min_load_elf64 (ruint8 * buf, ruint8 data, rsize * slot_off)
   return cur;
 }
 
+static void
+wr_shdr32 (ruint8 * p, rboolean be, rsize name, rsize type, rsize flags,
+    rsize addr, rsize offset, rsize size, rsize link, rsize info,
+    rsize addralign, rsize entsize)
+{
+  w32 (p +  0, be, name);  w32 (p +  4, be, type);   w32 (p +  8, be, flags);
+  w32 (p + 12, be, addr);  w32 (p + 16, be, offset); w32 (p + 20, be, size);
+  w32 (p + 24, be, link);  w32 (p + 28, be, info);   w32 (p + 32, be, addralign);
+  w32 (p + 36, be, entsize);
+}
+
+/* Build a minimal ELF32 (i386) with .text / .symtab / .rela.text / .rel.text /
+ * .note.test / .dynamic / .strtab / .shstrtab, in the byte order named by
+ * @p data.  Gives positive coverage of the 32-bit swap and accessor paths. */
+static rsize
+build_min_elf32 (ruint8 * buf, ruint8 data)
+{
+  const rboolean be = (data == R_ELF_DATA2MSB);
+  static const rchar shstr[] =
+      "\0.text\0.symtab\0.rela.text\0.rel.text\0.note.test\0.dynamic\0.strtab\0.shstrtab";
+  static const rchar symstr[] = "\0rfunc";
+  static const rchar note_name[] = "GNU";
+  static const ruint8 note_desc[] = { 0xca, 0xfe, 0xba, 0xbe };
+  const ruint32 n_text = 1, n_symtab = 7, n_rela = 15, n_rel = 26, n_note = 36,
+      n_dynamic = 47, n_strtab = 56, n_shstrtab = 64;
+  const rsize note_sz =
+      sizeof (RElf32NHdr) + sizeof (note_name) + sizeof (note_desc);
+  rsize off_ph, off_text, off_shstr, off_symstr, off_symtab, off_rela, off_rel,
+      off_note, off_dyn, off_sht, cur;
+  ruint8 * p;
+
+  cur = sizeof (RElf32EHdr);
+  off_ph = cur;     cur += sizeof (RElf32PHdr);
+  off_text = cur;   cur += 4;
+  off_shstr = cur;  cur += sizeof (shstr);
+  off_symstr = cur; cur += sizeof (symstr);
+  cur = (cur + 3) & ~(rsize)3;
+  off_symtab = cur; cur += 2 * sizeof (RElf32Sym);
+  off_rela = cur;   cur += sizeof (RElf32Rela);
+  off_rel = cur;    cur += sizeof (RElf32Rel);
+  off_note = cur;   cur += note_sz;
+  off_dyn = cur;    cur += 2 * sizeof (RElf32Dyn);
+  cur = (cur + 3) & ~(rsize)3;
+  off_sht = cur;    cur += 9 * sizeof (RElf32SHdr);
+
+  r_memset (buf, 0, cur);
+
+  buf[R_ELF_IDX_MAG0] = R_ELF_MAG0; buf[R_ELF_IDX_MAG1] = R_ELF_MAG1;
+  buf[R_ELF_IDX_MAG2] = R_ELF_MAG2; buf[R_ELF_IDX_MAG3] = R_ELF_MAG3;
+  buf[R_ELF_IDX_CLASS] = R_ELF_CLASS32;
+  buf[R_ELF_IDX_DATA] = data;
+  buf[R_ELF_IDX_VERSION] = R_ELF_VER_CURRENT;
+  w16 (buf + 16, be, R_ELF_ETYPE_REL);
+  w16 (buf + 18, be, R_ELF_MACHINE_386);
+  w32 (buf + 20, be, R_ELF_VER_CURRENT);
+  w32 (buf + 24, be, 0);                    /* entry */
+  w32 (buf + 28, be, off_ph);               /* phoff */
+  w32 (buf + 32, be, off_sht);              /* shoff */
+  w32 (buf + 36, be, 0);                    /* flags */
+  w16 (buf + 40, be, sizeof (RElf32EHdr));
+  w16 (buf + 42, be, sizeof (RElf32PHdr));
+  w16 (buf + 44, be, 1);                    /* phnum */
+  w16 (buf + 46, be, sizeof (RElf32SHdr));
+  w16 (buf + 48, be, 9);                    /* shnum */
+  w16 (buf + 50, be, 8);                    /* shstrndx */
+
+  p = buf + off_ph;
+  w32 (p +  0, be, R_ELF_PTYPE_LOAD);
+  w32 (p +  4, be, 0);                      /* offset */
+  w32 (p +  8, be, 0x8048000);              /* vaddr */
+  w32 (p + 12, be, 0x8048000);              /* paddr */
+  w32 (p + 16, be, cur);                    /* filesz */
+  w32 (p + 20, be, cur);                    /* memsz */
+  w32 (p + 24, be, R_ELF_PFLAGS_R | R_ELF_PFLAGS_X);
+  w32 (p + 28, be, 0x1000);
+
+  r_memset (buf + off_text, 0x90, 4);
+  r_memcpy (buf + off_shstr, shstr, sizeof (shstr));
+  r_memcpy (buf + off_symstr, symstr, sizeof (symstr));
+
+  /* .symtab[1] = GLOBAL FUNC "rfunc" in .text */
+  p = buf + off_symtab + sizeof (RElf32Sym);
+  w32 (p +  0, be, 1);                      /* name */
+  w32 (p +  4, be, 0x100);                  /* value */
+  w32 (p +  8, be, 0x20);                   /* size */
+  p[12] = R_ELF_SYMINFO_CREATE (R_ELF_SYMBIND_GLOBAL, R_ELF_SYMTYPE_FUNC);
+  p[13] = R_ELF_SYMOTHER_DEFAULT;
+  w16 (p + 14, be, 1);                      /* shndx -> .text */
+
+  p = buf + off_rela;
+  w32 (p + 0, be, 0x4);
+  w32 (p + 4, be, ((ruint32) 1 << 8) | R_ELF_RELTYPE_386_32);
+  w32 (p + 8, be, 0x9);                     /* addend */
+
+  p = buf + off_rel;
+  w32 (p + 0, be, 0x8);
+  w32 (p + 4, be, ((ruint32) 1 << 8) | R_ELF_RELTYPE_386_PC32);
+
+  p = buf + off_note;
+  w32 (p + 0, be, sizeof (note_name));
+  w32 (p + 4, be, sizeof (note_desc));
+  w32 (p + 8, be, 1);
+  r_memcpy (p + 12, note_name, sizeof (note_name));
+  r_memcpy (p + 16, note_desc, sizeof (note_desc));
+
+  /* .dynamic: DT_SONAME -> "rfunc" in .strtab, DT_NULL */
+  p = buf + off_dyn;
+  w32 (p + 0, be, R_ELF_DTYPE_SONAME); w32 (p + 4, be, 1);
+  w32 (p + 8, be, R_ELF_DTYPE_NULL);   w32 (p + 12, be, 0);
+
+  wr_shdr32 (buf + off_sht + 0 * sizeof (RElf32SHdr), be,
+      0, R_ELF_STYPE_NULL, 0, 0, 0, 0, 0, 0, 0, 0);
+  wr_shdr32 (buf + off_sht + 1 * sizeof (RElf32SHdr), be,
+      n_text, R_ELF_STYPE_PROGBITS, R_ELF_SFLAGS_ALLOC | R_ELF_SFLAGS_EXECINSTR,
+      0, off_text, 4, 0, 0, 1, 0);
+  wr_shdr32 (buf + off_sht + 2 * sizeof (RElf32SHdr), be,
+      n_symtab, R_ELF_STYPE_SYMTAB, 0, 0, off_symtab, 2 * sizeof (RElf32Sym),
+      7, 1, 4, sizeof (RElf32Sym));
+  wr_shdr32 (buf + off_sht + 3 * sizeof (RElf32SHdr), be,
+      n_rela, R_ELF_STYPE_RELA, R_ELF_SFLAGS_INFO_LINK, 0, off_rela,
+      sizeof (RElf32Rela), 2, 1, 4, sizeof (RElf32Rela));
+  wr_shdr32 (buf + off_sht + 4 * sizeof (RElf32SHdr), be,
+      n_rel, R_ELF_STYPE_REL, R_ELF_SFLAGS_INFO_LINK, 0, off_rel,
+      sizeof (RElf32Rel), 2, 1, 4, sizeof (RElf32Rel));
+  wr_shdr32 (buf + off_sht + 5 * sizeof (RElf32SHdr), be,
+      n_note, R_ELF_STYPE_NOTE, 0, 0, off_note, note_sz, 0, 0, 4, 0);
+  wr_shdr32 (buf + off_sht + 6 * sizeof (RElf32SHdr), be,
+      n_dynamic, R_ELF_STYPE_DYNAMIC, R_ELF_SFLAGS_ALLOC, 0, off_dyn,
+      2 * sizeof (RElf32Dyn), 7, 0, 4, sizeof (RElf32Dyn));
+  wr_shdr32 (buf + off_sht + 7 * sizeof (RElf32SHdr), be,
+      n_strtab, R_ELF_STYPE_STRTAB, 0, 0, off_symstr, sizeof (symstr),
+      0, 0, 1, 0);
+  wr_shdr32 (buf + off_sht + 8 * sizeof (RElf32SHdr), be,
+      n_shstrtab, R_ELF_STYPE_STRTAB, 0, 0, off_shstr, sizeof (shstr),
+      0, 0, 1, 0);
+
+  return cur;
+}
+
 /* Assert the parser produced the known field values, regardless of the
  * source byte order. */
 static void
@@ -851,6 +990,93 @@ RTEST (relf, load_malformed, RTEST_FAST)
   if (img != NULL)
     r_elf_image_unref (img);
   r_elf_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (relf, parse32, RTEST_FAST)
+{
+  ruint8 buf[1024];
+  int i;
+
+  /* Positive 32-bit coverage in both byte orders: exercises the *32 swap and
+   * accessor paths the 64-bit fixtures only hit via NULL-return checks. */
+  for (i = 0; i < 2; i++) {
+    ruint8 enc = (i == 0) ? R_ELF_DATA2LSB : R_ELF_DATA2MSB;
+    RElfParser * parser;
+    RElf32EHdr * eh;
+    RElf32PHdr * ph;
+    RElf32SHdr * sh;
+    RElf32Sym * sym;
+    RElf32Rela * rela;
+    RElf32Rel * rel;
+    RElf32NHdr * nhdr;
+    RElf32Dyn * dyn;
+    rsize sz = build_min_elf32 (buf, enc);
+
+    r_assert_cmpptr ((parser = r_elf_parser_new_from_mem (buf, sz)), !=, NULL);
+    r_assert_cmpuint (r_elf_parser_get_class (parser), ==, R_ELF_CLASS32);
+    r_assert_cmpptr (r_elf_parser_get_ehdr64 (parser), ==, NULL);
+    r_assert_cmpptr ((eh = r_elf_parser_get_ehdr32 (parser)), !=, NULL);
+    r_assert_cmpuint (eh->machine, ==, R_ELF_MACHINE_386);
+    r_assert_cmpuint (eh->shnum, ==, 9);
+    r_assert_cmpuint (eh->shstrndx, ==, 8);
+
+    r_assert_cmpptr ((ph = r_elf_parser_find_phdr32_by_type (parser,
+          R_ELF_PTYPE_LOAD)), !=, NULL);
+    r_assert_cmpuint (ph->vaddr, ==, 0x8048000);
+    r_assert_cmpptr (r_elf_parser_find_phdr64_by_type (parser,
+          R_ELF_PTYPE_LOAD), ==, NULL);
+
+    r_assert_cmpptr ((sh = r_elf_parser_find_shdr32 (parser, ".text", -1)),
+        !=, NULL);
+    r_assert_cmpuint (sh->type, ==, R_ELF_STYPE_PROGBITS);
+    r_assert_cmpuint (sh->size, ==, 4);
+
+    r_assert_cmpptr ((sh = r_elf_parser_find_shdr32_by_type (parser,
+          R_ELF_STYPE_SYMTAB)), !=, NULL);
+    r_assert_cmpuint (r_elf_parser_symtbl32_sym_count (parser, sh), ==, 2);
+    r_assert_cmpptr ((sym = r_elf_parser_symtbl32_get_sym (parser, sh, 1)),
+        !=, NULL);
+    r_assert_cmpstr (r_elf_parser_symtbl32_sym32_get_name (parser, sh, sym),
+        ==, "rfunc");
+    r_assert_cmpuint (sym->value, ==, 0x100);
+    r_assert_cmpuint (sym->size, ==, 0x20);
+    r_assert_cmpuint (R_ELF_SYMINFO_BIND (sym->info), ==, R_ELF_SYMBIND_GLOBAL);
+    r_assert_cmpuint (R_ELF_SYMINFO_TYPE (sym->info), ==, R_ELF_SYMTYPE_FUNC);
+
+    r_assert_cmpptr ((sh = r_elf_parser_find_shdr32_by_type (parser,
+          R_ELF_STYPE_RELA)), !=, NULL);
+    r_assert_cmpuint (r_elf_parser_relatbl32_rela_count (parser, sh), ==, 1);
+    r_assert_cmpptr ((rela = r_elf_parser_relatbl32_get_rela (parser, sh, 0)),
+        !=, NULL);
+    r_assert_cmpuint (rela->offset, ==, 0x4);
+    r_assert_cmpuint (R_ELF32_RELINFO_SYM (rela->info), ==, 1);
+    r_assert_cmpint (rela->addend, ==, 0x9);
+
+    r_assert_cmpptr ((sh = r_elf_parser_find_shdr32_by_type (parser,
+          R_ELF_STYPE_REL)), !=, NULL);
+    r_assert_cmpuint (r_elf_parser_reltbl32_rel_count (parser, sh), ==, 1);
+    r_assert_cmpptr ((rel = r_elf_parser_reltbl32_get_rel (parser, sh, 0)),
+        !=, NULL);
+    r_assert_cmpuint (rel->offset, ==, 0x8);
+    r_assert_cmpuint (R_ELF32_RELINFO_SYM (rel->info), ==, 1);
+    r_assert_cmpuint (R_ELF32_RELINFO_TYPE (rel->info), ==, R_ELF_RELTYPE_386_PC32);
+
+    r_assert_cmpptr ((sh = r_elf_parser_find_shdr32_by_type (parser,
+          R_ELF_STYPE_NOTE)), !=, NULL);
+    r_assert_cmpuint (r_elf_parser_notetbl32_note_count (parser, sh), ==, 1);
+    r_assert_cmpptr ((nhdr = r_elf_parser_notetbl32_get_note (parser, sh, 0)),
+        !=, NULL);
+    r_assert_cmpstr (r_elf_nhdr32_get_name (nhdr), ==, "GNU");
+
+    r_assert_cmpptr ((sh = r_elf_parser_find_shdr32_by_type (parser,
+          R_ELF_STYPE_DYNAMIC)), !=, NULL);
+    r_assert_cmpptr ((dyn = r_elf_parser_dyntbl32_find_dyn_by_tag (parser, sh,
+          R_ELF_DTYPE_SONAME)), !=, NULL);
+    r_assert_cmpstr (r_elf_parser_dyn32_get_str (parser, sh, dyn), ==, "rfunc");
+
+    r_elf_parser_unref (parser);
+  }
 }
 RTEST_END;
 

--- a/test/relf.c
+++ b/test/relf.c
@@ -162,6 +162,60 @@ build_min_elf64 (ruint8 * buf, ruint8 data)
   return cur;
 }
 
+/* Build a section-less ELF64 (core-dump style) whose only structure is a
+ * single PT_NOTE segment, in the byte order named by @p data.  Exercises the
+ * segment-note normalization path, where no NOTE section aliases the bytes. */
+static rsize
+build_min_note_elf64 (ruint8 * buf, ruint8 data)
+{
+  const rboolean be = (data == R_ELF_DATA2MSB);
+  static const rchar note_name[] = "CORE";   /* sizeof 5 -> 4-byte-padded to 8 */
+  static const ruint8 note_desc[] = { 0x01, 0x02, 0x03, 0x04 };
+  const rsize namepad = (sizeof (note_name) + 3) & ~(rsize)3;
+  const rsize descpad = (sizeof (note_desc) + 3) & ~(rsize)3;
+  const rsize note_sz = sizeof (RElf64NHdr) + namepad + descpad;
+  rsize off_ph, off_note, cur;
+  ruint8 * p;
+
+  cur = sizeof (RElf64EHdr);
+  off_ph = cur;     cur += sizeof (RElf64PHdr);
+  off_note = cur;   cur += note_sz;
+
+  r_memset (buf, 0, cur);
+
+  buf[R_ELF_IDX_MAG0] = R_ELF_MAG0; buf[R_ELF_IDX_MAG1] = R_ELF_MAG1;
+  buf[R_ELF_IDX_MAG2] = R_ELF_MAG2; buf[R_ELF_IDX_MAG3] = R_ELF_MAG3;
+  buf[R_ELF_IDX_CLASS] = R_ELF_CLASS64;
+  buf[R_ELF_IDX_DATA] = data;
+  buf[R_ELF_IDX_VERSION] = R_ELF_VER_CURRENT;
+  w16 (buf + 16, be, R_ELF_ETYPE_CORE);     /* type */
+  w16 (buf + 18, be, R_ELF_MACHINE_X86_64); /* machine */
+  w32 (buf + 20, be, R_ELF_VER_CURRENT);    /* version */
+  w64 (buf + 32, be, off_ph);               /* phoff */
+  w64 (buf + 40, be, 0);                    /* shoff (no sections) */
+  w16 (buf + 52, be, sizeof (RElf64EHdr));  /* ehsize */
+  w16 (buf + 54, be, sizeof (RElf64PHdr));  /* phentsize */
+  w16 (buf + 56, be, 1);                    /* phnum */
+  /* shentsize / shnum / shstrndx stay 0 */
+
+  p = buf + off_ph;
+  w32 (p +  0, be, R_ELF_PTYPE_NOTE);       /* type */
+  w32 (p +  4, be, R_ELF_PFLAGS_R);         /* flags */
+  w64 (p +  8, be, off_note);               /* offset */
+  w64 (p + 32, be, note_sz);                /* filesz */
+  w64 (p + 40, be, note_sz);                /* memsz */
+  w64 (p + 48, be, 4);                      /* align */
+
+  p = buf + off_note;
+  w32 (p + 0, be, sizeof (note_name));      /* namesz */
+  w32 (p + 4, be, sizeof (note_desc));      /* descsz */
+  w32 (p + 8, be, R_ELF_NTYPE_PRSTATUS);    /* type */
+  r_memcpy (p + 12, note_name, sizeof (note_name));
+  r_memcpy (p + 12 + namepad, note_desc, sizeof (note_desc));
+
+  return cur;
+}
+
 /* Assert the parser produced the known field values, regardless of the
  * source byte order. */
 static void
@@ -244,6 +298,42 @@ verify_min_elf64 (RElfParser * parser)
         !=, NULL);
     r_assert_cmpstr (r_elf_parser_symtbl64_sym64_get_name (parser, relsymtbl, sym),
         ==, "rfunc");
+  }
+
+  {
+    RElf64NHdr * nhdr;
+    ruint8 * desc;
+    rsize dsize = 0;
+
+    r_assert_cmpptr ((sh = r_elf_parser_find_shdr64_by_type (parser,
+          R_ELF_STYPE_NOTE)), !=, NULL);
+    r_assert_cmpuint (r_elf_parser_notetbl64_note_count (parser, sh), ==, 1);
+    r_assert_cmpptr (r_elf_parser_notetbl64_get_note (parser, sh, 1), ==, NULL);
+    r_assert_cmpptr ((nhdr = r_elf_parser_notetbl64_get_note (parser, sh, 0)),
+        !=, NULL);
+    r_assert_cmpuint (nhdr->namesz, ==, 4);
+    r_assert_cmpuint (nhdr->descsz, ==, 4);
+    r_assert_cmpuint (nhdr->type, ==, 1);
+    r_assert_cmpstr (r_elf_nhdr64_get_name (nhdr), ==, "GNU");
+    r_assert_cmpptr ((desc = r_elf_nhdr64_get_desc (nhdr, &dsize)),
+        !=, NULL);
+    r_assert_cmpuint (dsize, ==, 4);
+    r_assert_cmpuint (desc[0], ==, 0xde);
+    r_assert_cmpuint (desc[3], ==, 0xef);
+  }
+
+  /* The PT_NOTE segment aliases the .note.test section bytes; same note. */
+  {
+    RElf64PHdr * ph;
+    RElf64NHdr * nhdr;
+
+    r_assert_cmpptr ((ph = r_elf_parser_find_phdr64_by_type (parser,
+          R_ELF_PTYPE_NOTE)), !=, NULL);
+    r_assert_cmpuint (r_elf_parser_phdr64_note_count (parser, ph), ==, 1);
+    r_assert_cmpptr ((nhdr = r_elf_parser_phdr64_get_note (parser, ph, 0)),
+        !=, NULL);
+    r_assert_cmpuint (nhdr->type, ==, 1);
+    r_assert_cmpstr (r_elf_nhdr64_get_name (nhdr), ==, "GNU");
   }
 }
 
@@ -329,6 +419,83 @@ RTEST (relf, rel, RTEST_FAST)
   }
 
   r_elf_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (relf, note, RTEST_FAST)
+{
+  ruint8 buf[1024];
+  RElfParser * parser;
+  RElf64SHdr * sh, * text;
+  RElf64NHdr * nhdr;
+  rsize sz, dsize = 0;
+
+  sz = build_min_elf64 (buf, R_ELF_DATA2LSB);
+  r_assert_cmpptr ((parser = r_elf_parser_new_from_mem (buf, sz)), !=, NULL);
+
+  r_assert_cmpptr ((sh = r_elf_parser_find_shdr64_by_type (parser,
+        R_ELF_STYPE_NOTE)), !=, NULL);
+  r_assert_cmpstr (r_elf_parser_shdr64_get_name (parser, sh), ==, ".note.test");
+  r_assert_cmpuint (r_elf_parser_notetbl64_note_count (parser, sh), ==, 1);
+  r_assert_cmpptr ((nhdr = r_elf_parser_notetbl64_get_note (parser, sh, 0)),
+      !=, NULL);
+  r_assert_cmpstr (r_elf_nhdr64_get_name (nhdr), ==, "GNU");
+  r_assert_cmpptr (r_elf_nhdr64_get_desc (nhdr, &dsize), !=, NULL);
+  r_assert_cmpuint (dsize, ==, 4);
+
+  /* 32-bit accessors on a 64-bit ELF yield nothing. */
+  r_assert_cmpuint (r_elf_parser_notetbl32_note_count (parser,
+        (RElf32SHdr *) sh), ==, 0);
+  r_assert_cmpptr (r_elf_parser_notetbl32_get_note (parser,
+        (RElf32SHdr *) sh, 0), ==, NULL);
+
+  /* A non-NOTE section reports zero notes and no entry. */
+  r_assert_cmpptr ((text = r_elf_parser_find_shdr64 (parser, ".text", -1)),
+      !=, NULL);
+  r_assert_cmpuint (r_elf_parser_notetbl64_note_count (parser, text), ==, 0);
+  r_assert_cmpptr (r_elf_parser_notetbl64_get_note (parser, text, 0), ==, NULL);
+
+  /* NULL inputs are rejected. */
+  r_assert_cmpptr (r_elf_nhdr64_get_name (NULL), ==, NULL);
+  r_assert_cmpptr (r_elf_nhdr64_get_desc (NULL, &dsize), ==, NULL);
+  r_assert_cmpuint (dsize, ==, 0);
+
+  r_elf_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (relf, note_segment, RTEST_FAST)
+{
+  ruint8 buf[256];
+  int i;
+
+  /* A section-less image exposes its notes only via the PT_NOTE segment; run
+   * both byte orders so the segment-note normalization fallback is covered. */
+  for (i = 0; i < 2; i++) {
+    ruint8 enc = (i == 0) ? R_ELF_DATA2LSB : R_ELF_DATA2MSB;
+    RElfParser * parser;
+    RElf64PHdr * ph;
+    RElf64NHdr * nhdr;
+    ruint8 * desc;
+    rsize dsize = 0;
+    rsize sz = build_min_note_elf64 (buf, enc);
+
+    r_assert_cmpptr ((parser = r_elf_parser_new_from_mem (buf, sz)), !=, NULL);
+    r_assert_cmpuint (r_elf_parser_section_header_count (parser), ==, 0);
+    r_assert_cmpptr ((ph = r_elf_parser_find_phdr64_by_type (parser,
+          R_ELF_PTYPE_NOTE)), !=, NULL);
+    r_assert_cmpuint (r_elf_parser_phdr64_note_count (parser, ph), ==, 1);
+    r_assert_cmpptr ((nhdr = r_elf_parser_phdr64_get_note (parser, ph, 0)),
+        !=, NULL);
+    r_assert_cmpuint (nhdr->type, ==, R_ELF_NTYPE_PRSTATUS);
+    r_assert_cmpstr (r_elf_nhdr64_get_name (nhdr), ==, "CORE");
+    r_assert_cmpptr ((desc = r_elf_nhdr64_get_desc (nhdr, &dsize)), !=, NULL);
+    r_assert_cmpuint (dsize, ==, 4);
+    r_assert_cmpuint (desc[0], ==, 0x01);
+    r_assert_cmpuint (desc[3], ==, 0x04);
+
+    r_elf_parser_unref (parser);
+  }
 }
 RTEST_END;
 

--- a/test/relf.c
+++ b/test/relf.c
@@ -215,6 +215,23 @@ verify_min_elf64 (RElfParser * parser)
       !=, NULL);
   r_assert_cmpstr (r_elf_parser_symtbl64_sym64_get_name (parser, symtbl, sym),
       ==, "rfunc");
+
+  {
+    RElf64Rel * rel;
+    RElf64SHdr * relsymtbl = NULL;
+
+    r_assert_cmpptr ((sh = r_elf_parser_find_shdr64_by_type (parser,
+          R_ELF_STYPE_REL)), !=, NULL);
+    r_assert_cmpuint (r_elf_parser_reltbl64_rel_count (parser, sh), ==, 1);
+    r_assert_cmpptr ((rel = r_elf_parser_reltbl64_get_rel (parser, sh, 0)), !=, NULL);
+    r_assert_cmpuint (rel->offset, ==, 0x8);
+    r_assert_cmpuint (R_ELF64_RELINFO_SYM (rel->info), ==, 1);
+    r_assert_cmpuint (R_ELF64_RELINFO_TYPE (rel->info), ==, R_ELF_RELTYPE_X86_64_PC32);
+    r_assert_cmpptr ((sym = r_elf_parser_rel64_get_sym (parser, sh, rel, &relsymtbl)),
+        !=, NULL);
+    r_assert_cmpstr (r_elf_parser_symtbl64_sym64_get_name (parser, relsymtbl, sym),
+        ==, "rfunc");
+  }
 }
 
 RTEST (relf, endianness, RTEST_FAST)
@@ -246,6 +263,59 @@ RTEST (relf, endianness, RTEST_FAST)
 
   /* The caller's big-endian buffer must be left untouched (we copy). */
   r_assert_cmpint (r_memcmp (be, be_copy, sz_be), ==, 0);
+}
+RTEST_END;
+
+RTEST (relf, rel, RTEST_FAST)
+{
+  ruint8 buf[1024];
+  RElfParser * parser;
+  RElf64SHdr * sh;
+  RElf64Rel * rel;
+  rsize sz;
+
+  sz = build_min_elf64 (buf, R_ELF_DATA2LSB);
+  r_assert_cmpptr ((parser = r_elf_parser_new_from_mem (buf, sz)), !=, NULL);
+
+  /* 32-bit accessors return nothing on a 64-bit ELF. */
+  r_assert_cmpptr (r_elf_parser_find_shdr32_by_type (parser, R_ELF_STYPE_REL),
+      ==, NULL);
+
+  r_assert_cmpptr ((sh = r_elf_parser_find_shdr64_by_type (parser,
+        R_ELF_STYPE_REL)), !=, NULL);
+  r_assert_cmpstr (r_elf_parser_shdr64_get_name (parser, sh), ==, ".rel.text");
+  r_assert_cmpuint (sh->entsize, ==, sizeof (RElf64Rel));
+
+  r_assert_cmpuint (r_elf_parser_reltbl64_rel_count (parser, sh), ==, 1);
+  /* Out-of-range index must not return an entry. */
+  r_assert_cmpptr (r_elf_parser_reltbl64_get_rel (parser, sh, 1), ==, NULL);
+  r_assert_cmpptr ((rel = r_elf_parser_reltbl64_get_rel (parser, sh, 0)), !=, NULL);
+
+  r_assert_cmpuint (rel->offset, ==, 0x8);
+  r_assert_cmpuint (R_ELF64_RELINFO_SYM (rel->info), ==, 1);
+  r_assert_cmpuint (R_ELF64_RELINFO_TYPE (rel->info), ==, R_ELF_RELTYPE_X86_64_PC32);
+
+  /* dst points at the patched location in the linked (.text) section. */
+  r_assert_cmpptr (r_elf_parser_rel64_get_dst (parser, sh, rel), ==,
+      (ruint8 *)r_elf_parser_shdr64_get_data_by_idx (parser, sh->info, NULL)
+        + rel->offset);
+
+  /* The relocation section relocating .text (section index 1): both
+   * .rela.text and .rel.text target it; the first in section order wins. */
+  {
+    RElf64SHdr * rsh;
+    r_assert_cmpptr ((rsh = r_elf_parser_find_reloc_shdr64 (parser, 1)), !=, NULL);
+    r_assert_cmpuint (rsh->info, ==, 1);
+    r_assert_cmpstr (r_elf_parser_shdr64_get_name (parser, rsh), ==, ".rela.text");
+
+    /* A section nothing relocates, the UNDEF index, and a wrong-class lookup
+     * all return NULL. */
+    r_assert_cmpptr (r_elf_parser_find_reloc_shdr64 (parser, 2), ==, NULL);
+    r_assert_cmpptr (r_elf_parser_find_reloc_shdr64 (parser, 0), ==, NULL);
+    r_assert_cmpptr (r_elf_parser_find_reloc_shdr32 (parser, 1), ==, NULL);
+  }
+
+  r_elf_parser_unref (parser);
 }
 RTEST_END;
 

--- a/test/relf.c
+++ b/test/relf.c
@@ -297,6 +297,159 @@ build_min_dyn_elf64 (ruint8 * buf, ruint8 data)
   return cur;
 }
 
+/* Build a loadable ELF64 (ET_DYN) where vaddr == file offset: one PT_LOAD
+ * covering the file plus a 16-byte zero-initialized bss tail, and a .dynamic
+ * describing .dynsym / .dynstr / .rela.dyn / .rela.plt / .rel.dyn.  The six
+ * .data slots exercise RELATIVE, absolute (X86_64_64), GLOB_DAT, JMP_SLOT
+ * (via DT_JMPREL), an undefined-symbol reloc (left zero), and a REL-form
+ * RELATIVE.  e_entry points into .data.  @p slot_off returns .data's file
+ * offset (== vaddr); returns the file (not image) size. */
+static rsize
+build_min_load_elf64 (ruint8 * buf, ruint8 data, rsize * slot_off)
+{
+  const rboolean be = (data == R_ELF_DATA2MSB);
+  static const rchar dynstr[] = "\0datasym\0undefsym";
+  static const rchar shstr[] =
+      "\0.data\0.dynsym\0.dynstr\0.rela.dyn\0.rela.plt\0.rel.dyn\0.dynamic\0.shstrtab";
+  const ruint32 n_data = 1, n_dynsym = 7, n_dynstr = 15, n_reladyn = 23,
+      n_relaplt = 33, n_reldyn = 43, n_dynamic = 52, n_shstrtab = 61;
+  rsize off_ph, off_data, off_dynsym, off_dynstr, off_rela, off_relplt, off_rel,
+      off_dyn, off_shstr, off_sht, cur;
+  ruint8 * p;
+
+  cur = sizeof (RElf64EHdr);
+  off_ph = cur;     cur += 2 * sizeof (RElf64PHdr);
+  off_data = cur;   cur += 6 * 8;                    /* six 8-byte slots */
+  off_dynsym = cur; cur += 3 * sizeof (RElf64Sym);
+  off_dynstr = cur; cur += sizeof (dynstr);
+  cur = (cur + 7) & ~(rsize)7;
+  off_rela = cur;   cur += 4 * sizeof (RElf64Rela);
+  off_relplt = cur; cur += 1 * sizeof (RElf64Rela);
+  off_rel = cur;    cur += 1 * sizeof (RElf64Rel);
+  off_dyn = cur;    cur += 14 * sizeof (RElf64Dyn);
+  off_shstr = cur;  cur += sizeof (shstr);
+  cur = (cur + 7) & ~(rsize)7;
+  off_sht = cur;    cur += 9 * sizeof (RElf64SHdr);
+
+  r_memset (buf, 0, cur);
+  *slot_off = off_data;
+
+  buf[R_ELF_IDX_MAG0] = R_ELF_MAG0; buf[R_ELF_IDX_MAG1] = R_ELF_MAG1;
+  buf[R_ELF_IDX_MAG2] = R_ELF_MAG2; buf[R_ELF_IDX_MAG3] = R_ELF_MAG3;
+  buf[R_ELF_IDX_CLASS] = R_ELF_CLASS64;
+  buf[R_ELF_IDX_DATA] = data;
+  buf[R_ELF_IDX_VERSION] = R_ELF_VER_CURRENT;
+  w16 (buf + 16, be, R_ELF_ETYPE_DYN);
+  w16 (buf + 18, be, R_ELF_MACHINE_X86_64);
+  w32 (buf + 20, be, R_ELF_VER_CURRENT);
+  w64 (buf + 24, be, off_data);             /* e_entry -> .data */
+  w64 (buf + 32, be, off_ph);
+  w64 (buf + 40, be, off_sht);
+  w16 (buf + 52, be, sizeof (RElf64EHdr));
+  w16 (buf + 54, be, sizeof (RElf64PHdr));
+  w16 (buf + 56, be, 2);
+  w16 (buf + 58, be, sizeof (RElf64SHdr));
+  w16 (buf + 60, be, 9);
+  w16 (buf + 62, be, 8);
+
+  /* PT_LOAD: whole file at vaddr 0 + 16-byte bss tail (memsz > filesz). */
+  p = buf + off_ph;
+  w32 (p +  0, be, R_ELF_PTYPE_LOAD);
+  w32 (p +  4, be, R_ELF_PFLAGS_R | R_ELF_PFLAGS_W);
+  w64 (p +  8, be, 0);
+  w64 (p + 16, be, 0);
+  w64 (p + 24, be, 0);
+  w64 (p + 32, be, cur);                    /* filesz */
+  w64 (p + 40, be, cur + 16);               /* memsz (bss tail) */
+  w64 (p + 48, be, 0x1000);
+  p = buf + off_ph + sizeof (RElf64PHdr);
+  w32 (p +  0, be, R_ELF_PTYPE_DYNAMIC);
+  w32 (p +  4, be, R_ELF_PFLAGS_R | R_ELF_PFLAGS_W);
+  w64 (p +  8, be, off_dyn);
+  w64 (p + 16, be, off_dyn);
+  w64 (p + 24, be, off_dyn);
+  w64 (p + 32, be, 14 * sizeof (RElf64Dyn));
+  w64 (p + 40, be, 14 * sizeof (RElf64Dyn));
+  w64 (p + 48, be, 8);
+
+  /* .dynsym: [1] datasym (defined in .data), [2] undefsym (undefined) */
+  p = buf + off_dynsym + sizeof (RElf64Sym);
+  w32 (p +  0, be, n_data);                 /* reuse offset 1 == "datasym" */
+  p[4] = R_ELF_SYMINFO_CREATE (R_ELF_SYMBIND_GLOBAL, R_ELF_SYMTYPE_OBJECT);
+  w16 (p +  6, be, 1);                      /* shndx -> .data */
+  w64 (p +  8, be, off_data);
+  w64 (p + 16, be, 8);
+  p = buf + off_dynsym + 2 * sizeof (RElf64Sym);
+  w32 (p +  0, be, 9);                      /* "undefsym" */
+  p[4] = R_ELF_SYMINFO_CREATE (R_ELF_SYMBIND_GLOBAL, R_ELF_SYMTYPE_NOTYPE);
+  w16 (p +  6, be, R_ELF_SHN_UNDEF);
+
+  r_memcpy (buf + off_dynstr, dynstr, sizeof (dynstr));
+  r_memcpy (buf + off_shstr, shstr, sizeof (shstr));
+
+  /* .rela.dyn: RELATIVE, absolute, GLOB_DAT (vs datasym), undef (vs undefsym) */
+  p = buf + off_rela;
+  w64 (p +  0, be, off_data + 0 * 8); w64 (p +  8, be, R_ELF_RELTYPE_X86_64_RELATIVE); w64 (p + 16, be, 0x1000);
+  w64 (p + 24, be, off_data + 1 * 8); w64 (p + 32, be, ((ruint64) 1 << 32) | R_ELF_RELTYPE_X86_64_64); w64 (p + 40, be, 0x2);
+  w64 (p + 48, be, off_data + 2 * 8); w64 (p + 56, be, ((ruint64) 1 << 32) | R_ELF_RELTYPE_X86_64_GLOB_DAT); w64 (p + 64, be, 0);
+  w64 (p + 72, be, off_data + 4 * 8); w64 (p + 80, be, ((ruint64) 2 << 32) | R_ELF_RELTYPE_X86_64_64); w64 (p + 88, be, 0);
+
+  /* .rela.plt: JMP_SLOT (vs datasym) */
+  p = buf + off_relplt;
+  w64 (p +  0, be, off_data + 3 * 8); w64 (p +  8, be, ((ruint64) 1 << 32) | R_ELF_RELTYPE_X86_64_JUMP_SLOT); w64 (p + 16, be, 0);
+
+  /* .rel.dyn: REL-form RELATIVE on slot 5 */
+  p = buf + off_rel;
+  w64 (p +  0, be, off_data + 5 * 8); w64 (p +  8, be, R_ELF_RELTYPE_X86_64_RELATIVE);
+
+  /* .dynamic */
+  p = buf + off_dyn;
+  w64 (p +   0, be, R_ELF_DTYPE_SYMTAB);  w64 (p +   8, be, off_dynsym);
+  w64 (p +  16, be, R_ELF_DTYPE_SYMENT);  w64 (p +  24, be, sizeof (RElf64Sym));
+  w64 (p +  32, be, R_ELF_DTYPE_STRTAB);  w64 (p +  40, be, off_dynstr);
+  w64 (p +  48, be, R_ELF_DTYPE_STRSZ);   w64 (p +  56, be, sizeof (dynstr));
+  w64 (p +  64, be, R_ELF_DTYPE_RELA);    w64 (p +  72, be, off_rela);
+  w64 (p +  80, be, R_ELF_DTYPE_RELASZ);  w64 (p +  88, be, 4 * sizeof (RElf64Rela));
+  w64 (p +  96, be, R_ELF_DTYPE_RELAENT); w64 (p + 104, be, sizeof (RElf64Rela));
+  w64 (p + 112, be, R_ELF_DTYPE_REL);     w64 (p + 120, be, off_rel);
+  w64 (p + 128, be, R_ELF_DTYPE_RELSZ);   w64 (p + 136, be, sizeof (RElf64Rel));
+  w64 (p + 144, be, R_ELF_DTYPE_RELENT);  w64 (p + 152, be, sizeof (RElf64Rel));
+  w64 (p + 160, be, R_ELF_DTYPE_JMPREL);  w64 (p + 168, be, off_relplt);
+  w64 (p + 176, be, R_ELF_DTYPE_PLTRELSZ);w64 (p + 184, be, sizeof (RElf64Rela));
+  w64 (p + 192, be, R_ELF_DTYPE_PLTREL);  w64 (p + 200, be, R_ELF_DTYPE_RELA);
+  w64 (p + 208, be, R_ELF_DTYPE_NULL);    w64 (p + 216, be, 0);
+
+  /* section header table */
+  wr_shdr64 (buf + off_sht + 0 * sizeof (RElf64SHdr), be,
+      0, R_ELF_STYPE_NULL, 0, 0, 0, 0, 0, 0, 0, 0);
+  wr_shdr64 (buf + off_sht + 1 * sizeof (RElf64SHdr), be,
+      n_data, R_ELF_STYPE_PROGBITS, R_ELF_SFLAGS_ALLOC | R_ELF_SFLAGS_WRITE,
+      off_data, off_data, 6 * 8, 0, 0, 8, 0);
+  wr_shdr64 (buf + off_sht + 2 * sizeof (RElf64SHdr), be,
+      n_dynsym, R_ELF_STYPE_DYNSYM, R_ELF_SFLAGS_ALLOC, off_dynsym, off_dynsym,
+      3 * sizeof (RElf64Sym), 3, 1, 8, sizeof (RElf64Sym));
+  wr_shdr64 (buf + off_sht + 3 * sizeof (RElf64SHdr), be,
+      n_dynstr, R_ELF_STYPE_STRTAB, R_ELF_SFLAGS_ALLOC, off_dynstr, off_dynstr,
+      sizeof (dynstr), 0, 0, 1, 0);
+  wr_shdr64 (buf + off_sht + 4 * sizeof (RElf64SHdr), be,
+      n_reladyn, R_ELF_STYPE_RELA, R_ELF_SFLAGS_ALLOC, off_rela, off_rela,
+      4 * sizeof (RElf64Rela), 2, 0, 8, sizeof (RElf64Rela));
+  wr_shdr64 (buf + off_sht + 5 * sizeof (RElf64SHdr), be,
+      n_relaplt, R_ELF_STYPE_RELA, R_ELF_SFLAGS_ALLOC, off_relplt, off_relplt,
+      sizeof (RElf64Rela), 2, 1, 8, sizeof (RElf64Rela));
+  wr_shdr64 (buf + off_sht + 6 * sizeof (RElf64SHdr), be,
+      n_reldyn, R_ELF_STYPE_REL, R_ELF_SFLAGS_ALLOC, off_rel, off_rel,
+      sizeof (RElf64Rel), 2, 0, 8, sizeof (RElf64Rel));
+  wr_shdr64 (buf + off_sht + 7 * sizeof (RElf64SHdr), be,
+      n_dynamic, R_ELF_STYPE_DYNAMIC, R_ELF_SFLAGS_WRITE | R_ELF_SFLAGS_ALLOC,
+      off_dyn, off_dyn, 14 * sizeof (RElf64Dyn), 3, 0, 8, sizeof (RElf64Dyn));
+  wr_shdr64 (buf + off_sht + 8 * sizeof (RElf64SHdr), be,
+      n_shstrtab, R_ELF_STYPE_STRTAB, 0, 0, off_shstr, sizeof (shstr),
+      0, 0, 1, 0);
+
+  return cur;
+}
+
 /* Assert the parser produced the known field values, regardless of the
  * source byte order. */
 static void
@@ -631,6 +784,73 @@ RTEST (relf, dynamic, RTEST_FAST)
 
     r_elf_parser_unref (parser);
   }
+}
+RTEST_END;
+
+RTEST (relf, load, RTEST_FAST)
+{
+  ruint8 buf[2048];
+  int i;
+
+  /* Both byte orders: the image is copied from the normalized file view. */
+  for (i = 0; i < 2; i++) {
+    ruint8 enc = (i == 0) ? R_ELF_DATA2LSB : R_ELF_DATA2MSB;
+    RElfParser * parser;
+    RElfImage * img;
+    ruint8 * base;
+    ruint64 * slot, bias;
+    rsize slot_off = 0, k;
+    rsize sz = build_min_load_elf64 (buf, enc, &slot_off);
+
+    r_assert_cmpptr ((parser = r_elf_parser_new_from_mem (buf, sz)), !=, NULL);
+    r_assert_cmpptr ((img = r_elf_parser_load (parser)), !=, NULL);
+
+    r_assert_cmpptr ((base = r_elf_image_get_mem (img)), !=, NULL);
+    r_assert_cmpuint (r_elf_image_get_size (img), ==, sz + 16);
+    bias = (ruint64)(ruintptr) base;        /* image is at vaddr-base 0 */
+    slot = (ruint64 *)(base + slot_off);
+
+    r_assert_cmpuint (slot[0], ==, bias + 0x1000);         /* RELATIVE */
+    r_assert_cmpuint (slot[1], ==, bias + slot_off + 0x2); /* X86_64_64 */
+    r_assert_cmpuint (slot[2], ==, bias + slot_off);       /* GLOB_DAT */
+    r_assert_cmpuint (slot[3], ==, bias + slot_off);       /* JMP_SLOT (plt) */
+    r_assert_cmpuint (slot[4], ==, 0);                     /* undef -> left 0 */
+    r_assert_cmpuint (slot[5], ==, bias);                  /* REL RELATIVE */
+
+    /* The bss tail (past the file image) is zeroed. */
+    for (k = sz; k < sz + 16; k++)
+      r_assert_cmpuint (base[k], ==, 0);
+
+    r_assert_cmpptr (r_elf_image_get_entry (img), ==, base + slot_off);
+    r_assert_cmpptr (r_elf_image_resolve (img, "datasym"), ==, base + slot_off);
+    r_assert_cmpptr (r_elf_image_resolve (img, "undefsym"), ==, NULL);
+    r_assert_cmpptr (r_elf_image_resolve (img, "nope"), ==, NULL);
+
+    r_assert_cmpptr (r_elf_image_ref (img), ==, img);
+    r_elf_image_unref (img);                /* drops the extra ref */
+    r_elf_image_unref (img);
+    r_elf_parser_unref (parser);
+  }
+}
+RTEST_END;
+
+RTEST (relf, load_malformed, RTEST_FAST)
+{
+  ruint8 buf[2048];
+  RElfParser * parser;
+  RElfImage * img;
+  rsize slot_off = 0;
+  rsize sz = build_min_load_elf64 (buf, R_ELF_DATA2LSB, &slot_off);
+
+  /* Shrink the PT_LOAD p_memsz below its p_filesz: the segment copy must be
+   * refused rather than overflow the (now tiny) image. */
+  r_store_le64 (buf + sizeof (RElf64EHdr) + 40, 8);
+
+  r_assert_cmpptr ((parser = r_elf_parser_new_from_mem (buf, sz)), !=, NULL);
+  img = r_elf_parser_load (parser);         /* must not overflow the heap */
+  if (img != NULL)
+    r_elf_image_unref (img);
+  r_elf_parser_unref (parser);
 }
 RTEST_END;
 

--- a/test/relf.c
+++ b/test/relf.c
@@ -1,6 +1,254 @@
 #include <rlib/rbinfmt.h>
 #include "elfobj.inc"
 
+/* Endianness-independent field writers, selecting big- or little-endian
+ * stores so the same builder can emit either byte order. */
+static void w16 (ruint8 * p, rboolean be, rsize v)
+{ if (be) r_store_be16 (p, (ruint16) v); else r_store_le16 (p, (ruint16) v); }
+static void w32 (ruint8 * p, rboolean be, rsize v)
+{ if (be) r_store_be32 (p, (ruint32) v); else r_store_le32 (p, (ruint32) v); }
+static void w64 (ruint8 * p, rboolean be, ruint64 v)
+{ if (be) r_store_be64 (p, v); else r_store_le64 (p, v); }
+
+static void
+wr_shdr64 (ruint8 * p, rboolean be, ruint32 name, ruint32 type, ruint64 flags,
+    ruint64 addr, ruint64 offset, ruint64 size, ruint32 link, ruint32 info,
+    ruint64 addralign, ruint64 entsize)
+{
+  w32 (p +  0, be, name);   w32 (p +  4, be, type);  w64 (p +  8, be, flags);
+  w64 (p + 16, be, addr);   w64 (p + 24, be, offset); w64 (p + 32, be, size);
+  w32 (p + 40, be, link);   w32 (p + 44, be, info);  w64 (p + 48, be, addralign);
+  w64 (p + 56, be, entsize);
+}
+
+/* Build a minimal but self-consistent ELF64 (1 PT_LOAD segment; .text /
+ * .symtab / .rela.text / .strtab / .shstrtab sections) in @p buf, encoded in
+ * the byte order named by @p data.  Returns the image size.  Used as an
+ * independent oracle for the parser's endianness normalization. */
+static rsize
+build_min_elf64 (ruint8 * buf, ruint8 data)
+{
+  const rboolean be = (data == R_ELF_DATA2MSB);
+  static const rchar shstr[] =
+      "\0.text\0.symtab\0.rela.text\0.rel.text\0.note.test\0.strtab\0.shstrtab";
+  static const rchar symstr[] = "\0rfunc";
+  static const rchar note_name[] = "GNU";              /* sizeof == 4 (w/ NUL) */
+  static const ruint8 note_desc[] = { 0xde, 0xad, 0xbe, 0xef };
+  const ruint32 n_text = 1, n_symtab = 7, n_rela = 15, n_rel = 26,
+      n_note = 36, n_strtab = 47, n_shstrtab = 55; /* name offsets within shstr */
+  const rsize note_sz =
+      sizeof (RElf64NHdr) + sizeof (note_name) + sizeof (note_desc);
+  rsize off_ph, off_text, off_shstr, off_symstr, off_symtab, off_rela, off_rel,
+      off_note, off_sht;
+  rsize cur;
+  ruint8 * p;
+
+  cur = sizeof (RElf64EHdr);
+  off_ph = cur;     cur += 2 * sizeof (RElf64PHdr);   /* PT_LOAD + PT_NOTE */
+  off_text = cur;   cur += 4;
+  off_shstr = cur;  cur += sizeof (shstr);
+  off_symstr = cur; cur += sizeof (symstr);
+  cur = (cur + 7) & ~(rsize)7;
+  off_symtab = cur; cur += 2 * sizeof (RElf64Sym);
+  off_rela = cur;   cur += sizeof (RElf64Rela);
+  off_rel = cur;    cur += sizeof (RElf64Rel);
+  off_note = cur;   cur += note_sz;
+  cur = (cur + 7) & ~(rsize)7;
+  off_sht = cur;    cur += 8 * sizeof (RElf64SHdr);
+
+  r_memset (buf, 0, cur);
+
+  /* ELF header */
+  buf[R_ELF_IDX_MAG0] = R_ELF_MAG0; buf[R_ELF_IDX_MAG1] = R_ELF_MAG1;
+  buf[R_ELF_IDX_MAG2] = R_ELF_MAG2; buf[R_ELF_IDX_MAG3] = R_ELF_MAG3;
+  buf[R_ELF_IDX_CLASS] = R_ELF_CLASS64;
+  buf[R_ELF_IDX_DATA] = data;
+  buf[R_ELF_IDX_VERSION] = R_ELF_VER_CURRENT;
+  w16 (buf + 16, be, R_ELF_ETYPE_REL);      /* type */
+  w16 (buf + 18, be, R_ELF_MACHINE_X86_64); /* machine */
+  w32 (buf + 20, be, R_ELF_VER_CURRENT);    /* version */
+  w64 (buf + 24, be, 0);                    /* entry */
+  w64 (buf + 32, be, off_ph);               /* phoff */
+  w64 (buf + 40, be, off_sht);              /* shoff */
+  w32 (buf + 48, be, 0);                    /* flags */
+  w16 (buf + 52, be, sizeof (RElf64EHdr));  /* ehsize */
+  w16 (buf + 54, be, sizeof (RElf64PHdr));  /* phentsize */
+  w16 (buf + 56, be, 2);                    /* phnum */
+  w16 (buf + 58, be, sizeof (RElf64SHdr));  /* shentsize */
+  w16 (buf + 60, be, 8);                    /* shnum */
+  w16 (buf + 62, be, 7);                    /* shstrndx */
+
+  /* Program header (PT_LOAD) */
+  p = buf + off_ph;
+  w32 (p +  0, be, R_ELF_PTYPE_LOAD);       /* type */
+  w32 (p +  4, be, R_ELF_PFLAGS_R | R_ELF_PFLAGS_X); /* flags */
+  w64 (p +  8, be, 0);                      /* offset */
+  w64 (p + 16, be, 0x400000);               /* vaddr */
+  w64 (p + 24, be, 0x400000);               /* paddr */
+  w64 (p + 32, be, cur);                    /* filesz */
+  w64 (p + 40, be, cur);                    /* memsz */
+  w64 (p + 48, be, 0x1000);                 /* align */
+
+  /* Program header (PT_NOTE) aliasing the .note.test section bytes */
+  p = buf + off_ph + sizeof (RElf64PHdr);
+  w32 (p +  0, be, R_ELF_PTYPE_NOTE);       /* type */
+  w32 (p +  4, be, R_ELF_PFLAGS_R);         /* flags */
+  w64 (p +  8, be, off_note);               /* offset */
+  w64 (p + 16, be, 0);                      /* vaddr */
+  w64 (p + 24, be, 0);                      /* paddr */
+  w64 (p + 32, be, note_sz);                /* filesz */
+  w64 (p + 40, be, note_sz);                /* memsz */
+  w64 (p + 48, be, 4);                      /* align */
+
+  /* .text */
+  r_memset (buf + off_text, 0x90, 4);
+
+  /* string tables */
+  r_memcpy (buf + off_shstr, shstr, sizeof (shstr));
+  r_memcpy (buf + off_symstr, symstr, sizeof (symstr));
+
+  /* .symtab: [0] = undefined, [1] = GLOBAL FUNC "rfunc" */
+  p = buf + off_symtab + sizeof (RElf64Sym);
+  w32 (p +  0, be, 1);                      /* name -> "rfunc" */
+  p[4] = R_ELF_SYMINFO_CREATE (R_ELF_SYMBIND_GLOBAL, R_ELF_SYMTYPE_FUNC);
+  p[5] = R_ELF_SYMOTHER_DEFAULT;
+  w16 (p +  6, be, 1);                      /* shndx -> .text */
+  w64 (p +  8, be, 0x100);                  /* value */
+  w64 (p + 16, be, 0x20);                   /* size */
+
+  /* .rela.text: one entry against symbol 1, negative addend */
+  p = buf + off_rela;
+  w64 (p +  0, be, 0x4);                                    /* offset */
+  w64 (p +  8, be, ((ruint64) 1 << 32) | R_ELF_RELTYPE_X86_64_64); /* info */
+  w64 (p + 16, be, (ruint64) (rint64) -8);                 /* addend */
+
+  /* .rel.text: one entry against symbol 1 (no addend) */
+  p = buf + off_rel;
+  w64 (p +  0, be, 0x8);                                    /* offset */
+  w64 (p +  8, be, ((ruint64) 1 << 32) | R_ELF_RELTYPE_X86_64_PC32); /* info */
+
+  /* .note.test: one note (name "GNU", 4-byte descriptor) */
+  p = buf + off_note;
+  w32 (p + 0, be, sizeof (note_name));      /* namesz (incl. NUL) */
+  w32 (p + 4, be, sizeof (note_desc));      /* descsz */
+  w32 (p + 8, be, 1);                       /* type */
+  r_memcpy (p + 12, note_name, sizeof (note_name));
+  r_memcpy (p + 16, note_desc, sizeof (note_desc));
+
+  /* section header table */
+  wr_shdr64 (buf + off_sht + 0 * sizeof (RElf64SHdr), be,
+      0, R_ELF_STYPE_NULL, 0, 0, 0, 0, 0, 0, 0, 0);
+  wr_shdr64 (buf + off_sht + 1 * sizeof (RElf64SHdr), be,
+      n_text, R_ELF_STYPE_PROGBITS, R_ELF_SFLAGS_ALLOC | R_ELF_SFLAGS_EXECINSTR,
+      0, off_text, 4, 0, 0, 1, 0);
+  wr_shdr64 (buf + off_sht + 2 * sizeof (RElf64SHdr), be,
+      n_symtab, R_ELF_STYPE_SYMTAB, 0, 0, off_symtab, 2 * sizeof (RElf64Sym),
+      6, 1, 8, sizeof (RElf64Sym));
+  wr_shdr64 (buf + off_sht + 3 * sizeof (RElf64SHdr), be,
+      n_rela, R_ELF_STYPE_RELA, R_ELF_SFLAGS_INFO_LINK, 0, off_rela,
+      sizeof (RElf64Rela), 2, 1, 8, sizeof (RElf64Rela));
+  wr_shdr64 (buf + off_sht + 4 * sizeof (RElf64SHdr), be,
+      n_rel, R_ELF_STYPE_REL, R_ELF_SFLAGS_INFO_LINK, 0, off_rel,
+      sizeof (RElf64Rel), 2, 1, 8, sizeof (RElf64Rel));
+  wr_shdr64 (buf + off_sht + 5 * sizeof (RElf64SHdr), be,
+      n_note, R_ELF_STYPE_NOTE, 0, 0, off_note, note_sz, 0, 0, 4, 0);
+  wr_shdr64 (buf + off_sht + 6 * sizeof (RElf64SHdr), be,
+      n_strtab, R_ELF_STYPE_STRTAB, 0, 0, off_symstr, sizeof (symstr),
+      0, 0, 1, 0);
+  wr_shdr64 (buf + off_sht + 7 * sizeof (RElf64SHdr), be,
+      n_shstrtab, R_ELF_STYPE_STRTAB, 0, 0, off_shstr, sizeof (shstr),
+      0, 0, 1, 0);
+
+  return cur;
+}
+
+/* Assert the parser produced the known field values, regardless of the
+ * source byte order. */
+static void
+verify_min_elf64 (RElfParser * parser)
+{
+  RElf64EHdr * eh;
+  RElf64PHdr * ph;
+  RElf64SHdr * sh, * symtbl = NULL;
+  RElf64Sym * sym;
+  RElf64Rela * rela;
+
+  r_assert_cmpuint (r_elf_parser_get_class (parser), ==, R_ELF_CLASS64);
+
+  r_assert_cmpptr ((eh = r_elf_parser_get_ehdr64 (parser)), !=, NULL);
+  r_assert_cmpuint (eh->type, ==, R_ELF_ETYPE_REL);
+  r_assert_cmpuint (eh->machine, ==, R_ELF_MACHINE_X86_64);
+  r_assert_cmpuint (eh->phnum, ==, 2);
+  r_assert_cmpuint (eh->shnum, ==, 8);
+  r_assert_cmpuint (eh->shstrndx, ==, 7);
+
+  r_assert_cmpptr ((ph = r_elf_parser_get_phdr64 (parser, 0)), !=, NULL);
+  r_assert_cmpuint (ph->type, ==, R_ELF_PTYPE_LOAD);
+  r_assert_cmpuint (ph->vaddr, ==, 0x400000);
+  r_assert_cmpuint (ph->align, ==, 0x1000);
+
+  r_assert_cmpptr ((sh = r_elf_parser_find_shdr64 (parser, ".text", -1)), !=, NULL);
+  r_assert_cmpuint (sh->type, ==, R_ELF_STYPE_PROGBITS);
+  r_assert_cmpuint (sh->size, ==, 4);
+
+  r_assert_cmpptr ((sh = r_elf_parser_find_shdr64_by_type (parser,
+        R_ELF_STYPE_SYMTAB)), !=, NULL);
+  r_assert_cmpuint (r_elf_parser_symtbl64_sym_count (parser, sh), ==, 2);
+  r_assert_cmpptr ((sym = r_elf_parser_symtbl64_get_sym (parser, sh, 1)), !=, NULL);
+  r_assert_cmpstr (r_elf_parser_symtbl64_sym64_get_name (parser, sh, sym),
+      ==, "rfunc");
+  r_assert_cmpuint (sym->value, ==, 0x100);
+  r_assert_cmpuint (sym->size, ==, 0x20);
+  r_assert_cmpuint (R_ELF_SYMINFO_BIND (sym->info), ==, R_ELF_SYMBIND_GLOBAL);
+  r_assert_cmpuint (R_ELF_SYMINFO_TYPE (sym->info), ==, R_ELF_SYMTYPE_FUNC);
+  r_assert_cmpuint (sym->shndx, ==, 1);
+
+  r_assert_cmpptr ((sh = r_elf_parser_find_shdr64_by_type (parser,
+        R_ELF_STYPE_RELA)), !=, NULL);
+  r_assert_cmpuint (r_elf_parser_relatbl64_rela_count (parser, sh), ==, 1);
+  r_assert_cmpptr ((rela = r_elf_parser_relatbl64_get_rela (parser, sh, 0)), !=, NULL);
+  r_assert_cmpuint (rela->offset, ==, 0x4);
+  r_assert_cmpuint (R_ELF64_RELINFO_SYM (rela->info), ==, 1);
+  r_assert_cmpuint (R_ELF64_RELINFO_TYPE (rela->info), ==, R_ELF_RELTYPE_X86_64_64);
+  r_assert_cmpint (rela->addend, ==, -8);
+  r_assert_cmpptr ((sym = r_elf_parser_rela64_get_sym (parser, sh, rela, &symtbl)),
+      !=, NULL);
+  r_assert_cmpstr (r_elf_parser_symtbl64_sym64_get_name (parser, symtbl, sym),
+      ==, "rfunc");
+}
+
+RTEST (relf, endianness, RTEST_FAST)
+{
+  ruint8 le[1024], be[1024], be_copy[1024];
+  RElfParser * parser;
+  rsize sz_le, sz_be;
+
+  sz_le = build_min_elf64 (le, R_ELF_DATA2LSB);
+  sz_be = build_min_elf64 (be, R_ELF_DATA2MSB);
+  r_assert_cmpuint (sz_le, ==, sz_be);
+  r_memcpy (be_copy, be, sz_be);
+
+  /* calc_size is endianness-aware and agrees across byte orders. */
+  r_assert_cmpuint (r_elf_calc_size (le), ==, sz_le);
+  r_assert_cmpuint (r_elf_calc_size (be), ==, sz_be);
+
+  /* Native little-endian image: parsed in place, identical field values. */
+  r_assert_cmpptr ((parser = r_elf_parser_new_from_mem (le, sz_le)), !=, NULL);
+  r_assert_cmpuint (r_elf_parser_get_data (parser), ==, R_ELF_DATA2LSB);
+  verify_min_elf64 (parser);
+  r_elf_parser_unref (parser);
+
+  /* Non-native big-endian image: normalized on a private copy, same values. */
+  r_assert_cmpptr ((parser = r_elf_parser_new_from_mem (be, sz_be)), !=, NULL);
+  r_assert_cmpuint (r_elf_parser_get_data (parser), ==, R_ELF_DATA2MSB);
+  verify_min_elf64 (parser);
+  r_elf_parser_unref (parser);
+
+  /* The caller's big-endian buffer must be left untouched (we copy). */
+  r_assert_cmpint (r_memcmp (be, be_copy, sz_be), ==, 0);
+}
+RTEST_END;
+
 RTEST (relf, calc_size, RTEST_FAST)
 {
   ruint8 bad_elf[] = { 0xBA, 0xDE, 0x1F, 0x01, 0xBA, 0xDE, 0x1F, 0x02 };

--- a/test/relf.c
+++ b/test/relf.c
@@ -216,6 +216,87 @@ build_min_note_elf64 (ruint8 * buf, ruint8 data)
   return cur;
 }
 
+/* Build a shared-object-style ELF64 with a PT_DYNAMIC segment plus .dynamic /
+ * .dynstr sections (DT_NEEDED, DT_SONAME, DT_STRTAB, DT_STRSZ, DT_NULL), in
+ * the byte order named by @p data.  Returns the image size. */
+static rsize
+build_min_dyn_elf64 (ruint8 * buf, ruint8 data)
+{
+  const rboolean be = (data == R_ELF_DATA2MSB);
+  static const rchar dynstr[] = "\0libc.so.6\0mylib.so";
+  static const rchar shstr[] = "\0.dynstr\0.dynamic\0.shstrtab";
+  const ruint32 n_needed = 1, n_soname = 11;          /* offsets in dynstr */
+  const ruint32 n_dynstr = 1, n_dynamic = 9, n_shstrtab = 18; /* offsets in shstr */
+  const rsize dynsz = 5 * sizeof (RElf64Dyn);
+  rsize off_ph, off_dynstr, off_dyn, off_shstr, off_sht, cur;
+  ruint8 * p;
+
+  cur = sizeof (RElf64EHdr);
+  off_ph = cur;     cur += sizeof (RElf64PHdr);
+  off_dynstr = cur; cur += sizeof (dynstr);
+  cur = (cur + 7) & ~(rsize)7;
+  off_dyn = cur;    cur += dynsz;
+  off_shstr = cur;  cur += sizeof (shstr);
+  cur = (cur + 7) & ~(rsize)7;
+  off_sht = cur;    cur += 4 * sizeof (RElf64SHdr);
+
+  r_memset (buf, 0, cur);
+
+  buf[R_ELF_IDX_MAG0] = R_ELF_MAG0; buf[R_ELF_IDX_MAG1] = R_ELF_MAG1;
+  buf[R_ELF_IDX_MAG2] = R_ELF_MAG2; buf[R_ELF_IDX_MAG3] = R_ELF_MAG3;
+  buf[R_ELF_IDX_CLASS] = R_ELF_CLASS64;
+  buf[R_ELF_IDX_DATA] = data;
+  buf[R_ELF_IDX_VERSION] = R_ELF_VER_CURRENT;
+  w16 (buf + 16, be, R_ELF_ETYPE_DYN);      /* type */
+  w16 (buf + 18, be, R_ELF_MACHINE_X86_64); /* machine */
+  w32 (buf + 20, be, R_ELF_VER_CURRENT);    /* version */
+  w64 (buf + 32, be, off_ph);               /* phoff */
+  w64 (buf + 40, be, off_sht);              /* shoff */
+  w16 (buf + 52, be, sizeof (RElf64EHdr));  /* ehsize */
+  w16 (buf + 54, be, sizeof (RElf64PHdr));  /* phentsize */
+  w16 (buf + 56, be, 1);                    /* phnum */
+  w16 (buf + 58, be, sizeof (RElf64SHdr));  /* shentsize */
+  w16 (buf + 60, be, 4);                    /* shnum */
+  w16 (buf + 62, be, 3);                    /* shstrndx */
+
+  /* Program header (PT_DYNAMIC) pointing at the .dynamic section */
+  p = buf + off_ph;
+  w32 (p +  0, be, R_ELF_PTYPE_DYNAMIC);    /* type */
+  w32 (p +  4, be, R_ELF_PFLAGS_R | R_ELF_PFLAGS_W); /* flags */
+  w64 (p +  8, be, off_dyn);                /* offset */
+  w64 (p + 16, be, off_dyn);                /* vaddr */
+  w64 (p + 24, be, off_dyn);                /* paddr */
+  w64 (p + 32, be, dynsz);                  /* filesz */
+  w64 (p + 40, be, dynsz);                  /* memsz */
+  w64 (p + 48, be, 8);                      /* align */
+
+  r_memcpy (buf + off_dynstr, dynstr, sizeof (dynstr));
+  r_memcpy (buf + off_shstr, shstr, sizeof (shstr));
+
+  /* .dynamic entries */
+  p = buf + off_dyn;
+  w64 (p +  0, be, R_ELF_DTYPE_NEEDED); w64 (p +  8, be, n_needed);
+  w64 (p + 16, be, R_ELF_DTYPE_SONAME); w64 (p + 24, be, n_soname);
+  w64 (p + 32, be, R_ELF_DTYPE_STRTAB); w64 (p + 40, be, off_dynstr);
+  w64 (p + 48, be, R_ELF_DTYPE_STRSZ);  w64 (p + 56, be, sizeof (dynstr));
+  w64 (p + 64, be, R_ELF_DTYPE_NULL);   w64 (p + 72, be, 0);
+
+  /* section header table */
+  wr_shdr64 (buf + off_sht + 0 * sizeof (RElf64SHdr), be,
+      0, R_ELF_STYPE_NULL, 0, 0, 0, 0, 0, 0, 0, 0);
+  wr_shdr64 (buf + off_sht + 1 * sizeof (RElf64SHdr), be,
+      n_dynstr, R_ELF_STYPE_STRTAB, R_ELF_SFLAGS_ALLOC, 0, off_dynstr,
+      sizeof (dynstr), 0, 0, 1, 0);
+  wr_shdr64 (buf + off_sht + 2 * sizeof (RElf64SHdr), be,
+      n_dynamic, R_ELF_STYPE_DYNAMIC, R_ELF_SFLAGS_WRITE | R_ELF_SFLAGS_ALLOC,
+      0, off_dyn, dynsz, 1, 0, 8, sizeof (RElf64Dyn));
+  wr_shdr64 (buf + off_sht + 3 * sizeof (RElf64SHdr), be,
+      n_shstrtab, R_ELF_STYPE_STRTAB, 0, 0, off_shstr, sizeof (shstr),
+      0, 0, 1, 0);
+
+  return cur;
+}
+
 /* Assert the parser produced the known field values, regardless of the
  * source byte order. */
 static void
@@ -493,6 +574,60 @@ RTEST (relf, note_segment, RTEST_FAST)
     r_assert_cmpuint (dsize, ==, 4);
     r_assert_cmpuint (desc[0], ==, 0x01);
     r_assert_cmpuint (desc[3], ==, 0x04);
+
+    r_elf_parser_unref (parser);
+  }
+}
+RTEST_END;
+
+RTEST (relf, dynamic, RTEST_FAST)
+{
+  ruint8 buf[512];
+  int i;
+
+  /* Run both byte orders so DYNAMIC-entry normalization is covered. */
+  for (i = 0; i < 2; i++) {
+    ruint8 enc = (i == 0) ? R_ELF_DATA2LSB : R_ELF_DATA2MSB;
+    RElfParser * parser;
+    RElf64SHdr * dyn;
+    RElf64Dyn * d;
+    rsize sz = build_min_dyn_elf64 (buf, enc);
+
+    r_assert_cmpptr ((parser = r_elf_parser_new_from_mem (buf, sz)), !=, NULL);
+
+    r_assert_cmpptr ((dyn = r_elf_parser_find_shdr64_by_type (parser,
+          R_ELF_STYPE_DYNAMIC)), !=, NULL);
+    r_assert_cmpstr (r_elf_parser_shdr64_get_name (parser, dyn), ==, ".dynamic");
+    r_assert_cmpuint (r_elf_parser_dyntbl64_dyn_count (parser, dyn), ==, 5);
+
+    r_assert_cmpptr ((d = r_elf_parser_dyntbl64_get_dyn (parser, dyn, 0)),
+        !=, NULL);
+    r_assert_cmpint (d->tag, ==, R_ELF_DTYPE_NEEDED);
+    /* Out-of-range index yields no entry. */
+    r_assert_cmpptr (r_elf_parser_dyntbl64_get_dyn (parser, dyn, 5), ==, NULL);
+
+    /* String-valued tags resolve through the linked .dynstr. */
+    r_assert_cmpptr ((d = r_elf_parser_dyntbl64_find_dyn_by_tag (parser, dyn,
+          R_ELF_DTYPE_SONAME)), !=, NULL);
+    r_assert_cmpstr (r_elf_parser_dyn64_get_str (parser, dyn, d), ==, "mylib.so");
+    r_assert_cmpptr ((d = r_elf_parser_dyntbl64_find_dyn_by_tag (parser, dyn,
+          R_ELF_DTYPE_NEEDED)), !=, NULL);
+    r_assert_cmpstr (r_elf_parser_dyn64_get_str (parser, dyn, d), ==, "libc.so.6");
+
+    /* Integer-valued tag. */
+    r_assert_cmpptr ((d = r_elf_parser_dyntbl64_find_dyn_by_tag (parser, dyn,
+          R_ELF_DTYPE_STRSZ)), !=, NULL);
+    r_assert_cmpuint (d->un.val, ==, 20);
+
+    /* Absent tag and wrong-class lookups yield nothing. */
+    r_assert_cmpptr (r_elf_parser_dyntbl64_find_dyn_by_tag (parser, dyn,
+          R_ELF_DTYPE_RPATH), ==, NULL);
+    r_assert_cmpuint (r_elf_parser_dyntbl32_dyn_count (parser,
+          (RElf32SHdr *) dyn), ==, 0);
+
+    /* PT_DYNAMIC segment is found too. */
+    r_assert_cmpptr (r_elf_parser_find_phdr64_by_type (parser,
+          R_ELF_PTYPE_DYNAMIC), !=, NULL);
 
     r_elf_parser_unref (parser);
   }


### PR DESCRIPTION
Rounds out `RElfParser` across the #228 roadmap, with no breaking changes to
the existing accessors.

## What's added

- **Non-native-endianness reading** — a non-native ELF is normalized to host
  byte order on a private copy at parse time (header, program/section tables,
  and the symbol/relocation/note/dynamic entries they describe); native ELFs
  take the same path as before. `r_elf_calc_size` is endianness-aware too.
- **REL relocations + find-reloc** — the previously stubbed REL (no-addend)
  accessors mirroring RELA, plus `r_elf_parser_find_reloc_shdr32/64` to locate
  the REL/RELA section whose `sh_info` targets a given section.
- **Program-header API** — `find_phdr32/64_by_type` and
  `phdr32/64_get_data` (bounds-checked; allows a segment at `p_offset == 0`).
- **Note API** — iterate notes in a `SHT_NOTE` section or a `PT_NOTE` segment
  and slice each note's name and descriptor.
- **Dynamic-section API** — `DT_*` tag constants and `dyntbl32/64` accessors
  (count / get / find-by-tag) over `.dynamic`, plus `dyn*_get_str` to resolve
  string-valued tags (`DT_SONAME`, `DT_NEEDED`, ...) through the linked
  string table.
- **Single-object image loader** — `r_elf_parser_load` maps an object's
  `PT_LOAD` segments, zeroes the bss tail, and applies the object's own
  relocations (RELATIVE / absolute / GLOB_DAT / JMP_SLOT); `r_elf_image_resolve`
  resolves a defined dynamic symbol's address in the image.

## Tests

Programmatic little-/big-endian builders (using independent `r_store_*` stores
as an oracle) exercise every accessor in both byte orders, including positive
32-bit (i386) parse coverage, comprehensive loader relocation coverage (bss
zeroing, undefined symbols, entry point), and a malformed-input regression for
the loader's segment-copy bounds check.

Verified: full suite green under epoll, rpoll and ASan+UBSan; mingw cross
`-Werror` clean; Doxygen 0 warnings.

## Out of scope

Recursive `DT_NEEDED` dependency loading and cross-object symbol binding
(runtime-linker behaviour) are intentionally excluded — that is not a parser
library's concern. In-process loading is 64-bit only by design: a 32-bit
object's relocation slots cannot hold a 64-bit host address, so it parses but
does not load in-process.

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)
