### PR TITLE
test: bind ephemeral ports in networking tests

### DIFF
--- a/include/rlib/net/rhttpserver.h
+++ b/include/rlib/net/rhttpserver.h
@@ -97,6 +97,16 @@ R_API rboolean r_http_server_set_handler (RHttpServer * server,
 /** @brief Start accepting connections on @p addr. */
 R_API rboolean r_http_server_listen (RHttpServer * server, RSocketAddress * addr);
 /**
+ * @brief Local address of the server's first listener.
+ *
+ * Useful after listening on an ephemeral port (port 0) to learn the port the
+ * OS actually assigned.
+ *
+ * @return A new @ref RSocketAddress the caller must unref, or @c NULL if the
+ *         server is not listening.
+ */
+R_API RSocketAddress * r_http_server_get_local_address (RHttpServer * server);
+/**
  * @brief Stop the server; @p func fires once shutdown completes.
  * @return Number of sockets (listeners + client connections) being closed.
  */

--- a/rlib/net/rhttpserver.c
+++ b/rlib/net/rhttpserver.c
@@ -543,6 +543,15 @@ r_http_server_listen (RHttpServer * server, RSocketAddress * addr)
   return FALSE;
 }
 
+RSocketAddress *
+r_http_server_get_local_address (RHttpServer * server)
+{
+  if (R_UNLIKELY (server == NULL) || r_ptr_array_size (server->listen) == 0)
+    return NULL;
+
+  return r_ev_tcp_get_local_address (r_ptr_array_get (server->listen, 0));
+}
+
 typedef struct {
   RRef ref;
   RHttpServer * server;

--- a/test/revtcp.c
+++ b/test/revtcp.c
@@ -86,8 +86,10 @@ RTEST (revtcp, listen_connect_accept_send_recv, RTEST_FAST | RTEST_SYSTEM)
 
   r_assert_cmpptr ((client = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
   r_assert_cmpptr ((server = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x6363)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
   r_assert_cmpint (r_ev_tcp_bind (server, addr, TRUE), ==, R_SOCKET_OK);
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_ev_tcp_get_local_address (server)), !=, NULL);
 
   r_assert_cmpint (r_ev_tcp_listen (server, 10, new_connection_ready, &servcli, NULL), ==, R_SOCKET_OK);
   r_assert_cmpptr (servcli, ==, NULL);
@@ -142,8 +144,10 @@ RTEST (revtcp, queued_send_recv, RTEST_FAST | RTEST_SYSTEM)
 
   r_assert_cmpptr ((client = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
   r_assert_cmpptr ((server = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x6364)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
   r_assert_cmpint (r_ev_tcp_bind (server, addr, TRUE), ==, R_SOCKET_OK);
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_ev_tcp_get_local_address (server)), !=, NULL);
   r_assert_cmpint (r_ev_tcp_listen (server, 10, new_connection_ready, &servcli, NULL), ==, R_SOCKET_OK);
   r_assert_cmpint (r_ev_tcp_connect (client, addr, client_connected, &conn, NULL), ==, R_SOCKET_WOULD_BLOCK);
   r_socket_address_unref (addr);
@@ -198,8 +202,10 @@ RTEST (revtcp, recv_error_handler, RTEST_FAST | RTEST_SYSTEM)
 
   r_assert_cmpptr ((client = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
   r_assert_cmpptr ((server = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x6364)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
   r_assert_cmpint (r_ev_tcp_bind (server, addr, TRUE), ==, R_SOCKET_OK);
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_ev_tcp_get_local_address (server)), !=, NULL);
   r_assert_cmpint (r_ev_tcp_listen (server, 10, new_connection_ready, &servcli, NULL), ==, R_SOCKET_OK);
   r_assert_cmpint (r_ev_tcp_connect (client, addr, client_connected, &conn, NULL), ==, R_SOCKET_WOULD_BLOCK);
   r_socket_address_unref (addr);
@@ -260,8 +266,10 @@ RTEST (revtcp, recv_error_no_handler, RTEST_FAST | RTEST_SYSTEM)
 
   r_assert_cmpptr ((client = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
   r_assert_cmpptr ((server = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x6365)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
   r_assert_cmpint (r_ev_tcp_bind (server, addr, TRUE), ==, R_SOCKET_OK);
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_ev_tcp_get_local_address (server)), !=, NULL);
   r_assert_cmpint (r_ev_tcp_listen (server, 10, new_connection_ready, &servcli, NULL), ==, R_SOCKET_OK);
   r_assert_cmpint (r_ev_tcp_connect (client, addr, client_connected, &conn, NULL), ==, R_SOCKET_WOULD_BLOCK);
   r_socket_address_unref (addr);

--- a/test/rhttpclient.c
+++ b/test/rhttpclient.c
@@ -1,8 +1,10 @@
 #include <rlib/rnet.h>
 #include <rlib/rev.h>
 
-/* Each test uses a distinct port: on Windows rtest runs single-process, so a
- * shared port can collide with a previous test's not-yet-torn-down socket. */
+/* Servers here bind an ephemeral port (0) and read back the OS-assigned port
+ * (see r_test_http_listen_ephemeral): a fixed port collides with a previous
+ * run's socket still in TIME_WAIT -- notably under meson test --repeat, and on
+ * Windows where rtest runs single-process. */
 #define R_TEST_HTTP_CLIENT_BODY   "hello from rlib"
 
 typedef struct {
@@ -87,14 +89,31 @@ r_test_http_client_handler (rpointer data, RHttpRequest * req,
   return res;
 }
 
+/* Listen on an ephemeral port (the OS picks it) and return the bound address
+ * the caller must unref. A fixed port collides with the previous run's socket
+ * still in TIME_WAIT -- notably under meson test --repeat and single-process
+ * rtest -- so every server here binds 0 and reads back the real port. */
+static RSocketAddress *
+r_test_http_listen_ephemeral (RHttpServer * srv)
+{
+  RSocketAddress * addr, * bound = NULL;
+
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)),
+      !=, NULL);
+  if (r_http_server_listen (srv, addr))
+    bound = r_http_server_get_local_address (srv);
+  r_socket_address_unref (addr);
+
+  return bound;
+}
+
 /* Build a listening server with a handler at @p path returning @p status
  * (with a body); the address to connect to is returned in *out. */
 static RHttpServer *
-r_test_http_client_server (REvLoop * loop, ruint16 port, const rchar * path,
+r_test_http_client_server (REvLoop * loop, const rchar * path,
     RHttpStatus status, RSocketAddress ** out)
 {
   RHttpServer * srv;
-  RSocketAddress * addr;
 
   if ((srv = r_http_server_new (loop)) == NULL)
     return NULL;
@@ -102,11 +121,8 @@ r_test_http_client_server (REvLoop * loop, ruint16 port, const rchar * path,
   r_assert (r_http_server_set_handler (srv, path, -1,
         r_test_http_client_handler, RUINT_TO_POINTER (status), NULL));
 
-  addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, port);
-  r_assert_cmpptr (addr, !=, NULL);
-  r_assert (r_http_server_listen (srv, addr));
-
-  *out = addr;
+  *out = r_test_http_listen_ephemeral (srv);
+  r_assert_cmpptr (*out, !=, NULL);
   return srv;
 }
 
@@ -140,7 +156,7 @@ RTEST (rhttpclient, request_get, RTEST_FAST | RTEST_SYSTEM)
   r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
   r_clock_unref (clock);
 
-  r_assert_cmpptr ((srv = r_test_http_client_server (loop, 47654, "/",
+  r_assert_cmpptr ((srv = r_test_http_client_server (loop, "/",
           R_HTTP_STATUS_OK, &addr)), !=, NULL);
   r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
 
@@ -177,18 +193,21 @@ RTEST (rhttpclient, request_get_uri, RTEST_FAST | RTEST_SYSTEM)
   RHttpResponse * res;
   RSocketAddress * addr;
   RHttpClientResult result;
-  rchar * body;
+  rchar * body, * uri;
 
   r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
   r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
   r_clock_unref (clock);
 
-  r_assert_cmpptr ((srv = r_test_http_client_server (loop, 47664, "/",
+  r_assert_cmpptr ((srv = r_test_http_client_server (loop, "/",
           R_HTTP_STATUS_OK, &addr)), !=, NULL);
   r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
 
-  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
-          "http://127.0.0.1:47664/", NULL, NULL)), !=, NULL);
+  uri = r_strprintf ("http://127.0.0.1:%u/",
+      r_socket_address_ipv4_get_port (addr));
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET, uri, NULL,
+          NULL)), !=, NULL);
+  r_free (uri);
 
   res = r_test_http_send_uri (loop, client, req, &result);
   r_http_request_unref (req);
@@ -249,7 +268,7 @@ RTEST (rhttpclient, request_not_found, RTEST_FAST | RTEST_SYSTEM)
 
   /* Handler is registered at "/specific"; request an unrelated path so no
    * handler (nor any parent with one) matches -> 404. */
-  r_assert_cmpptr ((srv = r_test_http_client_server (loop, 47655, "/specific",
+  r_assert_cmpptr ((srv = r_test_http_client_server (loop, "/specific",
           R_HTTP_STATUS_OK, &addr)), !=, NULL);
   r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
 
@@ -358,9 +377,7 @@ RTEST (rhttpclient, request_large_body, RTEST_FAST | RTEST_SYSTEM)
   r_assert_cmpptr ((srv = r_http_server_new (loop)), !=, NULL);
   r_assert (r_http_server_set_handler (srv, "/", -1,
         r_test_http_client_big_handler, NULL, NULL));
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1,
-          47657)), !=, NULL);
-  r_assert (r_http_server_listen (srv, addr));
+  r_assert_cmpptr ((addr = r_test_http_listen_ephemeral (srv)), !=, NULL);
 
   r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
   r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
@@ -405,7 +422,7 @@ RTEST (rhttpclient, request_head, RTEST_FAST | RTEST_SYSTEM)
   r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
   r_clock_unref (clock);
 
-  r_assert_cmpptr ((srv = r_test_http_client_server (loop, 47658, "/",
+  r_assert_cmpptr ((srv = r_test_http_client_server (loop, "/",
           R_HTTP_STATUS_OK, &addr)), !=, NULL);
   r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
 
@@ -461,9 +478,7 @@ RTEST (rhttpclient, server_stop_during_request, RTEST_FAST | RTEST_SYSTEM)
   r_assert_cmpptr ((srv = r_http_server_new (loop)), !=, NULL);
   r_assert (r_http_server_set_handler (srv, "/", -1,
         r_test_http_client_stop_handler, NULL, NULL));
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1,
-          47659)), !=, NULL);
-  r_assert (r_http_server_listen (srv, addr));
+  r_assert_cmpptr ((addr = r_test_http_listen_ephemeral (srv)), !=, NULL);
 
   r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
   r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
@@ -513,18 +528,24 @@ r_test_raw_conn_ready (rpointer data, REvTCP * newtcp, REvTCP * listening)
 }
 
 static RTestRawServer *
-r_test_raw_server_new (REvLoop * loop, ruint16 port, const rchar * blob,
+r_test_raw_server_new (REvLoop * loop, const rchar * blob,
     rsize blen, RSocketAddress ** out)
 {
   RTestRawServer * s = r_mem_new0 (RTestRawServer);
+  RSocketAddress * bind;
 
-  *out = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, port);
-  r_assert_cmpptr (*out, !=, NULL);
+  /* Ephemeral port (read back from the listener) -- see the comment on
+   * r_test_http_listen_ephemeral. */
+  r_assert_cmpptr ((bind = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)),
+      !=, NULL);
   s->blob = blob;
   s->blen = blen;
-  r_assert_cmpptr ((s->listen = r_ev_tcp_new_bind (*out, loop)), !=, NULL);
+  r_assert_cmpptr ((s->listen = r_ev_tcp_new_bind (bind, loop)), !=, NULL);
+  r_socket_address_unref (bind);
   r_assert_cmpint (r_ev_tcp_listen (s->listen, R_SOCKET_DEFAULT_BACKLOG,
         r_test_raw_conn_ready, s, NULL), >=, R_SOCKET_OK);
+  *out = r_ev_tcp_get_local_address (s->listen);
+  r_assert_cmpptr (*out, !=, NULL);
   return s;
 }
 
@@ -541,8 +562,7 @@ r_test_raw_server_free (RTestRawServer * s)
 }
 
 static RHttpClientResult
-r_test_http_client_raw_body (ruint16 port, const rchar * blob,
-    const rchar * expect_body)
+r_test_http_client_raw_body (const rchar * blob, const rchar * expect_body)
 {
   REvLoop * loop;
   RClock * clock;
@@ -557,7 +577,7 @@ r_test_http_client_raw_body (ruint16 port, const rchar * blob,
   r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
   r_clock_unref (clock);
 
-  raw = r_test_raw_server_new (loop, port, blob, r_strlen (blob), &addr);
+  raw = r_test_raw_server_new (loop, blob, r_strlen (blob), &addr);
   r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
   r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
           "http://127.0.0.1/", NULL, NULL)), !=, NULL);
