### PR TITLE
rpoll: winsock select() backend on Windows + reactor abort close

### DIFF
--- a/include/rlib/rpoll.h
+++ b/include/rlib/rpoll.h
@@ -40,7 +40,7 @@
  *
  * @ref r_poll takes a flat @ref RPoll array and waits with the host's
  * readiness primitive: @c ppoll() / @c poll() or @c select() on POSIX,
- * and a @c WSAEventSelect + @c WaitForMultipleObjectsEx wait on Windows.
+ * and winsock @c select() on Windows.
  * @ref RPollSet adds bookkeeping for an arbitrary-size set with
  * per-handle user data and constant-time lookups (handle → index,
  * handle → user pointer).
@@ -77,14 +77,6 @@ typedef struct {
   RIOHandle handle;   /**< Handle to poll. */
   rushort events;     /**< Requested events bitmask (@c R_IO_* flags). */
   rushort revents;    /**< Returned events, filled by @ref r_poll. */
-#ifdef R_OS_WIN32
-  /* Win32 only: the WSAEVENT a socket handle is associated with through
-   * WSAEventSelect, so WaitForMultipleObjectsEx waits on socket readiness
-   * rather than the bare socket. NULL for a non-socket handle (e.g. the
-   * loop wakeup event), which is waited on directly. Owned by the
-   * @ref RPollSet that manages this entry. */
-  rpointer wsaevent;
-#endif
 } RPoll;
 
 /**

--- a/rlib/ev/revtcp.c
+++ b/rlib/ev/revtcp.c
@@ -770,10 +770,18 @@ r_ev_tcp_abort (REvTCP * evtcp, REvIOFunc close_cb, rpointer data, RDestroyNotif
   /* Discard anything still queued -- abort does not wait to deliver it. */
   r_queue_clear (&evtcp->qsend, r_ev_tcp_send_ctx_free);
 
-  /* No half-close (FIN) here, deliberately: the connection ends when the
-   * handle is released, honouring the socket's linger setting -- so a caller
-   * that set SO_LINGER to 0 gets the abortive RST it asked for, which a
-   * shutdown(FIN) would pre-empt. */
+#if !defined (R_OS_WIN32) || defined (R_EV_USE_RPOLL)
+  /* Reactor (readiness) backends: close the socket now, not at the last unref.
+   * The close is what tells the peer the connection ended -- a FIN, or a RST if
+   * the caller set SO_LINGER to 0 (closesocket honours the linger setting).
+   * Leaving it to free made peer notification depend on the refcount dropping
+   * promptly, which it does not always do; a peer waiting on the close would
+   * then hang. A proactor (completion) backend must NOT do this: its in-flight
+   * overlapped ops hold refs and reference the socket, so the handle can only
+   * be released once they have drained -- hence the deferred close there. */
+  r_socket_close (evtcp->socket);
+#endif
+
   return r_ev_tcp_teardown (evtcp, close_cb, data, datanotify);
 }
 

--- a/rlib/ev/revwakeup.c
+++ b/rlib/ev/revwakeup.c
@@ -22,6 +22,9 @@
 
 #include <rlib/rio.h>
 
+#if defined (R_OS_WIN32)
+#include <winsock2.h>   /* before windows.h: winsock select()/socketpair wakeup */
+#endif
 #if defined (HAVE_WINDOWS_H)
 #include <windows.h>
 #endif
@@ -38,6 +41,53 @@
 #include <errno.h>
 
 #define R_LOG_CAT_DEFAULT &revlogcat
