### PR TITLE
DIAG #310 v2: trace the residual with the probe present (DO NOT MERGE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,20 @@ jobs:
       - name: Build
         run: meson compile -C build
       - name: Test
-        run: meson test -C build --print-errorlogs --timeout-multiplier 6
+        # DIAG #310 v2 (strip before merge): loop the http suites until the
+        # server_stop hang reproduces (with the probe present + the fix). Each
+        # run is timeout-wrapped so a hung rtest can't run away -- it is killed,
+        # the step fails, and the DIAG310 select() trace up to the wedge is in
+        # the log. Stops at the first hang.
+        shell: bash
+        run: |
+          export PATH="$PWD/build/rlib:$PATH"
+          for i in $(seq 1 300); do
+            echo "=== iter $i ==="
+            timeout 45 ./build/test/rlibtest.exe -f /rhttpclient/* -f /rhttpserver/* \
+              || { echo "=== HUNG/FAILED at iter $i (exit $?) ==="; exit 1; }
+          done
+          echo "=== 300 iterations clean (did not reproduce) ==="
       - name: Upload test logs on failure
         if: failure()
         uses: actions/upload-artifact@v7

--- a/rlib/ev/revloop.c
+++ b/rlib/ev/revloop.c
@@ -24,6 +24,7 @@
 
 #include <rlib/rassert.h>
 #include <rlib/concurrency/ratomic.h>
+#include <rlib/os/rtty.h>    /* DIAG #310: r_printerr, revert before merge */
 #include <rlib/rio.h>
 #include <rlib/rmem.h>
 #include <rlib/rpoll.h>
