### PR TITLE
net/rtp: RTCP serialization and RTP padding/extension/feedback

### DIFF
--- a/include/rlib/net/proto/rrtp.h
+++ b/include/rlib/net/proto/rrtp.h
@@ -136,6 +136,14 @@ R_API rboolean r_rtp_buffer_unmap (RRTPBuffer * rtp, RBuffer * buf);
 /* READ / getters */
 /** @brief @c TRUE if the padding bit is set. */
 R_API rboolean r_rtp_buffer_has_padding (const RRTPBuffer * rtp);
+/**
+ * @brief Number of trailing padding octets when the padding bit is set, else 0.
+ *
+ * The count is the packet's last octet (RFC 3550 §5.1, which counts itself),
+ * taken verbatim; for malformed input it may exceed the payload, so treat it
+ * as advisory (@ref r_rtp_buffer_map already clamps the payload mapping).
+ */
+R_API ruint8 r_rtp_buffer_get_padding (const RRTPBuffer * rtp);
 /** @brief @c TRUE if the extension bit is set. */
 R_API rboolean r_rtp_buffer_has_extension (const RRTPBuffer * rtp);
 /** @brief @c TRUE if the marker bit is set. */
@@ -166,7 +174,6 @@ R_API void r_rtp_buffer_set_seq (RRTPBuffer * rtp, ruint16 seq);
 R_API void r_rtp_buffer_set_timestamp (RRTPBuffer * rtp, ruint32 ts);
 /** @brief Set the @p n-th contributing source (CSRC) identifier. */
 R_API rboolean r_rtp_buffer_set_csrc (RRTPBuffer * rtp, ruint8 n, ruint32 csrc);
-/* TODO: padding */
 /* TODO: extension */
 
 