@@ -581,15 +601,15 @@ r_test_http_client_raw_body (ruint16 port, const rchar * blob,
 }
 
 static RHttpClientResult
-r_test_http_client_raw (ruint16 port, const rchar * blob)
+r_test_http_client_raw (const rchar * blob)
 {
-  return r_test_http_client_raw_body (port, blob, NULL);
+  return r_test_http_client_raw_body (blob, NULL);
 }
 
 /* A chunked response is decoded back into the reassembled body. */
 RTEST (rhttpclient, response_chunked, RTEST_FAST | RTEST_SYSTEM)
 {
-  r_assert_cmpint (r_test_http_client_raw_body (47660,
+  r_assert_cmpint (r_test_http_client_raw_body (
         "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
         "4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n", "Wikipedia"),
       ==, R_HTTP_CLIENT_OK);
@@ -599,7 +619,7 @@ RTEST_END;
 /* A response that is not valid HTTP is a parse failure. */
 RTEST (rhttpclient, response_malformed, RTEST_FAST | RTEST_SYSTEM)
 {
-  r_assert_cmpint (r_test_http_client_raw (47661,
+  r_assert_cmpint (r_test_http_client_raw (
         "totally not a http response\r\n\r\n"), ==, R_HTTP_CLIENT_PARSE_FAILED);
 }
 RTEST_END;
@@ -642,10 +662,12 @@ RTEST (rhttpclientsync, request, RTEST_FAST | RTEST_SYSTEM)
 
   r_assert_cmpptr ((listen = r_socket_new (R_SOCKET_FAMILY_IPV4,
           R_SOCKET_TYPE_STREAM, R_SOCKET_PROTOCOL_TCP)), !=, NULL);
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1,
-          47662)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)),
+      !=, NULL);
   r_assert_cmpint (r_socket_bind (listen, addr, TRUE), ==, R_SOCKET_OK);
   r_assert_cmpint (r_socket_listen (listen), ==, R_SOCKET_OK);
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_socket_get_local_address (listen)), !=, NULL);
   /* Block in accept until the client connects (the thread starts first). */
   r_assert (r_socket_set_blocking (listen, TRUE));
   r_assert_cmpptr ((thread = r_thread_new (NULL,
@@ -685,21 +707,26 @@ RTEST (rhttpclientsync, request_uri, RTEST_FAST | RTEST_SYSTEM)
   RHttpRequest * req;
   RHttpResponse * res;
   RHttpClientResult result;
-  rchar * body;
+  rchar * body, * uri;
 
   r_assert_cmpptr ((listen = r_socket_new (R_SOCKET_FAMILY_IPV4,
           R_SOCKET_TYPE_STREAM, R_SOCKET_PROTOCOL_TCP)), !=, NULL);
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1,
-          47666)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)),
+      !=, NULL);
   r_assert_cmpint (r_socket_bind (listen, addr, TRUE), ==, R_SOCKET_OK);
   r_assert_cmpint (r_socket_listen (listen), ==, R_SOCKET_OK);
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_socket_get_local_address (listen)), !=, NULL);
   r_assert (r_socket_set_blocking (listen, TRUE));
   r_assert_cmpptr ((thread = r_thread_new (NULL,
           r_test_http_blocking_responder, listen)), !=, NULL);
 
   r_assert_cmpptr ((sync = r_http_client_sync_new ()), !=, NULL);
