### PR TITLE
test: bind ephemeral ports in rsocket UDP datagram tests

### DIFF
--- a/test/rsocket.c
+++ b/test/rsocket.c
@@ -308,11 +308,18 @@ RTEST (rsocket, sendto_recvfrom, RTEST_FAST | RTEST_SYSTEM)
   r_assert_cmpptr ((sock2 = r_socket_new (R_SOCKET_FAMILY_IPV4,
           R_SOCKET_TYPE_DATAGRAM, R_SOCKET_PROTOCOL_UDP)), !=, NULL);
 
-  r_assert_cmpptr ((addr1 = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x4242)), !=, NULL);
-  r_assert_cmpptr ((addr2 = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x2222)), !=, NULL);
   r_assert_cmpptr ((srcaddr = r_socket_address_new ()), !=, NULL);
+  /* Ephemeral ports read back from the sockets: fixed UDP ports collide under
+   * meson test --repeat (SO_REUSEPORT can even misroute a datagram to a prior
+   * run's leftover socket). */
+  r_assert_cmpptr ((addr1 = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
+  r_assert_cmpptr ((addr2 = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
   r_assert_cmpint (r_socket_bind (sock1, addr1, TRUE), ==, R_SOCKET_OK);
   r_assert_cmpint (r_socket_bind (sock2, addr2, TRUE), ==, R_SOCKET_OK);
+  r_socket_address_unref (addr1);
+  r_socket_address_unref (addr2);
+  r_assert_cmpptr ((addr1 = r_socket_get_local_address (sock1)), !=, NULL);
+  r_assert_cmpptr ((addr2 = r_socket_get_local_address (sock2)), !=, NULL);
 
   /* sendto and recvfrom */
   {
@@ -353,11 +360,18 @@ RTEST (rsocket, sendmsg_recvmsg, RTEST_FAST | RTEST_SYSTEM)
   r_assert_cmpptr ((sock2 = r_socket_new (R_SOCKET_FAMILY_IPV4,
           R_SOCKET_TYPE_DATAGRAM, R_SOCKET_PROTOCOL_UDP)), !=, NULL);
 
-  r_assert_cmpptr ((addr1 = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x4242)), !=, NULL);
-  r_assert_cmpptr ((addr2 = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x2222)), !=, NULL);
   r_assert_cmpptr ((srcaddr = r_socket_address_new ()), !=, NULL);
+  /* Ephemeral ports read back from the sockets: fixed UDP ports collide under
+   * meson test --repeat (SO_REUSEPORT can even misroute a datagram to a prior
+   * run's leftover socket). */
+  r_assert_cmpptr ((addr1 = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
+  r_assert_cmpptr ((addr2 = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
   r_assert_cmpint (r_socket_bind (sock1, addr1, TRUE), ==, R_SOCKET_OK);
   r_assert_cmpint (r_socket_bind (sock2, addr2, TRUE), ==, R_SOCKET_OK);
+  r_socket_address_unref (addr1);
+  r_socket_address_unref (addr2);
+  r_assert_cmpptr ((addr1 = r_socket_get_local_address (sock1)), !=, NULL);
+  r_assert_cmpptr ((addr2 = r_socket_get_local_address (sock2)), !=, NULL);
 
   /* sendmsg and recvmsg */
   {


### PR DESCRIPTION
Follow-up to #314/#315 — the last fixed-port tests that actually flake under
`--repeat`.

`rsocket`'s `sendto_recvfrom` / `sendmsg_recvmsg` bound fixed UDP ports
(`0x4242` / `0x2222`). Under `meson test --repeat` those collide with a previous
run's socket — and because `reuse=TRUE` sets `SO_REUSEPORT` for UDP, a datagram
can be load-balanced to a **leftover socket from the prior run**, so the real
receiver times out. (Confirmed: `sendmsg_recvmsg` flaked under a local Linux
rpoll `--repeat` run.) `SO_REUSEADDR`/`SO_REUSEPORT` is the wrong tool here;
ephemeral ports are.

Bind `0` on both sockets and read back the OS-assigned addresses
(`r_socket_get_local_address`) to send between; the source-address assertion
still holds. Left alone (low-risk / intentional): the bind-mechanics tests
(`bind`/`listen`/`accept`), `get_local_address` (asserts the exact bound port),
and `connect_would_block` (never binds a listener).

Full Linux suite green (epoll + rpoll), `/rsocket` green, mingw `-Werror` clean.