### PR TITLE
ev/tcp: split connection teardown into graceful close and immediate abort

### DIFF
--- a/include/rlib/ev/revtcp.h
+++ b/include/rlib/ev/revtcp.h
@@ -78,8 +78,65 @@ typedef void (*REvTCPErrorFunc) (rpointer data, REvTCP * evtcp, RSocketStatus er
 R_API REvTCP * r_ev_tcp_new (RSocketFamily family, REvLoop * loop);
 /** @brief Create a TCP socket already bound to @p addr. */
 R_API REvTCP * r_ev_tcp_new_bind (const RSocketAddress * addr, REvLoop * loop);
-/** @brief Close the socket; @p close_cb fires once closed. */
+/**
+ * @brief Close the connection gracefully: flush, half-close, then finish.
+ *
+ * Any data already queued with @ref r_ev_tcp_send is flushed to the peer
+ * first; once the send queue is empty the write side is shut down (a TCP
+ * @c FIN, so the peer reads end-of-stream) and the socket is closed.
+ * Because the flush may take several loop iterations, the close is
+ * asynchronous: @p close_cb fires on the loop thread once the socket is
+ * fully closed (the queue drained and the handle released), never before.
+ *
+ * Receiving is stopped immediately -- no further receive callbacks fire and
+ * any unread inbound bytes are discarded; only the *write* side is drained.
+ * If the peer is not reading, a full kernel send buffer can hold the flush
+ * (and therefore @p close_cb) off indefinitely; use @ref r_ev_tcp_abort when
+ * a bounded, immediate teardown matters more than delivering queued bytes.
+ *
+ * Idempotent and safe to call from within the socket's own callbacks. Use
+ * this for an orderly shutdown where the queued bytes must reach the peer
+ * (e.g. a final response before closing a connection).
+ *
+ * @param evtcp       the connection to close; @c NULL is a no-op.
+ * @param close_cb    fired once, after the socket is fully closed; may be
+ *                    @c NULL.
+ * @param data        user data passed to @p close_cb.
+ * @param datanotify  invoked on @p data when the close completes (or is
+ *                    superseded); may be @c NULL.
+ * @return @c TRUE if the close was initiated.
+ *
+ * @sa r_ev_tcp_abort
+ */
 R_API rboolean r_ev_tcp_close (REvTCP * evtcp, REvIOFunc close_cb,
+    rpointer data, RDestroyNotify datanotify);
+/**
+ * @brief Close the connection immediately, discarding queued sends.
+ *
+ * The counterpart to @ref r_ev_tcp_close. Any bytes still queued with
+ * @ref r_ev_tcp_send are dropped unsent, both directions are torn down at
+ * once, and the socket is closed without waiting for a flush. The peer may
+ * observe this as a connection reset rather than an orderly @c FIN.
+ *
+ * Receiving and sending stop immediately. @p close_cb still fires on the
+ * loop thread once the handle is released, but -- unlike the graceful close
+ * -- it is not gated on delivering queued data, so it completes promptly and
+ * cannot stall on a stuck peer.
+ *
+ * Idempotent and safe to call from within the socket's own callbacks. Use
+ * this for connection eviction / error teardown, or wherever pending output
+ * is not worth waiting for.
+ *
+ * @param evtcp       the connection to abort; @c NULL is a no-op.
+ * @param close_cb    fired once, after the socket is closed; may be @c NULL.
+ * @param data        user data passed to @p close_cb.
+ * @param datanotify  invoked on @p data when the close completes; may be
+ *                    @c NULL.
+ * @return @c TRUE if the abort was initiated.
+ *
+ * @sa r_ev_tcp_close
+ */
+R_API rboolean r_ev_tcp_abort (REvTCP * evtcp, REvIOFunc close_cb,
     rpointer data, RDestroyNotify datanotify);
 /** @brief Take a reference (alias for @ref r_ref_ref). */
 #define r_ev_tcp_ref r_ref_ref

--- a/rlib/ev/revtcp.c
+++ b/rlib/ev/revtcp.c
@@ -86,6 +86,14 @@ struct REvTCP {
 
   RQueue qsend;
 
+  /* Graceful close (r_ev_tcp_close): set while the send queue is draining
+   * before the half-close. Once qsend empties (or a send fails) the write
+   * side is shut down and these fire the deferred close. */
+  rboolean closing;
+  REvIOFunc close_cb;
+  rpointer close_data;
+  RDestroyNotify close_datanotify;
+
 #if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
   /* Completion (proactor) backend: an op is posted, its completion delivers
    * the result. Each in-flight op holds one ref on this REvTCP. */
@@ -115,6 +123,12 @@ static void
 r_ev_tcp_free (REvTCP * evtcp)
 {
   r_queue_clear (&evtcp->qsend, r_ev_tcp_send_ctx_free);
+
+  /* A graceful close that never reached its finalizer (e.g. the last ref was
+   * dropped while the queue was still draining) still owns the caller's close
+   * data; release it so its notify cannot leak. */
+  if (evtcp->close_datanotify != NULL)
+    evtcp->close_datanotify (evtcp->close_data);
 #if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
   /* No ops can be in flight here: each holds a ref, so the last unref (which
    * brought us here) cannot run while one is outstanding. Release whatever
@@ -142,6 +156,10 @@ r_ev_tcp_free (REvTCP * evtcp)
   r_ev_io_clear (&evtcp->evio);
   r_free (evtcp);
 }
+
+/* Finish a graceful close once its send queue has drained (defined with the
+ * close API below; called from the send-completion paths above it). */
+static void r_ev_tcp_finalize_close (REvTCP * evtcp);
 
 static REvTCP *
 r_ev_tcp_new_with_socket (RSocket * socket, REvLoop * loop)
@@ -456,6 +474,14 @@ r_ev_tcp_iocp_send_complete (REvIOCPOp * op, REvLoop * loop, rsize bytes)
       evtcp->error (evtcp->error_data, evtcp, r_ev_tcp_iocp_status (err));
   }
 
+  /* Graceful close waiting on this queue (r_ev_tcp_close): finish once it has
+   * drained, or once a send failed and the tail can never go out. An aborted
+   * op belongs to a teardown already in progress, so it is left alone. */
+  if (evtcp->closing &&
+      (r_queue_peek (&evtcp->qsend) == NULL ||
+       (err != 0 && err != ERROR_OPERATION_ABORTED)))
+    r_ev_tcp_finalize_close (evtcp);
+
   r_ev_tcp_unref (evtcp);
 }
 
@@ -609,11 +635,14 @@ r_ev_tcp_iocp_connect_complete (REvIOCPOp * op, REvLoop * loop, rsize bytes)
 }
 #endif /* R_OS_WIN32 && !R_EV_USE_RPOLL */
 
