### PR TITLE
rpoll: one slot per handle + synchronous close removal (pollset hardening)

### DIFF
--- a/include/rlib/rpoll.h
+++ b/include/rlib/rpoll.h
@@ -104,6 +104,8 @@ typedef struct {
   ruint count;                /**< Number of in-use entries. */
   ruint alloc;                /**< Capacity of the @c handles array. */
   RPoll * handles;            /**< Backing array of @c count active entries. */
+  rpointer owner;             /**< Internal: owning thread, asserted in debug
+                                   builds -- a set is single-thread (loop) owned. */
 } RPollSet;
 
 /** @brief Initialise @p ps with an initial capacity of @p alloc entries. */

--- a/rlib/ev/revloop.c
+++ b/rlib/ev/revloop.c
@@ -1208,10 +1208,29 @@ r_ev_io_close (REvIO * evio, REvIOFunc close_cb,
     evio->alnk = NULL;
   }
 
+#if defined (USE_RPOLL)
+  /* Remove the entry from the readiness set now, not via the change queue.
+   * Leaving a closed fd's entry until a later poll trips on it keeps the freed
+   * evio referenced as the entry's user -- a stale-pointer deref in the reactive
+   * prune -- and on Windows makes select() fail with WSAENOTSOCK until it is
+   * pruned. The run loop snapshots its dispatch list before invoking callbacks,
+   * so removing here is safe even from within one. The get_user guard avoids
+   * evicting a newer evio that has already taken over a recycled handle. */
+  if (R_EV_IO_IS_CHANGING (evio)) {
+    r_queue_remove_link (&evio->loop->chg, evio->chglnk);
+    evio->chglnk = NULL;
+  }
+  if (R_EV_IO_IS_ADDED (evio)) {
+    if (r_poll_set_get_user (&evio->loop->pollset, evio->handle) == evio)
+      r_poll_set_remove (&evio->loop->pollset, evio->handle);
+    evio->flags &= ~R_EV_IO_ADDED;
+  }
+#else
   if (R_EV_IO_IS_ACTIVE (evio) || R_EV_IO_IS_INTERNAL (evio)) {
     if (!R_EV_IO_IS_CHANGING (evio))
       evio->chglnk = r_queue_push (&evio->loop->chg, evio);
   }
+#endif
 
   r_cbqueue_push (&evio->loop->acbs, (RFunc)close_cb,
       data, datanotify, r_ev_io_ref (evio), r_ev_io_unref);

--- a/rlib/ev/revloop.c
+++ b/rlib/ev/revloop.c
@@ -639,8 +639,15 @@ r_ev_loop_io_wait (REvLoop * loop, RClockTime deadline)
       r_ev_io_invoke_iocb (dispatch[j].evio, dispatch[j].rev);
     }
 
-    for (j = 0; j < ndead; j++)
-      r_poll_set_remove (&loop->pollset, dead[j]);
+    for (j = 0; j < ndead; j++) {
+      /* A callback during dispatch may have closed this handle and the OS
+       * recycled its value into a brand-new socket that was then added to the
+       * set; only prune it if it is still unowned or owned by a closed evio,
+       * never a live recycled entry. */
+      REvIO * d = r_poll_set_get_user (&loop->pollset, dead[j]);
+      if (d == NULL || R_EV_IO_IS_CLOSED (d))
+        r_poll_set_remove (&loop->pollset, dead[j]);
+    }
   } else {
     R_LOG_ERROR ("r_poll for loop %p failed with error %d", loop, ret);
   }

--- a/rlib/rpoll.c
+++ b/rlib/rpoll.c
@@ -327,6 +327,20 @@ r_poll_set_add (RPollSet * ps, RIOHandle handle, rushort events, rpointer user)
   if (R_UNLIKELY (ps == NULL)) return -1;
   if (R_UNLIKELY (handle == R_IO_HANDLE_INVALID)) return -1;
 
