### PR TITLE
ev/udp: ephemeral ports in revudp tests

### DIFF
--- a/include/rlib/ev/revudp.h
+++ b/include/rlib/ev/revudp.h
@@ -75,6 +75,13 @@ R_API REvUDP * r_ev_udp_new (RSocketFamily family, REvLoop * loop);
 /** @brief Bind to @p address; @p reuse sets @c SO_REUSEADDR. */
 R_API rboolean r_ev_udp_bind (REvUDP * evudp,
     const RSocketAddress * address, rboolean reuse);
+/**
+ * @brief Local address of the bound socket.
+ *
+ * Useful after binding an ephemeral port (port 0) to learn the OS-assigned
+ * port. @return A new @ref RSocketAddress the caller must unref, or @c NULL.
+ */
+R_API RSocketAddress * r_ev_udp_get_local_address (const REvUDP * evudp);
 /** @brief Start receiving datagrams; @p alloc supplies buffers, @p recv delivers them. */
 R_API rboolean r_ev_udp_recv_start (REvUDP * evudp,
     REvUDPBufferAllocFunc alloc, REvUDPBufferFunc recv,

--- a/rlib/ev/revudp.c
+++ b/rlib/ev/revudp.c
@@ -145,6 +145,12 @@ r_ev_udp_bind (REvUDP * evudp, const RSocketAddress * address, rboolean reuse)
     r_socket_bind (evudp->socket, address, reuse) == R_SOCKET_OK;
 }
 
+RSocketAddress *
+r_ev_udp_get_local_address (const REvUDP * evudp)
+{
+  return evudp != NULL ? r_socket_get_local_address (evudp->socket) : NULL;
+}
+
 #define R_EV_UDP_BUFFER_SIZE        4096
 
 static RBuffer *

--- a/test/revudp.c
+++ b/test/revudp.c
@@ -48,8 +48,10 @@ RTEST (revudp, bind_recv, RTEST_FAST | RTEST_SYSTEM)
   r_clock_unref (clock);
 
   r_assert_cmpptr ((evudp = r_ev_udp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x4242)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
   r_assert (r_ev_udp_bind (evudp, addr, TRUE));
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_ev_udp_get_local_address (evudp)), !=, NULL);
 
   r_assert (r_ev_udp_recv_start (evudp, NULL, buffer_recv, &ctx, NULL));
 
@@ -98,8 +100,10 @@ RTEST (revudp, send_recv, RTEST_FAST | RTEST_SYSTEM)
   r_clock_unref (clock);
 
   r_assert_cmpptr ((udp1 = r_ev_udp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x4242)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
   r_assert (r_ev_udp_bind (udp1, addr, TRUE));
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_ev_udp_get_local_address (udp1)), !=, NULL);
 
   r_assert (r_ev_udp_recv_start (udp1, NULL, buffer_recv, &ctx, NULL));
 
@@ -157,8 +161,10 @@ RTEST (revudp, send_recv_multi, RTEST_FAST | RTEST_SYSTEM)
   r_clock_unref (clock);
 
   r_assert_cmpptr ((udp1 = r_ev_udp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x4242)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
   r_assert (r_ev_udp_bind (udp1, addr, TRUE));
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_ev_udp_get_local_address (udp1)), !=, NULL);
   r_assert (r_ev_udp_recv_start (udp1, NULL, buffer_recv, &ctx, NULL));
 
   r_assert_cmpptr ((udp2 = r_ev_udp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
@@ -204,8 +210,10 @@ RTEST (revudp, task_recv, RTEST_FAST | RTEST_SYSTEM)
   r_clock_unref (clock);
 
   r_assert_cmpptr ((udp1 = r_ev_udp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x4242)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
   r_assert (r_ev_udp_bind (udp1, addr, TRUE));
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_ev_udp_get_local_address (udp1)), !=, NULL);
 
   r_assert (r_ev_udp_task_recv_start (udp1, 0, NULL, buffer_recv, &ctx, NULL));
 


### PR DESCRIPTION
Follow-up to #314, same rationale: the `revudp` bind/recv tests bound a **fixed**
UDP port (`0x4242`), which collides with a previous run's socket under
`meson test --repeat` — the bind fails and the dependent send/recv tests then
time out. (Found while stress-testing the rpoll suite under `--repeat`; UDP is
not as `TIME_WAIT`-immune as it looks back-to-back.)

## Change

- **New API** `r_ev_udp_get_local_address` — returns the bound socket's local
  address so a caller that bound port `0` can learn the OS-assigned port
  (mirrors the existing `r_ev_tcp_get_local_address`).
- Convert the four `revudp` bind sites to bind `0` and read the receiver's
  address back for the sender to target. The `MSG_SIZE` test keeps a fixed port
  — it uses the address only as an unbound send target.

## Verification

Full Linux suite green; `revudp` green; mingw cross `-Werror` clean; Doxygen 0
warnings (new API documented).

Note: the **Windows rpoll** job may show the pre-existing `server_stop` flake
(separate rpoll-backend bug, fixed on its own branch) — unrelated to this change.