-  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
-          "http://127.0.0.1:47666/", NULL, NULL)), !=, NULL);
+  uri = r_strprintf ("http://127.0.0.1:%u/",
+      r_socket_address_ipv4_get_port (addr));
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET, uri, NULL,
+          NULL)), !=, NULL);
+  r_free (uri);
 
   res = r_http_client_sync_request (sync, req, &result);
   r_http_request_unref (req);
@@ -794,18 +821,20 @@ r_test_ka_responder (rpointer data)
 }
 
 static RThread *
-r_test_ka_start (RTestKaServer * s, ruint16 port, RSocketAddress ** out)
+r_test_ka_start (RTestKaServer * s, RSocketAddress ** out)
 {
   RSocketAddress * addr;
 
   r_assert_cmpptr ((s->listen = r_socket_new (R_SOCKET_FAMILY_IPV4,
           R_SOCKET_TYPE_STREAM, R_SOCKET_PROTOCOL_TCP)), !=, NULL);
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1,
-          port)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)),
+      !=, NULL);
   r_assert_cmpint (r_socket_bind (s->listen, addr, TRUE), ==, R_SOCKET_OK);
   r_assert_cmpint (r_socket_listen (s->listen), ==, R_SOCKET_OK);
   r_assert (r_socket_set_blocking (s->listen, TRUE));