--- a/include/rlib/net/proto/rrtp.h
+++ b/include/rlib/net/proto/rrtp.h
@@ -337,6 +337,17 @@ R_API rboolean r_rtcp_buffer_add_sr (RBuffer * buf, const RRTCPSenderInfo * srin
  * @return @c TRUE on success.
  */
 R_API rboolean r_rtcp_buffer_add_rr (RBuffer * buf, ruint32 ssrc, const RRTCPReportBlock * rb, ruint8 nrb);
+/**
+ * @brief Append a Source Description (SDES) packet with a single chunk.
+ * @param buf     Compound RTCP buffer to append to.
+ * @param ssrc    The chunk's SSRC/CSRC.
+ * @param items   Array of @p nitems SDES items (@c type / @c len / @c data).
+ * @param nitems  Number of items (0 produces an empty chunk).
+ * @return @c TRUE on success.
+ *
+ * Builds one chunk (source count 1); call again to describe further sources.
+ */
+R_API rboolean r_rtcp_buffer_add_sdes (RBuffer * buf, ruint32 ssrc, const RRTCPSDESItem * items, ruint8 nitems);
 
 /** @brief Map @p buf into @p rtcp for packet iteration. */
 R_API rboolean r_rtcp_buffer_map (RRTCPBuffer * rtcp, RBuffer * buf, RMemMapFlags flags);

--- a/include/rlib/net/proto/rrtp.h
+++ b/include/rlib/net/proto/rrtp.h
@@ -348,6 +348,26 @@ R_API rboolean r_rtcp_buffer_add_rr (RBuffer * buf, ruint32 ssrc, const RRTCPRep
  * Builds one chunk (source count 1); call again to describe further sources.
  */
 R_API rboolean r_rtcp_buffer_add_sdes (RBuffer * buf, ruint32 ssrc, const RRTCPSDESItem * items, ruint8 nitems);
+/**
+ * @brief Append a BYE packet.
+ * @param buf     Compound RTCP buffer to append to.
+ * @param ssrcs   Array of @p nssrc leaving SSRCs.
+ * @param nssrc   Number of SSRCs (0..31).
+ * @param reason  Optional NUL-terminated reason-for-leaving (<= 255 bytes), or @c NULL.
+ * @return @c TRUE on success.
+ */
+R_API rboolean r_rtcp_buffer_add_bye (RBuffer * buf, const ruint32 * ssrcs, ruint8 nssrc, const rchar * reason);
+/**
+ * @brief Append an APP (application-defined) packet.
+ * @param buf      Compound RTCP buffer to append to.
+ * @param subtype  Application subtype (0..31).
+ * @param ssrc     SSRC/CSRC of the source.
+ * @param name     4-octet application name.
+ * @param data     Application data (@p size bytes), or @c NULL.
+ * @param size     Application data size; must be a multiple of 4.
+ * @return @c TRUE on success.
+ */
+R_API rboolean r_rtcp_buffer_add_app (RBuffer * buf, ruint8 subtype, ruint32 ssrc, const rchar name[4], const ruint8 * data, ruint16 size);
 
 /** @brief Map @p buf into @p rtcp for packet iteration. */
 R_API rboolean r_rtcp_buffer_map (RRTCPBuffer * rtcp, RBuffer * buf, RMemMapFlags flags);

--- a/include/rlib/net/proto/rrtp.h
+++ b/include/rlib/net/proto/rrtp.h
@@ -368,6 +368,18 @@ R_API rboolean r_rtcp_buffer_add_bye (RBuffer * buf, const ruint32 * ssrcs, ruin
  * @return @c TRUE on success.
  */
 R_API rboolean r_rtcp_buffer_add_app (RBuffer * buf, ruint8 subtype, ruint32 ssrc, const rchar name[4], const ruint8 * data, ruint16 size);
+/**
+ * @brief Append a feedback (RTPFB or PSFB) packet (RFC 4585).
+ * @param buf      Compound RTCP buffer to append to.
+ * @param pt       @c R_RTCP_PT_RTPFB or @c R_RTCP_PT_PSFB.
+ * @param fmt      Feedback message type (0..31; see @ref RRTCPRTPFBType / @ref RRTCPPSFBType).
+ * @param sender   SSRC of the feedback sender.
+ * @param media    SSRC of the media source.
+ * @param fci      Feedback Control Information (@p fcisize bytes), or @c NULL.
+ * @param fcisize  FCI size; must be a multiple of 4.
+ * @return @c TRUE on success.
+ */
+R_API rboolean r_rtcp_buffer_add_fb (RBuffer * buf, RRTCPPacketType pt, ruint8 fmt, ruint32 sender, ruint32 media, const ruint8 * fci, ruint16 fcisize);
 
 /** @brief Map @p buf into @p rtcp for packet iteration. */
 R_API rboolean r_rtcp_buffer_map (RRTCPBuffer * rtcp, RBuffer * buf, RMemMapFlags flags);
@@ -452,7 +464,37 @@ R_API const rchar * r_rtcp_packet_app_get_name (const RRTCPPacket * packet);
 /** @brief Return the application-defined data of an APP @p packet; @p size receives its length. */
 R_API const ruint8 * r_rtcp_packet_app_get_data (const RRTCPPacket * packet, ruint16 * size);
 
-/* TODO: Feedback */
+
+/* RTCP feedback (RTPFB / PSFB) -- RFC 4585 / 5104.  The feedback message type
+ * (FMT) is carried in the packet's count field; the body is the sender SSRC,
+ * the media-source SSRC and type-specific Feedback Control Information (FCI). */
+/** @brief Transport-layer (RTPFB) feedback message type. */
+typedef enum {
+  R_RTCP_RTPFB_FMT_NACK   = 1,    /**< Generic NACK (RFC 4585). */
+  R_RTCP_RTPFB_FMT_TMMBR  = 3,    /**< Temporary Max Media Bitrate Request (RFC 5104). */
+  R_RTCP_RTPFB_FMT_TMMBN  = 4,    /**< Temporary Max Media Bitrate Notification (RFC 5104). */
+} RRTCPRTPFBType;
+
+/** @brief Payload-specific (PSFB) feedback message type. */
+typedef enum {
+  R_RTCP_PSFB_FMT_PLI   = 1,      /**< Picture Loss Indication (RFC 4585). */
+  R_RTCP_PSFB_FMT_SLI   = 2,      /**< Slice Loss Indication. */
+  R_RTCP_PSFB_FMT_RPSI  = 3,      /**< Reference Picture Selection Indication. */
+  R_RTCP_PSFB_FMT_FIR   = 4,      /**< Full Intra Request (RFC 5104). */
+  R_RTCP_PSFB_FMT_TSTR  = 5,      /**< Temporal-Spatial Trade-off Request. */
+  R_RTCP_PSFB_FMT_TSTN  = 6,      /**< Temporal-Spatial Trade-off Notification. */
+  R_RTCP_PSFB_FMT_VBCM  = 7,      /**< Video Back Channel Message. */
+  R_RTCP_PSFB_FMT_AFB   = 15,     /**< Application Layer Feedback. */
+} RRTCPPSFBType;
+
+/** @brief Feedback message type (FMT) of an RTPFB/PSFB @p packet, else 0. */
+R_API ruint8 r_rtcp_packet_fb_get_fmt (const RRTCPPacket * packet);
+/** @brief SSRC of the feedback packet sender. */
+R_API ruint32 r_rtcp_packet_fb_get_sender_ssrc (const RRTCPPacket * packet);
+/** @brief SSRC of the media source the feedback refers to. */
+R_API ruint32 r_rtcp_packet_fb_get_media_ssrc (const RRTCPPacket * packet);
+/** @brief Pointer to the Feedback Control Information; @p size receives its length. */
+R_API const ruint8 * r_rtcp_packet_fb_get_fci (const RRTCPPacket * packet, ruint16 * size);
 
 R_END_DECLS
 

--- a/include/rlib/net/proto/rrtp.h
+++ b/include/rlib/net/proto/rrtp.h
@@ -24,7 +24,8 @@
 
 /**
  * @file rlib/net/proto/rrtp.h
- * @brief RTP / RTCP (RFC 3550) packet validation, header access and parsing.
+ * @brief RTP / RTCP (RFC 3550): packet validation, header access, parsing and
+ * serialization.
  */
 
 #include <rlib/rtypes.h>
@@ -211,12 +212,13 @@ R_API ruint64 r_rtp_buffer_estimate_seq_idx (RRTPBuffer * rtp, ruint64 curidx);
  * @defgroup r_rtcp RTCP / SDES
  * @ingroup r_net
  *
- * @brief Parse RTCP compound packets (RFC 3550) over an @ref RBuffer.
+ * @brief Parse and build RTCP compound packets (RFC 3550) over an @ref RBuffer.
  *
  * An @ref RRTCPBuffer maps an @ref RBuffer with @ref r_rtcp_buffer_map and
  * iterates its packets via @ref r_rtcp_buffer_get_next_packet. Per
  * packet type, accessors decode Sender/Receiver Reports, Source
- * Description (SDES) chunks and items, BYE and APP packets.
+ * Description (SDES) chunks and items, BYE and APP packets; the
+ * @c r_rtcp_buffer_add_* helpers build the same packet types.
  *
  * @{
  */
@@ -312,7 +314,29 @@ typedef struct {
 /** @brief Static initialiser for an empty @ref RRTCPSDESItem. */
 #define R_RTCP_SDES_ITEM_INIT     { R_RTCP_SDES_UNKNOWN, 0, NULL }
 
-/* TODO: Add construction/writing of RTCP buffers and packets */
+/* WRITE / construction
+ *
+ * RTCP packets are appended to a plain @ref RBuffer (start with
+ * @ref r_buffer_new); each @c r_rtcp_buffer_add_* call appends one packet,
+ * forming a compound buffer readable with @ref r_rtcp_buffer_map. */
+/**
+ * @brief Append a Sender Report (SR) packet.
+ * @param buf     Compound RTCP buffer to append to.
+ * @param srinfo  Sender info (its @c ssrc is the report sender).
+ * @param rb      Array of @p nrb reception report blocks (may be @c NULL if 0).
+ * @param nrb     Number of report blocks (0..31).
+ * @return @c TRUE on success.
+ */
+R_API rboolean r_rtcp_buffer_add_sr (RBuffer * buf, const RRTCPSenderInfo * srinfo, const RRTCPReportBlock * rb, ruint8 nrb);
+/**
+ * @brief Append a Receiver Report (RR) packet.
+ * @param buf   Compound RTCP buffer to append to.
+ * @param ssrc  SSRC of the report sender.
+ * @param rb    Array of @p nrb reception report blocks (may be @c NULL if 0).
+ * @param nrb   Number of report blocks (0..31).
+ * @return @c TRUE on success.
+ */
+R_API rboolean r_rtcp_buffer_add_rr (RBuffer * buf, ruint32 ssrc, const RRTCPReportBlock * rb, ruint8 nrb);
 
 /** @brief Map @p buf into @p rtcp for packet iteration. */
 R_API rboolean r_rtcp_buffer_map (RRTCPBuffer * rtcp, RBuffer * buf, RMemMapFlags flags);

--- a/include/rlib/net/proto/rrtp.h
+++ b/include/rlib/net/proto/rrtp.h
@@ -127,6 +127,17 @@ R_API RBuffer * r_buffer_new_rtp_buffer (RBuffer * payload, ruint8 pad, ruint8 c
 R_API RBuffer * r_buffer_new_rtp_buffer_take (rpointer payload, rsize size, ruint8 pad, ruint8 cc);
 /** @brief Allocate a new RTP buffer with a @p payload-byte payload, @p pad padding and @p cc CSRC entries. */
 R_API RBuffer * r_buffer_new_rtp_buffer_alloc (rsize payload, ruint8 pad, ruint8 cc);
+/**
+ * @brief Allocate a new RTP buffer carrying a header extension.
+ * @param payload  Payload buffer to wrap.
+ * @param pad      Number of trailing padding octets (0 for none).
+ * @param cc       Number of CSRC entries (0..15).
+ * @param profile  The 16-bit profile-defined field of the extension.
+ * @param extdata  Extension payload (@p extsize bytes), or @c NULL to zero-fill.
+ * @param extsize  Extension payload size; must be a multiple of 4 (RFC 3550 5.3.1).
+ * @return New buffer, or @c NULL on bad arguments / allocation failure.
+ */
+R_API RBuffer * r_buffer_new_rtp_buffer_ext (RBuffer * payload, ruint8 pad, ruint8 cc, ruint16 profile, rconstpointer extdata, rsize extsize);
 
 /** @brief Map @p buf into @p rtp for header/payload access. */
 R_API rboolean r_rtp_buffer_map (RRTPBuffer * rtp, RBuffer * buf, RMemMapFlags flags);
@@ -146,6 +157,15 @@ R_API rboolean r_rtp_buffer_has_padding (const RRTPBuffer * rtp);
 R_API ruint8 r_rtp_buffer_get_padding (const RRTPBuffer * rtp);
 /** @brief @c TRUE if the extension bit is set. */
 R_API rboolean r_rtp_buffer_has_extension (const RRTPBuffer * rtp);
+/**
+ * @brief Read the header extension's profile field, data pointer and size.
+ * @param rtp      The mapped RTP buffer.
+ * @param profile  Out: the 16-bit profile-defined field. Pass @c NULL to skip.
+ * @param data     Out: pointer to the extension data (past the 4-byte header).
+ * @param size     Out: extension data size in bytes (a multiple of 4).
+ * @return @c TRUE if an extension is present, else @c FALSE.
+ */
+R_API rboolean r_rtp_buffer_get_extension (const RRTPBuffer * rtp, ruint16 * profile, const ruint8 ** data, ruint16 * size);
 /** @brief @c TRUE if the marker bit is set. */
 R_API rboolean r_rtp_buffer_has_marker (const RRTPBuffer * rtp);
 /** @brief Return the synchronisation source (SSRC) identifier. */
@@ -174,7 +194,6 @@ R_API void r_rtp_buffer_set_seq (RRTPBuffer * rtp, ruint16 seq);
 R_API void r_rtp_buffer_set_timestamp (RRTPBuffer * rtp, ruint32 ts);
 /** @brief Set the @p n-th contributing source (CSRC) identifier. */
 R_API rboolean r_rtp_buffer_set_csrc (RRTPBuffer * rtp, ruint8 n, ruint32 csrc);
-/* TODO: extension */
 
 
 /** @brief Extend a 16-bit sequence number @p seq to a 48-bit index, given the current index @p curidx. */

--- a/rlib/net/proto/rrtcp.c
+++ b/rlib/net/proto/rrtcp.c
@@ -398,3 +398,121 @@ r_rtcp_packet_app_get_data (const RRTCPPacket * packet, ruint16 * size)
   return NULL;
 }
 
+
+/* ------------------------------------------------------------------------- *
+ * RTCP serialization
+ *
+ * Packets are appended to a plain RBuffer (one RMem segment each), producing
+ * a compound buffer with the same on-wire layout the parser above reads back.
+ * ------------------------------------------------------------------------- */
+
+#define R_RTCP_REPORT_BLOCK_SIZE  (6 * sizeof (ruint32))
+
+/* Append [v=2 p=0 c=count | pt | len | body]; bodylen is a whole word count. */
+static rboolean
+r_rtcp_append (RBuffer * buf, ruint8 pt, ruint8 count,
+    const ruint8 * body, rsize bodylen)
+{
+  RRTCPPacket * h;
+  RMem * mem;
+  ruint8 * pkt;
+  rsize total, words;
+  rboolean res;
+
+  if (R_UNLIKELY (buf == NULL || (bodylen & 0x3) != 0))
+    return FALSE;
+  total = sizeof (ruint32) + bodylen;
+  words = total / sizeof (ruint32);
+  if (R_UNLIKELY (words == 0 || words - 1 > 0xffff))
+    return FALSE;
+  if (R_UNLIKELY ((pkt = r_malloc0 (total)) == NULL))
+    return FALSE;
+
+  h = (RRTCPPacket *)pkt;
+  h->v = R_RTP_VERSION;
+  h->p = 0;
+  h->c = count;
+  h->pt = pt;
+  h->len = RUINT16_TO_BE ((ruint16)(words - 1));
+  if (bodylen > 0 && body != NULL)
+    r_memcpy (pkt + sizeof (ruint32), body, bodylen);
+
+  if (R_UNLIKELY ((mem = r_mem_new_take (R_MEM_FLAG_NONE, pkt, total, total, 0)) == NULL)) {
+    r_free (pkt);
+    return FALSE;
+  }
+  res = r_buffer_mem_append (buf, mem);
+  r_mem_unref (mem);
+  return res;
+}
+
+static void
+r_rtcp_write_report_block (ruint8 * p, const RRTCPReportBlock * rb)
+{
+  r_store_be32 (&p[0],  rb->ssrc);
+  r_store_be32 (&p[4],  ((ruint32)rb->fractionlost << 24) |
+      ((ruint32)rb->packetslost & 0x00ffffff));
+  r_store_be32 (&p[8],  rb->exthighestseq);
+  r_store_be32 (&p[12], rb->jitter);
+  r_store_be32 (&p[16], rb->lsr);
+  r_store_be32 (&p[20], rb->dlsr);
+}
+
+rboolean
+r_rtcp_buffer_add_sr (RBuffer * buf, const RRTCPSenderInfo * srinfo,
+    const RRTCPReportBlock * rb, ruint8 nrb)
+{
+  ruint8 * body;
+  rsize bodylen;
+  rboolean res;
+  ruint8 i;
+
+  if (R_UNLIKELY (buf == NULL || srinfo == NULL || nrb > 0x1f))
+    return FALSE;
+  if (R_UNLIKELY (nrb > 0 && rb == NULL))
+    return FALSE;
+
+  /* sender info: ssrc + ntp(2 words) + rtptime + packets + bytes = 6 words */
+  bodylen = 6 * sizeof (ruint32) + (rsize)nrb * R_RTCP_REPORT_BLOCK_SIZE;
+  if (R_UNLIKELY ((body = r_malloc0 (bodylen)) == NULL))
+    return FALSE;
+
+  r_store_be32 (&body[0],  srinfo->ssrc);
+  r_store_be64 (&body[4],  srinfo->ntptime);
+  r_store_be32 (&body[12], srinfo->rtptime);
+  r_store_be32 (&body[16], srinfo->packets);
+  r_store_be32 (&body[20], srinfo->bytes);
+  for (i = 0; i < nrb; i++)
+    r_rtcp_write_report_block (&body[24 + (rsize)i * R_RTCP_REPORT_BLOCK_SIZE], &rb[i]);
+
+  res = r_rtcp_append (buf, R_RTCP_PT_SR, nrb, body, bodylen);
+  r_free (body);
+  return res;
+}
+
+rboolean
+r_rtcp_buffer_add_rr (RBuffer * buf, ruint32 ssrc,
+    const RRTCPReportBlock * rb, ruint8 nrb)
+{
+  ruint8 * body;
+  rsize bodylen;
+  rboolean res;
+  ruint8 i;
+
+  if (R_UNLIKELY (buf == NULL || nrb > 0x1f))
+    return FALSE;
+  if (R_UNLIKELY (nrb > 0 && rb == NULL))
+    return FALSE;
+
+  bodylen = sizeof (ruint32) + (rsize)nrb * R_RTCP_REPORT_BLOCK_SIZE;
+  if (R_UNLIKELY ((body = r_malloc0 (bodylen)) == NULL))
+    return FALSE;
+
+  r_store_be32 (&body[0], ssrc);
+  for (i = 0; i < nrb; i++)
+    r_rtcp_write_report_block (&body[4 + (rsize)i * R_RTCP_REPORT_BLOCK_SIZE], &rb[i]);
+
+  res = r_rtcp_append (buf, R_RTCP_PT_RR, nrb, body, bodylen);
+  r_free (body);
+  return res;
+}

--- a/rlib/net/proto/rrtcp.c
+++ b/rlib/net/proto/rrtcp.c
@@ -19,6 +19,8 @@
 #include "config.h"
 #include <rlib/net/proto/rrtp.h>
 
+#include <rlib/rstr.h>
+
 #define R_RTCP_MINSIZE                (2 * sizeof (ruint32))
 #define r_rtcp_packet_end(packet) (((const ruint8 *)packet) + r_rtcp_packet_get_length (packet))
 
@@ -557,6 +559,74 @@ r_rtcp_buffer_add_sdes (RBuffer * buf, ruint32 ssrc,
   /* The trailing bytes (terminator + padding) are already zero. */
 
   res = r_rtcp_append (buf, R_RTCP_PT_SDES, 1, body, bodylen);
+  r_free (body);
+  return res;
+}
+
+rboolean
+r_rtcp_buffer_add_bye (RBuffer * buf, const ruint32 * ssrcs, ruint8 nssrc,
+    const rchar * reason)
+{
+  ruint8 * body;
+  rsize bodylen, rlen = 0, off;
+  rboolean res;
+  ruint8 i;
+
+  if (R_UNLIKELY (buf == NULL || nssrc > 0x1f))
+    return FALSE;
+  if (R_UNLIKELY (nssrc > 0 && ssrcs == NULL))
+    return FALSE;
+  if (reason != NULL) {
+    rlen = r_strlen (reason);
+    if (R_UNLIKELY (rlen > 0xff))
+      return FALSE;
+  }
+
+  bodylen = (rsize)nssrc * sizeof (ruint32);
+  if (reason != NULL)               /* length octet + text, padded to 32 bits */
+    bodylen += ((1 + rlen) + 3) & ~(rsize)3;
+  if (R_UNLIKELY ((body = r_malloc0 (bodylen)) == NULL))
+    return FALSE;
+
+  for (i = 0; i < nssrc; i++)
+    r_store_be32 (&body[(rsize)i * sizeof (ruint32)], ssrcs[i]);
+  if (reason != NULL) {
+    off = (rsize)nssrc * sizeof (ruint32);
+    body[off++] = (ruint8) rlen;
+    if (rlen > 0)
+      r_memcpy (&body[off], reason, rlen);
+  }
+
+  res = r_rtcp_append (buf, R_RTCP_PT_BYE, nssrc, body, bodylen);
+  r_free (body);
+  return res;
+}
+
+rboolean
+r_rtcp_buffer_add_app (RBuffer * buf, ruint8 subtype, ruint32 ssrc,
+    const rchar name[4], const ruint8 * data, ruint16 size)
+{
+  ruint8 * body;
+  rsize bodylen;
+  rboolean res;
+
+  if (R_UNLIKELY (buf == NULL || subtype > 0x1f || name == NULL))
+    return FALSE;
+  if (R_UNLIKELY ((size & 0x3) != 0))   /* application data is 32-bit aligned */
+    return FALSE;
+  if (R_UNLIKELY (size > 0 && data == NULL))
+    return FALSE;
+
+  bodylen = 2 * sizeof (ruint32) + size;   /* ssrc + 4-octet name + data */
+  if (R_UNLIKELY ((body = r_malloc0 (bodylen)) == NULL))
+    return FALSE;
+
+  r_store_be32 (&body[0], ssrc);
+  r_memcpy (&body[sizeof (ruint32)], name, 4);
+  if (size > 0)
+    r_memcpy (&body[2 * sizeof (ruint32)], data, size);
+
+  res = r_rtcp_append (buf, R_RTCP_PT_APP, subtype, body, bodylen);
   r_free (body);
   return res;
 }

--- a/rlib/net/proto/rrtcp.c
+++ b/rlib/net/proto/rrtcp.c
@@ -516,3 +516,47 @@ r_rtcp_buffer_add_rr (RBuffer * buf, ruint32 ssrc,
   r_free (body);
   return res;
 }
+
+rboolean
+r_rtcp_buffer_add_sdes (RBuffer * buf, ruint32 ssrc,
+    const RRTCPSDESItem * items, ruint8 nitems)
+{
+  ruint8 * body;
+  rsize bodylen, itemsbytes = 0, off;
+  rboolean res;
+  ruint8 i;
+
+  if (R_UNLIKELY (buf == NULL))
+    return FALSE;
+  if (R_UNLIKELY (nitems > 0 && items == NULL))
+    return FALSE;
+  for (i = 0; i < nitems; i++) {
+    if (R_UNLIKELY (items[i].type < R_RTCP_SDES_CNAME ||
+            items[i].type >= R_RTCP_SDES_MAX))
+      return FALSE;
+    if (R_UNLIKELY (items[i].len > 0 && items[i].data == NULL))
+      return FALSE;
+    itemsbytes += 2u + items[i].len;
+  }
+
+  /* chunk = ssrc + items + >=1 null terminator, padded to a 32-bit boundary. */
+  bodylen = sizeof (ruint32) + (((itemsbytes + 1) + 3) & ~(rsize)3);
+  if (R_UNLIKELY ((body = r_malloc0 (bodylen)) == NULL))
+    return FALSE;
+
+  r_store_be32 (&body[0], ssrc);
+  off = sizeof (ruint32);
+  for (i = 0; i < nitems; i++) {
+    body[off++] = (ruint8) items[i].type;
+    body[off++] = items[i].len;
+    if (items[i].len > 0) {
+      r_memcpy (&body[off], items[i].data, items[i].len);
+      off += items[i].len;
+    }
+  }
+  /* The trailing bytes (terminator + padding) are already zero. */
+
+  res = r_rtcp_append (buf, R_RTCP_PT_SDES, 1, body, bodylen);
+  r_free (body);
+  return res;
+}

--- a/rlib/net/proto/rrtcp.c
+++ b/rlib/net/proto/rrtcp.c
@@ -630,3 +630,79 @@ r_rtcp_buffer_add_app (RBuffer * buf, ruint8 subtype, ruint32 ssrc,
   r_free (body);
   return res;
 }
+
+#define r_rtcp_packet_is_fb(p) \
+  (r_rtcp_packet_get_type (p) == R_RTCP_PT_RTPFB || \
+   r_rtcp_packet_get_type (p) == R_RTCP_PT_PSFB)
+
+ruint8
+r_rtcp_packet_fb_get_fmt (const RRTCPPacket * packet)
+{
+  return r_rtcp_packet_is_fb (packet) ? r_rtcp_packet_get_count (packet) : 0;
+}
+
+ruint32
+r_rtcp_packet_fb_get_sender_ssrc (const RRTCPPacket * packet)
+{
+  if (r_rtcp_packet_is_fb (packet) &&
+      r_rtcp_packet_get_length (packet) >= 3 * sizeof (ruint32))
+    return RUINT32_FROM_BE (*(const ruint32 *)&packet->data[0]);
+  return 0;
+}
+
+ruint32
+r_rtcp_packet_fb_get_media_ssrc (const RRTCPPacket * packet)
+{
+  if (r_rtcp_packet_is_fb (packet) &&
+      r_rtcp_packet_get_length (packet) >= 3 * sizeof (ruint32))
+    return RUINT32_FROM_BE (*(const ruint32 *)&packet->data[sizeof (ruint32)]);
+  return 0;
+}
+
+const ruint8 *
+r_rtcp_packet_fb_get_fci (const RRTCPPacket * packet, ruint16 * size)
+{
+  if (r_rtcp_packet_is_fb (packet)) {
+    ruint len = r_rtcp_packet_get_length (packet);
+    if (len >= 3 * sizeof (ruint32)) {
+      if (size != NULL)
+        *size = (ruint16)(len - 3 * sizeof (ruint32));
+      return &packet->data[2 * sizeof (ruint32)];
+    }
+  }
+
+  if (size != NULL)
+    *size = 0;
+  return NULL;
+}
+
+rboolean
+r_rtcp_buffer_add_fb (RBuffer * buf, RRTCPPacketType pt, ruint8 fmt,
+    ruint32 sender, ruint32 media, const ruint8 * fci, ruint16 fcisize)
+{
+  ruint8 * body;
+  rsize bodylen;
+  rboolean res;
+
+  if (R_UNLIKELY (buf == NULL || fmt > 0x1f))
+    return FALSE;
+  if (R_UNLIKELY (pt != R_RTCP_PT_RTPFB && pt != R_RTCP_PT_PSFB))
+    return FALSE;
+  if (R_UNLIKELY ((fcisize & 0x3) != 0))    /* FCI is 32-bit aligned */
+    return FALSE;
+  if (R_UNLIKELY (fcisize > 0 && fci == NULL))
+    return FALSE;
+
+  bodylen = 2 * sizeof (ruint32) + fcisize;  /* sender + media + FCI */
+  if (R_UNLIKELY ((body = r_malloc0 (bodylen)) == NULL))
+    return FALSE;
+
+  r_store_be32 (&body[0], sender);
+  r_store_be32 (&body[sizeof (ruint32)], media);
+  if (fcisize > 0)
+    r_memcpy (&body[2 * sizeof (ruint32)], fci, fcisize);
+
+  res = r_rtcp_append (buf, (ruint8) pt, fmt, body, bodylen);
+  r_free (body);
+  return res;
+}

--- a/rlib/net/proto/rrtp.c
+++ b/rlib/net/proto/rrtp.c
@@ -252,6 +252,30 @@ r_rtp_buffer_has_padding (const RRTPBuffer * rtp)
   return hdr->p;
 }
 
+ruint8
+r_rtp_buffer_get_padding (const RRTPBuffer * rtp)
+{
+  const RRTPHdr * hdr;
+  rsize total;
+  ruint8 pad = 0;
+
+  if (R_UNLIKELY (rtp == NULL || rtp->hdr.data == NULL || rtp->buffer == NULL))
+    return 0;
+  hdr = (const RRTPHdr *)rtp->hdr.data;
+  if (!hdr->p)
+    return 0;
+
+  /* The pad count is the packet's last octet regardless of how the payload was
+   * mapped (it may be excluded from rtp->pay), so read it from the buffer. */
+  total = r_buffer_get_size (rtp->buffer);
+  if (R_UNLIKELY (total == 0))
+    return 0;
+  if (R_UNLIKELY (r_buffer_extract (rtp->buffer, total - 1, &pad, 1) != 1))
+    return 0;
+
+  return pad;
+}
+
 rboolean
 r_rtp_buffer_has_extension (const RRTPBuffer * rtp)
 {

--- a/rlib/net/proto/rrtp.c
+++ b/rlib/net/proto/rrtp.c
@@ -75,13 +75,18 @@ r_rtp_is_valid_hdr (rconstpointer buf, rsize size)
   return size >= minsize;
 }
 
-RBuffer *
-r_buffer_new_rtp_buffer (RBuffer * payload, ruint8 pad, ruint8 cc)
+static RBuffer *
+r_rtp_new (RBuffer * payload, ruint8 pad, ruint8 cc, rboolean ext,
+    ruint16 profile, rconstpointer extdata, rsize extsize)
 {
   RBuffer * ret;
 
   if (R_UNLIKELY (payload == NULL)) return NULL;
   if (R_UNLIKELY (cc > 0x0f)) return NULL;
+  /* The extension is a whole number of 32-bit words, counted by a 16-bit
+   * length field (RFC 3550 5.3.1). */
+  if (R_UNLIKELY (ext && ((extsize & 0x3) != 0 ||
+          extsize > (rsize)0xffff * sizeof (ruint32)))) return NULL;
 
   if ((ret = r_buffer_new ()) != NULL) {
     RRTPHdr * hdr;
@@ -95,7 +100,7 @@ r_buffer_new_rtp_buffer (RBuffer * payload, ruint8 pad, ruint8 cc)
 
     hdr->v = R_RTP_VERSION;
     hdr->p = pad > 0 ? 1 : 0;
-    hdr->x = 0;
+    hdr->x = ext ? 1 : 0;
     hdr->cc = cc;
     if (R_UNLIKELY ((mem = r_mem_new_take (R_MEM_FLAG_NONE, hdr, size, size, 0)) == NULL)) {
       r_free (hdr);
@@ -106,6 +111,30 @@ r_buffer_new_rtp_buffer (RBuffer * payload, ruint8 pad, ruint8 cc)
     r_mem_unref (mem);
     if (R_UNLIKELY (!res))
       goto error;
+
+    if (ext) {
+      ruint8 * e;
+
+      size = sizeof (ruint32) + extsize;     /* profile+length word, then data */
+      if (R_UNLIKELY ((e = r_malloc0 (size)) == NULL))
+        goto error;
+
+      *(ruint16 *)&e[0] = RUINT16_TO_BE (profile);
+      *(ruint16 *)&e[sizeof (ruint16)] =
+          RUINT16_TO_BE ((ruint16)(extsize / sizeof (ruint32)));
+      if (extsize > 0 && extdata != NULL)
+        r_memcpy (e + sizeof (ruint32), extdata, extsize);
+
+      if (R_UNLIKELY ((mem = r_mem_new_take (R_MEM_FLAG_NONE, e, size, size, 0)) == NULL)) {
+        r_free (e);
+        goto error;
+      }
+
+      res = r_buffer_mem_append (ret, mem);
+      r_mem_unref (mem);
+      if (R_UNLIKELY (!res))
+        goto error;
+    }
 
     if (R_UNLIKELY (!r_buffer_append_mem_from_buffer (ret, payload)))
       goto error;
@@ -134,6 +163,19 @@ r_buffer_new_rtp_buffer (RBuffer * payload, ruint8 pad, ruint8 cc)
 error:
   r_buffer_unref (ret);
   return NULL;
+}
+
+RBuffer *
+r_buffer_new_rtp_buffer (RBuffer * payload, ruint8 pad, ruint8 cc)
+{
+  return r_rtp_new (payload, pad, cc, FALSE, 0, NULL, 0);
+}
+
+RBuffer *
+r_buffer_new_rtp_buffer_ext (RBuffer * payload, ruint8 pad, ruint8 cc,
+    ruint16 profile, rconstpointer extdata, rsize extsize)
+{
+  return r_rtp_new (payload, pad, cc, TRUE, profile, extdata, extsize);
 }
 
 RBuffer *
@@ -281,6 +323,30 @@ r_rtp_buffer_has_extension (const RRTPBuffer * rtp)
 {
   const RRTPHdr * hdr = (const RRTPHdr *)rtp->hdr.data;
   return hdr->x;
+}
+
+rboolean
+r_rtp_buffer_get_extension (const RRTPBuffer * rtp, ruint16 * profile,
+    const ruint8 ** data, ruint16 * size)
+{
+  const RRTPHdr * hdr;
+
+  if (R_UNLIKELY (rtp == NULL || rtp->hdr.data == NULL))
+    return FALSE;
+  hdr = (const RRTPHdr *)rtp->hdr.data;
+  if (!hdr->x || rtp->ext.data == NULL || rtp->ext.size < sizeof (ruint32))
+    return FALSE;
+
+  /* ext region: [profile(16) | length-in-words(16) | data...]; the mapped
+   * size already accounts for length, so data is everything past the word. */
+  if (profile != NULL)
+    *profile = RUINT16_FROM_BE (*(const ruint16 *)rtp->ext.data);
+  if (data != NULL)
+    *data = rtp->ext.data + sizeof (ruint32);
+  if (size != NULL)
+    *size = (ruint16)(rtp->ext.size - sizeof (ruint32));
+
+  return TRUE;
 }
 
 rboolean

--- a/test/rrtp.c
+++ b/test/rrtp.c
@@ -52,6 +52,51 @@ RTEST (rrtp, is_valid_hdr, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rrtcp, sdes_two_items_wire, RTEST_FAST)
+{
+  /* SDES chunk with two items (CNAME + TOOL). */
+  static const ruint8 golden[] = {
+    0x81, 0xca, 0x00, 0x04,                          /* V2 SC1, PT=SDES, len=4 */
+    0xca, 0xfe, 0xf0, 0x0d,                          /* chunk ssrc */
+    0x01, 0x03, 0x61, 0x62, 0x63,                    /* CNAME "abc" */
+    0x06, 0x04, 0x72, 0x6c, 0x69, 0x62,              /* TOOL "rlib" */
+    0x00                                             /* terminator (already word-aligned) */
+  };
+  static const ruint8 cname[] = "abc";
+  static const ruint8 tool[] = "rlib";
+  RRTCPSDESItem items[2];
+  RBuffer * buf;
+  RRTCPBuffer rtcp = R_RTCP_BUFFER_INIT;
+  RRTCPPacket * pkt;
+  RRTCPSDESChunk * chunk;
+  RRTCPSDESItem item = R_RTCP_SDES_ITEM_INIT;
+
+  items[0].type = R_RTCP_SDES_CNAME; items[0].len = 3; items[0].data = (ruint8 *) cname;
+  items[1].type = R_RTCP_SDES_TOOL;  items[1].len = 4; items[1].data = (ruint8 *) tool;
+
+  r_assert_cmpptr ((buf = r_buffer_new ()), !=, NULL);
+  r_assert (r_rtcp_buffer_add_sdes (buf, 0xcafef00d, items, 2));
+  r_assert_cmpbufmem (buf, 0, -1, ==, golden, sizeof (golden));
+  r_buffer_unref (buf);
+
+  r_assert_cmpptr ((buf = r_buffer_new_dup (golden, sizeof (golden))), !=, NULL);
+  r_assert (r_rtcp_buffer_map (&rtcp, buf, R_MEM_MAP_READ));
+  r_assert_cmpptr ((pkt = r_rtcp_buffer_get_next_packet (&rtcp, NULL)), !=, NULL);
+  r_assert_cmpuint (r_rtcp_packet_get_type (pkt), ==, R_RTCP_PT_SDES);
+  r_assert_cmpptr ((chunk = r_rtcp_packet_sdes_get_next_chunk (pkt, NULL)), !=, NULL);
+  r_assert_cmphex (r_rtcp_packet_sdes_chunk_get_ssrc (pkt, chunk), ==, 0xcafef00d);
+  r_assert_cmpint (r_rtcp_packet_sdes_chunk_get_next_item (pkt, chunk, &item), ==, R_RTCP_PARSE_OK);
+  r_assert_cmpuint (item.type, ==, R_RTCP_SDES_CNAME);
+  r_assert_cmpmem (item.data, ==, cname, 3);
+  r_assert_cmpint (r_rtcp_packet_sdes_chunk_get_next_item (pkt, chunk, &item), ==, R_RTCP_PARSE_OK);
+  r_assert_cmpuint (item.type, ==, R_RTCP_SDES_TOOL);
+  r_assert_cmpmem (item.data, ==, tool, 4);
+  r_assert_cmpint (r_rtcp_packet_sdes_chunk_get_next_item (pkt, chunk, &item), ==, R_RTCP_PARSE_ZERO);
+  r_assert (r_rtcp_buffer_unmap (&rtcp, buf));
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
 RTEST (rrtcp, sr_sender_only_wire, RTEST_FAST)
 {
   /* SR with no report blocks (RC=0): serialize to exact wire bytes, and parse
@@ -671,6 +716,45 @@ RTEST (rrtcp, write_sr_rr_compound, RTEST_FAST)
   r_assert_cmpint (grb.packetslost, ==, rb.packetslost);
 
   r_assert_cmpptr (r_rtcp_buffer_get_next_packet (&rtcp, pkt), ==, NULL);
+
+  r_assert (r_rtcp_buffer_unmap (&rtcp, buf));
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
+RTEST (rrtcp, write_sdes, RTEST_FAST)
+{
+  /* Build a single-chunk SDES with a CNAME item and read it back. */
+  RBuffer * buf;
+  RRTCPBuffer rtcp = R_RTCP_BUFFER_INIT;
+  RRTCPPacket * pkt;
+  RRTCPSDESChunk * chunk;
+  RRTCPSDESItem item = R_RTCP_SDES_ITEM_INIT;
+  static const ruint8 cname[] = "alice@example";
+  RRTCPSDESItem items[1];
+
+  items[0].type = R_RTCP_SDES_CNAME;
+  items[0].len = sizeof (cname) - 1;
+  items[0].data = (ruint8 *) cname;
+
+  r_assert_cmpptr ((buf = r_buffer_new ()), !=, NULL);
+  r_assert (r_rtcp_buffer_add_sdes (buf, 0xcafef00d, items, 1));
+
+  r_assert (r_rtcp_buffer_map (&rtcp, buf, R_MEM_MAP_READ));
+  r_assert_cmpptr ((pkt = r_rtcp_buffer_get_next_packet (&rtcp, NULL)), !=, NULL);
+  r_assert_cmpuint (r_rtcp_packet_get_type (pkt), ==, R_RTCP_PT_SDES);
+  r_assert_cmpuint (r_rtcp_packet_get_count (pkt), ==, 1);
+
+  r_assert_cmpptr ((chunk = r_rtcp_packet_sdes_get_next_chunk (pkt, NULL)), !=, NULL);
+  r_assert_cmphex (r_rtcp_packet_sdes_chunk_get_ssrc (pkt, chunk), ==, 0xcafef00d);
+  r_assert_cmpint (r_rtcp_packet_sdes_chunk_get_next_item (pkt, chunk, &item),
+      ==, R_RTCP_PARSE_OK);
+  r_assert_cmpuint (item.type, ==, R_RTCP_SDES_CNAME);
+  r_assert_cmpuint (item.len, ==, sizeof (cname) - 1);
+  r_assert_cmpmem (item.data, ==, cname, sizeof (cname) - 1);
+  /* the list terminates */
+  r_assert_cmpint (r_rtcp_packet_sdes_chunk_get_next_item (pkt, chunk, &item),
+      ==, R_RTCP_PARSE_ZERO);
 
   r_assert (r_rtcp_buffer_unmap (&rtcp, buf));
   r_buffer_unref (buf);

--- a/test/rrtp.c
+++ b/test/rrtp.c
@@ -52,6 +52,73 @@ RTEST (rrtp, is_valid_hdr, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rrtcp, bye_no_reason_wire, RTEST_FAST)
+{
+  /* BYE with a single SSRC and no reason string. */
+  static const ruint8 golden[] = {
+    0x81, 0xcb, 0x00, 0x01,                          /* V2 SC1, PT=BYE, len=1 */
+    0x11, 0x11, 0x11, 0x11                           /* ssrc */
+  };
+  ruint32 ssrcs[1] = { 0x11111111 };
+  RBuffer * buf;
+  RRTCPBuffer rtcp = R_RTCP_BUFFER_INIT;
+  RRTCPPacket * pkt;
+  ruint8 rlen = 0xaa;
+
+  r_assert_cmpptr ((buf = r_buffer_new ()), !=, NULL);
+  r_assert (r_rtcp_buffer_add_bye (buf, ssrcs, 1, NULL));
+  r_assert_cmpbufmem (buf, 0, -1, ==, golden, sizeof (golden));
+  r_buffer_unref (buf);
+
+  r_assert_cmpptr ((buf = r_buffer_new_dup (golden, sizeof (golden))), !=, NULL);
+  r_assert (r_rtcp_buffer_map (&rtcp, buf, R_MEM_MAP_READ));
+  r_assert_cmpptr ((pkt = r_rtcp_buffer_get_next_packet (&rtcp, NULL)), !=, NULL);
+  r_assert_cmpuint (r_rtcp_packet_get_type (pkt), ==, R_RTCP_PT_BYE);
+  r_assert_cmpuint (r_rtcp_packet_bye_get_ssrc_count (pkt), ==, 1);
+  r_assert_cmphex (r_rtcp_packet_bye_get_ssrc (pkt, 0), ==, 0x11111111);
+  /* no reason present */
+  r_assert_cmpint (r_rtcp_packet_bye_get_reason (pkt, NULL, 0, &rlen), ==, R_RTCP_PARSE_ZERO);
+  r_assert_cmpuint (rlen, ==, 0);
+  r_assert (r_rtcp_buffer_unmap (&rtcp, buf));
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
+RTEST (rrtcp, app_wire, RTEST_FAST)
+{
+  static const ruint8 golden[] = {
+    0x83, 0xcc, 0x00, 0x04,                          /* V2 subtype=3, PT=APP, len=4 */
+    0x33, 0x33, 0x33, 0x33,                          /* ssrc */
+    0x50, 0x49, 0x4e, 0x47,                          /* "PING" */
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08   /* data */
+  };
+  static const ruint8 appdata[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+  RBuffer * buf;
+  RRTCPBuffer rtcp = R_RTCP_BUFFER_INIT;
+  RRTCPPacket * pkt;
+  const ruint8 * adata;
+  ruint16 asize = 0;
+
+  r_assert_cmpptr ((buf = r_buffer_new ()), !=, NULL);
+  r_assert (r_rtcp_buffer_add_app (buf, 3, 0x33333333, "PING", appdata, sizeof (appdata)));
+  r_assert_cmpbufmem (buf, 0, -1, ==, golden, sizeof (golden));
+  r_buffer_unref (buf);
+
+  r_assert_cmpptr ((buf = r_buffer_new_dup (golden, sizeof (golden))), !=, NULL);
+  r_assert (r_rtcp_buffer_map (&rtcp, buf, R_MEM_MAP_READ));
+  r_assert_cmpptr ((pkt = r_rtcp_buffer_get_next_packet (&rtcp, NULL)), !=, NULL);
+  r_assert_cmpuint (r_rtcp_packet_get_type (pkt), ==, R_RTCP_PT_APP);
+  r_assert_cmpuint (r_rtcp_packet_get_count (pkt), ==, 3);
+  r_assert_cmphex (r_rtcp_packet_app_get_ssrc (pkt), ==, 0x33333333);
+  r_assert_cmpmem (r_rtcp_packet_app_get_name (pkt), ==, "PING", 4);
+  r_assert_cmpptr ((adata = r_rtcp_packet_app_get_data (pkt, &asize)), !=, NULL);
+  r_assert_cmpuint (asize, ==, sizeof (appdata));
+  r_assert_cmpmem (adata, ==, appdata, sizeof (appdata));
+  r_assert (r_rtcp_buffer_unmap (&rtcp, buf));
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
 RTEST (rrtcp, sdes_two_items_wire, RTEST_FAST)
 {
   /* SDES chunk with two items (CNAME + TOOL). */
@@ -755,6 +822,51 @@ RTEST (rrtcp, write_sdes, RTEST_FAST)
   /* the list terminates */
   r_assert_cmpint (r_rtcp_packet_sdes_chunk_get_next_item (pkt, chunk, &item),
       ==, R_RTCP_PARSE_ZERO);
+
+  r_assert (r_rtcp_buffer_unmap (&rtcp, buf));
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
+RTEST (rrtcp, write_bye_app, RTEST_FAST)
+{
+  /* Build a BYE (with reason) + APP compound and read it back. */
+  RBuffer * buf;
+  RRTCPBuffer rtcp = R_RTCP_BUFFER_INIT;
+  RRTCPPacket * pkt;
+  ruint32 ssrcs[2] = { 0x11111111, 0x22222222 };
+  static const rchar reason[] = "bye now";
+  static const ruint8 appdata[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+  rchar rbuf[32];
+  ruint8 rlen = 0;
+  const ruint8 * adata;
+  ruint16 asize = 0;
+
+  r_assert_cmpptr ((buf = r_buffer_new ()), !=, NULL);
+  r_assert (r_rtcp_buffer_add_bye (buf, ssrcs, 2, reason));
+  r_assert (r_rtcp_buffer_add_app (buf, 3, 0x33333333, "PING", appdata, sizeof (appdata)));
+
+  r_assert (r_rtcp_buffer_map (&rtcp, buf, R_MEM_MAP_READ));
+  r_assert_cmpuint (r_rtcp_buffer_get_packet_count (&rtcp), ==, 2);
+
+  r_assert_cmpptr ((pkt = r_rtcp_buffer_get_next_packet (&rtcp, NULL)), !=, NULL);
+  r_assert_cmpuint (r_rtcp_packet_get_type (pkt), ==, R_RTCP_PT_BYE);
+  r_assert_cmpuint (r_rtcp_packet_bye_get_ssrc_count (pkt), ==, 2);
+  r_assert_cmphex (r_rtcp_packet_bye_get_ssrc (pkt, 0), ==, 0x11111111);
+  r_assert_cmphex (r_rtcp_packet_bye_get_ssrc (pkt, 1), ==, 0x22222222);
+  r_assert_cmpint (r_rtcp_packet_bye_get_reason (pkt, rbuf, sizeof (rbuf), &rlen),
+      ==, R_RTCP_PARSE_OK);
+  r_assert_cmpuint (rlen, ==, sizeof (reason) - 1);
+  r_assert_cmpstr (rbuf, ==, reason);
+
+  r_assert_cmpptr ((pkt = r_rtcp_buffer_get_next_packet (&rtcp, pkt)), !=, NULL);
+  r_assert_cmpuint (r_rtcp_packet_get_type (pkt), ==, R_RTCP_PT_APP);
+  r_assert_cmpuint (r_rtcp_packet_get_count (pkt), ==, 3);   /* subtype */
+  r_assert_cmphex (r_rtcp_packet_app_get_ssrc (pkt), ==, 0x33333333);
+  r_assert_cmpmem (r_rtcp_packet_app_get_name (pkt), ==, "PING", 4);
+  r_assert_cmpptr ((adata = r_rtcp_packet_app_get_data (pkt, &asize)), !=, NULL);
+  r_assert_cmpuint (asize, ==, sizeof (appdata));
+  r_assert_cmpmem (adata, ==, appdata, sizeof (appdata));
 
   r_assert (r_rtcp_buffer_unmap (&rtcp, buf));
   r_buffer_unref (buf);

--- a/test/rrtp.c
+++ b/test/rrtp.c
@@ -105,6 +105,7 @@ RTEST (rrtp, read_plain_hdr_pcmu_payload, RTEST_FAST)
   r_assert_cmpuint (rtp.hdr.size + rtp.ext.size + rtp.pay.size, ==, sizeof (pkt_rtp_pcmu));
 
   r_assert (!r_rtp_buffer_has_padding (&rtp));
+  r_assert_cmpuint (r_rtp_buffer_get_padding (&rtp), ==, 0);
   r_assert (!r_rtp_buffer_has_extension (&rtp));
   r_assert (r_rtp_buffer_has_marker (&rtp));
 
@@ -133,8 +134,31 @@ RTEST (rrtp, padding_underflow, RTEST_FAST)
   r_assert_cmpptr ((buf = r_buffer_new_dup (pkt, sizeof (pkt))), !=, NULL);
   r_assert (r_rtp_buffer_map (&rtp, buf, R_MEM_MAP_READ));
   r_assert (r_rtp_buffer_has_padding (&rtp));
+  r_assert_cmpuint (r_rtp_buffer_get_padding (&rtp), ==, 0xff);  /* verbatim */
   r_assert_cmpuint (rtp.pay.size, <=, 2);
   r_assert (r_rtp_buffer_unmap (&rtp, buf));
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
+RTEST (rrtp, padding_count, RTEST_FAST)
+{
+  /* A constructed packet with N padding octets reports N, and the payload
+   * mapping excludes them. */
+  RBuffer * buf, * payload;
+  RRTPBuffer rtp = R_RTP_BUFFER_INIT;
+  ruint8 data[4] = { 1, 2, 3, 4 };
+
+  r_assert_cmpptr ((payload = r_buffer_new_dup (data, sizeof (data))), !=, NULL);
+  r_assert_cmpptr ((buf = r_buffer_new_rtp_buffer (payload, 5, 0)), !=, NULL);
+  r_buffer_unref (payload);
+
+  r_assert (r_rtp_buffer_map (&rtp, buf, R_MEM_MAP_READ));
+  r_assert (r_rtp_buffer_has_padding (&rtp));
+  r_assert_cmpuint (r_rtp_buffer_get_padding (&rtp), ==, 5);
+  r_assert_cmpuint (rtp.pay.size, ==, sizeof (data));
+  r_assert (r_rtp_buffer_unmap (&rtp, buf));
+
   r_buffer_unref (buf);
 }
 RTEST_END;

--- a/test/rrtp.c
+++ b/test/rrtp.c
@@ -52,6 +52,55 @@ RTEST (rrtp, is_valid_hdr, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rrtcp, feedback_pli_nack_wire, RTEST_FAST)
+{
+  /* PSFB/PLI (no FCI) followed by RTPFB/Generic-NACK (one FCI entry). */
+  static const ruint8 golden[] = {
+    0x81, 0xce, 0x00, 0x02,                          /* PSFB FMT=PLI, len=2 */
+    0xaa, 0xaa, 0x00, 0x01,                          /* sender */
+    0xbb, 0xbb, 0x00, 0x02,                          /* media */
+    0x81, 0xcd, 0x00, 0x03,                          /* RTPFB FMT=NACK, len=3 */
+    0xaa, 0xaa, 0x00, 0x01,                          /* sender */
+    0xbb, 0xbb, 0x00, 0x02,                          /* media */
+    0x12, 0x34, 0x00, 0xff                           /* FCI: PID, BLP */
+  };
+  ruint8 nackfci[4];
+  RBuffer * buf;
+  RRTCPBuffer rtcp = R_RTCP_BUFFER_INIT;
+  RRTCPPacket * pkt;
+  const ruint8 * fci;
+  ruint16 fcisize = 0;
+
+  r_store_be16 (&nackfci[0], 0x1234);
+  r_store_be16 (&nackfci[2], 0x00ff);
+
+  r_assert_cmpptr ((buf = r_buffer_new ()), !=, NULL);
+  r_assert (r_rtcp_buffer_add_fb (buf, R_RTCP_PT_PSFB, R_RTCP_PSFB_FMT_PLI, 0xaaaa0001, 0xbbbb0002, NULL, 0));
+  r_assert (r_rtcp_buffer_add_fb (buf, R_RTCP_PT_RTPFB, R_RTCP_RTPFB_FMT_NACK, 0xaaaa0001, 0xbbbb0002, nackfci, 4));
+  r_assert_cmpbufmem (buf, 0, -1, ==, golden, sizeof (golden));
+  r_buffer_unref (buf);
+
+  r_assert_cmpptr ((buf = r_buffer_new_dup (golden, sizeof (golden))), !=, NULL);
+  r_assert (r_rtcp_buffer_map (&rtcp, buf, R_MEM_MAP_READ));
+  r_assert_cmpuint (r_rtcp_buffer_get_packet_count (&rtcp), ==, 2);
+  r_assert_cmpptr ((pkt = r_rtcp_buffer_get_next_packet (&rtcp, NULL)), !=, NULL);
+  r_assert_cmpuint (r_rtcp_packet_get_type (pkt), ==, R_RTCP_PT_PSFB);
+  r_assert_cmpuint (r_rtcp_packet_fb_get_fmt (pkt), ==, R_RTCP_PSFB_FMT_PLI);
+  r_assert_cmphex (r_rtcp_packet_fb_get_sender_ssrc (pkt), ==, 0xaaaa0001);
+  r_assert_cmphex (r_rtcp_packet_fb_get_media_ssrc (pkt), ==, 0xbbbb0002);
+  r_rtcp_packet_fb_get_fci (pkt, &fcisize);
+  r_assert_cmpuint (fcisize, ==, 0);
+  r_assert_cmpptr ((pkt = r_rtcp_buffer_get_next_packet (&rtcp, pkt)), !=, NULL);
+  r_assert_cmpuint (r_rtcp_packet_get_type (pkt), ==, R_RTCP_PT_RTPFB);
+  r_assert_cmpuint (r_rtcp_packet_fb_get_fmt (pkt), ==, R_RTCP_RTPFB_FMT_NACK);
+  r_assert_cmpptr ((fci = r_rtcp_packet_fb_get_fci (pkt, &fcisize)), !=, NULL);
+  r_assert_cmpuint (fcisize, ==, 4);
+  r_assert_cmpmem (fci, ==, nackfci, 4);
+  r_assert (r_rtcp_buffer_unmap (&rtcp, buf));
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
 RTEST (rrtcp, bye_no_reason_wire, RTEST_FAST)
 {
   /* BYE with a single SSRC and no reason string. */
@@ -867,6 +916,52 @@ RTEST (rrtcp, write_bye_app, RTEST_FAST)
   r_assert_cmpptr ((adata = r_rtcp_packet_app_get_data (pkt, &asize)), !=, NULL);
   r_assert_cmpuint (asize, ==, sizeof (appdata));
   r_assert_cmpmem (adata, ==, appdata, sizeof (appdata));
+
+  r_assert (r_rtcp_buffer_unmap (&rtcp, buf));
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
+RTEST (rrtcp, write_feedback, RTEST_FAST)
+{
+  /* A PSFB/PLI (no FCI) and an RTPFB/Generic-NACK (one FCI entry). */
+  RBuffer * buf;
+  RRTCPBuffer rtcp = R_RTCP_BUFFER_INIT;
+  RRTCPPacket * pkt;
+  ruint8 nackfci[4];
+  const ruint8 * fci;
+  ruint16 fcisize = 0;
+
+  r_store_be16 (&nackfci[0], 0x1234);   /* PID */
+  r_store_be16 (&nackfci[2], 0x00ff);   /* BLP */
+
+  r_assert_cmpptr ((buf = r_buffer_new ()), !=, NULL);
+  r_assert (r_rtcp_buffer_add_fb (buf, R_RTCP_PT_PSFB, R_RTCP_PSFB_FMT_PLI,
+          0xaaaa0001, 0xbbbb0002, NULL, 0));
+  r_assert (r_rtcp_buffer_add_fb (buf, R_RTCP_PT_RTPFB, R_RTCP_RTPFB_FMT_NACK,
+          0xaaaa0001, 0xbbbb0002, nackfci, sizeof (nackfci)));
+  /* invalid: wrong PT and non-word-aligned FCI are rejected */
+  r_assert (!r_rtcp_buffer_add_fb (buf, R_RTCP_PT_SR, 1, 0, 0, NULL, 0));
+  r_assert (!r_rtcp_buffer_add_fb (buf, R_RTCP_PT_RTPFB, 1, 0, 0, nackfci, 3));
+
+  r_assert (r_rtcp_buffer_map (&rtcp, buf, R_MEM_MAP_READ));
+  r_assert_cmpuint (r_rtcp_buffer_get_packet_count (&rtcp), ==, 2);
+
+  r_assert_cmpptr ((pkt = r_rtcp_buffer_get_next_packet (&rtcp, NULL)), !=, NULL);
+  r_assert_cmpuint (r_rtcp_packet_get_type (pkt), ==, R_RTCP_PT_PSFB);
+  r_assert_cmpuint (r_rtcp_packet_fb_get_fmt (pkt), ==, R_RTCP_PSFB_FMT_PLI);
+  r_assert_cmphex (r_rtcp_packet_fb_get_sender_ssrc (pkt), ==, 0xaaaa0001);
+  r_assert_cmphex (r_rtcp_packet_fb_get_media_ssrc (pkt), ==, 0xbbbb0002);
+  r_rtcp_packet_fb_get_fci (pkt, &fcisize);
+  r_assert_cmpuint (fcisize, ==, 0);
+
+  r_assert_cmpptr ((pkt = r_rtcp_buffer_get_next_packet (&rtcp, pkt)), !=, NULL);
+  r_assert_cmpuint (r_rtcp_packet_get_type (pkt), ==, R_RTCP_PT_RTPFB);
+  r_assert_cmpuint (r_rtcp_packet_fb_get_fmt (pkt), ==, R_RTCP_RTPFB_FMT_NACK);
+  r_assert_cmphex (r_rtcp_packet_fb_get_media_ssrc (pkt), ==, 0xbbbb0002);
+  r_assert_cmpptr ((fci = r_rtcp_packet_fb_get_fci (pkt, &fcisize)), !=, NULL);
+  r_assert_cmpuint (fcisize, ==, sizeof (nackfci));
+  r_assert_cmpmem (fci, ==, nackfci, sizeof (nackfci));
 
   r_assert (r_rtcp_buffer_unmap (&rtcp, buf));
   r_buffer_unref (buf);

--- a/test/rrtp.c
+++ b/test/rrtp.c
@@ -52,6 +52,61 @@ RTEST (rrtp, is_valid_hdr, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rrtp, ext_with_csrc_wire, RTEST_FAST)
+{
+  /* RTP packet with both a CSRC entry and a header extension: serialize to
+   * exact wire bytes (constructor + setters) and parse the same bytes back. */
+  static const ruint8 golden[] = {
+    0x91, 0x60, 0x00, 0x01,                          /* V2 X=1 CC=1, PT=96, seq=1 */
+    0x00, 0x00, 0x00, 0x10,                          /* timestamp = 0x10 */
+    0xde, 0xad, 0xbe, 0xef,                          /* ssrc */
+    0x11, 0x22, 0x33, 0x44,                          /* csrc[0] */
+    0xbe, 0xde, 0x00, 0x01,                          /* ext: profile=0xbede, len=1 */
+    0xaa, 0xbb, 0xcc, 0xdd,                          /* ext data */
+    0x01, 0x02                                       /* payload */
+  };
+  static const ruint8 extdata[4] = { 0xaa, 0xbb, 0xcc, 0xdd };
+  static const ruint8 pay[2] = { 0x01, 0x02 };
+  RBuffer * buf, * payload;
+  RRTPBuffer rtp = R_RTP_BUFFER_INIT;
+  ruint16 profile = 0, esize = 0;
+  const ruint8 * edata = NULL;
+
+  /* serialize */
+  r_assert_cmpptr ((payload = r_buffer_new_dup (pay, sizeof (pay))), !=, NULL);
+  r_assert_cmpptr ((buf = r_buffer_new_rtp_buffer_ext (payload, 0, 1,
+          0xbede, extdata, sizeof (extdata))), !=, NULL);
+  r_buffer_unref (payload);
+  r_assert (r_rtp_buffer_map (&rtp, buf, R_MEM_MAP_WRITE));
+  r_rtp_buffer_set_pt (&rtp, 96);
+  r_rtp_buffer_set_seq (&rtp, 1);
+  r_rtp_buffer_set_timestamp (&rtp, 0x10);
+  r_rtp_buffer_set_ssrc (&rtp, 0xdeadbeef);
+  r_assert (r_rtp_buffer_set_csrc (&rtp, 0, 0x11223344));
+  r_assert (r_rtp_buffer_unmap (&rtp, buf));
+  r_assert_cmpbufmem (buf, 0, -1, ==, golden, sizeof (golden));
+  r_buffer_unref (buf);
+
+  /* deserialize the same bytes */
+  r_assert_cmpptr ((buf = r_buffer_new_dup (golden, sizeof (golden))), !=, NULL);
+  r_assert (r_rtp_buffer_map (&rtp, buf, R_MEM_MAP_READ));
+  r_assert_cmpuint (r_rtp_buffer_get_csrc_count (&rtp), ==, 1);
+  r_assert_cmphex (r_rtp_buffer_get_csrc (&rtp, 0), ==, 0x11223344);
+  r_assert (r_rtp_buffer_has_extension (&rtp));
+  r_assert (r_rtp_buffer_get_extension (&rtp, &profile, &edata, &esize));
+  r_assert_cmphex (profile, ==, 0xbede);
+  r_assert_cmpuint (esize, ==, sizeof (extdata));
+  r_assert_cmpmem (edata, ==, extdata, sizeof (extdata));
+  r_assert_cmpuint (r_rtp_buffer_get_pt (&rtp), ==, 96);
+  r_assert_cmpuint (r_rtp_buffer_get_seq (&rtp), ==, 1);
+  r_assert_cmphex (r_rtp_buffer_get_ssrc (&rtp), ==, 0xdeadbeef);
+  r_assert_cmpuint (rtp.pay.size, ==, sizeof (pay));
+  r_assert_cmpmem (rtp.pay.data, ==, pay, sizeof (pay));
+  r_assert (r_rtp_buffer_unmap (&rtp, buf));
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
 RTEST (rrtp, new_rtp_buffer, RTEST_FAST)
 {
   RBuffer * buf, * payload;
@@ -237,6 +292,14 @@ RTEST (rrtp, read_ext_hdr_opus_payload, RTEST_FAST)
 
   r_assert (!r_rtp_buffer_has_padding (&rtp));
   r_assert (r_rtp_buffer_has_extension (&rtp));
+  {
+    ruint16 profile = 0, esize = 0;
+    const ruint8 * edata = NULL;
+    r_assert (r_rtp_buffer_get_extension (&rtp, &profile, &edata, &esize));
+    r_assert_cmphex (profile, ==, RUINT16_FROM_BE (*(const ruint16 *)rtp.ext.data));
+    r_assert_cmpuint (esize, ==, rtp.ext.size - 4);
+    r_assert_cmpptr (edata, ==, rtp.ext.data + 4);
+  }
   r_assert (!r_rtp_buffer_has_marker (&rtp));
 
   r_assert_cmpuint (r_rtp_buffer_get_csrc_count (&rtp), ==, 0);
@@ -247,6 +310,40 @@ RTEST (rrtp, read_ext_hdr_opus_payload, RTEST_FAST)
 
   r_assert (r_rtp_buffer_unmap (&rtp, buf));
   r_buffer_unref (buf);
+}
+RTEST_END;
+
+RTEST (rrtp, write_ext_hdr, RTEST_FAST)
+{
+  /* Construct a packet with a header extension and read it back. */
+  RBuffer * buf, * payload;
+  RRTPBuffer rtp = R_RTP_BUFFER_INIT;
+  static const ruint8 extdata[8] = { 0x10,0x11,0x12,0x13,0x14,0x15,0x16,0x17 };
+  static const ruint8 pay[4] = { 0xaa, 0xbb, 0xcc, 0xdd };
+  ruint16 profile = 0, esize = 0;
+  const ruint8 * edata = NULL;
+
+  r_assert_cmpptr ((payload = r_buffer_new_dup (pay, sizeof (pay))), !=, NULL);
+  r_assert_cmpptr ((buf = r_buffer_new_rtp_buffer_ext (payload, 0, 0,
+          0xbede, extdata, sizeof (extdata))), !=, NULL);
+  r_buffer_unref (payload);
+
+  r_assert (r_rtp_buffer_map (&rtp, buf, R_MEM_MAP_READ));
+  r_assert (r_rtp_buffer_has_extension (&rtp));
+  r_assert (r_rtp_buffer_get_extension (&rtp, &profile, &edata, &esize));
+  r_assert_cmphex (profile, ==, 0xbede);
+  r_assert_cmpuint (esize, ==, sizeof (extdata));
+  r_assert_cmpmem (edata, ==, extdata, sizeof (extdata));
+  r_assert_cmpuint (rtp.pay.size, ==, sizeof (pay));
+  r_assert_cmpmem (rtp.pay.data, ==, pay, sizeof (pay));
+  r_assert (r_rtp_buffer_unmap (&rtp, buf));
+  r_buffer_unref (buf);
+
+  /* A non-word-aligned extension size is rejected. */
+  r_assert_cmpptr ((payload = r_buffer_new_dup (pay, sizeof (pay))), !=, NULL);
+  r_assert_cmpptr (r_buffer_new_rtp_buffer_ext (payload, 0, 0, 0xbede, extdata, 3),
+      ==, NULL);
+  r_buffer_unref (payload);
 }
 RTEST_END;
 

--- a/test/rrtp.c
+++ b/test/rrtp.c
@@ -52,6 +52,101 @@ RTEST (rrtp, is_valid_hdr, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rrtcp, sr_sender_only_wire, RTEST_FAST)
+{
+  /* SR with no report blocks (RC=0): serialize to exact wire bytes, and parse
+   * the same bytes back -- each side checked against the spec independently. */
+  static const ruint8 golden[] = {
+    0x80, 0xc8, 0x00, 0x06,                          /* V2 RC0, PT=SR, len=6 */
+    0x11, 0x22, 0x33, 0x44,                          /* ssrc */
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,  /* ntp */
+    0xde, 0xad, 0xbe, 0xef,                          /* rtptime */
+    0x00, 0x00, 0x00, 0x64,                          /* packets = 100 */
+    0x00, 0x00, 0x4e, 0x20                           /* bytes = 20000 */
+  };
+  /* field order: ssrc, rtptime, ntptime, packets, bytes */
+  RRTCPSenderInfo si = { 0x11223344, 0xdeadbeef, 0x0102030405060708, 100, 20000 };
+  RBuffer * buf;
+  RRTCPBuffer rtcp = R_RTCP_BUFFER_INIT;
+  RRTCPPacket * pkt;
+  RRTCPSenderInfo gsi;
+  RRTCPReportBlock grb;
+
+  r_assert_cmpptr ((buf = r_buffer_new ()), !=, NULL);
+  r_assert (r_rtcp_buffer_add_sr (buf, &si, NULL, 0));
+  r_assert_cmpbufmem (buf, 0, -1, ==, golden, sizeof (golden));
+  r_buffer_unref (buf);
+
+  r_assert_cmpptr ((buf = r_buffer_new_dup (golden, sizeof (golden))), !=, NULL);
+  r_assert (r_rtcp_buffer_map (&rtcp, buf, R_MEM_MAP_READ));
+  r_assert_cmpptr ((pkt = r_rtcp_buffer_get_next_packet (&rtcp, NULL)), !=, NULL);
+  r_assert_cmpuint (r_rtcp_packet_get_type (pkt), ==, R_RTCP_PT_SR);
+  r_assert_cmpuint (r_rtcp_packet_get_count (pkt), ==, 0);
+  r_assert (r_rtcp_packet_sr_get_sender_info (pkt, &gsi));
+  r_assert_cmphex (gsi.ssrc, ==, 0x11223344);
+  r_assert_cmphex (gsi.ntptime, ==, 0x0102030405060708);
+  r_assert_cmphex (gsi.rtptime, ==, 0xdeadbeef);
+  r_assert_cmpuint (gsi.packets, ==, 100);
+  r_assert_cmpuint (gsi.bytes, ==, 20000);
+  r_assert (!r_rtcp_packet_sr_get_report_block (pkt, 0, &grb));
+  r_assert (r_rtcp_buffer_unmap (&rtcp, buf));
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
+RTEST (rrtcp, rr_two_blocks_wire, RTEST_FAST)
+{
+  /* RR with two report blocks (RC=2): exercises the idx>0 block offsets. */
+  static const ruint8 golden[] = {
+    0x82, 0xc9, 0x00, 0x0d,                          /* V2 RC2, PT=RR, len=13 */
+    0x99, 0xaa, 0xbb, 0xcc,                          /* reporter ssrc */
+    0x55, 0x66, 0x77, 0x88,                          /* rb0 ssrc */
+    0x05, 0xff, 0xff, 0xfd,                          /* frac=5, lost=-3 */
+    0x00, 0x00, 0x10, 0x00,                          /* exthighestseq */
+    0x00, 0x00, 0x00, 0x40,                          /* jitter */
+    0xaa, 0xbb, 0xcc, 0xdd,                          /* lsr */
+    0x00, 0x00, 0x00, 0x11,                          /* dlsr */
+    0x12, 0x34, 0x56, 0x78,                          /* rb1 ssrc */
+    0x00, 0x00, 0x00, 0x00,                          /* frac=0, lost=0 */
+    0x00, 0x00, 0x20, 0x00,                          /* exthighestseq */
+    0x00, 0x00, 0x00, 0x80,                          /* jitter */
+    0x12, 0x34, 0x56, 0x78,                          /* lsr */
+    0x00, 0x00, 0x00, 0x22                           /* dlsr */
+  };
+  RRTCPReportBlock rb[2] = {
+    { 0x55667788, 5, -3, 0x1000, 0x40, 0xaabbccdd, 0x11 },
+    { 0x12345678, 0,  0, 0x2000, 0x80, 0x12345678, 0x22 }
+  };
+  RBuffer * buf;
+  RRTCPBuffer rtcp = R_RTCP_BUFFER_INIT;
+  RRTCPPacket * pkt;
+  RRTCPReportBlock grb;
+
+  r_assert_cmpptr ((buf = r_buffer_new ()), !=, NULL);
+  r_assert (r_rtcp_buffer_add_rr (buf, 0x99aabbcc, rb, 2));
+  r_assert_cmpbufmem (buf, 0, -1, ==, golden, sizeof (golden));
+  r_buffer_unref (buf);
+
+  r_assert_cmpptr ((buf = r_buffer_new_dup (golden, sizeof (golden))), !=, NULL);
+  r_assert (r_rtcp_buffer_map (&rtcp, buf, R_MEM_MAP_READ));
+  r_assert_cmpptr ((pkt = r_rtcp_buffer_get_next_packet (&rtcp, NULL)), !=, NULL);
+  r_assert_cmpuint (r_rtcp_packet_get_type (pkt), ==, R_RTCP_PT_RR);
+  r_assert_cmpuint (r_rtcp_packet_get_count (pkt), ==, 2);
+  r_assert_cmphex (r_rtcp_packet_rr_get_ssrc (pkt), ==, 0x99aabbcc);
+  r_assert (r_rtcp_packet_sr_get_report_block (pkt, 0, &grb));
+  r_assert_cmphex (grb.ssrc, ==, 0x55667788);
+  r_assert_cmpint (grb.packetslost, ==, -3);
+  r_assert (r_rtcp_packet_sr_get_report_block (pkt, 1, &grb));
+  r_assert_cmphex (grb.ssrc, ==, 0x12345678);
+  r_assert_cmpint (grb.packetslost, ==, 0);
+  r_assert_cmphex (grb.exthighestseq, ==, 0x2000);
+  r_assert_cmphex (grb.dlsr, ==, 0x22);
+  r_assert (!r_rtcp_packet_sr_get_report_block (pkt, 2, &grb));
+  r_assert (r_rtcp_buffer_unmap (&rtcp, buf));
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
 RTEST (rrtp, ext_with_csrc_wire, RTEST_FAST)
 {
   /* RTP packet with both a CSRC entry and a header extension: serialize to
@@ -528,3 +623,56 @@ RTEST (rrtcp, rr_bye_compound_packet, RTEST_FAST)
 }
 RTEST_END;
 
+
+RTEST (rrtcp, write_sr_rr_compound, RTEST_FAST)
+{
+  /* Build an SR + RR compound, then read it back via the parser. */
+  RBuffer * buf;
+  RRTCPBuffer rtcp = R_RTCP_BUFFER_INIT;
+  RRTCPPacket * pkt;
+  /* RRTCPSenderInfo field order: ssrc, rtptime, ntptime, packets, bytes */
+  RRTCPSenderInfo si = { 0x11223344, 0xdeadbeef, 0x0102030405060708, 100, 20000 };
+  /* RRTCPReportBlock: ssrc, fractionlost, packetslost, exthighestseq, jitter, lsr, dlsr */
+  RRTCPReportBlock rb = { 0x55667788, 5, -3, 0x1000, 0x40, 0xaabbccdd, 0x11 };
+  RRTCPSenderInfo gsi;
+  RRTCPReportBlock grb;
+
+  r_assert_cmpptr ((buf = r_buffer_new ()), !=, NULL);
+  r_assert (r_rtcp_buffer_add_sr (buf, &si, &rb, 1));
+  r_assert (r_rtcp_buffer_add_rr (buf, 0x99aabbcc, &rb, 1));
+
+  r_assert (r_rtcp_buffer_map (&rtcp, buf, R_MEM_MAP_READ));
+  r_assert_cmpuint (r_rtcp_buffer_get_packet_count (&rtcp), ==, 2);
+
+  r_assert_cmpptr ((pkt = r_rtcp_buffer_get_next_packet (&rtcp, NULL)), !=, NULL);
+  r_assert_cmpuint (r_rtcp_packet_get_type (pkt), ==, R_RTCP_PT_SR);
+  r_assert_cmpuint (r_rtcp_packet_get_count (pkt), ==, 1);
+  r_assert (r_rtcp_packet_sr_get_sender_info (pkt, &gsi));
+  r_assert_cmphex (gsi.ssrc, ==, si.ssrc);
+  r_assert_cmphex (gsi.ntptime, ==, si.ntptime);
+  r_assert_cmphex (gsi.rtptime, ==, si.rtptime);
+  r_assert_cmpuint (gsi.packets, ==, si.packets);
+  r_assert_cmpuint (gsi.bytes, ==, si.bytes);
+  r_assert (r_rtcp_packet_sr_get_report_block (pkt, 0, &grb));
+  r_assert_cmphex (grb.ssrc, ==, rb.ssrc);
+  r_assert_cmpuint (grb.fractionlost, ==, rb.fractionlost);
+  r_assert_cmpint (grb.packetslost, ==, rb.packetslost);
+  r_assert_cmpuint (grb.exthighestseq, ==, rb.exthighestseq);
+  r_assert_cmpuint (grb.jitter, ==, rb.jitter);
+  r_assert_cmphex (grb.lsr, ==, rb.lsr);
+  r_assert_cmpuint (grb.dlsr, ==, rb.dlsr);
+
+  r_assert_cmpptr ((pkt = r_rtcp_buffer_get_next_packet (&rtcp, pkt)), !=, NULL);
+  r_assert_cmpuint (r_rtcp_packet_get_type (pkt), ==, R_RTCP_PT_RR);
+  r_assert_cmpuint (r_rtcp_packet_get_count (pkt), ==, 1);
+  r_assert_cmphex (r_rtcp_packet_rr_get_ssrc (pkt), ==, 0x99aabbcc);
+  r_assert (r_rtcp_packet_sr_get_report_block (pkt, 0, &grb));
+  r_assert_cmphex (grb.ssrc, ==, rb.ssrc);
+  r_assert_cmpint (grb.packetslost, ==, rb.packetslost);
+
+  r_assert_cmpptr (r_rtcp_buffer_get_next_packet (&rtcp, pkt), ==, NULL);
+
+  r_assert (r_rtcp_buffer_unmap (&rtcp, buf));
+  r_buffer_unref (buf);
+}
+RTEST_END;


### PR DESCRIPTION
Builds out the write/serialization side of RTP/RTCP and the
padding / extension / feedback handling flagged by the TODOs in
`rrtp.h`, mirroring the existing parse API.

## What's added

- **RTP padding** — `r_rtp_buffer_get_padding` returns the trailing pad
  count (read from the packet's last octet, independent of how the payload
  was mapped).
- **RTP header extension** — `r_rtp_buffer_get_extension` (profile / data /
  size) for reading, and `r_buffer_new_rtp_buffer_ext` to construct a packet
  with one (word-aligned per RFC 3550 §5.3.1).
- **RTCP serialization** — the previously parse-only RTCP API gains a write
  side: `r_rtcp_buffer_add_sr` / `_rr` / `_sdes` / `_bye` / `_app` append
  packets to a compound `RBuffer`.
- **RTCP feedback (RFC 4585)** — `RRTCPRTPFBType` / `RRTCPPSFBType` FMT
  enums, parse accessors (`r_rtcp_packet_fb_get_fmt` / `_sender_ssrc` /
  `_media_ssrc` / `_fci`) and a generic writer `r_rtcp_buffer_add_fb` for
  RTPFB/PSFB packets.

All serialization uses the unaligned-safe `r_store_be*` helpers. The
`@file` / `@defgroup r_rtcp` briefs are updated to cover the write side.

## Tests

Three layers, so a bug in either direction is caught:

- **Round-trip** — build a packet, parse it back.
- **Isolated serialization** — build a packet and assert the exact wire
  bytes against a hand-built, RFC-derived golden vector.
- **Isolated deserialization** — parse the same golden bytes and assert the
  decoded fields.

Checking each side against the spec vector (not against each other) guards
against compensating serialize/deserialize bugs. The golden vectors also
exercise the corner cases: SR with no report blocks, multi-block RR, a
multi-item SDES chunk, a BYE without a reason, and an RTP extension
alongside a CSRC list.

Verified: full suite green under epoll, rpoll and ASan+UBSan; mingw cross
`-Werror` clean; Doxygen 0 warnings.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)