-rboolean
-r_ev_tcp_close (REvTCP * evtcp, REvIOFunc close_cb, rpointer data, RDestroyNotify datanotify)
+/* Tear down all I/O watches, mark the handle closed, and schedule @close_cb.
+ * The underlying socket is released when the last reference drops in
+ * r_ev_tcp_free. Shared by the immediate abort and the graceful-close
+ * finalizer; idempotent with respect to the individual watches. */
+static rboolean
+r_ev_tcp_teardown (REvTCP * evtcp, REvIOFunc close_cb, rpointer data,
+    RDestroyNotify datanotify)
 {
-  R_LOG_DEBUG ("loop %p evio "R_EV_IO_FORMAT,
-      evtcp->evio.loop, R_EV_IO_ARGS (evtcp));
 #if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
   /* Cancel every in-flight overlapped op on the socket; each completes with
    * ERROR_OPERATION_ABORTED, drops its ref, and the socket is finally closed
@@ -627,8 +656,6 @@ r_ev_tcp_close (REvTCP * evtcp, REvIOFunc close_cb, rpointer data, RDestroyNotif
     r_task_unref (evtcp->recv_task);
     evtcp->recv_task = NULL;
   }
-  evtcp->evio.flags |= R_EV_IO_CLOSED;
-  return r_ev_io_close ((REvIO *)evtcp, close_cb, data, datanotify);
 #else
   r_ev_tcp_recv_stop (evtcp);
 
@@ -644,11 +671,110 @@ r_ev_tcp_close (REvTCP * evtcp, REvIOFunc close_cb, rpointer data, RDestroyNotif
     r_ev_io_stop (&evtcp->evio, evtcp->listen_iocb_ctx);
     evtcp->listen_iocb_ctx = NULL;
   }
+#endif
 
-  /* Mark as closed, but close is actually happening in r_socket_free -> FIXME? */
   evtcp->evio.flags |= R_EV_IO_CLOSED;
   return r_ev_io_close ((REvIO *)evtcp, close_cb, data, datanotify);
-#endif
+}
+
+/* Deferred half of the graceful close: runs as a loop callback so the watch
+ * teardown never happens inside the send path's own dispatch. */
+static void
+r_ev_tcp_finalize_teardown (rpointer data, REvLoop * loop)
+{
+  REvTCP * evtcp = data;
+  REvIOFunc close_cb = evtcp->close_cb;
+  rpointer cdata = evtcp->close_data;
+  RDestroyNotify cnotify = evtcp->close_datanotify;
+  (void) loop;
+
+  evtcp->close_cb = NULL;
+  evtcp->close_data = NULL;
+  evtcp->close_datanotify = NULL;
+  r_ev_tcp_teardown (evtcp, close_cb, cdata, cnotify);
+}
+
+/* The send queue has drained (or a send failed) during a graceful close:
+ * half-close the write side so the peer reads end-of-stream, then finish the
+ * teardown. Idempotent -- only the first call, while still closing, acts. */
+static void
+r_ev_tcp_finalize_close (REvTCP * evtcp)
+{
+  if (!evtcp->closing)
+    return;
+  evtcp->closing = FALSE;
+
+  r_io_socket_shutdown (evtcp->evio.handle, FALSE, TRUE);
+  /* Defer the watch teardown: we are called from within the send path, where
+   * stopping the send watcher synchronously would corrupt loop iteration. */
+  r_ev_loop_add_callback (evtcp->evio.loop, FALSE,
+      r_ev_tcp_finalize_teardown, r_ev_tcp_ref (evtcp), r_ev_tcp_unref);
+}
+
+rboolean
+r_ev_tcp_close (REvTCP * evtcp, REvIOFunc close_cb, rpointer data, RDestroyNotify datanotify)
+{
+  if (R_UNLIKELY (evtcp == NULL)) return FALSE;
+
+  R_LOG_DEBUG ("loop %p evio "R_EV_IO_FORMAT,
+      evtcp->evio.loop, R_EV_IO_ARGS (evtcp));
+
+  /* Already closed, or a graceful close is already draining: nothing to add. */
+  if ((evtcp->evio.flags & R_EV_IO_CLOSED) || evtcp->closing) {
+    if (datanotify != NULL)
+      datanotify (data);
+    return FALSE;
+  }
+
+  /* Receiving stops immediately; only the write side is drained. */
+  r_ev_tcp_recv_stop (evtcp);
+
+  /* With nothing queued there is nothing to flush: half-close and finish now.
+   * Otherwise hand off to the send path, which finalizes once the queue
+   * drains (or a send fails and the tail becomes undeliverable). */
+  if (r_queue_peek (&evtcp->qsend) == NULL) {
+    r_io_socket_shutdown (evtcp->evio.handle, FALSE, TRUE);
+    return r_ev_tcp_teardown (evtcp, close_cb, data, datanotify);
+  }
+
+  evtcp->closing = TRUE;
+  evtcp->close_cb = close_cb;
+  evtcp->close_data = data;
+  evtcp->close_datanotify = datanotify;
+  return TRUE;
+}
+
+rboolean
+r_ev_tcp_abort (REvTCP * evtcp, REvIOFunc close_cb, rpointer data, RDestroyNotify datanotify)
+{
+  if (R_UNLIKELY (evtcp == NULL)) return FALSE;
+
+  R_LOG_DEBUG ("loop %p evio "R_EV_IO_FORMAT,
+      evtcp->evio.loop, R_EV_IO_ARGS (evtcp));
+
+  if (evtcp->evio.flags & R_EV_IO_CLOSED) {
+    if (datanotify != NULL)
+      datanotify (data);
+    return FALSE;
+  }
+
+  /* A graceful close may have been mid-drain: drop its deferred state and the
+   * data it was holding before tearing the socket down underneath it. */
+  evtcp->closing = FALSE;
+  if (evtcp->close_datanotify != NULL)
+    evtcp->close_datanotify (evtcp->close_data);
+  evtcp->close_cb = NULL;
+  evtcp->close_data = NULL;
+  evtcp->close_datanotify = NULL;
+
+  /* Discard anything still queued -- abort does not wait to deliver it. */
+  r_queue_clear (&evtcp->qsend, r_ev_tcp_send_ctx_free);
+
+  /* No half-close (FIN) here, deliberately: the connection ends when the
+   * handle is released, honouring the socket's linger setting -- so a caller
+   * that set SO_LINGER to 0 gets the abortive RST it asked for, which a
+   * shutdown(FIN) would pre-empt. */
+  return r_ev_tcp_teardown (evtcp, close_cb, data, datanotify);
 }
 
 RSocket *