-  *out = addr;
+  r_socket_address_unref (addr);
+  *out = r_socket_get_local_address (s->listen);
+  r_assert_cmpptr (*out, !=, NULL);
   return r_thread_new (NULL, r_test_ka_responder, s);
 }
 
@@ -836,7 +865,7 @@ RTEST (rhttpclientsync, keepalive_reuse, RTEST_FAST | RTEST_SYSTEM)
   RSocketAddress * addr;
   RHttpClientSync * sync;
 
-  thread = r_test_ka_start (&s, 47667, &addr);
+  thread = r_test_ka_start (&s, &addr);
   r_assert_cmpptr ((sync = r_http_client_sync_new ()), !=, NULL);
 
   r_test_ka_request (sync, addr);
@@ -863,7 +892,7 @@ RTEST (rhttpclientsync, keepalive_reuse_chunked, RTEST_FAST | RTEST_SYSTEM)
   RSocketAddress * addr;
   RHttpClientSync * sync;
 
-  thread = r_test_ka_start (&s, 47671, &addr);
+  thread = r_test_ka_start (&s, &addr);
   r_assert_cmpptr ((sync = r_http_client_sync_new ()), !=, NULL);
 
   r_test_ka_request (sync, addr);
@@ -889,7 +918,7 @@ RTEST (rhttpclientsync, keepalive_disabled, RTEST_FAST | RTEST_SYSTEM)
   RSocketAddress * addr;
   RHttpClientSync * sync;
 