@@ -1221,6 +1222,11 @@ r_ev_io_close (REvIO * evio, REvIOFunc close_cb,
     evio->chglnk = NULL;
   }
   if (R_EV_IO_IS_ADDED (evio)) {
+    r_printerr ("DIAG310: io_close handle=%p evio=%p get_user=%p %s\n",
+        (void *) (ruintptr) evio->handle, (void *) evio,
+        (void *) r_poll_set_get_user (&evio->loop->pollset, evio->handle),
+        r_poll_set_get_user (&evio->loop->pollset, evio->handle) == evio
+          ? "REMOVE" : "SKIP");
     if (r_poll_set_get_user (&evio->loop->pollset, evio->handle) == evio)
       r_poll_set_remove (&evio->loop->pollset, evio->handle);
     evio->flags &= ~R_EV_IO_ADDED;

--- a/rlib/ev/revloop.c
+++ b/rlib/ev/revloop.c
@@ -1208,10 +1208,29 @@ r_ev_io_close (REvIO * evio, REvIOFunc close_cb,
     evio->alnk = NULL;
   }
 
+#if defined (USE_RPOLL)
+  /* Remove the entry from the readiness set now, not via the change queue.
+   * Leaving a closed fd's entry until a later poll trips on it keeps the freed
+   * evio referenced as the entry's user -- a stale-pointer deref in the reactive
+   * prune -- and on Windows makes select() fail with WSAENOTSOCK until it is
+   * pruned. The run loop snapshots its dispatch list before invoking callbacks,
+   * so removing here is safe even from within one. The get_user guard avoids
+   * evicting a newer evio that has already taken over a recycled handle. */
+  if (R_EV_IO_IS_CHANGING (evio)) {
+    r_queue_remove_link (&evio->loop->chg, evio->chglnk);
+    evio->chglnk = NULL;
+  }
+  if (R_EV_IO_IS_ADDED (evio)) {
+    if (r_poll_set_get_user (&evio->loop->pollset, evio->handle) == evio)
+      r_poll_set_remove (&evio->loop->pollset, evio->handle);
+    evio->flags &= ~R_EV_IO_ADDED;
+  }
+#else
   if (R_EV_IO_IS_ACTIVE (evio) || R_EV_IO_IS_INTERNAL (evio)) {
     if (!R_EV_IO_IS_CHANGING (evio))
       evio->chglnk = r_queue_push (&evio->loop->chg, evio);
   }
+#endif
 
   r_cbqueue_push (&evio->loop->acbs, (RFunc)close_cb,
       data, datanotify, r_ev_io_ref (evio), r_ev_io_unref);

--- a/rlib/ev/revtcp.c
+++ b/rlib/ev/revtcp.c
@@ -19,6 +19,8 @@
 #include "config.h"
 /* Before rsocket-private.h / rev-private.h: orders <winsock2.h> first. */
 #include "rev-iocp-private.h"
+
+#include <rlib/os/rtty.h> /* DIAG #310: r_printerr markers, revert before merge */
 #include "rev-private.h"
 #include "../net/rsocket-private.h"
 #include "../net/rnet-private.h"
@@ -122,6 +124,8 @@ struct REvTCP {
 static void
 r_ev_tcp_free (REvTCP * evtcp)
 {
+  r_printerr ("DIAG310: evtcp_free evtcp=%p sock=%p\n", (void *)evtcp,
+      (void *)(ruintptr)evtcp->evio.handle);
   r_queue_clear (&evtcp->qsend, r_ev_tcp_send_ctx_free);
 
   /* A graceful close that never reached its finalizer (e.g. the last ref was
@@ -749,6 +753,11 @@ r_ev_tcp_abort (REvTCP * evtcp, REvIOFunc close_cb, rpointer data, RDestroyNotif
 {
   if (R_UNLIKELY (evtcp == NULL)) return FALSE;
 
+  r_printerr ("DIAG310: abort evtcp=%p sock=%p closed=%d refcount=%u\n",
+      (void *)evtcp, (void *)(ruintptr)evtcp->evio.handle,
+      (evtcp->evio.flags & R_EV_IO_CLOSED) ? 1 : 0,
+      (ruint)r_ref_refcount (evtcp));
+
   R_LOG_DEBUG ("loop %p evio "R_EV_IO_FORMAT,
       evtcp->evio.loop, R_EV_IO_ARGS (evtcp));
 
@@ -1054,6 +1063,9 @@ r_ev_tcp_recv_iocb (REvTCP * evtcp)
     }
 
     res = r_socket_receive_message (evtcp->socket, NULL, buf, &size);
+    r_printerr ("DIAG310: recv_iocb sock=%p res=%d size=%"RSIZE_FMT"\n",
+        (void *)(ruintptr)evtcp->evio.handle, (int)res,
+        res == R_SOCKET_OK ? size : (rsize)0);
     switch (res) {
       case R_SOCKET_OK:
         if (size > 0) {

--- a/rlib/ev/revwakeup.c
+++ b/rlib/ev/revwakeup.c
@@ -19,6 +19,7 @@
 #include "config.h"
 #include "rev-private.h"
 #include <rlib/ev/revwakeup.h>
+#include <rlib/os/rtty.h>    /* DIAG #310: r_printerr, revert before merge */
 
 #include <rlib/rio.h>
 
@@ -79,6 +80,11 @@ r_ev_wakeup_win_socketpair (SOCKET * rd, SOCKET * wr)
   ioctlsocket (c, FIONBIO, &nb);
   *rd = a;
   *wr = c;
+  /* DIAG #310: log the pair so the wakeup's readable fd can be matched against
+   * the r_poll fd-set trace. Revert before merge. */
+  r_printerr ("DIAG310: wakeup_pair rd=%p wr=%p port=%u\n",
+      (void *) (ruintptr) a, (void *) (ruintptr) c,
+      (unsigned) ntohs (addr.sin_port));
   return TRUE;
 
 fail:

--- a/rlib/net/rhttpclient.c
+++ b/rlib/net/rhttpclient.c
@@ -20,6 +20,8 @@
 #include "../rlib-private.h"
 #include <rlib/net/rhttpclient.h>
 
+#include <rlib/os/rtty.h> /* DIAG #310: r_printerr markers, revert before merge */
+
 #include <rlib/ev/revtcp.h>
 #include <rlib/ev/revresolve.h>
 
@@ -228,6 +230,9 @@ r_http_client_conn_recv (rpointer data, RBuffer * buf, REvTCP * evtcp)
   RHttpClientConn * conn = data;
   (void) evtcp;
 
+  r_printerr ("DIAG310: cli conn_recv conn=%p buf=%p req=%p finished=%d\n",
+      (void *)conn, (void *)buf, (void *)conn->req,
+      conn->req ? (int)conn->req->finished : -1);
   if (conn->req == NULL || conn->req->finished) {
     /* Bytes or EOF on a parked connection: the peer is done with it. */
     r_http_client_conn_evict (conn);
@@ -242,6 +247,8 @@ r_http_client_conn_error (rpointer data, REvTCP * evtcp, RSocketStatus error)
   RHttpClientConn * conn = data;
   (void) evtcp;
 
+  r_printerr ("DIAG310: cli conn_error conn=%p err=%d req=%p\n",
+      (void *)conn, (int)error, (void *)conn->req);
   R_LOG_DEBUG ("%p: connection %p socket error (%d)", conn->client, conn,
       (int) error);
   if (conn->req == NULL)
@@ -256,6 +263,8 @@ r_http_client_conn_connected (rpointer data, REvTCP * evtcp, int status)
   RHttpClientConn * conn = data;
   (void) evtcp;
 
+  r_printerr ("DIAG310: cli conn_connected conn=%p status=%d req=%p\n",
+      (void *) conn, status, (void *) conn->req);
   if (conn->req == NULL)        /* request gone (e.g. torn down); drop conn */
     return;
   if (status != 0) {
@@ -360,6 +369,9 @@ r_http_client_req_complete (RHttpClientReqCtx * ctx, RHttpClientResult result,
     return;
   ctx->finished = TRUE;
 
+  r_printerr ("DIAG310: cli req_complete ctx=%p result=%d\n",
+      (void *)ctx, (int)result);
+
   /* Keep ctx alive across the callback and the array removal below. */
   r_ref_ref (ctx);
 
@@ -400,6 +412,9 @@ r_http_client_req_fail (RHttpClientReqCtx * ctx, RHttpClientResult result,
 {
   if (ctx->finished)
     return;
+
+  r_printerr ("DIAG310: cli req_fail ctx=%p result=%d reused=%d retried=%d\n",
+      (void *)ctx, (int)result, ctx->reused, ctx->retried);
 
   if (ctx->reused && !ctx->retried && ctx->res == NULL) {
     RHttpClientConn * conn = ctx->conn;
@@ -566,6 +581,8 @@ r_http_client_req_connect (RHttpClientReqCtx * ctx, rboolean defer)
   }
   ctx->conn = conn;     /* ctx owns the new connection's reference */
   conn->req = ctx;
+  r_printerr ("DIAG310: cli connect_issued conn=%p evtcp=%p ctx=%p\n",
+      (void *) conn, (void *) conn->evtcp, (void *) ctx);
   if (r_ev_tcp_connect (conn->evtcp, ctx->dest,
         r_http_client_conn_connected, conn, NULL) < R_SOCKET_OK)
     r_http_client_req_complete (ctx, R_HTTP_CLIENT_CONNECT_FAILED, defer);

--- a/rlib/net/rhttpserver.c
+++ b/rlib/net/rhttpserver.c
@@ -19,6 +19,8 @@
 #include "config.h"
 #include "../rlib-private.h"
 #include "../ev/rev-private.h"
+
+#include <rlib/os/rtty.h> /* DIAG #310: r_printerr markers, revert before merge */
 #include <rlib/net/rhttpserver.h>
 
 #include <rlib/ev/revtcp.h>
@@ -120,6 +122,10 @@ r_http_client_ctx_tcp_response_ready (rpointer data, RHttpResponse * res,
   RHttpClientCtx * ctx = data;
   RBuffer * buf;
 
+  r_printerr ("DIAG310: server response_ready ctx=%p evtcp=%p keepalive=%d"
+      " clients=%"RSIZE_FMT"\n", (void *)ctx, (void *)ctx->evtcp, ctx->keepalive,
+      (rsize)r_ptr_array_size (ctx->server->clients));
+
   /* A response on a kept-alive connection must be self-delimiting or the client
    * cannot tell where it ends (it would wait for a close that never comes).
    * Frame any response that is neither chunked nor already length-delimited --
@@ -157,6 +163,9 @@ r_http_client_ctx_process (RHttpClientCtx * ctx)
   RSocketAddress * addr = r_ev_tcp_get_remote_address (ctx->evtcp);
   rboolean ret;
 
+  r_printerr ("DIAG310: server ctx_process ctx=%p evtcp=%p req=%p\n",
+      (void *)ctx, (void *)ctx->evtcp, (void *)ctx->req);
+
   if ((ret = r_http_server_process_request (ctx->server, ctx->req, addr,
       r_http_client_ctx_tcp_response_ready, r_ref_ref (ctx), r_ref_unref))) {
     r_http_request_unref (ctx->req);
@@ -174,6 +183,10 @@ r_http_client_ctx_tcp_recv (rpointer data, RBuffer * buf, REvTCP * evtcp)
 {
   RHttpClientCtx * ctx = data;
   RHttpError err;
+
+  r_printerr ("DIAG310: server tcp_recv ctx=%p evtcp=%p buf=%p size=%"
+      RSIZE_FMT" req=%p\n", (void *)ctx, (void *)evtcp, (void *)buf,
+      buf != NULL ? r_buffer_get_size (buf) : (rsize)0, (void *)ctx->req);
 
   if (buf != NULL) {
     R_LOG_TRACE ("%p: Buffer %p on "R_EV_IO_FORMAT" (%"RSIZE_FMT")",
@@ -498,6 +511,8 @@ r_http_server_tcp_connection_ready (rpointer data,
   RHttpServer * server = data;
   RHttpClientCtx * ctx;
 
+  r_printerr ("DIAG310: server accept newtcp=%p listening=%p\n",
+      (void *) newtcp, (void *) listening);
   if ((ctx = r_http_client_ctx_new (server, newtcp)) != NULL) {
     R_LOG_TRACE ("%p: New connection "R_EV_IO_FORMAT" on "R_EV_IO_FORMAT,
         server, R_EV_IO_ARGS (newtcp), R_EV_IO_ARGS (listening));
@@ -591,6 +606,8 @@ r_http_server_close_client_ctx (rpointer data, rpointer user)
 {
   RHttpClientCtx * cli = data;
   RHttpServerStopCtx * ctx = user;
+  r_printerr ("DIAG310: server force-close client ctx=%p evtcp=%p\n",
+      (void *)cli, (void *)cli->evtcp);
   R_LOG_DEBUG ("%p: Force close client socket "R_EV_IO_FORMAT,
       ctx->server, R_EV_IO_ARGS (cli->evtcp));
   /* Close only; the array removal (and the context's last unref) is done by
@@ -607,6 +624,10 @@ r_http_server_stop (RHttpServer * server, RHttpServerStop func,
 {
   RHttpServerStopCtx * ctx;
   rsize ret;
+
+  r_printerr ("DIAG310: server_stop nclients=%"RSIZE_FMT" nlisten=%"RSIZE_FMT
+      "\n", (rsize)r_ptr_array_size (server->clients),
+      (rsize)r_ptr_array_size (server->listen));
 
   if ((ctx = r_mem_new (RHttpServerStopCtx)) != NULL) {
     r_ref_init (ctx, r_http_server_stop_ctx_free);

--- a/rlib/rpoll.c
+++ b/rlib/rpoll.c
@@ -39,6 +39,7 @@
 #include <windows.h>
 #endif
 #include <errno.h>
+#include <rlib/os/rtty.h>    /* DIAG #310: r_printerr, revert before merge */
 
 #define R_LOG_CAT_DEFAULT &rlib_logcat
 
@@ -160,7 +161,18 @@ r_poll (RPoll * handles, ruint count, RClockTime timeout)
   }
 
   /* nfds is ignored on Windows; the fd_count fields drive the call. */
-  ret = select (0, (fd_set *) rset, (fd_set *) wset, (fd_set *) xset, ptv);
+  {
+    ruint k;        /* DIAG #310: plain trace, revert before merge */
+    r_printerr ("DIAG310: r_poll enter count=%u timeout=%lld r=%u w=%u x=%u\n",
+        count, (long long) timeout, (unsigned) rset->fd_count,
+        (unsigned) wset->fd_count, (unsigned) xset->fd_count);
+    for (k = 0; k < count; k++)
+      r_printerr ("DIAG310:   fd[%u] sock=%p ev=%x\n", k,
+          (void *) (ruintptr) handles[k].handle, (unsigned) handles[k].events);
+    ret = select (0, (fd_set *) rset, (fd_set *) wset, (fd_set *) xset, ptv);
+    r_printerr ("DIAG310: r_poll exit ret=%d err=%d\n", ret,
+        ret == SOCKET_ERROR ? WSAGetLastError () : 0);
+  }
 
   if (ret == SOCKET_ERROR && WSAGetLastError () == WSAENOTSOCK) {
     /* select() fails atomically if any descriptor is not a socket -- which
@@ -336,6 +348,8 @@ r_poll_set_add (RPollSet * ps, RIOHandle handle, rushort events, rpointer user)
   {
     int existing = r_poll_set_find (ps, handle);
     if (existing >= 0) {
+      r_printerr ("DIAG310: ps_add ps=%p handle=%p user=%p REUSE idx=%d\n",
+          (void *) ps, (void *) (ruintptr) handle, user, existing);
       r_poll_set_update (ps, (ruint) existing, handle, events, user);
       return existing;
     }
@@ -357,6 +371,8 @@ r_poll_set_add (RPollSet * ps, RIOHandle handle, rushort events, rpointer user)
   }
 
   idx = ps->count++;
+  r_printerr ("DIAG310: ps_add ps=%p handle=%p user=%p NEW idx=%u count=%u\n",
+      (void *) ps, (void *) (ruintptr) handle, user, idx, ps->count);
   r_poll_set_update (ps, idx, handle, events, user);
   return (int)idx;
 }
@@ -370,6 +386,8 @@ r_poll_set_remove_idx (RPollSet * ps, int idx)
   if (R_UNLIKELY ((ruint)idx >= ps->count)) return FALSE;
 
   key = RIO_HANDLE_TO_POINTER (ps->handles[idx].handle);
+  r_printerr ("DIAG310: ps_remove_idx ps=%p handle=%p idx=%d count=%u\n",
+      (void *) ps, (void *) (ruintptr) ps->handles[idx].handle, idx, ps->count);
   if (r_hash_table_remove_full (ps->handle_user, key, NULL, &user) == R_HASH_TABLE_OK) {
     r_hash_table_remove (ps->handle_idx, key);
 
@@ -377,10 +395,16 @@ r_poll_set_remove_idx (RPollSet * ps, int idx)
       RPoll * last = &ps->handles[ps->count];
       rpointer last_user;
 
+      r_printerr ("DIAG310: ps_remove_idx compact slot=%d <- handle=%p (from %u)\n",
+          idx, (void *) (ruintptr) last->handle, ps->count);
       if (r_hash_table_lookup_full (ps->handle_user, RIO_HANDLE_TO_POINTER (last->handle),
             NULL, &last_user) == R_HASH_TABLE_OK) {
+        r_printerr ("DIAG310: ps_remove_idx compact OK slot=%d <- handle=%p user=%p\n",
+            idx, (void *) (ruintptr) last->handle, last_user);
         r_poll_set_update (ps, (ruint)idx, last->handle, last->events, last_user);
       } else {
+        r_printerr ("DIAG310: ps_remove_idx compact FAIL slot=%d <- handle=%p (no user) -- STALE LEFT\n",
+            idx, (void *) (ruintptr) last->handle);
         return FALSE;
       }
     }
@@ -394,8 +418,12 @@ r_poll_set_remove_idx (RPollSet * ps, int idx)
 rboolean
 r_poll_set_remove (RPollSet * ps, RIOHandle handle)
 {
+  int idx;
   if (R_UNLIKELY (ps == NULL)) return FALSE;
-  return r_poll_set_remove_idx (ps, r_poll_set_find (ps, handle));
+  idx = r_poll_set_find (ps, handle);
+  r_printerr ("DIAG310: ps_remove ps=%p handle=%p found_idx=%d\n",
+      (void *) ps, (void *) (ruintptr) handle, idx);
+  return r_poll_set_remove_idx (ps, idx);
 }
 
 rboolean

--- a/rlib/rpoll.c
+++ b/rlib/rpoll.c
@@ -327,6 +327,20 @@ r_poll_set_add (RPollSet * ps, RIOHandle handle, rushort events, rpointer user)
   if (R_UNLIKELY (ps == NULL)) return -1;
   if (R_UNLIKELY (handle == R_IO_HANDLE_INVALID)) return -1;
 
+  /* One slot per handle. If this handle is already present -- e.g. a closed fd
+   * whose entry has not been pruned yet, and whose value the OS recycled into a
+   * new socket -- update that slot in place. Appending a second slot for the
+   * same handle leaves an orphan that remove-by-handle can never reach (it only
+   * unmaps the one the index points at), and select() then spins on the dead
+   * duplicate (WSAENOTSOCK). */
+  {
+    int existing = r_poll_set_find (ps, handle);
+    if (existing >= 0) {
+      r_poll_set_update (ps, (ruint) existing, handle, events, user);
+      return existing;
+    }
+  }
+
   if (ps->count >= ps->alloc) {
     ruint nalloc = ps->alloc;
     RPoll * nhandles;

--- a/test/rpoll.c
+++ b/test/rpoll.c
@@ -223,3 +223,67 @@ RTEST (rpollset, add_grow_oom_keeps_set_intact, RTEST_FAST)
 }
 RTEST_END;
 
+/* Re-adding a handle already in the set must update its one slot in place, not
+ * append a second. (A handle reappears when a closed fd's entry lingers and the
+ * OS recycles its value into a new socket.) */
+RTEST (rpollset, re_add_existing_updates_in_place, RTEST_FAST)
+{
+  RPollSet ps;
+
+  r_poll_set_init (&ps, 0);
+
+  r_assert_cmpint (r_poll_set_add (&ps, (RIOHandle)1, R_IO_IN, (rpointer)0xA), ==, 0);
+  r_assert_cmpuint (ps.count, ==, 1);
+
+  /* Same handle again -> same slot, updated user + events, no growth. */
+  r_assert_cmpint (r_poll_set_add (&ps, (RIOHandle)1, R_IO_OUT, (rpointer)0xB), ==, 0);
+  r_assert_cmpuint (ps.count, ==, 1);
+  r_assert_cmpuint (r_hash_table_size (ps.handle_user), ==, 1);
+  r_assert_cmpuint (r_hash_table_size (ps.handle_idx), ==, 1);
+  r_assert_cmpptr (r_poll_set_get_user (&ps, (RIOHandle)1), ==, (rpointer)0xB);
+  r_assert_cmpuint (ps.handles[0].events, ==, R_IO_OUT);
+
+  /* A single remove fully evicts it: no orphaned second slot left behind. */
+  r_assert (r_poll_set_remove (&ps, (RIOHandle)1));
+  r_assert_cmpuint (ps.count, ==, 0);
+  r_assert_cmpint (r_poll_set_find (&ps, (RIOHandle)1), <, 0);
+  r_assert_cmpptr (r_poll_set_get_user (&ps, (RIOHandle)1), ==, NULL);
+
+  r_poll_set_clear (&ps);
+}
+RTEST_END;
+
+/* The #310 shape at the set level: a handle entered and never removed, its fd
+ * value recycled into a new socket and re-added, then the original "pruned".
+ * A blind append would leave a stale handles[] slot for that handle with no
+ * hash entry -- unremovable, and poll() spins on the dead duplicate. With one
+ * slot per handle there is no orphan. */
+RTEST (rpollset, recycled_handle_leaves_no_orphan, RTEST_FAST)
+{
+  RPollSet ps;
+  ruint i;
+  rboolean stale;
+
+  r_poll_set_init (&ps, 0);
+
+  r_assert_cmpint (r_poll_set_add (&ps, (RIOHandle)7, R_IO_IN, (rpointer)0xA), ==, 0);
+  r_assert_cmpint (r_poll_set_add (&ps, (RIOHandle)8, R_IO_IN, (rpointer)0xB), ==, 1);
+  /* fd 7 recycled into a new socket, re-added while the old entry still lingers */
+  r_poll_set_add (&ps, (RIOHandle)7, R_IO_OUT, (rpointer)0xC);
+  r_assert_cmpuint (ps.count, ==, 2);           /* two slots, not three */
+
+  r_assert (r_poll_set_remove (&ps, (RIOHandle)7));
+  r_assert_cmpuint (ps.count, ==, 1);
+  r_assert_cmpint (r_poll_set_find (&ps, (RIOHandle)7), <, 0);
+  r_assert_cmpptr (r_poll_set_get_user (&ps, (RIOHandle)7), ==, NULL);
+  r_assert_cmpptr (r_poll_set_get_user (&ps, (RIOHandle)8), ==, (rpointer)0xB);
+
+  for (i = 0, stale = FALSE; i < ps.count; i++)
+    if (ps.handles[i].handle == (RIOHandle)7)
+      stale = TRUE;
+  r_assert (!stale);                            /* no orphaned slot for 7 */
+
+  r_poll_set_clear (&ps);
+}
+RTEST_END;
+


### PR DESCRIPTION
Do not merge. Diagnostics on top of #321 (so the probe + fixes are in place), looping the http suites timeout-wrapped to reproduce the server_stop hang and capture the select() trace at the wedge — to settle whether the residual is a dead-fd spin or a genuine block now that #321's orphan/UAF fixes are applied.