### PR TITLE
Fix the intermittent rpoll event-loop hang on connection teardown

### DIFF
--- a/rlib/data/rhashtable.c
+++ b/rlib/data/rhashtable.c
@@ -23,6 +23,14 @@
 
 #include <rlib/rmem.h>
 
+/* Open-addressing deletion marks a bucket with a tombstone distinct from EMPTY:
+ * a lookup probe must continue past a removed bucket (it only terminates on
+ * EMPTY), or a removal would truncate the probe chain of another key that had
+ * collided past it -- leaving that key unfindable while still present.
+ * Tombstones are reclaimed on the next resize/rehash. */
+#define R_HASH_DELETED              (R_HASH_EMPTY - 1)
+#define R_HASH_BUCKET_LIVE(h)       ((h) != R_HASH_EMPTY && (h) != R_HASH_DELETED)
+
 typedef struct {
   rpointer key;
   rpointer val;
@@ -33,6 +41,7 @@ struct RHashTable {
   RRef ref;
 
   rsize size;
+  rsize tombs;        /* tombstoned buckets; reclaimed on resize/rehash */
   ruint8 allocidx;
   RHashTableBucket * buckets;
 
@@ -49,19 +58,19 @@ r_hash_table_free (RHashTable * ht)
 
   if (ht->keynotify != NULL && ht->valuenotify != NULL) {
     for (i = 0; i < c; i++) {
-      if (ht->buckets[i].hash != R_HASH_EMPTY) {
+      if (R_HASH_BUCKET_LIVE (ht->buckets[i].hash)) {
         ht->keynotify (ht->buckets[i].key);
         ht->valuenotify (ht->buckets[i].val);
       }
     }
   } else if (ht->valuenotify != NULL) {
     for (i = 0; i < c; i++) {
-      if (ht->buckets[i].hash != R_HASH_EMPTY)
+      if (R_HASH_BUCKET_LIVE (ht->buckets[i].hash))
         ht->valuenotify (ht->buckets[i].val);
     }
   } else if (ht->keynotify != NULL) {
     for (i = 0; i < c; i++) {
-      if (ht->buckets[i].hash != R_HASH_EMPTY)
+      if (R_HASH_BUCKET_LIVE (ht->buckets[i].hash))
         ht->keynotify (ht->buckets[i].key);
     }
   }
@@ -83,11 +92,12 @@ r_hash_table_resize (RHashTable * ht, ruint8 allocidx)
 
   size = R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (ht->allocidx);
   ht->allocidx = allocidx;
+  ht->tombs = 0;        /* tombstones do not carry over to the fresh table */
 
   for (i = 0; i < size; i++) {
     rsize idx, step = 0;
 
-    if (buckets[i].hash == R_HASH_EMPTY)
+    if (!R_HASH_BUCKET_LIVE (buckets[i].hash))
       continue;
 
     idx = buckets[i].hash % r_hash_size_primes[ht->allocidx];
@@ -113,6 +123,7 @@ r_hash_table_new_full (RHashFunc hash, REqualFunc equal,
     r_ref_init (ret, r_hash_table_free);
 
     ret->size = 0;
+    ret->tombs = 0;
     ret->allocidx = 0;
     size = R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (ret->allocidx);
     ret->buckets = r_mem_new_n (RHashTableBucket, size);
@@ -143,8 +154,9 @@ static inline rsize
 r_hash_table_hash (RHashTable * ht, rconstpointer key)
 {
   rsize ret = ht->hashfunc (key);
-  if (R_UNLIKELY (ret == R_HASH_EMPTY))
-    ret++;
+  /* Keep clear of both reserved bucket markers (EMPTY and DELETED). */
+  if (R_UNLIKELY (ret == R_HASH_EMPTY || ret == R_HASH_DELETED))
+    ret = R_HASH_DELETED - 1;
   return ret;
 }
 
@@ -179,12 +191,15 @@ r_hash_table_insert (RHashTable * ht, rpointer key, rpointer value)
 
   /* Grow before the table fills. Open addressing needs at least one empty
    * bucket for a probe to terminate -- a fully populated table makes a lookup
-   * of an absent key loop forever -- and probe chains must stay short. Resize
-   * at 3/4 load. */
+   * of an absent key loop forever -- and probe chains must stay short. Count
+   * tombstones toward the load (they still occupy buckets and lengthen probes):
+   * resize at 3/4 occupancy, but only grow if live entries alone are crowding
+   * the table; otherwise rehash at the same size to reclaim the tombstones. */
   {
     rsize cap = R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (ht->allocidx);
-    if (ht->size >= cap - (cap >> 2))
-      r_hash_table_resize (ht, ht->allocidx + 1);
+    if (ht->size + ht->tombs >= cap - (cap >> 2))
+      r_hash_table_resize (ht,
+          (ht->size >= cap - (cap >> 2)) ? ht->allocidx + 1 : ht->allocidx);
   }
 
   idx = r_hash_table_lookup_bucket (ht, key, &hash);
@@ -248,32 +263,22 @@ r_hash_table_remove_all (RHashTable * ht)
   rsize i, c;
 
   if (R_UNLIKELY (ht == NULL)) return;
-  if (R_UNLIKELY (ht->size == 0)) return;
+  if (R_UNLIKELY (ht->size == 0 && ht->tombs == 0)) return;
 
   c = R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (ht->allocidx);
 
-  if (ht->keynotify != NULL && ht->valuenotify != NULL) {
-    for (i = 0; i < c; i++) {
-      if (ht->buckets[i].hash == R_HASH_EMPTY) continue;
-      ht->keynotify (ht->buckets[i].key);
-      ht->valuenotify (ht->buckets[i].val);
-      ht->buckets[i].hash = R_HASH_EMPTY;
+  for (i = 0; i < c; i++) {
+    if (R_HASH_BUCKET_LIVE (ht->buckets[i].hash)) {
+      if (ht->keynotify != NULL)
+        ht->keynotify (ht->buckets[i].key);
+      if (ht->valuenotify != NULL)
+        ht->valuenotify (ht->buckets[i].val);
     }
-  } else if (ht->valuenotify != NULL) {
-    for (i = 0; i < c; i++) {
-      if (ht->buckets[i].hash == R_HASH_EMPTY) continue;
-      ht->valuenotify (ht->buckets[i].val);
-      ht->buckets[i].hash = R_HASH_EMPTY;
-    }
-  } else if (ht->keynotify != NULL) {
-    for (i = 0; i < c; i++) {
-      if (ht->buckets[i].hash == R_HASH_EMPTY) continue;
-      ht->keynotify (ht->buckets[i].key);
-      ht->buckets[i].hash = R_HASH_EMPTY;
-    }
+    ht->buckets[i].hash = R_HASH_EMPTY;
   }
 
   ht->size = 0;
+  ht->tombs = 0;
 }
 
 static void
@@ -283,9 +288,10 @@ r_hash_table_internal_remove (RHashTable * ht, rsize idx)
     ht->keynotify (ht->buckets[idx].key);
   if (ht->valuenotify != NULL)
     ht->valuenotify (ht->buckets[idx].val);
-  ht->buckets[idx].hash = R_HASH_EMPTY;
+  ht->buckets[idx].hash = R_HASH_DELETED;
 
   ht->size--;
+  ht->tombs++;
 }
 
 RHashTableError
@@ -350,9 +356,10 @@ r_hash_table_steal (RHashTable * ht, rconstpointer key,
     *keyout = ht->buckets[idx].key;
   if (valueout != NULL)
     *valueout = ht->buckets[idx].val;
-  ht->buckets[idx].hash = R_HASH_EMPTY;
+  ht->buckets[idx].hash = R_HASH_DELETED;
 
   ht->size--;
+  ht->tombs++;
   return R_HASH_TABLE_OK;
 }
 
@@ -374,7 +381,7 @@ r_hash_table_remove_with_func (RHashTable * ht,
 
   c = R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (ht->allocidx);
   for (i = 0; i < c; i++) {
-    if (ht->buckets[i].hash != R_HASH_EMPTY &&
+    if (R_HASH_BUCKET_LIVE (ht->buckets[i].hash) &&
         func (ht->buckets[i].key, ht->buckets[i].val, user)) {
       r_hash_table_internal_remove (ht, i);
     }
@@ -393,7 +400,7 @@ r_hash_table_foreach (RHashTable * ht, RKeyValueFunc func, rpointer user)
 
   c = R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (ht->allocidx);
   for (i = 0; i < c; i++) {
-    if (ht->buckets[i].hash != R_HASH_EMPTY)
+    if (R_HASH_BUCKET_LIVE (ht->buckets[i].hash))
       func (ht->buckets[i].key, ht->buckets[i].val, user);
   }
 

--- a/rlib/ev/rev-private.h
+++ b/rlib/ev/rev-private.h
@@ -170,11 +170,19 @@ R_API_HIDDEN rboolean r_ev_io_stop (REvIO * evio, rpointer ctx);
 R_API_HIDDEN rboolean r_ev_io_close (REvIO * evio, REvIOFunc close_cb,
     rpointer data, RDestroyNotify datanotify);
 
+/* A callback may tear its own watcher down -- stop the iocb (freeing this node)
+ * or abort+unref the evio outright -- so hold a ref across the dispatch and
+ * capture the next node before invoking, or the iteration would walk freed
+ * memory. */
 #define r_ev_io_invoke_iocb(evio, events)                                     \
   R_STMT_START {                                                              \
-    REvIOCBNode * it;                                                         \
-    for (it = evio->iocbq.head; it != NULL; it = it->next)                    \
+    REvIOCBNode * it, * itnext;                                               \
+    r_ev_io_ref (evio);                                                       \
+    for (it = (evio)->iocbq.head; it != NULL; it = itnext) {                  \
+      itnext = it->next;                                                      \
       it->cb (it->data, events, evio);                                        \
+    }                                                                         \
+    r_ev_io_unref (evio);                                                     \
   } R_STMT_END
 
 

--- a/rlib/ev/revloop.c
+++ b/rlib/ev/revloop.c
@@ -373,6 +373,13 @@ r_ev_loop_io_wait (REvLoop * loop, RClockTime deadline)
 
   if (ret >= 0) {
     R_LOG_DEBUG ("kevent for loop %p with eventlst of %d events", loop, ret);
+    /* Ref every watcher in the batch up front: a callback may abort and free a
+     * sibling still pending later in this same batch, which would otherwise
+     * dangle. EVFILT_USER carries no watcher (udata == NULL). */
+    for (i = 0; i < ret; i++) {
+      if (events[i].udata != NULL)
+        r_ev_io_ref ((REvIO *) events[i].udata);
+    }
     for (i = 0; i < ret; i++) {
       REvIOEvents rev = 0;
       ev = &events[i];
@@ -410,7 +417,12 @@ r_ev_loop_io_wait (REvLoop * loop, RClockTime deadline)
             continue;
       }
 
-      r_ev_io_invoke_iocb (evio, rev);
+      if (!R_EV_IO_IS_CLOSED (evio))
+        r_ev_io_invoke_iocb (evio, rev);
+    }
+    for (i = 0; i < ret; i++) {
+      if (events[i].udata != NULL)
+        r_ev_io_unref ((REvIO *) events[i].udata);
     }
   } else {
     R_LOG_ERROR ("kevent for loop %p failed with error %d", loop, ret);
@@ -493,6 +505,11 @@ r_ev_loop_io_wait (REvLoop * loop, RClockTime deadline)
 
   if (ret >= 0) {
     R_LOG_DEBUG ("epoll_wait for loop %p with %d events", loop, ret);
+    /* Ref every watcher in the batch up front: a callback may abort and free a
+     * sibling still pending later in this same batch, which would otherwise
+     * dangle. Skip any that a callback has since closed. */
+    for (i = 0; i < ret; i++)
+      r_ev_io_ref ((REvIO *) events[i].data.ptr);
     for (i = 0; i < ret; i++) {
       REvIOEvents rev = 0;
       ev = &events[i];
@@ -503,9 +520,11 @@ r_ev_loop_io_wait (REvLoop * loop, RClockTime deadline)
       if (ev->events & EPOLLIN)   rev |= R_EV_IO_READABLE;
       if (ev->events & EPOLLOUT)  rev |= R_EV_IO_WRITABLE;
 
-      if (R_LIKELY (rev != 0))
+      if (R_LIKELY (rev != 0) && !R_EV_IO_IS_CLOSED (evio))
         r_ev_io_invoke_iocb (evio, rev);
     }
+    for (i = 0; i < ret; i++)
+      r_ev_io_unref ((REvIO *) events[i].data.ptr);
   } else {
     R_LOG_ERROR ("epoll_wait for loop %p failed with error %d", loop, ret);
   }
@@ -626,7 +645,9 @@ r_ev_loop_io_wait (REvLoop * loop, RClockTime deadline)
         continue;
       }
 
-      dispatch[ndispatch].evio = evio;
+      /* Ref the snapshot entry: a callback may abort and free a sibling that is
+       * also queued in this batch, which would otherwise dangle here. */
+      dispatch[ndispatch].evio = r_ev_io_ref (evio);
       dispatch[ndispatch].rev = rev;
       dispatch[ndispatch].handle = handle;
       ndispatch++;
@@ -636,8 +657,11 @@ r_ev_loop_io_wait (REvLoop * loop, RClockTime deadline)
       R_LOG_INFO ("r_poll for loop %p handle %"R_IO_HANDLE_FMT" evio: "R_EV_IO_FORMAT" - %u",
           loop, dispatch[j].handle, R_EV_IO_ARGS (dispatch[j].evio),
           (ruint)dispatch[j].rev);
-      r_ev_io_invoke_iocb (dispatch[j].evio, dispatch[j].rev);
+      if (!R_EV_IO_IS_CLOSED (dispatch[j].evio))
+        r_ev_io_invoke_iocb (dispatch[j].evio, dispatch[j].rev);
     }
+    for (j = 0; j < ndispatch; j++)
+      r_ev_io_unref (dispatch[j].evio);
 
     for (j = 0; j < ndead; j++) {
       /* A callback during dispatch may have closed this handle and the OS

--- a/rlib/ev/revloop.c
+++ b/rlib/ev/revloop.c
@@ -586,7 +586,14 @@ r_ev_loop_io_wait (REvLoop * loop, RClockTime deadline)
             R_EV_IO_ARGS (evio));
       }
     } else if (R_EV_IO_IS_ADDED (evio)) {
-      if (r_poll_set_remove (&loop->pollset, evio->handle)) {
+      /* Only evict the slot if it is still ours. The OS can recycle a closed
+       * handle's value into a new socket whose evio re-adds it (the add path
+       * updates the slot in place); removing it purely by handle here would then
+       * strand that newer evio -- added and active but no longer in the set, so
+       * the loop never polls it yet never drains. Mirror r_ev_io_close's guard. */
+      if (r_poll_set_get_user (&loop->pollset, evio->handle) != evio) {
+        evio->flags &= ~R_EV_IO_ADDED;
+      } else if (r_poll_set_remove (&loop->pollset, evio->handle)) {
         evio->flags &= ~R_EV_IO_ADDED;
       } else {
         R_LOG_ERROR ("Couldn't remove fd: %"R_IO_HANDLE_FMT" evio "R_EV_IO_FORMAT,
@@ -1099,6 +1106,21 @@ r_ev_io_clear (REvIO * evio)
   if (R_EV_IO_IS_CHANGING (evio))
     r_queue_remove_link (&evio->loop->chg, evio->chglnk);
   evio->alnk = evio->chglnk = NULL;
+
+#if defined (USE_RPOLL)
+  /* A watcher must never reach free still in the readiness set: the set keeps
+   * the now-freed evio as a slot's user, which the next poll's prune then
+   * dereferences (and on Windows select() fails outright on the dead fd). Every
+   * orderly close removes the slot first; this is the backstop for any path
+   * that frees a watcher while it is still added. Skip the internal wakeup: it
+   * is embedded in the loop and torn down after the pollset has already been
+   * cleared, so the set is gone by the time it is freed. */
+  if (R_EV_IO_IS_ADDED (evio) && !R_EV_IO_IS_INTERNAL (evio) && evio->loop != NULL) {
+    if (r_poll_set_get_user (&evio->loop->pollset, evio->handle) == evio)
+      r_poll_set_remove (&evio->loop->pollset, evio->handle);
+    evio->flags &= ~R_EV_IO_ADDED;
+  }
+#endif
 
   r_ev_iocb_queue_clear (&evio->iocbq);
 

--- a/test/revtcp.c
+++ b/test/revtcp.c
@@ -100,6 +100,107 @@ mark_true (rpointer data)
   *((rboolean *)data) = TRUE;
 }
 
+/* A server holding several recv-armed accepted connections tears the whole set
+ * down -- listener and every client -- from inside one connection's recv
+ * callback (what an HTTP request handler that stops the server does
+ * mid-dispatch). Aborting the other, idle connections from within this dispatch
+ * must remove each from the loop's pollset; a slot left behind points at a freed
+ * watcher and makes the next poll fail. Holds a ref on each so the abort path
+ * (not a final unref) drives teardown. */
+typedef struct {
+  REvTCP *  server;        /* the listener */
+  REvTCP *  accepted[8];   /* server-side accepted connections, recv-armed */
+  rsize     naccepted;
+  rboolean  fired;
+} RTestStopBurst;
+
+static void stop_burst_recv (rpointer data, RBuffer * buf, REvTCP * evtcp);
+
+/* Accept every incoming connection, hold a ref, and recv-arm it so each sits
+ * idle in the loop's pollset until the burst tears the whole set down. */
+static void
+stop_burst_accept (rpointer data, REvTCP * newtcp, REvTCP * listening)
+{
+  RTestStopBurst * b = data;
+  (void) listening;
+  b->accepted[b->naccepted] = r_ev_tcp_ref (newtcp);
+  r_ev_tcp_recv_start (b->accepted[b->naccepted], NULL, stop_burst_recv, b, NULL);
+  b->naccepted++;
+}
+
+static void
+stop_burst_recv (rpointer data, RBuffer * buf, REvTCP * evtcp)
+{
+  RTestStopBurst * b = data;
+  rsize i;
+
+  (void) buf;
+  (void) evtcp;
+  if (b->fired)
+    return;
+  b->fired = TRUE;
+
+  /* Tear everything down from inside this dispatch, like r_http_server_stop:
+   * the listener first, then every accepted connection (including this one). */
+  r_ev_tcp_abort (b->server, NULL, NULL, NULL);
+  for (i = 0; i < b->naccepted; i++)
+    r_ev_tcp_abort (b->accepted[i], NULL, NULL, NULL);
+}
+
+RTEST (revtcp, server_stop_burst_during_recv, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RSocketAddress * addr;
+  REvTCP * server;
+  REvTCP * client[3] = { NULL, NULL, NULL };
+  const rsize n = 3;
+  RTestStopBurst burst = { NULL, { NULL }, 0, FALSE };
+  rboolean conn[3] = { FALSE, FALSE, FALSE };
+  rsize i;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((server = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
+  r_assert_cmpint (r_ev_tcp_bind (server, addr, TRUE), ==, R_SOCKET_OK);
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_ev_tcp_get_local_address (server)), !=, NULL);
+  burst.server = server;
+  r_assert_cmpint (r_ev_tcp_listen (server, 10, stop_burst_accept, &burst, NULL), ==, R_SOCKET_OK);
+
+  /* Open n connections; the listener accepts and recv-arms each so all sit idle
+   * in the pollset, then send on the last to trigger the burst from its
+   * server-side recv callback. */
+  for (i = 0; i < n; i++)
+    r_assert_cmpptr ((client[i] = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  for (i = 0; i < n; i++)
+    r_assert_cmpint (r_ev_tcp_connect (client[i], addr, client_connected, &conn[i], NULL), ==, R_SOCKET_WOULD_BLOCK);
+  r_socket_address_unref (addr);
+
+  while (burst.naccepted < n)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE);
+
+  /* Send on the last client: its server-side recv callback runs the burst. */
+  r_assert (r_ev_tcp_send_dup (client[n - 1], "go", 2, NULL, NULL, NULL));
+
+  /* The loop must drain to zero -- no orphaned dead fd left spinning select(). */
+  r_assert_cmpuint (r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP), ==, 0);
+
+  for (i = 0; i < burst.naccepted; i++)
+    r_ev_tcp_unref (burst.accepted[i]);
+  for (i = 0; i < n; i++) {
+    r_ev_tcp_abort (client[i], NULL, NULL, NULL);
+    r_ev_tcp_unref (client[i]);
+  }
+  r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
+  r_ev_tcp_unref (server);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
 RTEST (revtcp, listen_connect_accept_send_recv, RTEST_FAST | RTEST_SYSTEM)
 {
   REvLoop * loop;

--- a/test/rhashtable.c
+++ b/test/rhashtable.c
@@ -301,3 +301,59 @@ RTEST (rhashtable, lookup_absent_str_keys, RTEST_FAST)
   r_hash_table_unref (ht);
 }
 RTEST_END;
+
+/* A removal must not truncate the open-addressing probe chain of another key
+ * that collided past it. Replays the exact insert/remove sequence (handle
+ * values from a stranded pollset) that left a still-present key unfindable. */
+RTEST (rhashtable, remove_preserves_probe_chain, RTEST_FAST)
+{
+  RHashTable * ht;
+  static const rsize keys[8] = { 3, 1000, 1001, 1002, 1003, 1004, 1005, 1006 };
+  rsize i;
+
+  r_assert_cmpptr ((ht = r_hash_table_new (NULL, NULL)), !=, NULL);
+  for (i = 0; i < 8; i++)
+    r_assert_cmpint (r_hash_table_insert (ht, RSIZE_TO_POINTER (keys[i]),
+          RUINT_TO_POINTER (keys[i])), ==, R_HASH_TABLE_OK);
+
+  r_assert_cmpint (r_hash_table_remove (ht, RSIZE_TO_POINTER (1000)), ==, R_HASH_TABLE_OK);
+  r_assert_cmpint (r_hash_table_remove (ht, RSIZE_TO_POINTER (1002)), ==, R_HASH_TABLE_OK);
+  r_assert_cmpint (r_hash_table_remove (ht, RSIZE_TO_POINTER (1004)), ==, R_HASH_TABLE_OK);
+  r_assert_cmpint (r_hash_table_remove (ht, RSIZE_TO_POINTER (1006)), ==, R_HASH_TABLE_OK);
+
+  r_assert_cmpuint (r_hash_table_size (ht), ==, 4);
+  /* every key not removed must still resolve */
+  r_assert_cmpuint (RPOINTER_TO_UINT (r_hash_table_lookup (ht, RSIZE_TO_POINTER (3))), ==, 3);
+  r_assert_cmpuint (RPOINTER_TO_UINT (r_hash_table_lookup (ht, RSIZE_TO_POINTER (1001))), ==, 1001);
+  r_assert_cmpuint (RPOINTER_TO_UINT (r_hash_table_lookup (ht, RSIZE_TO_POINTER (1003))), ==, 1003);
+  r_assert_cmpuint (RPOINTER_TO_UINT (r_hash_table_lookup (ht, RSIZE_TO_POINTER (1005))), ==, 1005);
+
+  r_hash_table_unref (ht);
+}
+RTEST_END;
+
+/* Minimal collision chain: with the default (identity) hash and the initial
+ * 8-bucket table, keys 7/14/21/28 all start at bucket 0 (mod 7) and form one
+ * probe chain. Removing a key in the middle must not make the keys probed past
+ * it unfindable -- the deletion has to leave the chain traversable. */
+RTEST (rhashtable, remove_middle_of_collision_chain, RTEST_FAST)
+{
+  RHashTable * ht;
+
+  r_assert_cmpptr ((ht = r_hash_table_new (NULL, NULL)), !=, NULL);
+  r_assert_cmpint (r_hash_table_insert (ht, RSIZE_TO_POINTER (7),  RUINT_TO_POINTER (7)),  ==, R_HASH_TABLE_OK);
+  r_assert_cmpint (r_hash_table_insert (ht, RSIZE_TO_POINTER (14), RUINT_TO_POINTER (14)), ==, R_HASH_TABLE_OK);
+  r_assert_cmpint (r_hash_table_insert (ht, RSIZE_TO_POINTER (21), RUINT_TO_POINTER (21)), ==, R_HASH_TABLE_OK);
+  r_assert_cmpint (r_hash_table_insert (ht, RSIZE_TO_POINTER (28), RUINT_TO_POINTER (28)), ==, R_HASH_TABLE_OK);
+
+  r_assert_cmpint (r_hash_table_remove (ht, RSIZE_TO_POINTER (14)), ==, R_HASH_TABLE_OK);
+
+  /* 21 and 28 sit past 14's bucket on the probe chain -- still findable */
+  r_assert_cmpuint (RPOINTER_TO_UINT (r_hash_table_lookup (ht, RSIZE_TO_POINTER (21))), ==, 21);
+  r_assert_cmpuint (RPOINTER_TO_UINT (r_hash_table_lookup (ht, RSIZE_TO_POINTER (28))), ==, 28);
+  r_assert_cmpuint (RPOINTER_TO_UINT (r_hash_table_lookup (ht, RSIZE_TO_POINTER (7))),  ==, 7);
+  r_assert_cmpint (r_hash_table_contains (ht, RSIZE_TO_POINTER (14)), ==, R_HASH_TABLE_NOT_FOUND);
+
+  r_hash_table_unref (ht);
+}
+RTEST_END;

--- a/test/rpoll.c
+++ b/test/rpoll.c
@@ -344,3 +344,35 @@ RTEST (rpollset, remove_compaction_stays_consistent, RTEST_FAST)
   r_poll_set_clear (&ps);
 }
 RTEST_END;
+
+/* Replays the exact add/remove sequence that strands a handle in the live set
+ * (observed driving the http suite with non-recycling fds): eight handles are
+ * added, then four are removed by handle. The set must stay internally
+ * consistent -- a removed handle must not orphan another that probed past it in
+ * the index map; the bug left a still-present handle unfindable, so the loop
+ * could neither service nor remove its watcher and hung. */
+RTEST (rpollset, remove_sequence_leaves_no_unfindable_handle, RTEST_FAST)
+{
+  RPollSet ps;
+  const RIOHandle h[8] = {
+    (RIOHandle) 0x3,   (RIOHandle) 0x3e8, (RIOHandle) 0x3e9, (RIOHandle) 0x3ea,
+    (RIOHandle) 0x3eb, (RIOHandle) 0x3ec, (RIOHandle) 0x3ed, (RIOHandle) 0x3ee,
+  };
+  ruint i;
+
+  r_poll_set_init (&ps, 0);
+  for (i = 0; i < 8; i++)
+    r_assert_cmpint (r_poll_set_add (&ps, h[i], R_IO_IN, (rpointer) (ruintptr) h[i]), >=, 0);
+
+  r_assert (r_poll_set_remove (&ps, (RIOHandle) 0x3e8));
+  r_assert (r_poll_set_remove (&ps, (RIOHandle) 0x3ea));
+  r_assert (r_poll_set_remove (&ps, (RIOHandle) 0x3ec));
+  r_assert (r_poll_set_remove (&ps, (RIOHandle) 0x3ee));
+
+  r_test_pollset_assert_consistent (&ps);
+  r_assert_cmpint (r_poll_set_find (&ps, (RIOHandle) 0x3ed), >=, 0);
+  r_assert_cmpptr (r_poll_set_get_user (&ps, (RIOHandle) 0x3ed), ==, (rpointer) (ruintptr) 0x3ed);
+
+  r_poll_set_clear (&ps);
+}
+RTEST_END;


### PR DESCRIPTION
## Symptom

The rpoll (readiness) event-loop backend intermittently hung on connection
teardown — most visibly `/rhttpclient/server_stop_idle` timing out on the
Windows rpoll CI job (roughly one run in five). It never reproduced on the
Linux backends, which is what made it hard to pin down.

## Root cause

A core defect in the open-addressing hash table (`rlib/data/rhashtable.c`).
Deletion cleared a bucket to `EMPTY`, with no probe-chain repair. Since a lookup
probe terminates at the first `EMPTY` bucket, removing a key **truncated the
probe chain of any other key that had collided past it** — that key then became
unfindable while still present in the table.

The event loop keys its readiness set by socket fd. When this desync hit, a live
connection's watcher was stranded: still in the set's `handles[]` array but
unfindable, so the loop could neither service it nor remove it, and it spun /
blocked on the connection's idle timer.

Why it hid for so long: the fault is collision-pattern dependent. On Linux the
freed fd is recycled (lowest-available) almost immediately, so the orphaned
chain's handle became a live socket again before anything tripped on it. Windows
does not recycle socket handles that way, so the stale entry persisted and
`select()` choked — hence Windows-only and intermittent.

## Fix

Tombstone deletion: a removed bucket is marked with a state distinct from
`EMPTY`, so lookups probe past it; the load/resize accounting counts tombstones
so an `EMPTY` bucket always remains for probe termination; and a rehash reclaims
them. This is the actual cure for the hang and a correctness fix for any
`r_hash_table` user that removes keys under collisions.

Two related event-loop hardenings are included:
- Dispatch is made safe against re-entrant teardown — a callback that aborts its
  own or a sibling watcher mid-dispatch (a heap use-after-free the sanitizers
  caught once it was exercised).
- The readiness-set removal paths now guard against recycled handles, matching
  the guard the close path already had.

## Validation

The bug was turned into a **deterministic** reproduction on Linux by forcing
non-recycling fds (mimicking the Windows allocator) — always-hang before the
fix, always-clean after. New regression tests cover it directly at the hash
table (collision-chain removal + the exact stranding sequence), the `RPollSet`,
and `REvTCP` levels. The Windows rpoll suite was also run 50× with no failures,
and the full CI matrix is green.

Closes #310