+  /* One slot per handle. If this handle is already present -- e.g. a closed fd
+   * whose entry has not been pruned yet, and whose value the OS recycled into a
+   * new socket -- update that slot in place. Appending a second slot for the
+   * same handle leaves an orphan that remove-by-handle can never reach (it only
+   * unmaps the one the index points at), and select() then spins on the dead
+   * duplicate (WSAENOTSOCK). */
+  {
+    int existing = r_poll_set_find (ps, handle);
+    if (existing >= 0) {
+      r_poll_set_update (ps, (ruint) existing, handle, events, user);
+      return existing;
+    }
+  }
+
   if (ps->count >= ps->alloc) {
     ruint nalloc = ps->alloc;
     RPoll * nhandles;

--- a/rlib/rpoll.c
+++ b/rlib/rpoll.c
@@ -24,6 +24,7 @@
 #include <rlib/rlog.h>
 #include <rlib/rmem.h>
 #include <rlib/rtime.h>
+#include <rlib/concurrency/rthreads.h>
 
 #ifdef HAVE_POLL_H
 #include <poll.h>
@@ -267,6 +268,28 @@ r_poll (RPoll * handles, ruint count, RClockTime timeout)
 #error Need either 'poll' or 'select'
 #endif
 
+/* A poll set is owned by a single thread (the loop that drives it); every
+ * mutation must come from that thread. In debug builds, latch the first
+ * mutator's thread and assert the rest match -- this catches accidental
+ * cross-thread (or re-entrant) use, which would silently corrupt the set, with
+ * zero cost in release builds. */
+#ifndef NDEBUG
+static void
+r_poll_set_check_owner (RPollSet * ps)
+{
+  rpointer cur = (rpointer) r_thread_current ();
+  if (ps->owner == NULL) {
+    R_LOG_DEBUG ("RPollSet %p owner latched to thread %p", ps, cur);
+    ps->owner = cur;
+  } else {
+    r_assert (ps->owner == cur);
+  }
+}
+#define R_POLL_SET_CHECK_OWNER(ps)  r_poll_set_check_owner (ps)
+#else
+#define R_POLL_SET_CHECK_OWNER(ps)  R_STMT_START { } R_STMT_END
+#endif
+
 void
 r_poll_set_init (RPollSet * ps, ruint alloc)
 {
@@ -275,6 +298,7 @@ r_poll_set_init (RPollSet * ps, ruint alloc)
   ps->count = 0;
   ps->alloc = MAX (alloc, R_POLL_SET_MIN_INCREASE);
   ps->handles = r_mem_new0_n (RPoll, ps->alloc);
+  ps->owner = NULL;
 }
 
 void
@@ -326,6 +350,7 @@ r_poll_set_add (RPollSet * ps, RIOHandle handle, rushort events, rpointer user)
 
   if (R_UNLIKELY (ps == NULL)) return -1;
   if (R_UNLIKELY (handle == R_IO_HANDLE_INVALID)) return -1;
+  R_POLL_SET_CHECK_OWNER (ps);
 
   /* One slot per handle. If this handle is already present -- e.g. a closed fd
    * whose entry has not been pruned yet, and whose value the OS recycled into a
@@ -364,37 +389,42 @@ r_poll_set_add (RPollSet * ps, RIOHandle handle, rushort events, rpointer user)
 static rboolean
 r_poll_set_remove_idx (RPollSet * ps, int idx)
 {
-  rpointer key, user;
+  ruint last;
 
   if (R_UNLIKELY (idx < 0)) return FALSE;
   if (R_UNLIKELY ((ruint)idx >= ps->count)) return FALSE;
 
-  key = RIO_HANDLE_TO_POINTER (ps->handles[idx].handle);
-  if (r_hash_table_remove_full (ps->handle_user, key, NULL, &user) == R_HASH_TABLE_OK) {
-    r_hash_table_remove (ps->handle_idx, key);
+  /* Drop the removed handle's two mappings. */
+  r_hash_table_remove (ps->handle_user,
+      RIO_HANDLE_TO_POINTER (ps->handles[idx].handle));
+  r_hash_table_remove (ps->handle_idx,
+      RIO_HANDLE_TO_POINTER (ps->handles[idx].handle));
 
-    if ((ruint)idx < --ps->count) {
-      RPoll * last = &ps->handles[ps->count];
-      rpointer last_user;
-
-      if (r_hash_table_lookup_full (ps->handle_user, RIO_HANDLE_TO_POINTER (last->handle),
-            NULL, &last_user) == R_HASH_TABLE_OK) {
-        r_poll_set_update (ps, (ruint)idx, last->handle, last->events, last_user);
-      } else {
-        return FALSE;
-      }
-    }
-
-    return TRUE;
+  /* Swap the last live entry into the vacated slot. Its handle->user mapping is
+   * unchanged -- only its index moves -- so repoint handle_idx alone. Looking
+   * the user up again and bailing on a miss was the bug: it returned with the
+   * removed handle still in a live slot, stranding a dead fd that select() then
+   * spins on. Finally clear the now-dead tail slot so no duplicate handle
+   * lingers past count for a later find or compaction to trip on. */
+  last = --ps->count;
+  if ((ruint)idx < last) {
+    ps->handles[idx] = ps->handles[last];
+    r_hash_table_insert (ps->handle_idx,
+        RIO_HANDLE_TO_POINTER (ps->handles[idx].handle),
+        RUINT_TO_POINTER ((ruint)idx));
   }
+  ps->handles[last].handle = R_IO_HANDLE_INVALID;
+  ps->handles[last].events = 0;
+  ps->handles[last].revents = 0;
 
-  return FALSE;
+  return TRUE;
 }
 
 rboolean
 r_poll_set_remove (RPollSet * ps, RIOHandle handle)
 {
   if (R_UNLIKELY (ps == NULL)) return FALSE;
+  R_POLL_SET_CHECK_OWNER (ps);
   return r_poll_set_remove_idx (ps, r_poll_set_find (ps, handle));
 }
 