+
+#if defined (R_OS_WIN32)
+/* Windows winsock select() waits on sockets only, so the loop wakeup cannot be
+ * an event handle -- it must be a connected socket pair (a self-pipe). Windows
+ * has no socketpair(), so emulate one over the loopback interface: bind+listen
+ * an ephemeral port, connect a second socket to it, accept the peer. The
+ * connect completes against the loopback listener without an interleaved
+ * accept, so this is safe on a single thread. @rd is the readable wait end,
+ * @wr the end signalled to wake the loop; both are left non-blocking. */
+static rboolean
+r_ev_wakeup_win_socketpair (SOCKET * rd, SOCKET * wr)
+{
+  SOCKET listener = INVALID_SOCKET, c = INVALID_SOCKET, a = INVALID_SOCKET;
+  struct sockaddr_in addr;
+  int addrlen = (int) sizeof (addr);
+  u_long nb = 1;
+
+  if ((listener = socket (AF_INET, SOCK_STREAM, IPPROTO_TCP)) == INVALID_SOCKET)
+    goto fail;
+
+  r_memclear (&addr, sizeof (addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl (INADDR_LOOPBACK);
+  addr.sin_port = 0;
+  if (bind (listener, (struct sockaddr *)&addr, sizeof (addr)) != 0) goto fail;
+  if (getsockname (listener, (struct sockaddr *)&addr, &addrlen) != 0) goto fail;
+  if (listen (listener, 1) != 0) goto fail;
+
+  if ((c = socket (AF_INET, SOCK_STREAM, IPPROTO_TCP)) == INVALID_SOCKET)
+    goto fail;
+  if (connect (c, (struct sockaddr *)&addr, addrlen) != 0) goto fail;
+  if ((a = accept (listener, NULL, NULL)) == INVALID_SOCKET) goto fail;
+
+  closesocket (listener);
+  ioctlsocket (a, FIONBIO, &nb);
+  ioctlsocket (c, FIONBIO, &nb);
+  *rd = a;
+  *wr = c;
+  return TRUE;
+
+fail:
+  if (listener != INVALID_SOCKET) closesocket (listener);
+  if (c != INVALID_SOCKET) closesocket (c);
+  if (a != INVALID_SOCKET) closesocket (a);
+  return FALSE;
+}
+#endif
 
 static void
 r_ev_wakeup_free (REvWakeup * wakeup)
@@ -63,7 +113,14 @@ r_ev_wakeup_init (REvWakeup * wakeup, REvLoop * loop, RDestroyNotify notify)
   RIOHandle handle;
 
 #if defined (R_OS_WIN32)
-    wakeup->signal_handle = handle = CreateEvent (NULL, TRUE, FALSE, NULL);
+    SOCKET rd, wr;
+    if (!r_ev_wakeup_win_socketpair (&rd, &wr)) {
+      R_LOG_ERROR ("Failed to create wakeup socketpair for loop %p", loop);
+      abort ();
+    }
+    handle = (RIOHandle)(ruintptr) rd;            /* readable wait end */
+    wakeup->signal_handle = (RIOHandle)(ruintptr) wr;  /* signalled to wake */
+    /* Both ends are sockets; closed with closesocket in r_ev_wakeup_clear. */
     wakeup->close_handle = R_IO_HANDLE_INVALID;
 #elif defined (HAVE_EVENTFD)
     wakeup->signal_handle = handle = eventfd (0, EFD_CLOEXEC | EFD_NONBLOCK);
@@ -99,8 +156,18 @@ r_ev_wakeup_init (REvWakeup * wakeup, REvLoop * loop, RDestroyNotify notify)
 void
 r_ev_wakeup_clear (REvWakeup * wakeup)
 {
+#if defined (R_OS_WIN32)
+  /* Both ends are sockets: closesocket, not r_io_close (CloseHandle). The
+   * readable end (evio.handle) is otherwise never closed -- r_ev_io_clear does
+   * not touch the handle. */
+  if (wakeup->evio.handle != R_IO_HANDLE_INVALID)
+    closesocket ((SOCKET)(ruintptr) wakeup->evio.handle);
+  if (wakeup->signal_handle != R_IO_HANDLE_INVALID)
+    closesocket ((SOCKET)(ruintptr) wakeup->signal_handle);
+#else
   if (wakeup->close_handle != R_IO_HANDLE_INVALID)
     r_io_close (wakeup->close_handle);
+#endif
   r_ev_io_clear ((REvIO *)wakeup);
 }
 
@@ -108,7 +175,11 @@ void
 r_ev_wakeup_read (REvWakeup * wakeup)
 {
 #if defined (R_OS_WIN32)
-  ResetEvent ((HANDLE) wakeup->signal_handle);
+  char buf[64];
+  int r;
+  do {
+    r = recv ((SOCKET)(ruintptr) wakeup->evio.handle, buf, sizeof (buf), 0);
+  } while (r > 0);
 #else
   int r;
   ruint64 buf;
@@ -122,7 +193,8 @@ rboolean
 r_ev_wakeup_signal (REvWakeup * wakeup)
 {
 #if defined (R_OS_WIN32)
-  return SetEvent ((HANDLE) wakeup->signal_handle);
+  char b = 1;
+  return send ((SOCKET)(ruintptr) wakeup->signal_handle, &b, 1, 0) == 1;
 #else
   ruint64 buf = 1;
   return r_io_write (wakeup->signal_handle, &buf, sizeof (ruint64)) == sizeof (ruint64);

--- a/rlib/net/riosocket.c
+++ b/rlib/net/riosocket.c
@@ -82,8 +82,8 @@ r_io_socket (RSocketFamily family, RSocketType type, RSocketProtocol proto)
   RIOHandle ret;
 #ifdef HAVE_WINSOCK2
   /* WSA_FLAG_OVERLAPPED keeps the socket usable with the default IOCP backend's
-   * overlapped ops; it is harmless for the rpoll (WSAEventSelect) opt-out path,
-   * which issues non-overlapped WSARecv/WSASend regardless. */
+   * overlapped ops; it is harmless for the rpoll (select) opt-out path, which
+   * issues non-overlapped WSARecv/WSASend regardless. */
   ret = R_SOCKET_HANDLE_TO_IO_HANDLE (WSASocketW (family, type, proto, NULL, 0,
         WSA_FLAG_OVERLAPPED));
 #elif defined (HAVE_POSIX_SOCKETS)
@@ -323,9 +323,6 @@ r_io_socket_accept (RIOHandle handle, RSocketStatus * res)
   } while (ret == R_IO_HANDLE_INVALID && R_SOCKET_ERRNO == EINTR);
 
   if (ret != R_IO_HANDLE_INVALID) {
-#ifdef HAVE_WINSOCK2
-    WSAEventSelect (R_IO_HANDLE_TO_SOCKET_HANDLE (ret), NULL, 0);
-#endif
 #ifdef R_OS_UNIX
     r_io_unix_set_cloexec (ret, TRUE);
 #endif

--- a/rlib/rpoll.c
+++ b/rlib/rpoll.c
@@ -85,134 +85,122 @@ r_poll (RPoll * handles, ruint count, RClockTime timeout)
   return ret;
 }
 #elif defined (R_OS_WIN32)
-/* Cap on how long the Win32 wait actually blocks. WSAEventSelect records a
- * network event with WSAEnumNetworkEvents but does not always *signal* the
- * event object the wait blocks on (FD_CLOSE in particular is edge-triggered).
- * Capping the wait turns an indefinite block into a periodic re-check: every
- * wake -- including a timeout -- re-runs WSAEnumNetworkEvents and so picks up
- * any recorded-but-unsignalled readiness within the cap rather than sleeping
- * through it. */
-#define R_POLL_WIN32_MAX_WAIT_MS    1000
+/* winsock select() operates on SOCKETs only: its fd_set is an array of SOCKET
+ * handles and select() ignores the nfds argument. Every entry here is therefore
+ * a socket -- including the loop wakeup, which is a loopback socketpair (see
+ * revwakeup.c) rather than an event handle, precisely so it can sit in the read
+ * set. A peer close shows up as readable (recv then returns 0), level-triggered,
+ * exactly as on the poll()/select() backends above; a failed connect or socket
+ * error shows up in the except set. The header's fd_set is capped at FD_SETSIZE
+ * (64), so build our own sized to the entry count. */
+typedef struct {
+  u_int  fd_count;
+  SOCKET fd_array[1];   /* over-allocated to hold fd_count sockets */
+} RWinFdSet;
 
-/* Sentinel RPoll.wsaevent for a socket that could not be associated with a
- * WSAEVENT -- WSAEventSelect failed for a reason other than "not a socket",
- * i.e. the socket was already closed/closing. Such an entry must never be
- * waited on as a raw handle: a socket is not a waitable object, so the wait
- * fails (ACCESS_DENIED / INVALID_HANDLE) on every call forever. r_poll reports
- * it as an error instead, so the loop prunes it. */
-#define R_POLL_WSAEVENT_DEAD        ((rpointer) ~(rsize) 0)
-
-/* Map the requested R_IO_* readiness to the FD_* network events a socket is
- * associated with through WSAEventSelect. FD_CLOSE is folded into readability
- * so a peer reset / EOF wakes the read watcher (recv then reports the error). */
-static long
-r_poll_win32_fd_events (rushort events)
+static rboolean
+r_win_fd_isset (SOCKET s, const RWinFdSet * set)
 {
-  long ret = 0;
-
-  if (events & R_IO_IN)  ret |= FD_READ | FD_ACCEPT | FD_CLOSE;
-  if (events & R_IO_OUT) ret |= FD_WRITE | FD_CONNECT;
-  if (events & R_IO_PRI) ret |= FD_OOB;
-
-  return ret;
+  u_int i;
+  for (i = 0; i < set->fd_count; i++) {
+    if (set->fd_array[i] == s)
+      return TRUE;
+  }
+  return FALSE;
 }
 
 int
 r_poll (RPoll * handles, ruint count, RClockTime timeout)
 {
-  HANDLE waits[MAXIMUM_WAIT_OBJECTS];
+  RWinFdSet * rset, * wset, * xset;
+  rsize setsz;
+  struct timeval tv, * ptv;
   ruint i;
-  int ret = 0;
-  DWORD t, res;
+  int ret, nready = 0;
 
-  if (R_UNLIKELY (count > MAXIMUM_WAIT_OBJECTS)) {
-    errno = E2BIG;
+  for (i = 0; i < count; i++)
+    handles[i].revents = 0;
+
+  /* select() rejects a call with no descriptors; just honour the timeout. */
+  if (R_UNLIKELY (count == 0)) {
+    if (timeout != 0 && timeout != R_CLOCK_TIME_INFINITE)
+      Sleep ((DWORD) R_TIME_AS_MSECONDS (timeout));
+    return 0;
+  }
+
+  setsz = sizeof (u_int) + (rsize) count * sizeof (SOCKET);
+  if (R_UNLIKELY ((rset = r_malloc (setsz)) == NULL))
+    return -1;
+  if (R_UNLIKELY ((wset = r_malloc (setsz)) == NULL)) {
+    r_free (rset);
     return -1;
   }
-  if (R_UNLIKELY (count == 0))
-    return 0;
-
-  if (timeout == 0)
-    t = 0;
-  else if (timeout == R_CLOCK_TIME_INFINITE)
-    t = R_POLL_WIN32_MAX_WAIT_MS;
-  else
-    t = (DWORD) MIN (R_TIME_AS_MSECONDS (timeout) + 1, R_POLL_WIN32_MAX_WAIT_MS);
-
-  /* Build the wait set from the waitable entries only: a per-socket WSAEVENT
-   * (socket readiness), or a genuine non-socket handle such as the loop wakeup
-   * (waited on directly). A dead-socket entry is reported as an error and left
-   * out -- waiting on a raw socket handle fails the whole call forever. A
-   * WSAEVENT stays valid even after its socket is closed, so a closed-but-not-
-   * yet-pruned socket no longer fails the wait. */
-  {
-    ruint nwait = 0;
-    for (i = 0; i < count; i++) {
-      handles[i].revents = 0;
-      if (handles[i].wsaevent == R_POLL_WSAEVENT_DEAD) {
-        handles[i].revents = R_IO_ERR;
-        ret++;
-        continue;
-      }
-      waits[nwait++] = (handles[i].wsaevent != NULL) ?
-          (HANDLE)handles[i].wsaevent : (HANDLE)handles[i].handle;
-    }
-
-    /* With a dead entry to report, don't block -- return so the loop prunes it
-     * this turn (still harvest any concurrent real readiness). */
-    if (nwait > 0) {
-      res = WaitForMultipleObjectsEx ((DWORD)nwait, waits, FALSE,
-          ret > 0 ? 0 : t, FALSE);
-      if (R_UNLIKELY (res == WAIT_FAILED))
-        R_LOG_WARNING ("WaitForMultipleObjectsEx failed (%lu); probing handles",
-            (unsigned long) GetLastError ());
-    }
+  if (R_UNLIKELY ((xset = r_malloc (setsz)) == NULL)) {
+    r_free (rset); r_free (wset);
+    return -1;
   }
+  rset->fd_count = wset->fd_count = xset->fd_count = 0;
 
   for (i = 0; i < count; i++) {
-    if (handles[i].wsaevent == R_POLL_WSAEVENT_DEAD) {
-      continue;   /* already reported as an error above */
-    } else if (handles[i].wsaevent != NULL) {
-      WSANETWORKEVENTS ne;
+    SOCKET s = (SOCKET) (ruintptr) handles[i].handle;
+    if (handles[i].events & R_IO_IN)
+      rset->fd_array[rset->fd_count++] = s;
+    if (handles[i].events & R_IO_OUT)
+      wset->fd_array[wset->fd_count++] = s;
+    /* Always watch the except set: Windows reports a failed connect / socket
+     * error there, not as readable or writable. */
+    xset->fd_array[xset->fd_count++] = s;
+  }
+
+  if (timeout == R_CLOCK_TIME_INFINITE) {
+    ptv = NULL;
+  } else {
+    R_TIME_TO_TIMEVAL (timeout, tv);
+    ptv = &tv;
+  }
+
+  /* nfds is ignored on Windows; the fd_count fields drive the call. */
+  ret = select (0, (fd_set *) rset, (fd_set *) wset, (fd_set *) xset, ptv);
+
+  if (ret == SOCKET_ERROR && WSAGetLastError () == WSAENOTSOCK) {
+    /* select() fails atomically if any descriptor is not a socket -- which
+     * happens whenever a socket was closed but its entry is not pruned from the
+     * set yet. Don't fail the whole wait (the loop would never make progress
+     * and never prune it): probe each entry and report the dead ones as errors
+     * so the owner tears them down; the rest re-poll on the next call. */
+    for (i = 0; i < count; i++) {
+      int sotype, solen = (int) sizeof (sotype);
+      if (getsockopt ((SOCKET) (ruintptr) handles[i].handle, SOL_SOCKET,
+            SO_TYPE, (char *)&sotype, &solen) == SOCKET_ERROR) {
+        handles[i].revents = R_IO_ERR;
+        nready++;
+      }
+    }
+  } else if (ret > 0) {
+    for (i = 0; i < count; i++) {
+      SOCKET s = (SOCKET) (ruintptr) handles[i].handle;
       rushort rev = 0;
 
-      if (WSAEnumNetworkEvents ((SOCKET)(ruintptr)handles[i].handle,
-            (WSAEVENT)handles[i].wsaevent, &ne) != 0)
-        continue;   /* e.g. WSAENOTSOCK: a socket closed but not yet pruned */
-
-      if (ne.lNetworkEvents & (FD_READ | FD_ACCEPT | FD_CLOSE)) rev |= R_IO_IN;
-      if (ne.lNetworkEvents & FD_OOB)                           rev |= R_IO_PRI;
-      if (ne.lNetworkEvents & (FD_WRITE | FD_CONNECT))          rev |= R_IO_OUT;
-      /* A failed connect / abortive close surfaces as an error condition; the
-       * loop watches WRITABLE for connect and READABLE for recv. */
-      if ((ne.lNetworkEvents & FD_CONNECT) && ne.iErrorCode[FD_CONNECT_BIT] != 0)
-        rev |= R_IO_ERR | R_IO_OUT;
-      if ((ne.lNetworkEvents & FD_CLOSE) && ne.iErrorCode[FD_CLOSE_BIT] != 0)
-        rev |= R_IO_ERR | R_IO_IN;
+      if ((handles[i].events & R_IO_IN) && r_win_fd_isset (s, rset))
+        rev |= R_IO_IN;
+      if ((handles[i].events & R_IO_OUT) && r_win_fd_isset (s, wset))
+        rev |= R_IO_OUT;
+      if (r_win_fd_isset (s, xset))
+        rev |= R_IO_ERR;
 
       if (rev != 0) {
         handles[i].revents = rev;
-        ret++;
-      }
-    } else {
-      /* A genuine non-socket handle (the loop wakeup). WAIT_OBJECT_0 -> ready;
-       * WAIT_TIMEOUT -> not ready; WAIT_FAILED -> defensively report an error so
-       * an unexpectedly-invalid handle is torn down rather than spun on. */
-      DWORD w = WaitForSingleObject ((HANDLE)handles[i].handle, 0);
-      if (w == WAIT_OBJECT_0) {
-        handles[i].revents = handles[i].events;
-        ret++;
-      } else if (w == WAIT_FAILED) {
-        /* Not a waitable handle after all; mark it dead so it is excluded from
-         * the next wait (and reported now) rather than failing every call. */
-        handles[i].wsaevent = R_POLL_WSAEVENT_DEAD;
-        handles[i].revents = R_IO_ERR;
-        ret++;
+        nready++;
       }
     }
   }
 
-  return ret;
+  r_free (rset);
+  r_free (wset);
+  r_free (xset);
+
+  /* A genuine error with no dead entry to report stays an error. */
+  return (ret == SOCKET_ERROR && nready == 0) ? -1 : nready;
 }
 #elif defined (HAVE_SELECT)
 static inline int
@@ -279,68 +267,6 @@ r_poll (RPoll * handles, ruint count, RClockTime timeout)
 #error Need either 'poll' or 'select'
 #endif
 
-#ifdef R_OS_WIN32
-/* Associate a socket entry with a fresh WSAEVENT so r_poll can wait on its
- * readiness. A handle that is not a socket (the loop wakeup event) keeps
- * wsaevent == NULL and is waited on directly. */
-static void
-r_poll_entry_arm (RPoll * p)
-{
-  WSAEVENT ev;
-
-  p->wsaevent = NULL;
-  if ((ev = WSACreateEvent ()) == WSA_INVALID_EVENT)
-    return;
-
-  if (WSAEventSelect ((SOCKET)(ruintptr)p->handle, ev,
-        r_poll_win32_fd_events (p->events)) == 0) {
-    p->wsaevent = ev;
-  } else {
-    /* WSAEventSelect fails both for the loop wakeup (a real, waitable handle)
-     * and for an already closed/closing socket -- both report WSAENOTSOCK, so
-     * the error code can't tell them apart. Distinguish by whether the handle
-     * is waitable at all: a socket (open or closed) is not a waitable object,
-     * so WaitForSingleObject fails on it. Mark such an entry dead so r_poll
-     * never waits on the raw socket; only a genuinely waitable non-socket
-     * handle (the wakeup) keeps the bare direct-wait path. */
-    WSACloseEvent (ev);
-    if (WaitForSingleObject ((HANDLE)(ruintptr)p->handle, 0) == WAIT_FAILED)
-      p->wsaevent = R_POLL_WSAEVENT_DEAD;
-  }
-}
-
-/* Re-issue the WSAEventSelect association after the watched events changed. */
-static void
-r_poll_entry_rearm (RPoll * p)
-{
-  if (p->wsaevent != NULL && p->wsaevent != R_POLL_WSAEVENT_DEAD)
-    WSAEventSelect ((SOCKET)(ruintptr)p->handle, (WSAEVENT)p->wsaevent,
-        r_poll_win32_fd_events (p->events));
-}
-
-static void
-r_poll_entry_disarm (RPoll * p)
-{
-  if (p->wsaevent != NULL && p->wsaevent != R_POLL_WSAEVENT_DEAD) {
-    WSAEventSelect ((SOCKET)(ruintptr)p->handle, NULL, 0);
-    WSACloseEvent ((WSAEVENT)p->wsaevent);
-  }
-  p->wsaevent = NULL;
-}
-
-#define R_POLL_ENTRY_ARM(p)         r_poll_entry_arm (p)
-#define R_POLL_ENTRY_REARM(p)       r_poll_entry_rearm (p)
-#define R_POLL_ENTRY_DISARM(p)      r_poll_entry_disarm (p)
-#define R_POLL_ENTRY_TAKE(dst, src) R_STMT_START {                            \
-    (dst)->wsaevent = (src)->wsaevent; (src)->wsaevent = NULL;                \
-  } R_STMT_END
-#else
-#define R_POLL_ENTRY_ARM(p)         R_STMT_START { } R_STMT_END
-#define R_POLL_ENTRY_REARM(p)       R_STMT_START { } R_STMT_END
-#define R_POLL_ENTRY_DISARM(p)      R_STMT_START { } R_STMT_END
-#define R_POLL_ENTRY_TAKE(dst, src) R_STMT_START { } R_STMT_END
-#endif
-
 void
 r_poll_set_init (RPollSet * ps, ruint alloc)
 {
@@ -354,12 +280,6 @@ r_poll_set_init (RPollSet * ps, ruint alloc)
 void
 r_poll_set_clear (RPollSet * ps)
 {
-#ifdef R_OS_WIN32
-  ruint i;
-  for (i = 0; i < ps->count; i++)
-    R_POLL_ENTRY_DISARM (&ps->handles[i]);
-#endif
-
   r_free (ps->handles);
   r_hash_table_unref (ps->handle_idx);
   r_hash_table_unref (ps->handle_user);
@@ -424,7 +344,6 @@ r_poll_set_add (RPollSet * ps, RIOHandle handle, rushort events, rpointer user)
 
   idx = ps->count++;
   r_poll_set_update (ps, idx, handle, events, user);
-  R_POLL_ENTRY_ARM (&ps->handles[idx]);
   return (int)idx;
 }
 
@@ -439,7 +358,6 @@ r_poll_set_remove_idx (RPollSet * ps, int idx)
   key = RIO_HANDLE_TO_POINTER (ps->handles[idx].handle);
   if (r_hash_table_remove_full (ps->handle_user, key, NULL, &user) == R_HASH_TABLE_OK) {
     r_hash_table_remove (ps->handle_idx, key);
-    R_POLL_ENTRY_DISARM (&ps->handles[idx]);
 
     if ((ruint)idx < --ps->count) {
       RPoll * last = &ps->handles[ps->count];
@@ -448,9 +366,6 @@ r_poll_set_remove_idx (RPollSet * ps, int idx)
       if (r_hash_table_lookup_full (ps->handle_user, RIO_HANDLE_TO_POINTER (last->handle),
             NULL, &last_user) == R_HASH_TABLE_OK) {
         r_poll_set_update (ps, (ruint)idx, last->handle, last->events, last_user);
-        /* Carry the moved entry's WSAEVENT to its new slot (update only
-         * rewrites the poll fields, not the association). */
-        R_POLL_ENTRY_TAKE (&ps->handles[idx], last);
       } else {
         return FALSE;
       }
@@ -479,7 +394,6 @@ r_poll_set_modify (RPollSet * ps, RIOHandle handle, rushort events)
     return FALSE;
 
   ps->handles[idx].events = events;
-  R_POLL_ENTRY_REARM (&ps->handles[idx]);
   return TRUE;
 }
 


### PR DESCRIPTION
Replaces the Windows readiness (rpoll) backend's `WSAEventSelect` +
`WaitForMultipleObjectsEx` design with winsock `select()`, and fixes
`r_ev_tcp_abort` to close the socket promptly on reactor backends.

**Why `select()`**: `WSAEventSelect`'s `FD_CLOSE` is edge-triggered and
order-sensitive, and it pairs every socket with a `WSAEVENT` whose
arm/disarm lifecycle races socket close and fd recycling — a fragile model that
needed a growing pile of workarounds. `select()` mirrors the POSIX
`poll()`/`select()` paths the rest of rlib already uses: a peer close is just
readability (`recv` returns 0), level-triggered; a failed connect / error shows
in the except set. No per-socket event object, no arm/disarm, no recycle
hazard. `r_poll` builds its own `fd_set` sized to the entry count (the header
caps `FD_SETSIZE` at 64), and handles `select()`'s atomic `WSAENOTSOCK` failure
by probing entries and reporting dead ones rather than failing the whole wait.

`select()` waits on sockets only, so the loop wakeup becomes a loopback
socketpair (self-pipe) on Windows instead of an event handle.

**Abort close**: on the reactor backends, `r_ev_tcp_abort` now closes the
socket immediately (FIN, or RST with `SO_LINGER 0`) instead of deferring it to
the last unref — the close is what notifies the peer, and deferring it made
that hostage to refcount timing. The proactor (IOCP) backend keeps its deferred
close: its in-flight overlapped ops hold refs to the socket.

IOCP (the default Windows backend) and the POSIX backends are unaffected in
design; this is a net code reduction.

Motivated by the #310 investigation. It removes the whole `WSAEventSelect`
bug class and is a strict improvement over the previous rpoll backend. One
known item remains and is **not** fully addressed here: an intermittent
`server_stop_during_request` hang (~1%) that is *backend-independent* — it
reproduces identically on both the old and new backends and on the POSIX side,
so it is a logic race in the stop-mid-request path, tracked separately.

Validation: Linux epoll + rpoll + ASan full suites (incl. `--repeat`), mingw
cross `-Werror`, doxygen 0 warnings; full Windows CI matrix green.