-  thread = r_test_ka_start (&s, 47670, &addr);
+  thread = r_test_ka_start (&s, &addr);
   r_assert_cmpptr ((sync = r_http_client_sync_new ()), !=, NULL);
   r_assert (r_http_client_sync_get_keepalive (sync));   /* on by default */
   r_http_client_sync_set_keepalive (sync, FALSE);
@@ -919,7 +948,7 @@ RTEST (rhttpclientsync, keepalive_retry_stale, RTEST_FAST | RTEST_SYSTEM)
   RSocketAddress * addr;
   RHttpClientSync * sync;
 
-  thread = r_test_ka_start (&s, 47668, &addr);
+  thread = r_test_ka_start (&s, &addr);
   r_assert_cmpptr ((sync = r_http_client_sync_new ()), !=, NULL);
 
   r_test_ka_request (sync, addr);   /* pools the connection */
@@ -952,7 +981,7 @@ RTEST (rhttpclient, keepalive_idle_timeout, RTEST_FAST | RTEST_SYSTEM)
   RHttpClientResult result;
   int i;
 
-  thread = r_test_ka_start (&s, 47669, &addr);
+  thread = r_test_ka_start (&s, &addr);
   r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
   r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
   r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);

--- a/test/rhttpserver.c
+++ b/test/rhttpserver.c
@@ -20,7 +20,9 @@ RTEST (rhttpserver, listen, RTEST_FAST)
   r_clock_unref (clock);
 
   r_assert_cmpptr ((srv = r_http_server_new (loop)), !=, NULL);
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 4242)), !=, NULL);
+  /* Ephemeral port: a fixed port collides with a previous run's socket still
+   * in TIME_WAIT (notably under meson test --repeat). */
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
 
   r_assert (r_http_server_listen (srv, addr));
   r_socket_address_unref (addr);
@@ -205,9 +207,11 @@ RTEST (rhttpserver, keepalive_default_http11, RTEST_FAST | RTEST_SYSTEM)
   r_assert (r_http_server_set_handler (srv, "/", -1,
         r_test_http_simple_status_handler,
         RUINT_TO_POINTER (R_HTTP_STATUS_OK), NULL));
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 4243)),
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)),
       !=, NULL);
   r_assert (r_http_server_listen (srv, addr));
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_http_server_get_local_address (srv)), !=, NULL);
 
   c.addr = addr;
   r_assert_cmpptr ((thread = r_thread_new (NULL, r_test_persist_client, &c)),

--- a/test/rsocket.c
+++ b/test/rsocket.c
@@ -171,9 +171,11 @@ RTEST (rsocket, shutdown, RTEST_FAST | RTEST_SYSTEM)
   r_assert_cmpint (r_socket_shutdown (consock, FALSE, FALSE), ==, R_SOCKET_INVAL);
   r_assert_cmpint (r_socket_shutdown (consock, TRUE, TRUE), ==, R_SOCKET_NOT_CONNECTED);
 
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x4242)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
   r_assert_cmpint (r_socket_bind (lissock, addr, TRUE), ==, R_SOCKET_OK);
   r_assert_cmpint (r_socket_listen (lissock), ==, R_SOCKET_OK);
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_socket_get_local_address (lissock)), !=, NULL);
 
   r_assert_cmpint (r_socket_connect (consock, addr), ==, R_SOCKET_WOULD_BLOCK);
   r_assert (r_socket_set_blocking (lissock, TRUE));