@@ -404,6 +434,7 @@ r_poll_set_modify (RPollSet * ps, RIOHandle handle, rushort events)
   int idx;
 
   if (R_UNLIKELY (ps == NULL)) return FALSE;
+  R_POLL_SET_CHECK_OWNER (ps);
   if ((idx = r_poll_set_find (ps, handle)) < 0)
     return FALSE;
 

--- a/test/rpoll.c
+++ b/test/rpoll.c
@@ -287,3 +287,60 @@ RTEST (rpollset, recycled_handle_leaves_no_orphan, RTEST_FAST)
 }
 RTEST_END;
 
+
+/* A live pollset must stay internally consistent: handles[], handle_user and
+ * handle_idx in lockstep, no handle in two live slots, and every removed handle
+ * fully gone. The swap-compaction in r_poll_set_remove_idx is where this breaks
+ * (a stranded/duplicated slot is the #310 dead-fd-in-pollset). Heavy handle
+ * reuse mimics recycled fds. */
+static void
+r_test_pollset_assert_consistent (RPollSet * ps)
+{
+  ruint i, j;
+
+  r_assert_cmpuint (r_hash_table_size (ps->handle_user), ==, ps->count);
+  r_assert_cmpuint (r_hash_table_size (ps->handle_idx), ==, ps->count);
+
+  for (i = 0; i < ps->count; i++) {
+    RIOHandle h = ps->handles[i].handle;
+    /* the maps point this handle back at exactly this slot */
+    r_assert_cmpint (r_poll_set_find (ps, h), ==, (int) i);
+    r_assert_cmpptr (r_poll_set_get_user (ps, h), !=, NULL);
+    /* no other live slot holds the same handle */
+    for (j = i + 1; j < ps->count; j++)
+      r_assert_cmpint ((int) (ps->handles[j].handle == h), ==, 0);
+  }
+}
+
+RTEST (rpollset, remove_compaction_stays_consistent, RTEST_FAST)
+{
+  RPollSet ps;
+  ruint round, i;
+
+  r_poll_set_init (&ps, 0);
+
+  for (round = 0; round < 200; round++) {
+    /* Reuse a small handle space so adds keep hitting recycled values. Users
+     * are non-NULL (handle value) so get_user can flag a stranded slot. */
+    ruint n = 6 + (round % 5);
+    for (i = 0; i < n; i++) {
+      RIOHandle h = (RIOHandle) (rsize) (1 + ((round * 7 + i * 3) % 11));
+      r_poll_set_add (&ps, h, R_IO_IN, (rpointer) (rsize) h);
+      r_test_pollset_assert_consistent (&ps);
+    }
+    /* Remove every live entry, alternating front/back to drive the
+     * swap-compaction from both directions. */
+    while (ps.count > 0) {
+      ruint idx = (round & 1) ? 0 : ps.count - 1;
+      RIOHandle dead = ps.handles[idx].handle;
+      r_assert (r_poll_set_remove (&ps, dead));
+      r_assert_cmpint (r_poll_set_find (&ps, dead), <, 0);
+      r_assert_cmpptr (r_poll_set_get_user (&ps, dead), ==, NULL);
+      r_test_pollset_assert_consistent (&ps);
+    }
+    r_assert_cmpuint (ps.count, ==, 0);
+  }
+
+  r_poll_set_clear (&ps);
+}
+RTEST_END;

--- a/test/rpoll.c
+++ b/test/rpoll.c
@@ -223,3 +223,67 @@ RTEST (rpollset, add_grow_oom_keeps_set_intact, RTEST_FAST)
 }
 RTEST_END;
 
