### PR TITLE
Windows/mingw-w64: fix three runtime bugs and harden test-crash handling

### DIFF
--- a/rlib/concurrency/rthreads.c
+++ b/rlib/concurrency/rthreads.c
@@ -417,7 +417,9 @@ r_rwmutex_init (RRWMutex * mutex)
 void
 r_rwmutex_clear (RRWMutex * mutex)
 {
-#if defined (HAVE_PTHREAD_H)
+#if defined (R_OS_WIN32)
+  /* SRWLOCK has no teardown API */
+#elif defined (HAVE_PTHREAD_H)
   pthread_rwlock_destroy ((pthread_rwlock_t *)*mutex);
 #endif
   r_free (*mutex);
@@ -528,7 +530,9 @@ r_cond_init (RCond * cond)
 void
 r_cond_clear (RCond * cond)
 {
-#if defined (HAVE_PTHREAD_H)
+#if defined (R_OS_WIN32)
+  /* CONDITION_VARIABLE has no teardown API */
+#elif defined (HAVE_PTHREAD_H)
   pthread_cond_destroy ((pthread_cond_t *)*cond);
 #endif
   r_free (*cond);

--- a/rlib/file/rfile.c
+++ b/rlib/file/rfile.c
@@ -329,8 +329,11 @@ r_file_read_int (const rchar * filename, int def)
   RFile * f;
 
   if ((f = r_file_open (filename, "r")) != NULL) {
-    r_file_scanf (f, "%i", NULL, &def);
+    rintmax v = def;
+    r_file_scanf (f, "%"RINTMAX_MODIFIER"i", NULL, &v);
     r_file_unref (f);
+
+    def = (int)v;
   }
 
   return def;

--- a/rlib/os/rsys.c
+++ b/rlib/os/rsys.c
@@ -348,9 +348,14 @@ r_sys_cpuset_for_node (RBitset * cpuset, ruint node)
   r_bitset_clear (cpuset);
 #if defined (R_OS_WIN32)
   {
-    ULONGLONG mask;
+    ULONGLONG mask = 0;
     if (node < RUINT8_MAX && GetNumaNodeProcessorMask ((ruchar)node, &mask))
       ret = r_bitset_set_u64_at (cpuset, mask, 0);
+
+    /* A single node owns every online CPU; fall back to that when the
+     * per-node mask query yields nothing (empty mask or failed call). */
+    if (mask == 0 && node == 0 && r_sys_node_count () == 1)
+      ret = r_sys_cpuset_online (cpuset);
   }
 #elif defined (R_OS_LINUX)
   {

--- a/rlib/rtest.c
+++ b/rlib/rtest.c
@@ -1120,6 +1120,44 @@ r_test_run_nofork_cleanup (RTestRunNoForkCtx * ctx)
   ctx->thread = NULL;
 }
 
+/* Body of a single test run: position marker, optional setup, the test, and
+ * optional teardown. Returns the non-aborted outcome; asserts and timeouts
+ * longjmp out past this to the runner's setjmp. */
+static RTestRunState
+_r_test_run_body (const RTest * test, rsize __i, RTestRunNoForkCtx * ctx)
+{
+  _r_test_mark_position (test->name, (ruint)__i, test->suite, FALSE);
+  if (test->setup != NULL)    test->setup (test->fdata);
+  test->func (__i, test->fdata);
+  if (test->teardown != NULL) test->teardown (test->fdata);
+
+  return (ctx->failpos != NULL) ? R_TEST_RUN_STATE_FAILED
+                                : R_TEST_RUN_STATE_SUCCESS;
+}
+
+#if defined (_MSC_VER)
+static LONG
+_r_test_win32_seh_filter (PEXCEPTION_POINTERS ep)
+{
+  _r_test_win32_log_crash (ep);
+  return EXCEPTION_EXECUTE_HANDLER;
+}
+
+/* MSVC catches the hardware fault with SEH and unwinds cleanly, rather than
+ * longjmp-ing out of SetUnhandledExceptionFilter (which skips unwinding and
+ * can leak whatever the faulting test held). gcc/clang lack working __try for
+ * this target and fall back to that filter + longjmp. */
+static RTestRunState
+_r_test_run_guarded (const RTest * test, rsize __i, RTestRunNoForkCtx * ctx)
+{
+  __try {
+    return _r_test_run_body (test, __i, ctx);
+  } __except (_r_test_win32_seh_filter (GetExceptionInformation ())) {
+    return R_TEST_RUN_STATE_ERROR;
+  }
+}
+#endif
+
 RTestRunState
 r_test_run_nofork (const RTest * test, rsize __i, rboolean notimeout,
     RTestLastPos * lastpos, RTestLastPos * failpos, int * pid, int * exitcode)
@@ -1146,16 +1184,11 @@ r_test_run_nofork (const RTest * test, rsize __i, rboolean notimeout,
   ctx.start_ts = r_time_get_ts_monotonic ();
   R_LOG_DEBUG ("About to run: /%s/%s/%"RSIZE_FMT, test->suite, test->name, __i);
   if ((jmpres = setjmp (ctx.jb)) == 0) {
-    _r_test_mark_position (test->name, (ruint)__i, test->suite, FALSE);
-    if (test->setup != NULL)    test->setup (test->fdata);
-    test->func (__i, test->fdata);
-    if (test->teardown != NULL) test->teardown (test->fdata);
-
-    if (ctx.failpos != NULL) {
-      ret = R_TEST_RUN_STATE_FAILED;
-    } else {
-      ret = R_TEST_RUN_STATE_SUCCESS;
-    }
+#if defined (_MSC_VER)
+    ret = _r_test_run_guarded (test, __i, &ctx);
+#else
+    ret = _r_test_run_body (test, __i, &ctx);
+#endif
   } else {
     ret = (RTestRunState)jmpres;
   }

--- a/rlib/rtest.c
+++ b/rlib/rtest.c
@@ -820,37 +820,103 @@ _r_test_win32_log_stack (void)
   r_mutex_unlock (&g__r_test_win32_sym_mutex);
 }
 
+static const rchar *
+_r_test_win32_exception_name (DWORD code)
+{
+  switch (code) {
+    case EXCEPTION_ACCESS_VIOLATION:      return "ACCESS_VIOLATION";
+    case EXCEPTION_IN_PAGE_ERROR:         return "IN_PAGE_ERROR";
+    case EXCEPTION_STACK_OVERFLOW:        return "STACK_OVERFLOW";
+    case EXCEPTION_ILLEGAL_INSTRUCTION:   return "ILLEGAL_INSTRUCTION";
+    case EXCEPTION_PRIV_INSTRUCTION:      return "PRIV_INSTRUCTION";
+    case EXCEPTION_INT_DIVIDE_BY_ZERO:    return "INT_DIVIDE_BY_ZERO";
+    case EXCEPTION_INT_OVERFLOW:          return "INT_OVERFLOW";
+    case EXCEPTION_FLT_DIVIDE_BY_ZERO:    return "FLT_DIVIDE_BY_ZERO";
+    case EXCEPTION_DATATYPE_MISALIGNMENT: return "DATATYPE_MISALIGNMENT";
+    case EXCEPTION_ARRAY_BOUNDS_EXCEEDED: return "ARRAY_BOUNDS_EXCEEDED";
+    default:                              return "exception";
+  }
+}
+
+/* Identify the test in flight for crash diagnostics. */
 static void
-_r_test_win32_err_handler (int sig)
+_r_test_win32_cur_test (const rchar ** suite, const rchar ** name, rsize * __i)
+{
+  *suite = "???"; *name = "???"; *__i = 0;
+  if (g__r_test_nofork_ctx != NULL && g__r_test_nofork_ctx->test != NULL) {
+    *suite = g__r_test_nofork_ctx->test->suite;
+    *name  = g__r_test_nofork_ctx->test->name;
+    *__i   = g__r_test_nofork_ctx->__i;
+  }
+}
+
+/* Marshal the failure to the test runner: longjmp back when we're still on
+ * the test thread, otherwise terminate that thread from this one. */
+static void
+_r_test_win32_abort_current (RTestRunState state)
 {
   if (R_UNLIKELY (g__r_test_nofork_ctx == NULL))
     return;
 
-  R_LOG_ERROR ("Error sig: %d", sig);
+  if (g__r_test_nofork_ctx->thread == r_thread_current ()) {
+    longjmp (g__r_test_nofork_ctx->jb, state);
+  } else {
+    _r_test_nofork_win32_kill_test_thread (state);
+    r_thread_exit (RINT_TO_POINTER (state));
+  }
+}
+
+/* One unmistakable line naming the test, the exception and where it faulted. */
+static void
+_r_test_win32_log_crash (PEXCEPTION_POINTERS ep)
+{
+  PEXCEPTION_RECORD er = ep->ExceptionRecord;
+  const rchar * suite, * name;
+  rsize __i;
+
+  _r_test_win32_cur_test (&suite, &name, &__i);
+
+  if (er->ExceptionCode == EXCEPTION_ACCESS_VIOLATION ||
+      er->ExceptionCode == EXCEPTION_IN_PAGE_ERROR) {
+    R_LOG_ERROR ("TEST CRASHED: /%s/%s/%"RSIZE_FMT" -- %s %s %p (at %p)",
+        suite, name, __i, _r_test_win32_exception_name (er->ExceptionCode),
+        er->ExceptionInformation[0] == 0 ? "reading" :
+        er->ExceptionInformation[0] == 1 ? "writing" : "executing",
+        (rpointer) er->ExceptionInformation[1], er->ExceptionAddress);
+  } else {
+    R_LOG_ERROR ("TEST CRASHED: /%s/%s/%"RSIZE_FMT" -- %s (0x%08lx at %p)",
+        suite, name, __i, _r_test_win32_exception_name (er->ExceptionCode),
+        (unsigned long) er->ExceptionCode, er->ExceptionAddress);
+  }
+
+  /* The stack walk needs stack of its own; skip it when that is what blew. */
+  if (er->ExceptionCode != EXCEPTION_STACK_OVERFLOW)
+    _r_test_win32_log_stack ();
+}
+
+/* SIGABRT (abort()/assert) -- no EXCEPTION_POINTERS, log what we can. */
+static void
+_r_test_win32_err_handler (int sig)
+{
+  const rchar * suite, * name;
+  rsize __i;
+
+  if (R_UNLIKELY (g__r_test_nofork_ctx == NULL))
+    return;
+
+  _r_test_win32_cur_test (&suite, &name, &__i);
+  R_LOG_ERROR ("TEST ABORTED: /%s/%s/%"RSIZE_FMT" -- signal %d",
+      suite, name, __i, sig);
   _r_test_win32_log_stack ();
 
-  if (g__r_test_nofork_ctx->thread == r_thread_current ()) {
-    longjmp (g__r_test_nofork_ctx->jb, R_TEST_RUN_STATE_ERROR);
-  } else {
-    _r_test_nofork_win32_kill_test_thread (R_TEST_RUN_STATE_ERROR);
-    r_thread_exit (RINT_TO_POINTER (sig));
-  }
+  _r_test_win32_abort_current (R_TEST_RUN_STATE_ERROR);
 }
 
 static LONG WINAPI
 _r_test_win32_exception_filter (PEXCEPTION_POINTERS ep)
 {
-  const rchar * errfile = "???";
-  const rchar * errfunc = "???";
-  ruint errline = 0;
-
-  if (ep->ExceptionRecord->ExceptionCode != EXCEPTION_STACK_OVERFLOW) {
-    r_log (R_LOG_CAT_DEFAULT, R_LOG_LEVEL_ERROR, errfile, errline, errfunc,
-        "exception code: %lu", (unsigned long) ep->ExceptionRecord->ExceptionCode);
-  }
-
-  _r_test_win32_err_handler (SIGSEGV);
-
+  _r_test_win32_log_crash (ep);
+  _r_test_win32_abort_current (R_TEST_RUN_STATE_ERROR);
   return EXCEPTION_CONTINUE_SEARCH;
 }
 #elif defined (R_OS_UNIX)


### PR DESCRIPTION
Work surfaced by running the full test suite under **Wine + mingw-w64** — a
combination CI never exercised (the mingw cross job is build-only, MSVC has no
`pthread.h`), so several mingw-only runtime bugs had gone unseen. With these
fixes the suite is fully green under Wine (1998 passed, 0 failed, 0 errors),
giving a usable local Windows-ish test loop.

## Bug fixes (mingw-only, each invisible to the configs CI runs)

- **Heap corruption on every condvar/rwlock teardown.** `r_cond_clear` and
  `r_rwmutex_clear` lacked the `R_OS_WIN32` branch their `_init` counterparts
  (and `r_mutex_clear`/`r_rmutex_clear`) carry, so on mingw — where both
  `R_OS_WIN32` and `HAVE_PTHREAD_H` are defined — they ran `pthread_*_destroy`
  over memory holding a native `CONDITION_VARIABLE`/`SRWLOCK`.

- **`r_file_read_int` overflow was platform-dependent.** It scanned straight
  into the `int` with `"%i"`, inheriting the C runtime's out-of-range behaviour
  (glibc wraps, Microsoft's ucrt clamps). Now parses into a wide `rintmax` and
  narrow-casts, mirroring `r_file_read_uint`.

- **Empty per-node NUMA mask collapsed topology to zero.** When
  `GetNumaNodeProcessorMask` reports a node but returns an empty mask,
  `r_sys_cpuset_for_node` made the node own no CPUs, zeroing the node counts and
  the per-numa-node task queues built on them. A single-node system owns every
  online CPU, so it now falls back to the online set; real single/multi-node
  systems return a populated mask and never hit the fallback.

## Test-harness hardening (Windows)

- **Clear crash diagnostics.** A faulting test logged only the raw
  `exception code: 3221225477` / `Error sig: 11`. It now logs one line naming
  the test, decoding the exception, and giving the access/fault addresses, e.g.
  `TEST CRASHED: /rsys/foo/0 -- ACCESS_VIOLATION reading 0xa8 (at 0x...)`.

- **Cleaner recovery on MSVC.** The runner caught hardware faults by
  `longjmp`-ing out of `SetUnhandledExceptionFilter`, which abandons exception
  dispatch and skips unwinding. On MSVC it now uses SEH `__try/__except` to
  unwind cleanly; gcc/clang lack working `__try` for the mingw target and keep
  the filter+longjmp path (which still also covers non-test-thread faults).

## Verification

- Full suite green on Linux epoll **and** rpoll; ASan/UBSan clean on the
  touched suites; mingw cross `-Werror` (default + rpoll) builds clean; Doxygen
  0 warnings.
- Full suite under Wine (mingw rpoll): 1998 passed, 0 failed, 0 errors.
- The MSVC SEH path can't run on the dev box (gcc can't compile `__try`,
  clang-mingw compiles but doesn't dispatch it) — it's validated by the MSVC CI
  jobs here.