### PR TITLE
DIAG #310: instrument + repeat to capture the server_stop residual (DO NOT MERGE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,10 @@ jobs:
       - name: Build
         run: meson compile -C build
       - name: Test
-        run: meson test -C build --print-errorlogs --timeout-multiplier 6
+        # DIAG #310: repeat the full suite until the ~1% server_stop residual
+        # hangs (--maxfail 1 stops at the first), so the DIAG310 trace up to the
+        # wedge lands in the test log. Revert with the diagnostics before merge.
+        run: meson test -C build --print-errorlogs --timeout-multiplier 6 --repeat 50 --maxfail 1
       - name: Upload test logs on failure
         if: failure()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,23 +185,25 @@ jobs:
         run: meson setup build --buildtype=${{ matrix.buildtype }} -Drpoll=enabled
       - name: Build
         run: meson compile -C build
-      - name: Isolated repeat of server_stop (DIAG #310)
-        # Run the hung test ALONE many times with the r_poll trace enabled
-        # (DIAG310_POLL). If it wedges here it is a self-race + we get a clean
-        # select() trace; if it stays clean the residual is prior-test pollution.
-        # continue-on-error so the full-suite step below still runs either way.
+      - name: HTTP-suite repeat with select trace (DIAG #310)
+        # The residual is a per-connection-setup wedge that needs cross-test
+        # context (isolation of one test stayed clean over 300x). Loop the small
+        # http suites with the r_poll trace on: small enough that the full trace
+        # at the wedge survives gh log retrieval (the full suite truncates), broad
+        # enough to reproduce. Stops (non-zero) at the first hang -> the full-suite
+        # fallback step is then skipped. Revert with the diagnostics before merge.
         shell: bash
-        continue-on-error: true
         env:
           DIAG310_POLL: "1"
         run: |
           export PATH="$PWD/build/rlib:$PATH"
-          for i in $(seq 1 300); do
-            ./build/test/rlibtest.exe -f /rhttpclient/server_stop_during_request \
-              || { echo "=== isolated HUNG/FAILED at iteration $i ==="; exit 1; }
+          for i in $(seq 1 200); do
+            echo "=== http-suite iteration $i ==="
+            ./build/test/rlibtest.exe -f /rhttpclient/* -f /rhttpserver/* \
+              || { echo "=== HTTP-suite HUNG/FAILED at iteration $i ==="; exit 1; }
           done
-          echo "=== isolated: 300 iterations clean (did NOT reproduce in isolation) ==="
-      - name: Test
+          echo "=== http-suite: 200 iterations clean (did NOT reproduce) ==="
+      - name: Test (full-suite fallback)
         # DIAG #310: repeat the full suite until the server_stop residual hangs
         # (--maxfail 1 stops at the first), so the DIAG310 connect/accept trace up
         # to the wedge lands in the test log. r_poll trace left OFF here (it would

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,10 +185,27 @@ jobs:
         run: meson setup build --buildtype=${{ matrix.buildtype }} -Drpoll=enabled
       - name: Build
         run: meson compile -C build
+      - name: Isolated repeat of server_stop (DIAG #310)
+        # Run the hung test ALONE many times with the r_poll trace enabled
+        # (DIAG310_POLL). If it wedges here it is a self-race + we get a clean
+        # select() trace; if it stays clean the residual is prior-test pollution.
+        # continue-on-error so the full-suite step below still runs either way.
+        shell: bash
+        continue-on-error: true
+        env:
+          DIAG310_POLL: "1"
+        run: |
+          export PATH="$PWD/build/rlib:$PATH"
+          for i in $(seq 1 300); do
+            ./build/test/rlibtest.exe -f /rhttpclient/server_stop_during_request \
+              || { echo "=== isolated HUNG/FAILED at iteration $i ==="; exit 1; }
+          done
+          echo "=== isolated: 300 iterations clean (did NOT reproduce in isolation) ==="
       - name: Test
-        # DIAG #310: repeat the full suite until the ~1% server_stop residual
-        # hangs (--maxfail 1 stops at the first), so the DIAG310 trace up to the
-        # wedge lands in the test log. Revert with the diagnostics before merge.
+        # DIAG #310: repeat the full suite until the server_stop residual hangs
+        # (--maxfail 1 stops at the first), so the DIAG310 connect/accept trace up
+        # to the wedge lands in the test log. r_poll trace left OFF here (it would
+        # drown the full suite). Revert with the diagnostics before merge.
         run: meson test -C build --print-errorlogs --timeout-multiplier 6 --repeat 50 --maxfail 1
       - name: Upload test logs on failure
         if: failure()

--- a/bench/revudp.c
+++ b/bench/revudp.c
@@ -76,14 +76,6 @@ udp_recv (rpointer user, RBuffer * buf, RSocketAddress * addr, REvUDP * evudp)
 }
 
 static void
-aggregate_ctx_stats (REvUDPStats * dst, const REvUDPStats * add)
-{
-  dst->packets += add->packets;
-  dst->failed += add->failed;
-  dst->bytes += add->bytes;
-}
-
-static void
 print_udp_bench_ctx_stats (REvUDPBenchCtx * ctx, RClockTime now)
 {
   RClockTimeDiff cd = R_CLOCK_DIFF (ctx->ts, now);
@@ -151,107 +143,6 @@ RTEST_BENCH (revudp, single_loopback_receive, RTEST_FASTSLOW | RTEST_SYSTEM)
 
   r_socket_address_unref (ctx.addr);
   r_ev_udp_unref (ctx.evudp);
-  r_ev_loop_unref (loop);
-}
-RTEST_END;
-
-
-#define UDP_MULTI_SOCKETS     24
-static void
-stop_multi (rpointer data, REvLoop * loop)
-{
-  REvUDPBenchCtx * ctx = data;
-  ruint i;
-  (void) loop;
-
-  for (i = 0; i < UDP_MULTI_SOCKETS; i++)
-    r_assert (r_ev_udp_recv_stop (ctx[i].evudp));
-}
-
-RTEST_BENCH (revudp, multi_loopback_receive, RTEST_FASTSLOW | RTEST_SYSTEM)
-{
-  REvLoop * loop;
-  REvUDPBenchCtx ctx[UDP_MULTI_SOCKETS];
-  REvUDPBenchThreadCtx * tctx;
-  REvUDPStats tx_aggr, rx_aggr;
-  RTaskQueue * tq;
-  rsize cpus, tctxcount, d;
-  ruint i;
-  RClockTime ts;
-  RBitset * cpuset;
-
-  r_print ("%"R_TIME_FORMAT" --- %s ---\n", R_TIME_ARGS (0), R_STRFUNC);
-
-  r_memclear (ctx, R_N_ELEMENTS (ctx) * sizeof (REvUDPBenchCtx));
-  r_assert (r_bitset_init_stack (cpuset, r_sys_cpuset_max ()));
-  r_assert (r_sys_cpuset_allowed (cpuset));
-  r_assert_cmpptr ((cpus = r_bitset_popcount (cpuset)), >, 0);
-  tctxcount = CLAMP ((cpus / 2), 1, R_N_ELEMENTS (ctx));
-  r_assert_cmpptr ((tctx = r_alloca (sizeof (REvUDPBenchThreadCtx) * tctxcount)), !=, NULL);
-
-  r_assert_cmpptr ((tq = r_task_queue_new ((ruint)tctxcount, 1)), !=, NULL);
-  r_print ("\tTaskQueue with %u threads and %u groups\n",
-      r_task_queue_thread_count (tq), r_task_queue_group_count (tq));
-
-  ts = r_time_get_ts_monotonic ();
-  r_assert_cmpptr ((loop = r_ev_loop_new_full (NULL, tq)), !=, NULL);
-
-  d = R_N_ELEMENTS (ctx) / tctxcount;
-  for (i = 0; i < tctxcount; i++) {
-    tctx[i].count = d;
-    tctx[i].ctx = &ctx[i * d];
-  }
-  if (R_N_ELEMENTS (ctx) > i * d)
-    tctx[i - 1].count = R_N_ELEMENTS (ctx) - ((i - 1) * d);
-  for (i = 0; i < tctxcount; i++)
-    r_print ("\tSend thread %u: %u sockets\n", (ruint)i, (ruint)tctx[i].count);
-
-  for (i = 0; i < R_N_ELEMENTS (ctx); i++) {
-    ctx[i].start = ctx[i].ts = ts;
-    r_assert_cmpptr ((ctx[i].evudp = r_ev_udp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
-    r_assert_cmpptr ((ctx[i].addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0x4242 + i)), !=, NULL);
-    r_assert (r_ev_udp_bind (ctx[i].evudp, ctx[i].addr, TRUE));
-
-    r_assert (r_ev_udp_task_recv_start (ctx[i].evudp,
-          i % r_ev_loop_task_group_count (loop),
-          NULL, udp_recv, &ctx[i], NULL));
-  }
-  for (i = 0; i < tctxcount; i++) {
-    tctx[i].running = TRUE;
-    r_assert_cmpptr ((tctx[i].tsnd = r_thread_new ("multi-udp-send",
-            udp_send, &tctx[i])), !=, NULL);
-  }
-
-  r_assert (r_ev_loop_add_callback_later (loop, NULL, TOTAL_LENGTH, stop_multi, ctx, NULL));
-  r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
-
-  for (i = 0; i < tctxcount; i++) {
-    tctx[i].running = FALSE;
-    r_thread_join (tctx[i].tsnd);
-    r_thread_unref (tctx[i].tsnd);
-  }
-
-  r_memclear (&tx_aggr, sizeof (REvUDPStats));
-  r_memclear (&rx_aggr, sizeof (REvUDPStats));
-  ts = r_time_get_ts_monotonic ();
-  for (i = 0; i < R_N_ELEMENTS (ctx); i++) {
-    print_udp_bench_ctx_stats (&ctx[i], ts);
-    aggregate_ctx_stats (&tx_aggr, &ctx[i].tx);
-    aggregate_ctx_stats (&rx_aggr, &ctx[i].rx);
-    r_socket_address_unref (ctx[i].addr);
-    r_ev_udp_unref (ctx[i].evudp);
-  }
-
-  ts = r_time_get_ts_monotonic ();
-  r_print ("%"R_TIME_FORMAT" --------------------------------------------------------------\n"
-      "                 "
-      "  TX: %12"RSIZE_FMT" (%5"RSIZE_FMT") %16"RSIZE_FMT"\n"
-      "                 "
-      "  RX: %12"RSIZE_FMT" (%5"RSIZE_FMT") %16"RSIZE_FMT"\n",
-      R_TIME_ARGS (ts - ctx->start),
-      tx_aggr.packets, tx_aggr.failed, tx_aggr.bytes,
-      rx_aggr.packets, rx_aggr.failed, rx_aggr.bytes);
-  r_task_queue_unref (tq);
   r_ev_loop_unref (loop);
 }
 RTEST_END;

--- a/include/rlib/ev/revtcp.h
+++ b/include/rlib/ev/revtcp.h
@@ -46,11 +46,7 @@
  *
  * Receiving uses a caller-supplied allocator callback (to provide the
  * @ref RBuffer each read fills) plus a receive callback. Callbacks fire on
- * the loop thread, except the @c _task_recv_start variant, which hands
- * received buffers to a task group for off-thread processing. Because
- * @ref r_ev_tcp_recv_stop / @ref r_ev_tcp_close drain the last such task
- * from the loop thread, a task-group receive callback must not block on work
- * that needs the loop thread.
+ * the loop thread.
  *
  * @{
  */
@@ -167,10 +163,6 @@ R_API RSocketStatus r_ev_tcp_listen (REvTCP * evtcp, ruint8 backlog,
  * delivers the bytes read.
  */
 R_API rboolean r_ev_tcp_recv_start (REvTCP * evtcp,
-    REvTCPBufferAllocFunc alloc, REvTCPBufferFunc recv,
-    rpointer data, RDestroyNotify datanotify);
-/** @brief Like @ref r_ev_tcp_recv_start but dispatches received buffers to @p taskgroup. */
-R_API rboolean r_ev_tcp_task_recv_start (REvTCP * evtcp, ruint taskgroup,
     REvTCPBufferAllocFunc alloc, REvTCPBufferFunc recv,
     rpointer data, RDestroyNotify datanotify);
 /** @brief Stop receiving. */

--- a/include/rlib/ev/revudp.h
+++ b/include/rlib/ev/revudp.h
@@ -45,11 +45,7 @@
  *
  * As with @ref r_evtcp, receiving pairs an allocator callback (to
  * supply each datagram's @ref RBuffer) with a receive callback that
- * also reports the sender address. Callbacks fire on the loop thread,
- * except the @c _task_recv_start variant, which dispatches to a task
- * group. Because @ref r_ev_udp_recv_stop drains the last such task from
- * the loop thread, a task-group receive callback must not block on work
- * that needs the loop thread.
+ * also reports the sender address. Callbacks fire on the loop thread.
  *
  * @{
  */
@@ -84,10 +80,6 @@ R_API rboolean r_ev_udp_bind (REvUDP * evudp,
 R_API RSocketAddress * r_ev_udp_get_local_address (const REvUDP * evudp);
 /** @brief Start receiving datagrams; @p alloc supplies buffers, @p recv delivers them. */
 R_API rboolean r_ev_udp_recv_start (REvUDP * evudp,
-    REvUDPBufferAllocFunc alloc, REvUDPBufferFunc recv,
-    rpointer data, RDestroyNotify datanotify);
-/** @brief Like @ref r_ev_udp_recv_start but dispatches received datagrams to @p taskgroup. */
-R_API rboolean r_ev_udp_task_recv_start (REvUDP * evudp, ruint taskgroup,
     REvUDPBufferAllocFunc alloc, REvUDPBufferFunc recv,
     rpointer data, RDestroyNotify datanotify);
 /** @brief Stop receiving. */

--- a/rlib/ev/revloop.c
+++ b/rlib/ev/revloop.c
@@ -1208,10 +1208,29 @@ r_ev_io_close (REvIO * evio, REvIOFunc close_cb,
     evio->alnk = NULL;
   }
 
+#if defined (USE_RPOLL)
+  /* Drop the descriptor from the readiness set now rather than deferring it to
+   * the change queue. A closed fd left in the set fails the next select()
+   * atomically (Windows) or spins, and the fd can be recycled into a new socket
+   * before a deferred removal runs -- leaving two entries for one fd. The run
+   * loop snapshots its dispatch list before invoking callbacks, so removing
+   * here is safe even when called from within one. The get_user guard skips a
+   * handle already recycled to a newer evio. */
+  if (R_EV_IO_IS_CHANGING (evio)) {
+    r_queue_remove_link (&evio->loop->chg, evio->chglnk);
+    evio->chglnk = NULL;
+  }
+  if (R_EV_IO_IS_ADDED (evio)) {
+    if (r_poll_set_get_user (&evio->loop->pollset, evio->handle) == evio)
+      r_poll_set_remove (&evio->loop->pollset, evio->handle);
+    evio->flags &= ~R_EV_IO_ADDED;
+  }
+#else
   if (R_EV_IO_IS_ACTIVE (evio) || R_EV_IO_IS_INTERNAL (evio)) {
     if (!R_EV_IO_IS_CHANGING (evio))
       evio->chglnk = r_queue_push (&evio->loop->chg, evio);
   }
+#endif
 
   r_cbqueue_push (&evio->loop->acbs, (RFunc)close_cb,
       data, datanotify, r_ev_io_ref (evio), r_ev_io_unref);

--- a/rlib/ev/revtcp.c
+++ b/rlib/ev/revtcp.c
@@ -66,7 +66,6 @@ struct REvTCP {
   REvIO evio;
 
   RSocket * socket;
-  ruint taskgroup;
 
   REvTCPConnectionReadyFunc connection;
   REvTCPConnectedFunc connected;
@@ -81,8 +80,6 @@ struct REvTCP {
   rpointer connect_iocb_ctx;
   rpointer recv_iocb_ctx;
   rpointer send_iocb_ctx;
-  rauint recv_counter;
-  RTask * recv_task;
 
   RQueue qsend;
 
@@ -101,7 +98,6 @@ struct REvTCP {
   RBuffer * iocp_recv_buf;     /* buffer backing the in-flight WSARecv */
   RMemMapInfo iocp_recv_map;
   rboolean iocp_recv_active;   /* receiving (recv_start, not yet stopped) */
-  rboolean iocp_recv_task;     /* deliver received buffers via a task group */
 
   REvIOCPOp iocp_send;
   RMemMapInfo iocp_send_map;
@@ -308,66 +304,9 @@ r_ev_tcp_iocp_recv_teardown (REvTCP * evtcp, RSocketStatus res)
     evtcp->recv (evtcp->recv_data, NULL, evtcp);
 }
 
-/* Task-group delivery (r_ev_tcp_task_recv_start): the received buffer is
- * processed off the loop thread. The task carries a ref on the buffer and the
- * evtcp, both released (on the task thread) when the context is freed. No loop
- * 'done' callback is used, so the task is not an outstanding loop event -- the
- * re-armed WSARecv keeps the loop alive, and r_ev_tcp_recv_stop waits on the
- * last task. Each task chains on the previous, so they run in order. */
-typedef struct {
-  REvTCP * evtcp;
-  RBuffer * buf;
-} REvTCPRecvTaskCtx;
-
-static void
-r_ev_tcp_iocp_recv_task (rpointer data, RTaskQueue * queue, RTask * task)
-{
-  REvTCPRecvTaskCtx * ctx = data;
-  (void) queue;
-  (void) task;
-  ctx->evtcp->recv (ctx->evtcp->recv_data, ctx->buf, ctx->evtcp);
-}
-
-static void
-r_ev_tcp_iocp_recv_task_free (rpointer data)
-{
-  REvTCPRecvTaskCtx * ctx = data;
-  r_buffer_unref (ctx->buf);
-  r_ev_tcp_unref (ctx->evtcp);
-  r_free (ctx);
-}
-
 static void
 r_ev_tcp_iocp_recv_deliver (REvTCP * evtcp, RBuffer * buf)
 {
-  REvTCPRecvTaskCtx * ctx;
-  RTask * task;
-
-  if (!evtcp->iocp_recv_task) {
-    evtcp->recv (evtcp->recv_data, buf, evtcp);
-    r_buffer_unref (buf);
-    return;
-  }
-
-  /* Populate the context before queuing: the task may start on another thread
-   * the instant it is added. */
-  if ((ctx = r_mem_new (REvTCPRecvTaskCtx)) != NULL) {
-    ctx->evtcp = r_ev_tcp_ref (evtcp);
-    ctx->buf = buf;   /* ownership transferred to the task */
-    if ((task = r_ev_loop_add_task_full (evtcp->evio.loop, evtcp->taskgroup,
-            r_ev_tcp_iocp_recv_task, NULL, ctx, r_ev_tcp_iocp_recv_task_free,
-            evtcp->recv_task, NULL)) != NULL) {
-      if (evtcp->recv_task != NULL)
-        r_task_unref (evtcp->recv_task);
-      evtcp->recv_task = task;
-      return;
-    }
-    /* Queuing failed: undo without releasing buf (delivered inline below). */
-    r_ev_tcp_unref (ctx->evtcp);
-    r_free (ctx);
-  }
-
-  /* Could not offload: process inline rather than drop the data. */
   evtcp->recv (evtcp->recv_data, buf, evtcp);
   r_buffer_unref (buf);
 }
@@ -649,13 +588,6 @@ r_ev_tcp_teardown (REvTCP * evtcp, REvIOFunc close_cb, rpointer data,
    * when the last ref is released in r_ev_tcp_free -> r_socket_unref. */
   evtcp->iocp_recv_active = FALSE;
   CancelIoEx ((HANDLE) evtcp->socket->handle, NULL);
-  /* Task delivery: drain the last dispatched buffer's task, as recv_stop does
-   * -- otherwise closing during task-mode recv leaks the recv_task ref. */
-  if (evtcp->recv_task != NULL) {
-    r_task_wait (evtcp->recv_task);
-    r_task_unref (evtcp->recv_task);
-    evtcp->recv_task = NULL;
-  }
 #else
   r_ev_tcp_recv_stop (evtcp);
 
@@ -1025,10 +957,6 @@ r_ev_tcp_recv_teardown (REvTCP * evtcp, RSocketStatus res)
   r_ev_loop_add_cb_after (evtcp->evio.loop, r_ev_tcp_io_stop_after,
       r_ev_tcp_ref (evtcp), r_ev_tcp_unref, evtcp->recv_iocb_ctx, NULL);
   evtcp->recv_iocb_ctx = NULL;
-  if (evtcp->recv_task != NULL) {
-    r_task_unref (evtcp->recv_task);
-    evtcp->recv_task = NULL;
-  }
 
   if (res != R_SOCKET_OK && evtcp->error != NULL)
     evtcp->error (evtcp->error_data, evtcp, res);
@@ -1042,8 +970,6 @@ r_ev_tcp_recv_iocb (REvTCP * evtcp)
   RBuffer * buf;
   RSocketStatus res = R_SOCKET_WOULD_BLOCK;
   rsize size;
-
-  r_atomic_uint_store (&evtcp->recv_counter, 0);
 
   do {
     if (R_UNLIKELY (r_socket_is_closed (evtcp->socket)))
@@ -1174,49 +1100,6 @@ r_ev_tcp_iocb (rpointer data, REvIOEvents events, REvIO * evio)
   if (events & R_EV_IO_ERROR) r_ev_tcp_error_iocb ((REvTCP *)evio);
 }
 
-#if !defined (R_OS_WIN32) || defined (R_EV_USE_RPOLL)
-static void
-r_ev_tcp_recv_iocb_task (rpointer data, RTaskQueue * queue, RTask * task)
-{
-  (void) queue;
-  (void) task;
-  r_ev_tcp_recv_iocb (data);
-}
-#endif
-
-#if !defined (R_OS_WIN32) || defined (R_EV_USE_RPOLL)
-static void
-r_ev_tcp_task_recv_iocb (REvTCP * evtcp)
-{
-  RTask * task;
-
-  if (r_atomic_uint_fetch_add (&evtcp->recv_counter, 1) > 0)
-    return;
-
-  if ((task = r_ev_loop_add_task_full (evtcp->evio.loop,
-          evtcp->taskgroup, r_ev_tcp_recv_iocb_task, NULL,
-          r_ev_tcp_ref (evtcp), r_ev_tcp_unref, evtcp->recv_task, NULL)) != NULL) {
-    if (evtcp->recv_task != NULL)
-      r_task_unref (evtcp->recv_task);
-    evtcp->recv_task = task;
-  } else {
-    r_ev_tcp_unref (evtcp);
-  }
-}
-#endif
-
-#if !defined (R_OS_WIN32) || defined (R_EV_USE_RPOLL)
-static void
-r_ev_tcp_task_iocb (rpointer data, REvIOEvents events, REvIO * evio)
-{
-  (void) data;
-
-  if (events & R_EV_IO_READABLE) r_ev_tcp_task_recv_iocb ((REvTCP *)evio);
-  if (events & R_EV_IO_WRITABLE) r_ev_tcp_send_iocb ((REvTCP *)evio);
-  if (events & R_EV_IO_ERROR) r_ev_tcp_error_iocb ((REvTCP *)evio);
-}
-#endif
-
 rboolean
 r_ev_tcp_recv_start (REvTCP * evtcp,
     REvTCPBufferAllocFunc alloc, REvTCPBufferFunc recv,
@@ -1262,57 +1145,6 @@ r_ev_tcp_recv_start (REvTCP * evtcp,
 }
 
 rboolean
-r_ev_tcp_task_recv_start (REvTCP * evtcp, ruint taskgroup,
-    REvTCPBufferAllocFunc alloc, REvTCPBufferFunc recv,
-    rpointer data, RDestroyNotify datanotify)
-{
-  if (R_UNLIKELY (recv == NULL)) return FALSE;
-  if (R_UNLIKELY (evtcp->recv_iocb_ctx != NULL)) return FALSE;
-  if (R_UNLIKELY (!r_ev_io_validate_taskgroup (&evtcp->evio, taskgroup))) return FALSE;
-
-#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
-  if (R_UNLIKELY (evtcp->iocp_recv_active)) return FALSE;
-  if (alloc == NULL)
-    alloc = r_ev_tcp_buffer_alloc_default;
-  if (evtcp->recv_datanotify != NULL)
-    evtcp->recv_datanotify (evtcp->recv_data);
-  evtcp->taskgroup = taskgroup;
-  evtcp->alloc = alloc;
-  evtcp->recv = recv;
-  evtcp->recv_data = data;
-  evtcp->recv_datanotify = datanotify;
-  evtcp->iocp_recv_active = TRUE;
-  evtcp->iocp_recv_task = TRUE;
-  if (R_UNLIKELY (!r_ev_tcp_iocp_post_recv (evtcp))) {
-    evtcp->iocp_recv_active = FALSE;
-    evtcp->iocp_recv_task = FALSE;
-    evtcp->recv = NULL;
-    evtcp->recv_datanotify = NULL;
-    if (datanotify != NULL)
-      datanotify (data);
-    return FALSE;
-  }
-  return TRUE;
-#else
-  if ((evtcp->recv_iocb_ctx = r_ev_io_start (&evtcp->evio, R_EV_IO_READABLE,
-      r_ev_tcp_task_iocb, data, datanotify))) {
-    if (alloc == NULL)
-      alloc = r_ev_tcp_buffer_alloc_default;
-
-    evtcp->taskgroup = taskgroup;
-    evtcp->alloc = alloc;
-    evtcp->recv = recv;
-    evtcp->recv_data = data;
-    r_atomic_uint_store (&evtcp->recv_counter, 0);
-    evtcp->recv_task = NULL;
-    return TRUE;
-  }
-
-  return FALSE;
-#endif
-}
-
-rboolean
 r_ev_tcp_recv_stop (REvTCP * evtcp)
 {
 #if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
@@ -1323,23 +1155,12 @@ r_ev_tcp_recv_stop (REvTCP * evtcp)
   evtcp->iocp_recv_active = FALSE;
   if (evtcp->iocp_recv_buf != NULL)
     CancelIoEx ((HANDLE) evtcp->socket->handle, &evtcp->iocp_recv.overlapped);
-  /* Task delivery: wait for the last dispatched buffer to be processed. */
-  if (evtcp->recv_task != NULL) {
-    r_task_wait (evtcp->recv_task);
-    r_task_unref (evtcp->recv_task);
-    evtcp->recv_task = NULL;
-  }
   return TRUE;
 #else
   rboolean ret;
 
   ret = r_ev_io_stop (&evtcp->evio, evtcp->recv_iocb_ctx);
   evtcp->recv_iocb_ctx = NULL;
-  if (evtcp->recv_task != NULL) {
-    r_task_wait (evtcp->recv_task);
-    r_task_unref (evtcp->recv_task);
-    evtcp->recv_task = NULL;
-  }
 
   return ret;
 #endif

--- a/rlib/ev/revtcp.c
+++ b/rlib/ev/revtcp.c
@@ -19,6 +19,8 @@
 #include "config.h"
 /* Before rsocket-private.h / rev-private.h: orders <winsock2.h> first. */
 #include "rev-iocp-private.h"
+
+#include <rlib/os/rtty.h> /* DIAG #310: r_printerr markers, revert before merge */
 #include "rev-private.h"
 #include "../net/rsocket-private.h"
 #include "../net/rnet-private.h"
@@ -118,6 +120,8 @@ struct REvTCP {
 static void
 r_ev_tcp_free (REvTCP * evtcp)
 {
+  r_printerr ("DIAG310: evtcp_free evtcp=%p sock=%p\n", (void *)evtcp,
+      (void *)(ruintptr)evtcp->evio.handle);
   r_queue_clear (&evtcp->qsend, r_ev_tcp_send_ctx_free);
 
   /* A graceful close that never reached its finalizer (e.g. the last ref was
@@ -681,6 +685,11 @@ r_ev_tcp_abort (REvTCP * evtcp, REvIOFunc close_cb, rpointer data, RDestroyNotif
 {
   if (R_UNLIKELY (evtcp == NULL)) return FALSE;
 
+  r_printerr ("DIAG310: abort evtcp=%p sock=%p closed=%d refcount=%u\n",
+      (void *)evtcp, (void *)(ruintptr)evtcp->evio.handle,
+      (evtcp->evio.flags & R_EV_IO_CLOSED) ? 1 : 0,
+      (ruint)r_ref_refcount (evtcp));
+
   R_LOG_DEBUG ("loop %p evio "R_EV_IO_FORMAT,
       evtcp->evio.loop, R_EV_IO_ARGS (evtcp));
 
@@ -980,6 +989,9 @@ r_ev_tcp_recv_iocb (REvTCP * evtcp)
     }
 
     res = r_socket_receive_message (evtcp->socket, NULL, buf, &size);
+    r_printerr ("DIAG310: recv_iocb sock=%p res=%d size=%"RSIZE_FMT"\n",
+        (void *)(ruintptr)evtcp->evio.handle, (int)res,
+        res == R_SOCKET_OK ? size : (rsize)0);
     switch (res) {
       case R_SOCKET_OK:
         if (size > 0) {

--- a/rlib/ev/revudp.c
+++ b/rlib/ev/revudp.c
@@ -58,7 +58,6 @@ struct REvUDP {
 
   RSocketFamily family;
   RSocket * socket;
-  ruint taskgroup;
 
   REvUDPBufferAllocFunc alloc;
   REvUDPBufferFunc recv;
@@ -67,8 +66,6 @@ struct REvUDP {
   rpointer error_data;
   RDestroyNotify error_datanotify;
   rpointer recv_iocb_ctx;
-  rauint recv_counter;
-  RTask * recv_task;
 
   RQueue qsend;
 
@@ -83,7 +80,6 @@ struct REvUDP {
   INT iocp_recv_addrlen;
   DWORD iocp_recv_flags;
   rboolean iocp_recv_active;
-  rboolean iocp_recv_task;
   RDestroyNotify recv_datanotify;
 
   REvIOCPOp iocp_send;
@@ -172,7 +168,6 @@ r_ev_udp_recv_iocb (REvUDP * evudp)
   rsize size;
 
   r_memclear (&addr, sizeof (RSocketAddress));
-  r_atomic_uint_store (&evudp->recv_counter, 0);
 
   do {
     if ((buf = evudp->alloc (evudp->recv_data, evudp)) == NULL) {
@@ -250,16 +245,6 @@ r_ev_udp_error_iocb (REvUDP * evudp)
 }
 #endif
 
-#if !defined (R_OS_WIN32) || defined (R_EV_USE_RPOLL)
-static void
-r_ev_udp_recv_iocb_task (rpointer data, RTaskQueue * queue, RTask * task)
-{
-  (void) queue;
-  (void) task;
-  r_ev_udp_recv_iocb (data);
-}
-#endif
-
 static void
 r_ev_udp_send_iocb_ev (rpointer data, REvLoop * loop)
 {
@@ -276,39 +261,6 @@ r_ev_udp_iocb (rpointer data, REvIOEvents events, REvIO * evio)
   (void) data;
 
   if (events & R_EV_IO_READABLE) r_ev_udp_recv_iocb ((REvUDP *)evio);
-  if (events & R_EV_IO_WRITABLE) r_ev_udp_send_iocb ((REvUDP *)evio);
-  if (events & R_EV_IO_ERROR) r_ev_udp_error_iocb ((REvUDP *)evio);
-}
-#endif
-
-#if !defined (R_OS_WIN32) || defined (R_EV_USE_RPOLL)
-static void
-r_ev_udp_task_recv_iocb (REvUDP * evudp)
-{
-  RTask * task;
-
-  if (r_atomic_uint_fetch_add (&evudp->recv_counter, 1) > 0)
-    return;
-
-  if ((task = r_ev_loop_add_task_full (evudp->evio.loop,
-          evudp->taskgroup, r_ev_udp_recv_iocb_task, NULL,
-          r_ev_udp_ref (evudp), r_ev_udp_unref, evudp->recv_task, NULL)) != NULL) {
-    if (evudp->recv_task != NULL)
-      r_task_unref (evudp->recv_task);
-    evudp->recv_task = task;
-  } else {
-    r_ev_udp_unref (evudp);
-  }
-}
-#endif
-
-#if !defined (R_OS_WIN32) || defined (R_EV_USE_RPOLL)
-static void
-r_ev_udp_task_iocb (rpointer data, REvIOEvents events, REvIO * evio)
-{
-  (void) data;
-
-  if (events & R_EV_IO_READABLE) r_ev_udp_task_recv_iocb ((REvUDP *)evio);
   if (events & R_EV_IO_WRITABLE) r_ev_udp_send_iocb ((REvUDP *)evio);
   if (events & R_EV_IO_ERROR) r_ev_udp_error_iocb ((REvUDP *)evio);
 }
@@ -353,63 +305,9 @@ r_ev_udp_iocp_result (REvUDP * evudp, REvIOCPOp * op, rsize * bytes)
   return (DWORD) WSAGetLastError ();
 }
 
-/* Task-group delivery: hand the datagram to the task group; the buffer, sender
- * address and the evudp ref are released when the task context is freed. */
-typedef struct {
-  REvUDP * evudp;
-  RBuffer * buf;
-  RSocketAddress * addr;
-} REvUDPRecvTaskCtx;
-
-static void
-r_ev_udp_iocp_recv_task (rpointer data, RTaskQueue * queue, RTask * task)
-{
-  REvUDPRecvTaskCtx * ctx = data;
-  (void) queue;
-  (void) task;
-  ctx->evudp->recv (ctx->evudp->recv_data, ctx->buf, ctx->addr, ctx->evudp);
-}
-
-static void
-r_ev_udp_iocp_recv_task_free (rpointer data)
-{
-  REvUDPRecvTaskCtx * ctx = data;
-  r_socket_address_unref (ctx->addr);
-  r_buffer_unref (ctx->buf);
-  r_ev_udp_unref (ctx->evudp);
-  r_free (ctx);
-}
-
 static void
 r_ev_udp_iocp_recv_deliver (REvUDP * evudp, RBuffer * buf, RSocketAddress * addr)
 {
-  REvUDPRecvTaskCtx * ctx;
-  RTask * task;
-
-  if (!evudp->iocp_recv_task) {
-    evudp->recv (evudp->recv_data, buf, addr, evudp);
-    r_socket_address_unref (addr);
-    r_buffer_unref (buf);
-    return;
-  }
-
-  if ((ctx = r_mem_new (REvUDPRecvTaskCtx)) != NULL) {
-    ctx->evudp = r_ev_udp_ref (evudp);
-    ctx->buf = buf;     /* ownership transferred to the task */
-    ctx->addr = addr;
-    if ((task = r_ev_loop_add_task_full (evudp->evio.loop, evudp->taskgroup,
-            r_ev_udp_iocp_recv_task, NULL, ctx, r_ev_udp_iocp_recv_task_free,
-            evudp->recv_task, NULL)) != NULL) {
-      if (evudp->recv_task != NULL)
-        r_task_unref (evudp->recv_task);
-      evudp->recv_task = task;
-      return;
-    }
-    /* Queuing failed: undo without releasing buf/addr (delivered inline). */
-    r_ev_udp_unref (ctx->evudp);
-    r_free (ctx);
-  }
-
   evudp->recv (evudp->recv_data, buf, addr, evudp);
   r_socket_address_unref (addr);
   r_buffer_unref (buf);
@@ -635,57 +533,6 @@ r_ev_udp_recv_start (REvUDP * evudp,
 }
 
 rboolean
-r_ev_udp_task_recv_start (REvUDP * evudp, ruint taskgroup,
-    REvUDPBufferAllocFunc alloc, REvUDPBufferFunc recv,
-    rpointer data, RDestroyNotify datanotify)
-{
-  if (R_UNLIKELY (recv == NULL)) return FALSE;
-  if (R_UNLIKELY (evudp->recv_iocb_ctx != NULL)) return FALSE;
-  if (R_UNLIKELY (!r_ev_io_validate_taskgroup (&evudp->evio, taskgroup))) return FALSE;
-
-#if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
-  if (R_UNLIKELY (evudp->iocp_recv_active)) return FALSE;
-  if (alloc == NULL)
-    alloc = r_ev_udp_buffer_alloc_default;
-  if (evudp->recv_datanotify != NULL)
-    evudp->recv_datanotify (evudp->recv_data);
-  evudp->taskgroup = taskgroup;
-  evudp->alloc = alloc;
-  evudp->recv = recv;
-  evudp->recv_data = data;
-  evudp->recv_datanotify = datanotify;
-  evudp->iocp_recv_active = TRUE;
-  evudp->iocp_recv_task = TRUE;
-  if (R_UNLIKELY (!r_ev_udp_iocp_post_recv (evudp))) {
-    evudp->iocp_recv_active = FALSE;
-    evudp->iocp_recv_task = FALSE;
-    evudp->recv = NULL;
-    evudp->recv_datanotify = NULL;
-    if (datanotify != NULL)
-      datanotify (data);
-    return FALSE;
-  }
-  return TRUE;
-#else
-  if ((evudp->recv_iocb_ctx = r_ev_io_start (&evudp->evio, R_EV_IO_READABLE,
-      r_ev_udp_task_iocb, data, datanotify))) {
-    if (alloc == NULL)
-      alloc = r_ev_udp_buffer_alloc_default;
-
-    evudp->taskgroup = taskgroup;
-    evudp->alloc = alloc;
-    evudp->recv = recv;
-    evudp->recv_data = data;
-    r_atomic_uint_store (&evudp->recv_counter, 0);
-    evudp->recv_task = NULL;
-    return TRUE;
-  }
-
-  return FALSE;
-#endif
-}
-
-rboolean
 r_ev_udp_recv_stop (REvUDP * evudp)
 {
 #if defined (R_OS_WIN32) && !defined (R_EV_USE_RPOLL)
@@ -694,21 +541,12 @@ r_ev_udp_recv_stop (REvUDP * evudp)
   evudp->iocp_recv_active = FALSE;
   if (evudp->iocp_recv_buf != NULL)
     CancelIoEx ((HANDLE) evudp->socket->handle, &evudp->iocp_recv.overlapped);
-  if (evudp->recv_task != NULL) {
-    r_task_wait (evudp->recv_task);
-    r_task_unref (evudp->recv_task);
-    evudp->recv_task = NULL;
-  }
   return TRUE;
 #else
   rboolean ret;
 
   ret = r_ev_io_stop (&evudp->evio, evudp->recv_iocb_ctx);
   evudp->recv_iocb_ctx = NULL;
-  if (evudp->recv_task != NULL) {
-    r_task_wait (evudp->recv_task);
-    r_task_unref (evudp->recv_task);
-  }
 
   return ret;
 #endif

--- a/rlib/ev/revwakeup.c
+++ b/rlib/ev/revwakeup.c
@@ -19,6 +19,8 @@
 #include "config.h"
 #include "rev-private.h"
 #include <rlib/ev/revwakeup.h>
+#include <rlib/os/renv.h>    /* DIAG #310: r_getenv gate, revert before merge */
+#include <rlib/os/rtty.h>    /* DIAG #310: r_printerr, revert before merge */
 
 #include <rlib/rio.h>
 
@@ -79,6 +81,12 @@ r_ev_wakeup_win_socketpair (SOCKET * rd, SOCKET * wr)
   ioctlsocket (c, FIONBIO, &nb);
   *rd = a;
   *wr = c;
+  /* DIAG #310: log the pair so the wakeup's readable fd can be matched against
+   * the r_poll fd-set trace. Revert before merge. */
+  if (r_getenv ("DIAG310_POLL") != NULL)
+    r_printerr ("DIAG310: wakeup_pair rd=%p wr=%p port=%u\n",
+        (void *) (ruintptr) a, (void *) (ruintptr) c,
+        (unsigned) ntohs (addr.sin_port));
   return TRUE;
 
 fail:

--- a/rlib/net/rhttpclient.c
+++ b/rlib/net/rhttpclient.c
@@ -263,6 +263,8 @@ r_http_client_conn_connected (rpointer data, REvTCP * evtcp, int status)
   RHttpClientConn * conn = data;
   (void) evtcp;
 
+  r_printerr ("DIAG310: cli conn_connected conn=%p status=%d req=%p\n",
+      (void *) conn, status, (void *) conn->req);
   if (conn->req == NULL)        /* request gone (e.g. torn down); drop conn */
     return;
   if (status != 0) {
@@ -579,6 +581,8 @@ r_http_client_req_connect (RHttpClientReqCtx * ctx, rboolean defer)
   }
   ctx->conn = conn;     /* ctx owns the new connection's reference */
   conn->req = ctx;
+  r_printerr ("DIAG310: cli connect_issued conn=%p evtcp=%p ctx=%p\n",
+      (void *) conn, (void *) conn->evtcp, (void *) ctx);
   if (r_ev_tcp_connect (conn->evtcp, ctx->dest,
         r_http_client_conn_connected, conn, NULL) < R_SOCKET_OK)
     r_http_client_req_complete (ctx, R_HTTP_CLIENT_CONNECT_FAILED, defer);

--- a/rlib/net/rhttpclient.c
+++ b/rlib/net/rhttpclient.c
@@ -20,6 +20,8 @@
 #include "../rlib-private.h"
 #include <rlib/net/rhttpclient.h>
 
+#include <rlib/os/rtty.h> /* DIAG #310: r_printerr markers, revert before merge */
+
 #include <rlib/ev/revtcp.h>
 #include <rlib/ev/revresolve.h>
 
@@ -228,6 +230,9 @@ r_http_client_conn_recv (rpointer data, RBuffer * buf, REvTCP * evtcp)
   RHttpClientConn * conn = data;
   (void) evtcp;
 
+  r_printerr ("DIAG310: cli conn_recv conn=%p buf=%p req=%p finished=%d\n",
+      (void *)conn, (void *)buf, (void *)conn->req,
+      conn->req ? (int)conn->req->finished : -1);
   if (conn->req == NULL || conn->req->finished) {
     /* Bytes or EOF on a parked connection: the peer is done with it. */
     r_http_client_conn_evict (conn);
@@ -242,6 +247,8 @@ r_http_client_conn_error (rpointer data, REvTCP * evtcp, RSocketStatus error)
   RHttpClientConn * conn = data;
   (void) evtcp;
 
+  r_printerr ("DIAG310: cli conn_error conn=%p err=%d req=%p\n",
+      (void *)conn, (int)error, (void *)conn->req);
   R_LOG_DEBUG ("%p: connection %p socket error (%d)", conn->client, conn,
       (int) error);
   if (conn->req == NULL)
@@ -360,6 +367,9 @@ r_http_client_req_complete (RHttpClientReqCtx * ctx, RHttpClientResult result,
     return;
   ctx->finished = TRUE;
 
+  r_printerr ("DIAG310: cli req_complete ctx=%p result=%d\n",
+      (void *)ctx, (int)result);
+
   /* Keep ctx alive across the callback and the array removal below. */
   r_ref_ref (ctx);
 
@@ -400,6 +410,9 @@ r_http_client_req_fail (RHttpClientReqCtx * ctx, RHttpClientResult result,
 {
   if (ctx->finished)
     return;
+
+  r_printerr ("DIAG310: cli req_fail ctx=%p result=%d reused=%d retried=%d\n",
+      (void *)ctx, (int)result, ctx->reused, ctx->retried);
 
   if (ctx->reused && !ctx->retried && ctx->res == NULL) {
     RHttpClientConn * conn = ctx->conn;

--- a/rlib/net/rhttpserver.c
+++ b/rlib/net/rhttpserver.c
@@ -511,6 +511,8 @@ r_http_server_tcp_connection_ready (rpointer data,
   RHttpServer * server = data;
   RHttpClientCtx * ctx;
 
+  r_printerr ("DIAG310: server accept newtcp=%p listening=%p\n",
+      (void *) newtcp, (void *) listening);
   if ((ctx = r_http_client_ctx_new (server, newtcp)) != NULL) {
     R_LOG_TRACE ("%p: New connection "R_EV_IO_FORMAT" on "R_EV_IO_FORMAT,
         server, R_EV_IO_ARGS (newtcp), R_EV_IO_ARGS (listening));

--- a/rlib/net/rhttpserver.c
+++ b/rlib/net/rhttpserver.c
@@ -19,6 +19,8 @@
 #include "config.h"
 #include "../rlib-private.h"
 #include "../ev/rev-private.h"
+
+#include <rlib/os/rtty.h> /* DIAG #310: r_printerr markers, revert before merge */
 #include <rlib/net/rhttpserver.h>
 
 #include <rlib/ev/revtcp.h>
@@ -120,6 +122,10 @@ r_http_client_ctx_tcp_response_ready (rpointer data, RHttpResponse * res,
   RHttpClientCtx * ctx = data;
   RBuffer * buf;
 
+  r_printerr ("DIAG310: server response_ready ctx=%p evtcp=%p keepalive=%d"
+      " clients=%"RSIZE_FMT"\n", (void *)ctx, (void *)ctx->evtcp, ctx->keepalive,
+      (rsize)r_ptr_array_size (ctx->server->clients));
+
   /* A response on a kept-alive connection must be self-delimiting or the client
    * cannot tell where it ends (it would wait for a close that never comes).
    * Frame any response that is neither chunked nor already length-delimited --
@@ -157,6 +163,9 @@ r_http_client_ctx_process (RHttpClientCtx * ctx)
   RSocketAddress * addr = r_ev_tcp_get_remote_address (ctx->evtcp);
   rboolean ret;
 
+  r_printerr ("DIAG310: server ctx_process ctx=%p evtcp=%p req=%p\n",
+      (void *)ctx, (void *)ctx->evtcp, (void *)ctx->req);
+
   if ((ret = r_http_server_process_request (ctx->server, ctx->req, addr,
       r_http_client_ctx_tcp_response_ready, r_ref_ref (ctx), r_ref_unref))) {
     r_http_request_unref (ctx->req);
@@ -174,6 +183,10 @@ r_http_client_ctx_tcp_recv (rpointer data, RBuffer * buf, REvTCP * evtcp)
 {
   RHttpClientCtx * ctx = data;
   RHttpError err;
+
+  r_printerr ("DIAG310: server tcp_recv ctx=%p evtcp=%p buf=%p size=%"
+      RSIZE_FMT" req=%p\n", (void *)ctx, (void *)evtcp, (void *)buf,
+      buf != NULL ? r_buffer_get_size (buf) : (rsize)0, (void *)ctx->req);
 
   if (buf != NULL) {
     R_LOG_TRACE ("%p: Buffer %p on "R_EV_IO_FORMAT" (%"RSIZE_FMT")",
@@ -591,6 +604,8 @@ r_http_server_close_client_ctx (rpointer data, rpointer user)
 {
   RHttpClientCtx * cli = data;
   RHttpServerStopCtx * ctx = user;
+  r_printerr ("DIAG310: server force-close client ctx=%p evtcp=%p\n",
+      (void *)cli, (void *)cli->evtcp);
   R_LOG_DEBUG ("%p: Force close client socket "R_EV_IO_FORMAT,
       ctx->server, R_EV_IO_ARGS (cli->evtcp));
   /* Close only; the array removal (and the context's last unref) is done by
@@ -607,6 +622,10 @@ r_http_server_stop (RHttpServer * server, RHttpServerStop func,
 {
   RHttpServerStopCtx * ctx;
   rsize ret;
+
+  r_printerr ("DIAG310: server_stop nclients=%"RSIZE_FMT" nlisten=%"RSIZE_FMT
+      "\n", (rsize)r_ptr_array_size (server->clients),
+      (rsize)r_ptr_array_size (server->listen));
 
   if ((ctx = r_mem_new (RHttpServerStopCtx)) != NULL) {
     r_ref_init (ctx, r_http_server_stop_ctx_free);

--- a/rlib/rpoll.c
+++ b/rlib/rpoll.c
@@ -162,21 +162,7 @@ r_poll (RPoll * handles, ruint count, RClockTime timeout)
   /* nfds is ignored on Windows; the fd_count fields drive the call. */
   ret = select (0, (fd_set *) rset, (fd_set *) wset, (fd_set *) xset, ptv);
 
-  if (ret == SOCKET_ERROR && WSAGetLastError () == WSAENOTSOCK) {
-    /* select() fails atomically if any descriptor is not a socket -- which
-     * happens whenever a socket was closed but its entry is not pruned from the
-     * set yet. Don't fail the whole wait (the loop would never make progress
-     * and never prune it): probe each entry and report the dead ones as errors
-     * so the owner tears them down; the rest re-poll on the next call. */
-    for (i = 0; i < count; i++) {
-      int sotype, solen = (int) sizeof (sotype);
-      if (getsockopt ((SOCKET) (ruintptr) handles[i].handle, SOL_SOCKET,
-            SO_TYPE, (char *)&sotype, &solen) == SOCKET_ERROR) {
-        handles[i].revents = R_IO_ERR;
-        nready++;
-      }
-    }
-  } else if (ret > 0) {
+  if (ret > 0) {
     for (i = 0; i < count; i++) {
       SOCKET s = (SOCKET) (ruintptr) handles[i].handle;
       rushort rev = 0;
@@ -199,8 +185,7 @@ r_poll (RPoll * handles, ruint count, RClockTime timeout)
   r_free (wset);
   r_free (xset);
 
-  /* A genuine error with no dead entry to report stays an error. */
-  return (ret == SOCKET_ERROR && nready == 0) ? -1 : nready;
+  return (ret == SOCKET_ERROR) ? -1 : nready;
 }
 #elif defined (HAVE_SELECT)
 static inline int

--- a/rlib/rpoll.c
+++ b/rlib/rpoll.c
@@ -39,6 +39,8 @@
 #include <windows.h>
 #endif
 #include <errno.h>
+#include <stdlib.h>          /* DIAG #310: getenv gate, revert before merge */
+#include <rlib/os/rtty.h>    /* DIAG #310: r_printerr, revert before merge */
 
 #define R_LOG_CAT_DEFAULT &rlib_logcat
 
@@ -160,7 +162,25 @@ r_poll (RPoll * handles, ruint count, RClockTime timeout)
   }
 
   /* nfds is ignored on Windows; the fd_count fields drive the call. */
-  ret = select (0, (fd_set *) rset, (fd_set *) wset, (fd_set *) xset, ptv);
+  {
+    /* DIAG #310: env-gated so it only fires in the isolated-repeat CI step,
+     * not across the whole noisy suite. Revert before merge. */
+    static int diag = -1;
+    if (diag < 0) diag = (getenv ("DIAG310_POLL") != NULL) ? 1 : 0;
+    if (diag) {
+      ruint k;
+      r_printerr ("DIAG310: r_poll enter count=%u timeout=%lld r=%u w=%u x=%u\n",
+          count, (long long) timeout, (unsigned) rset->fd_count,
+          (unsigned) wset->fd_count, (unsigned) xset->fd_count);
+      for (k = 0; k < count; k++)
+        r_printerr ("DIAG310:   fd[%u] sock=%p ev=%x\n", k,
+            (void *) (ruintptr) handles[k].handle, (unsigned) handles[k].events);
+    }
+    ret = select (0, (fd_set *) rset, (fd_set *) wset, (fd_set *) xset, ptv);
+    if (diag)
+      r_printerr ("DIAG310: r_poll exit ret=%d err=%d\n", ret,
+          ret == SOCKET_ERROR ? WSAGetLastError () : 0);
+  }
 
   if (ret > 0) {
     for (i = 0; i < count; i++) {

--- a/rlib/rpoll.c
+++ b/rlib/rpoll.c
@@ -39,7 +39,7 @@
 #include <windows.h>
 #endif
 #include <errno.h>
-#include <stdlib.h>          /* DIAG #310: getenv gate, revert before merge */
+#include <rlib/os/renv.h>    /* DIAG #310: r_getenv gate, revert before merge */
 #include <rlib/os/rtty.h>    /* DIAG #310: r_printerr, revert before merge */
 
 #define R_LOG_CAT_DEFAULT &rlib_logcat
@@ -166,7 +166,7 @@ r_poll (RPoll * handles, ruint count, RClockTime timeout)
     /* DIAG #310: env-gated so it only fires in the isolated-repeat CI step,
      * not across the whole noisy suite. Revert before merge. */
     static int diag = -1;
-    if (diag < 0) diag = (getenv ("DIAG310_POLL") != NULL) ? 1 : 0;
+    if (diag < 0) diag = (r_getenv ("DIAG310_POLL") != NULL) ? 1 : 0;
     if (diag) {
       ruint k;
       r_printerr ("DIAG310: r_poll enter count=%u timeout=%lld r=%u w=%u x=%u\n",

--- a/test/revtcp.c
+++ b/test/revtcp.c
@@ -38,9 +38,38 @@ data_counted (rpointer data, RBuffer * buf, REvTCP * evtcp)
     *((rsize *)data) += r_buffer_get_size (buf);
 }
 
-/* The recv-error tests below need a backend that observes an abortive peer
- * close; the rpoll readiness backend cannot, so they are gated off there. */
-#ifndef R_EV_USE_RPOLL
+typedef struct {
+  rsize bytes;
+  rboolean eos;
+} RTestRecvCount;
+
+/* Count received bytes and note end-of-stream (recv NULL -- a clean FIN, or the
+ * fallback delivered when a peer reset arrives with no error handler set). */
+static void
+data_count_eos (rpointer data, RBuffer * buf, REvTCP * evtcp)
+{
+  RTestRecvCount * c = data;
+  (void) evtcp;
+  if (buf == NULL) {
+    c->eos = TRUE;
+    return;
+  }
+  c->bytes += r_buffer_get_size (buf);
+}
+
+/* Accept then immediately close, to churn pollset add/remove. The accept path
+ * drops its own ref after this returns; close holds its own until teardown. */
+static void
+accept_and_close (rpointer data, REvTCP * newtcp, REvTCP * listening)
+{
+  (void) data;
+  (void) listening;
+  r_ev_tcp_close (newtcp, NULL, NULL, NULL);
+}
+
+/* Helpers for the recv-error tests below, gated to the same backends -- see
+ * the comment there for why only a Windows rpoll build is excluded. */
+#if !(defined (R_OS_WIN32) && defined (R_EV_USE_RPOLL))
 static void
 error_received (rpointer data, REvTCP * evtcp, RSocketStatus error)
 {
@@ -178,13 +207,13 @@ RTEST (revtcp, queued_send_recv, RTEST_FAST | RTEST_SYSTEM)
 RTEST_END;
 
 /* These two exercise an abortive close (peer RST) and assert the client
- * observes it promptly. The rpoll readiness backend cannot do this reliably:
- * an abortive RST on a loopback socket is, intermittently, not surfaced by the
- * Windows stack (recv keeps returning WOULDBLOCK) until a multi-second TCP
- * abort timeout. A completion backend (IOCP, the Windows default) pre-posts
- * overlapped reads and observes it promptly, so these run everywhere except a
- * forced rpoll build. */
-#ifndef R_EV_USE_RPOLL
+ * observes it promptly. Every backend manages this except a forced Windows
+ * rpoll build: there, an abortive RST on a loopback socket is intermittently
+ * not surfaced by the Windows stack (recv keeps returning WOULDBLOCK) until a
+ * multi-second TCP abort timeout. Linux poll surfaces it via the recv error,
+ * and the Windows IOCP default pre-posts overlapped reads, so gate the pair off
+ * Windows rpoll only. */
+#if !(defined (R_OS_WIN32) && defined (R_EV_USE_RPOLL))
 RTEST (revtcp, recv_error_handler, RTEST_FAST | RTEST_SYSTEM)
 {
   REvLoop * loop;
@@ -300,7 +329,7 @@ RTEST (revtcp, recv_error_no_handler, RTEST_FAST | RTEST_SYSTEM)
   r_ev_loop_unref (loop);
 }
 RTEST_END;
-#endif /* !R_EV_USE_RPOLL */
+#endif /* !(R_OS_WIN32 && R_EV_USE_RPOLL) */
 
 /* The error handler's data is released (via datanotify) both when it is
  * replaced and when the socket is freed. */
@@ -326,6 +355,238 @@ RTEST (revtcp, error_handler_data_freed, RTEST_FAST)
   r_ev_tcp_unref (evtcp);                                  /* free -> frees data */
   r_assert (freed);
 
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+/* A graceful close with data still queued must flush every queued byte before
+ * the half-close: the peer receives all of it, then EOF. r_ev_tcp_send only
+ * queues and defers the write, so closing in the same tick leaves the queue
+ * non-empty and exercises the deferred-finalize path (close-with-pending-send),
+ * which no other test reaches. */
+RTEST (revtcp, close_flushes_pending_send, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RSocketAddress * addr;
+  REvTCP * server, * servcli = NULL, * client;
+  rboolean conn = FALSE;
+  RTestRecvCount rc = { 0, FALSE };
+  ruint8 chunk[4096];
+  ruint i;
+  const ruint nsends = 16;
+
+  r_memset (chunk, 0x5a, sizeof (chunk));
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((client = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpptr ((server = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
+  r_assert_cmpint (r_ev_tcp_bind (server, addr, TRUE), ==, R_SOCKET_OK);
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_ev_tcp_get_local_address (server)), !=, NULL);
+  r_assert_cmpint (r_ev_tcp_listen (server, 10, new_connection_ready, &servcli, NULL), ==, R_SOCKET_OK);
+  r_assert_cmpint (r_ev_tcp_connect (client, addr, client_connected, &conn, NULL), ==, R_SOCKET_WOULD_BLOCK);
+  r_socket_address_unref (addr);
+
+  while (servcli == NULL)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE);
+  r_assert (conn);
+  r_assert (r_ev_tcp_close (server, NULL, NULL, NULL));
+  r_ev_tcp_unref (server);
+
+  r_assert (r_ev_tcp_recv_start (servcli, NULL, data_count_eos, &rc, NULL));
+
+  /* Queue, then close in the same tick: the queue is non-empty, so close must
+   * drain it before the half-close. */
+  for (i = 0; i < nsends; i++)
+    r_assert (r_ev_tcp_send_dup (client, chunk, sizeof (chunk), NULL, NULL, NULL));
+  r_assert (r_ev_tcp_close (client, NULL, NULL, NULL));
+
+  while (!rc.eos)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE);
+
+  r_assert_cmpuint (rc.bytes, ==, (rsize)nsends * sizeof (chunk));
+
+  r_assert (r_ev_tcp_close (servcli, NULL, NULL, NULL));
+  r_assert_cmpuint (r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP), ==, 0);
+  r_ev_tcp_unref (client);
+  r_ev_tcp_unref (servcli);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+/* abort() discards everything still queued, so the peer must NOT receive the
+ * full payload. Many sends are queued; a completion backend posts only the
+ * head, a readiness backend posts none -- either way the bulk is dropped. */
+RTEST (revtcp, abort_drops_pending_send, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RSocketAddress * addr;
+  REvTCP * server, * servcli = NULL, * client;
+  rboolean conn = FALSE;
+  RTestRecvCount rc = { 0, FALSE };
+  ruint8 chunk[4096];
+  ruint i;
+  const ruint nsends = 32;
+
+  r_memset (chunk, 0x5a, sizeof (chunk));
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((client = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpptr ((server = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
+  r_assert_cmpint (r_ev_tcp_bind (server, addr, TRUE), ==, R_SOCKET_OK);
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_ev_tcp_get_local_address (server)), !=, NULL);
+  r_assert_cmpint (r_ev_tcp_listen (server, 10, new_connection_ready, &servcli, NULL), ==, R_SOCKET_OK);
+  r_assert_cmpint (r_ev_tcp_connect (client, addr, client_connected, &conn, NULL), ==, R_SOCKET_WOULD_BLOCK);
+  r_socket_address_unref (addr);
+
+  while (servcli == NULL)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE);
+  r_assert (conn);
+  r_assert (r_ev_tcp_close (server, NULL, NULL, NULL));
+  r_ev_tcp_unref (server);
+
+  r_assert (r_ev_tcp_recv_start (servcli, NULL, data_count_eos, &rc, NULL));
+
+  for (i = 0; i < nsends; i++)
+    r_assert (r_ev_tcp_send_dup (client, chunk, sizeof (chunk), NULL, NULL, NULL));
+  r_assert (r_ev_tcp_abort (client, NULL, NULL, NULL));
+  /* Drop our ref now: a proactor backend defers the socket close until its
+   * cancelled overlapped ops drain, so the peer only sees the end once the last
+   * ref goes. A reactor backend already closed inside abort. */
+  r_ev_tcp_unref (client);
+
+  while (!rc.eos)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE);
+
+  r_assert_cmpuint (rc.bytes, <, (rsize)nsends * sizeof (chunk));
+
+  r_assert (r_ev_tcp_close (servcli, NULL, NULL, NULL));
+  r_assert_cmpuint (r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP), ==, 0);
+  r_ev_tcp_unref (servcli);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+/* Connect, exchange, and tear down repeatedly on one loop. Each round releases
+ * the client and accepted fds, which the OS recycles into the next round --
+ * exercising synchronous pollset removal and the recycled-handle guard. */
+RTEST (revtcp, reconnect_same_loop, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RSocketAddress * addr;
+  REvTCP * server, * servcli = NULL;
+  ruint round, j;
+  const ruint rounds = 6;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((server = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
+  r_assert_cmpint (r_ev_tcp_bind (server, addr, TRUE), ==, R_SOCKET_OK);
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_ev_tcp_get_local_address (server)), !=, NULL);
+  r_assert_cmpint (r_ev_tcp_listen (server, 10, new_connection_ready, &servcli, NULL), ==, R_SOCKET_OK);
+
+  for (round = 0; round < rounds; round++) {
+    REvTCP * client;
+    rboolean conn = FALSE;
+    RBuffer * buf = NULL;
+
+    servcli = NULL;
+    r_assert_cmpptr ((client = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+    r_assert_cmpint (r_ev_tcp_connect (client, addr, client_connected, &conn, NULL), ==, R_SOCKET_WOULD_BLOCK);
+
+    while (servcli == NULL)
+      r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE);
+    r_assert (conn);
+
+    r_assert (r_ev_tcp_recv_start (servcli, NULL, data_received, &buf, NULL));
+    r_assert (r_ev_tcp_send_dup (client, "x", 1, NULL, NULL, NULL));
+    while (buf == NULL)
+      r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE);
+    r_assert_cmpbufsstr (buf, 0, -1, ==, "x");
+    r_buffer_unref (buf);
+    r_assert (r_ev_tcp_recv_stop (servcli));
+
+    r_assert (r_ev_tcp_close (client, NULL, NULL, NULL));
+    r_assert (r_ev_tcp_close (servcli, NULL, NULL, NULL));
+    r_ev_tcp_unref (client);
+    r_ev_tcp_unref (servcli);
+    /* Process the deferred teardowns so both fds are released (and recyclable)
+     * before the next round. The listener stays active, so a full RUN_LOOP
+     * would never return -- a few non-blocking ticks suffice. */
+    for (j = 0; j < 4; j++)
+      r_ev_loop_run (loop, R_EV_LOOP_RUN_NOWAIT);
+  }
+
+  r_socket_address_unref (addr);
+  r_assert (r_ev_tcp_close (server, NULL, NULL, NULL));
+  r_assert_cmpuint (r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP), ==, 0);
+  r_ev_tcp_unref (server);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+/* Hammer connect+teardown on one loop: half the clients are torn down while the
+ * connect is still in flight (half-open teardown), alternating close and abort,
+ * while the server accepts and immediately closes each. The loop must drain to
+ * zero with no hang and no leak. */
+RTEST (revtcp, open_close_churn, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RSocketAddress * addr;
+  REvTCP * server;
+  ruint i;
+  const ruint n = 64;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((server = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
+  r_assert_cmpint (r_ev_tcp_bind (server, addr, TRUE), ==, R_SOCKET_OK);
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_ev_tcp_get_local_address (server)), !=, NULL);
+  r_assert_cmpint (r_ev_tcp_listen (server, R_SOCKET_DEFAULT_BACKLOG, accept_and_close, NULL, NULL), ==, R_SOCKET_OK);
+
+  for (i = 0; i < n; i++) {
+    REvTCP * client;
+    rboolean conn = FALSE;
+
+    r_assert_cmpptr ((client = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+    r_assert_cmpint (r_ev_tcp_connect (client, addr, client_connected, &conn, NULL), ==, R_SOCKET_WOULD_BLOCK);
+
+    /* Even rounds tear down mid-connect; odd rounds let the handshake settle. */
+    if (i & 1)
+      r_ev_loop_run (loop, R_EV_LOOP_RUN_NOWAIT);
+    if (i & 2)
+      r_assert (r_ev_tcp_abort (client, NULL, NULL, NULL));
+    else
+      r_assert (r_ev_tcp_close (client, NULL, NULL, NULL));
+    r_ev_tcp_unref (client);
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_NOWAIT);
+  }
+
+  r_socket_address_unref (addr);
+  r_assert (r_ev_tcp_close (server, NULL, NULL, NULL));
+  r_assert_cmpuint (r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP), ==, 0);
+  r_ev_tcp_unref (server);
   r_ev_loop_unref (loop);
 }
 RTEST_END;

--- a/test/revudp.c
+++ b/test/revudp.c
@@ -3,9 +3,8 @@
 typedef struct {
   RList * buffers;
   RList * addrs;
-  rauint recvd;       /* bumped last in buffer_recv; lets a waiter on another
-                         thread observe delivery and synchronize-with the
-                         writes above (task_recv delivers off the loop thread). */
+  rauint recvd;       /* bumped per delivered datagram; lets a driver loop wait
+                         on the receive count instead of the buffer list. */
 } REvUDPTestRecvCtx;
 
 static void
@@ -188,68 +187,6 @@ RTEST (revudp, send_recv_multi, RTEST_FAST | RTEST_SYSTEM)
   r_ev_loop_unref (loop);
 }
 RTEST_END;
-
-RTEST (revudp, task_recv, RTEST_FAST | RTEST_SYSTEM)
-{
-  REvLoop * loop;
-  RClock * clock;
-  RTaskQueue * tq;
-  RSocketAddress * addr;
-  REvUDP * udp1, * udp2;
-  REvUDPTestRecvCtx ctx;
-  ruint8 sendbuf[512];
-  RBuffer * sentbuf;
-
-  r_memclear (&ctx, sizeof (REvUDPTestRecvCtx));
-  r_memset (sendbuf, 0x42, 512);
-  sentbuf = NULL;
-
-  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
-  r_assert_cmpptr ((tq = r_task_queue_new_pin_on_each_cpu (NULL, 1)), !=, NULL);
-  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, tq)), !=, NULL);
-  r_clock_unref (clock);
-
-  r_assert_cmpptr ((udp1 = r_ev_udp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
-  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
-  r_assert (r_ev_udp_bind (udp1, addr, TRUE));
-  r_socket_address_unref (addr);
-  r_assert_cmpptr ((addr = r_ev_udp_get_local_address (udp1)), !=, NULL);
-
-  r_assert (r_ev_udp_task_recv_start (udp1, 0, NULL, buffer_recv, &ctx, NULL));
-
-  r_assert_cmpptr ((udp2 = r_ev_udp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
-  r_assert (r_ev_udp_send_take (udp2, r_memdup (sendbuf, 512), 512, addr, buffer_send_done, &sentbuf, NULL));
-
-  /* Drive the loop until the datagram round-trips (see the note in send_recv).
-   * The recv is delivered on a task-group thread, so wait on the atomic counter
-   * rather than reading the lists directly -- it both signals delivery and
-   * synchronizes-with the worker's writes to ctx. */
-  while (sentbuf == NULL || r_atomic_uint_load (&ctx.recvd) == 0)
-    r_ev_loop_run (loop, R_EV_LOOP_RUN_NOWAIT);
-
-  r_assert (r_ev_udp_recv_stop (udp1));
-
-  r_assert_cmpptr (sentbuf, !=, NULL);
-  r_assert_cmpbufmem (sentbuf, 0, -1, ==, sendbuf, 512);
-
-  r_assert_cmpuint (r_list_len (ctx.buffers), ==, 1);
-  r_assert_cmpuint (r_list_len (ctx.addrs), ==, 1);
-  r_assert_cmpbufmem (ctx.buffers->data, 0, -1, ==, sendbuf, 512);
-
-  r_list_destroy_full (ctx.buffers, r_buffer_unref);
-  r_list_destroy_full (ctx.addrs, r_socket_address_unref);
-
-  r_buffer_unref (sentbuf);
-  r_socket_address_unref (addr);
-  r_ev_udp_unref (udp1);
-  r_ev_udp_unref (udp2);
-  /* Drain the cancelled in-flight recv (see bind_recv). */
-  r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
-  r_task_queue_unref (tq);
-  r_ev_loop_unref (loop);
-}
-RTEST_END;
-
 
 static void
 udp_error_received (rpointer data, REvUDP * evudp, RSocketStatus error)

--- a/test/rhttpclient.c
+++ b/test/rhttpclient.c
@@ -500,6 +500,93 @@ RTEST (rhttpclient, server_stop_during_request, RTEST_FAST | RTEST_SYSTEM)
 }
 RTEST_END;
 
+/* Stopping a server whose connection is idle but still open (the keepalive case)
+ * must force-close it and report it -- distinct from stopping mid-request. */
+RTEST (rhttpclient, server_stop_idle, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RHttpServer * srv;
+  RHttpClient * client;
+  RHttpRequest * req;
+  RHttpResponse * res;
+  RSocketAddress * addr;
+  RHttpClientResult result;
+  rsize closed;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((srv = r_test_http_client_server (loop, "/",
+          R_HTTP_STATUS_OK, &addr)), !=, NULL);
+  r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
+
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+          "http://127.0.0.1/", NULL, NULL)), !=, NULL);
+  res = r_test_http_send (loop, client, req, addr, &result);
+  r_http_request_unref (req);
+  r_assert_cmpint (result, ==, R_HTTP_CLIENT_OK);   /* completed cleanly */
+  r_assert_cmpptr (res, !=, NULL);
+  r_http_response_unref (res);
+
+  /* The connection is now idle but still open; stop must close it. */
+  closed = r_http_server_stop (srv, NULL, NULL, NULL);
+  r_assert_cmpuint (closed, ==, 1);
+  r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
+
+  r_socket_address_unref (addr);
+  r_http_client_unref (client);
+  r_http_server_unref (srv);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+/* Stop must force-close every open connection at once, not just one. */
+RTEST (rhttpclient, server_stop_multi_connection, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RHttpServer * srv;
+  RSocketAddress * addr;
+  RHttpClient * clients[3];
+  RHttpClientResult result;
+  rsize closed;
+  ruint i;
+  const ruint n = 3;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((srv = r_test_http_client_server (loop, "/",
+          R_HTTP_STATUS_OK, &addr)), !=, NULL);
+
+  /* Each client opens its own connection and leaves it open (keepalive). */
+  for (i = 0; i < n; i++) {
+    RHttpRequest * req;
+    RHttpResponse * res;
+    r_assert_cmpptr ((clients[i] = r_http_client_new (loop)), !=, NULL);
+    r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+            "http://127.0.0.1/", NULL, NULL)), !=, NULL);
+    res = r_test_http_send (loop, clients[i], req, addr, &result);
+    r_http_request_unref (req);
+    r_assert_cmpint (result, ==, R_HTTP_CLIENT_OK);
+    r_http_response_unref (res);
+  }
+
+  closed = r_http_server_stop (srv, NULL, NULL, NULL);
+  r_assert_cmpuint (closed, ==, n);     /* all closed in one stop */
+  r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
+
+  for (i = 0; i < n; i++)
+    r_http_client_unref (clients[i]);
+  r_socket_address_unref (addr);
+  r_http_server_unref (srv);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
 /* A minimal raw-TCP "server" that sends a fixed byte blob and closes, used to
  * feed the client responses RHttpServer cannot itself produce. */
 typedef struct {
@@ -621,6 +708,17 @@ RTEST (rhttpclient, response_malformed, RTEST_FAST | RTEST_SYSTEM)
 {
   r_assert_cmpint (r_test_http_client_raw (
         "totally not a http response\r\n\r\n"), ==, R_HTTP_CLIENT_PARSE_FAILED);
+}
+RTEST_END;
+
+/* A server that drops the connection mid-response -- promising more body than
+ * it sends -- is a transport failure; the client must not report success on a
+ * short read. */
+RTEST (rhttpclient, response_truncated_body, RTEST_FAST | RTEST_SYSTEM)
+{
+  r_assert_cmpint (r_test_http_client_raw (
+        "HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\nshort"),
+      ==, R_HTTP_CLIENT_RECV_FAILED);
 }
 RTEST_END;
 


### PR DESCRIPTION
**Do not merge.** Temporary diagnostic branch on top of #319 to capture the
intermittent `server_stop_during_request` hang on Windows-rpoll.

- Adds the DIAG310 `r_printerr` overlay (client conn_recv/conn_error/req_complete/
  req_fail, server stop/force-close/response_ready/ctx_process/tcp_recv, evtcp
  abort/free/recv_iocb).
- Repeats the full suite (Windows-rpoll job only) up to 50x with `--maxfail 1`
  so the ~1% hang reproduces and its trace lands in the test log.

Purpose: read the client's terminal path at the wedge. #319 (the synchronous
readiness-set removal) did **not** fix this residual, confirming it is not the
closed-fd-in-select window.