@@ -966,7 +1092,7 @@ static void
 r_ev_tcp_send_iocb (REvTCP * evtcp)
 {
   REvTCPSendCtx * ctx;
-  RSocketStatus res;
+  RSocketStatus res = R_SOCKET_OK;
   rsize sent;
 
   while ((ctx = r_queue_peek (&evtcp->qsend)) != NULL) {
@@ -1000,6 +1126,12 @@ r_ev_tcp_send_iocb (REvTCP * evtcp)
       break;
     }
   }
+
+  /* Graceful close waiting on this queue (r_ev_tcp_close): once it has fully
+   * drained -- or a send failed and the tail can never go out -- half-close
+   * and finish. A WOULD_BLOCK leaves the writable watcher armed to resume. */
+  if (evtcp->closing && res != R_SOCKET_WOULD_BLOCK)
+    r_ev_tcp_finalize_close (evtcp);
 }
 
 static void
@@ -1224,6 +1356,14 @@ r_ev_tcp_send (REvTCP * evtcp, RBuffer * buf,
 {
   REvTCPSendCtx * ctx;
   rboolean ret;
+
+  /* The write side is gone once a close has been requested: a graceful close
+   * is draining toward its half-close and an abort has already shut down, so a
+   * late send (e.g. a response produced after the connection was torn down)
+   * has nowhere to go -- and writing the half-closed/reset socket would raise
+   * EPIPE. Drop it rather than queue something that can never be sent. */
+  if ((evtcp->evio.flags & R_EV_IO_CLOSED) || evtcp->closing)
+    return FALSE;
 
   if ((ret = (ctx = r_mem_new (REvTCPSendCtx)) != NULL)) {
     ctx->buf = r_buffer_ref (buf);

--- a/rlib/net/rhttpclient.c
+++ b/rlib/net/rhttpclient.c
@@ -151,7 +151,7 @@ r_http_client_conn_free (RHttpClientConn * conn)
      * (closing == TRUE); otherwise (pool torn down with the client) close it
      * here, synchronously -- we are not inside an io callback. */
     if (!conn->closing)
-      r_ev_tcp_close (conn->evtcp, NULL, NULL, NULL);
+      r_ev_tcp_abort (conn->evtcp, NULL, NULL, NULL);
     r_ev_tcp_unref (conn->evtcp);
   }
   if (conn->addr != NULL)
@@ -165,7 +165,7 @@ r_http_client_conn_do_close (rpointer data, REvLoop * loop)
   RHttpClientConn * conn = data;
   (void) loop;
 
-  r_ev_tcp_close (conn->evtcp, NULL, NULL, NULL);
+  r_ev_tcp_abort (conn->evtcp, NULL, NULL, NULL);
 }
 
 /* Close conn's socket. Idempotent. @defer is TRUE when called from inside one
@@ -188,7 +188,7 @@ r_http_client_conn_close (RHttpClientConn * conn, rboolean defer)
           r_http_client_conn_do_close, r_http_client_conn_ref (conn),
           r_http_client_conn_unref);
     else
-      r_ev_tcp_close (conn->evtcp, NULL, NULL, NULL);
+      r_ev_tcp_abort (conn->evtcp, NULL, NULL, NULL);
   }
 }
 

--- a/rlib/net/rhttpserver.c
+++ b/rlib/net/rhttpserver.c
@@ -583,7 +583,7 @@ r_http_server_tcp_close (rpointer data, rpointer user)
 
   /* This looks wierd, and yes, no close callback,
    * but rather use ref counting of the ctx object */
-  r_ev_tcp_close (tcp, NULL, r_ref_ref (ctx), r_ref_unref);
+  r_ev_tcp_abort (tcp, NULL, r_ref_ref (ctx), r_ref_unref);
 }
 
 static void