@@ -218,9 +220,11 @@ RTEST (rsocket, listen_connect_accept, RTEST_FAST | RTEST_SYSTEM)
   r_assert_cmpptr ((addr = r_socket_get_remote_address (lissock)), ==, NULL);
   r_assert_cmpptr ((addr = r_socket_get_remote_address (consock)), ==, NULL);
 
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x4242)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
   r_assert_cmpint (r_socket_bind (lissock, addr, TRUE), ==, R_SOCKET_OK);
   r_assert_cmpint (r_socket_listen (lissock), ==, R_SOCKET_OK);
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_socket_get_local_address (lissock)), !=, NULL);
 
   r_assert_cmpptr ((accept_thread = r_thread_new (NULL, rsocket_test_accept, lissock)), !=, NULL);
   r_assert_cmpint (r_socket_connect (consock, addr), ==, R_SOCKET_OK);
@@ -256,9 +260,11 @@ RTEST (rsocket, send_recv, RTEST_FAST | RTEST_SYSTEM)
   r_assert_cmpint (r_socket_shutdown (consock, FALSE, FALSE), ==, R_SOCKET_INVAL);
   r_assert_cmpint (r_socket_shutdown (consock, TRUE, TRUE), ==, R_SOCKET_NOT_CONNECTED);
 
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x4242)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
   r_assert_cmpint (r_socket_bind (lissock, addr, TRUE), ==, R_SOCKET_OK);
   r_assert_cmpint (r_socket_listen (lissock), ==, R_SOCKET_OK);
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_socket_get_local_address (lissock)), !=, NULL);
 
   r_assert_cmpint (r_socket_connect (consock, addr), ==, R_SOCKET_WOULD_BLOCK);
   r_assert (r_socket_set_blocking (lissock, TRUE));


### PR DESCRIPTION
## Why

The HTTP and TCP tests bound **fixed ports** (`47654`, `0x6363`, `4243`, …).
A fixed port collides with a previous run's socket still in `TIME_WAIT`, so
running the suite back-to-back — `meson test --repeat`, or single-process
`rtest` on Windows — flakes with spurious connection failures, resets and
hangs that mask real bugs. (This surfaced while stress-testing the
Windows-rpoll suite: `keepalive_idle_timeout`, `keepalive_default_http11` and
`revtcp/listen_connect_accept_send_recv` all failed under `--repeat` on
**master**, independent of any rpoll change.)

## What

- **New API** `r_http_server_get_local_address` — returns the bound address of
  the server's first listener, so a caller that listened on an ephemeral port
  (`0`) can learn the OS-assigned port (thin wrapper over the existing
  `r_ev_tcp_get_local_address`).
- **Convert the networking tests to ephemeral ports**: every server binds `0`
  and reads back its real address (`r_http_server_get_local_address` /
  `r_ev_tcp_get_local_address` / `r_socket_get_local_address`) for the client
  to target; where a test connects via a request URI, the URI is built from
  that port. `connect_refused` keeps its fixed (unlistened) port on purpose.

Covers `rhttpclient.c`, `rhttpserver.c`, `revtcp.c`. `rsocket.c` binds ports
too but did not flake under `--repeat`; it can follow if needed.

## Verification

- Full Linux suite green (epoll); ASan/UBSan clean on `rhttpclient` /
  `rhttpserver` / `revtcp`; mingw cross `-Werror` builds clean; Doxygen 0
  warnings (new API documented). Ephemeral ports are cross-platform, so the
  test logic is validated on Linux.

Note: the **Windows rpoll** job may still show the pre-existing intermittent
`server_stop_during_request` hang — that's a separate rpoll-backend bug
(tracked, fixed on its own branch), not introduced here.