+/* Re-adding a handle already in the set must update its one slot in place, not
+ * append a second. (A handle reappears when a closed fd's entry lingers and the
+ * OS recycles its value into a new socket.) */
+RTEST (rpollset, re_add_existing_updates_in_place, RTEST_FAST)
+{
+  RPollSet ps;
+
+  r_poll_set_init (&ps, 0);
+
+  r_assert_cmpint (r_poll_set_add (&ps, (RIOHandle)1, R_IO_IN, (rpointer)0xA), ==, 0);
+  r_assert_cmpuint (ps.count, ==, 1);
+
+  /* Same handle again -> same slot, updated user + events, no growth. */
+  r_assert_cmpint (r_poll_set_add (&ps, (RIOHandle)1, R_IO_OUT, (rpointer)0xB), ==, 0);
+  r_assert_cmpuint (ps.count, ==, 1);
+  r_assert_cmpuint (r_hash_table_size (ps.handle_user), ==, 1);
+  r_assert_cmpuint (r_hash_table_size (ps.handle_idx), ==, 1);
+  r_assert_cmpptr (r_poll_set_get_user (&ps, (RIOHandle)1), ==, (rpointer)0xB);
+  r_assert_cmpuint (ps.handles[0].events, ==, R_IO_OUT);
+
+  /* A single remove fully evicts it: no orphaned second slot left behind. */
+  r_assert (r_poll_set_remove (&ps, (RIOHandle)1));
+  r_assert_cmpuint (ps.count, ==, 0);
+  r_assert_cmpint (r_poll_set_find (&ps, (RIOHandle)1), <, 0);
+  r_assert_cmpptr (r_poll_set_get_user (&ps, (RIOHandle)1), ==, NULL);
+
+  r_poll_set_clear (&ps);
+}
+RTEST_END;
+
+/* The #310 shape at the set level: a handle entered and never removed, its fd
+ * value recycled into a new socket and re-added, then the original "pruned".
+ * A blind append would leave a stale handles[] slot for that handle with no
+ * hash entry -- unremovable, and poll() spins on the dead duplicate. With one
+ * slot per handle there is no orphan. */
+RTEST (rpollset, recycled_handle_leaves_no_orphan, RTEST_FAST)
+{
+  RPollSet ps;
+  ruint i;
+  rboolean stale;
+
+  r_poll_set_init (&ps, 0);
+
+  r_assert_cmpint (r_poll_set_add (&ps, (RIOHandle)7, R_IO_IN, (rpointer)0xA), ==, 0);
+  r_assert_cmpint (r_poll_set_add (&ps, (RIOHandle)8, R_IO_IN, (rpointer)0xB), ==, 1);
+  /* fd 7 recycled into a new socket, re-added while the old entry still lingers */
+  r_poll_set_add (&ps, (RIOHandle)7, R_IO_OUT, (rpointer)0xC);
+  r_assert_cmpuint (ps.count, ==, 2);           /* two slots, not three */
+
+  r_assert (r_poll_set_remove (&ps, (RIOHandle)7));
+  r_assert_cmpuint (ps.count, ==, 1);
+  r_assert_cmpint (r_poll_set_find (&ps, (RIOHandle)7), <, 0);
+  r_assert_cmpptr (r_poll_set_get_user (&ps, (RIOHandle)7), ==, NULL);
+  r_assert_cmpptr (r_poll_set_get_user (&ps, (RIOHandle)8), ==, (rpointer)0xB);
+
+  for (i = 0, stale = FALSE; i < ps.count; i++)
+    if (ps.handles[i].handle == (RIOHandle)7)
+      stale = TRUE;
+  r_assert (!stale);                            /* no orphaned slot for 7 */
+
+  r_poll_set_clear (&ps);
+}
+RTEST_END;
+


### PR DESCRIPTION
Two pollset correctness fixes found while investigating the Windows-rpoll
`server_stop_during_request` hang (#310). They fix real bugs and reduce the
hang's rate, but it is not yet eliminated — #310 stays open and the
investigation continues.

## Fixes
- **`r_poll_set_add`: one slot per handle.** It appended unconditionally, so
  re-adding a handle already in the set (a closed fd's lingering entry whose
  value the OS recycled into a new socket) created a second `handles[]` slot.
  A later remove-by-handle unmapped only the indexed slot, orphaning the other
  — a slot with no hash entry that remove can never reach. Now the existing
  slot is updated in place.
- **`r_poll_set_remove`: never strand or duplicate on the swap-compaction**, and
  clear the vacated tail slot. Plus a debug-build assert that a poll set is only
  ever touched by its owning thread.
- **`r_ev_io_close`: remove the readiness entry synchronously** (readiness
  backends) instead of leaving it for the reactive prune — the lingering entry
  otherwise outlives the evio, a use-after-free in the prune.
- **dispatch dead-fd prune: skip recycled handles** a callback may have turned
  into a new live socket.

## Tests
New `rpollset` tests: `re_add_existing_updates_in_place`,
`recycled_handle_leaves_no_orphan`, and a remove/compaction consistency stress
test. The first two fail without the `r_poll_set_add` change.

## Verification
Clean builds on Linux (epoll), forced rpoll, ASan+UBSan, mingw (IOCP + rpoll,
`-Werror`); full suites green on all three local configs; Wine mingw-rpoll green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)