@@ -596,8 +596,9 @@ r_http_server_close_client_ctx (rpointer data, rpointer user)
   /* Close only; the array removal (and the context's last unref) is done by
    * the r_ptr_array_remove_all_full walk that invoked this. Calling
    * r_http_client_ctx_close here would remove the entry mid-walk and drop the
-   * reference twice. */
-  r_ev_tcp_close (cli->evtcp, NULL, r_ref_ref (ctx), r_ref_unref);
+   * reference twice. A forced stop aborts -- it must not block on a slow or
+   * stalled peer the way a graceful flush could. */
+  r_ev_tcp_abort (cli->evtcp, NULL, r_ref_ref (ctx), r_ref_unref);
 }
 
 rsize

--- a/test/revtcp.c
+++ b/test/revtcp.c
@@ -223,11 +223,12 @@ RTEST (revtcp, recv_error_handler, RTEST_FAST | RTEST_SYSTEM)
   r_ev_tcp_set_error_handler (client, error_received, &err, NULL);
   r_assert (r_ev_tcp_recv_start (client, NULL, data_received, &buf, NULL));
 
-  /* Close servcli abruptly so the idle client observes a connection-reset
-   * error rather than EOF. SO_LINGER with a zero timeout makes close send a
-   * TCP RST immediately and deterministically. */
+  /* Abort servcli so the idle client observes a connection-reset error rather
+   * than EOF. SO_LINGER with a zero timeout makes the closing handle send a
+   * TCP RST immediately and deterministically (abort adds no FIN that would
+   * pre-empt it). */
   r_assert (r_socket_set_linger (r_ev_tcp_get_socket (servcli), TRUE, 0));
-  r_assert (r_ev_tcp_close (servcli, NULL, NULL, NULL));
+  r_assert (r_ev_tcp_abort (servcli, NULL, NULL, NULL));
   r_ev_tcp_unref (servcli);
 
   /* Process the deferred close (which sends the RST) and the reset the
@@ -284,7 +285,7 @@ RTEST (revtcp, recv_error_no_handler, RTEST_FAST | RTEST_SYSTEM)
    * deterministic RST from the peer. */
   r_assert (r_ev_tcp_recv_start (client, NULL, eos_received, &eos, NULL));
   r_assert (r_socket_set_linger (r_ev_tcp_get_socket (servcli), TRUE, 0));
-  r_assert (r_ev_tcp_close (servcli, NULL, NULL, NULL));
+  r_assert (r_ev_tcp_abort (servcli, NULL, NULL, NULL));
   r_ev_tcp_unref (servcli);
 
   for (i = 0; i < 16 && !eos; i++)

--- a/test/rhttpclient.c
+++ b/test/rhttpclient.c
@@ -553,10 +553,10 @@ static void
 r_test_raw_server_free (RTestRawServer * s)
 {
   if (s->conn != NULL) {
-    r_ev_tcp_close (s->conn, NULL, NULL, NULL);
+    r_ev_tcp_abort (s->conn, NULL, NULL, NULL);
     r_ev_tcp_unref (s->conn);
   }
-  r_ev_tcp_close (s->listen, NULL, NULL, NULL);
+  r_ev_tcp_abort (s->listen, NULL, NULL, NULL);
   r_ev_tcp_unref (s->listen);
   r_free (s);
 }


### PR DESCRIPTION
`r_ev_tcp_close` had a single, underspecified behaviour: it stopped the I/O
watches and marked the handle closed, but left the send queue untouched (freed
unsent only at the final unref) and never half-closed — so a peer waiting on
end-of-stream could stall, and queued output could be silently dropped. The
code even carried a `/* close is actually happening in r_socket_free -> FIXME? */`.

This replaces that with two explicit, documented contracts:

- **`r_ev_tcp_close`** — graceful. Stop receiving, flush the send queue, then
  `shutdown(WR)` so the peer reads end-of-stream. The flush spans loop
  iterations, so `close_cb` fires once the socket is actually closed; the send
  path finalizes the close when the queue drains (or a send can no longer
  progress).
- **`r_ev_tcp_abort`** — immediate. Drop the queued sends and tear down at once,
  leaving the handle's linger setting to decide FIN vs RST — deliberately no
  `shutdown(WR)`, which would pre-empt an `SO_LINGER=0` reset.

`r_ev_tcp_send` now fails instead of queueing on a connection whose close has
begun (queuing there could never be sent and would raise `EPIPE` on the
half-closed socket).

Adoption of the split:
- HTTP server's orderly per-connection close stays graceful.
- A forced `r_http_server_stop` and the client connection-pool eviction abort —
  neither should block on a slow or stalled peer.
- The revtcp reset tests abort their peer: that is the abortive-RST behaviour
  they assert (a graceful FIN would pre-empt the `SO_LINGER=0` reset).

Motivated by the #310 teardown-race investigation. Both new symbols carry full
Doxygen.

Verification: full suite green on Linux epoll and rpoll, including `--repeat 200`
on each; ASan/UBSan clean (exercises the free-while-closing path); mingw cross
`-Werror` clean; doxygen 0 warnings.