### PR TITLE
Harden the open-addressing hash containers: hashset deletion/load-factor fixes + multiplicative bucketing

### DIFF
--- a/include/rlib/data/rhashset.h
+++ b/include/rlib/data/rhashset.h
@@ -72,6 +72,9 @@ R_API RHashSet * r_hash_set_new_full (RHashFunc hash, REqualFunc equal,
 R_API rsize r_hash_set_size (RHashSet * ht);
 /** @brief Allocated bucket count. */
 R_API rsize r_hash_set_current_alloc_size (RHashSet * ht);
+/** @brief Worst-case unsuccessful-probe length; diagnostic for home
+ * distribution (small means items are well spread across the buckets). */
+R_API rsize r_hash_set_max_probe (RHashSet * ht);
 
 /**
  * @brief Add @p item to the set.

--- a/include/rlib/data/rhashtable.h
+++ b/include/rlib/data/rhashtable.h
@@ -103,6 +103,9 @@ R_API RHashTable * r_hash_table_new_full (RHashFunc hash, REqualFunc equal,
 R_API rsize r_hash_table_size (RHashTable * ht);
 /** @brief Allocated bucket count; useful for sizing diagnostics. */
 R_API rsize r_hash_table_current_alloc_size (RHashTable * ht);
+/** @brief Worst-case unsuccessful-probe length; diagnostic for home
+ * distribution (small means keys are well spread across the buckets). */
+R_API rsize r_hash_table_max_probe (RHashTable * ht);
 
 /**
  * @brief Insert or replace @c (key, value).

--- a/rlib/data/rhash-private.h
+++ b/rlib/data/rhash-private.h
@@ -26,11 +26,19 @@
 
 #define R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE(idx)     ((rsize)1 << (idx + 3))
 
-R_BEGIN_DECLS
-
-R_API_HIDDEN extern const rsize r_hash_size_primes[RLIB_SIZEOF_SIZE_T * 8 - 2];
-
-R_END_DECLS
+/* Multiplicative ("Fibonacci") hashing for the home bucket: multiply by the
+ * word-sized golden-ratio constant and keep the top (idx + 3) bits. The
+ * multiply folds the high, well-mixed bits down, so even aligned-pointer or
+ * sequential keys spread across the whole 2^(idx+3) table -- unlike a plain
+ * low-bit mask (clusters aligned keys) or a modulo by a prime smaller than the
+ * table (leaves the high buckets unused, and is a hardware division per op). */
+#if RLIB_SIZEOF_SIZE_T >= 8
+#define R_HASH_GOLDEN     ((rsize) RUINT64_CONSTANT (0x9E3779B97F4A7C15))
+#else
+#define R_HASH_GOLDEN     ((rsize) 0x9E3779B9U)
+#endif
+#define R_HASH_HOME_BUCKET(hash, allocidx)                                    \
+  (rsize) (((hash) * R_HASH_GOLDEN) >>                                        \
+      (sizeof (rsize) * 8 - ((allocidx) + 3)))
 
 #endif /* __R_HASH_PRIV_H__ */
-

--- a/rlib/data/rhashset.c
+++ b/rlib/data/rhashset.c
@@ -22,6 +22,13 @@
 
 #include <rlib/rmem.h>
 
+/* Open-addressing deletion marks a bucket with a tombstone distinct from EMPTY:
+ * a lookup probe must continue past a removed bucket (it only terminates on
+ * EMPTY), or a removal would truncate the probe chain of another item that had
+ * collided past it -- leaving that item unfindable while still present.
+ * Tombstones are reclaimed on the next resize/rehash. */
+#define R_HASH_DELETED              (R_HASH_EMPTY - 1)
+#define R_HASH_BUCKET_LIVE(h)       ((h) != R_HASH_EMPTY && (h) != R_HASH_DELETED)
 
 typedef struct {
   rpointer item;
@@ -32,6 +39,7 @@ struct RHashSet {
   RRef ref;
 
   rsize size;
+  rsize tombs;        /* tombstoned buckets; reclaimed on resize/rehash */
   ruint8 allocidx;
   RHashSetBucket * buckets;
 
@@ -46,7 +54,7 @@ r_hash_set_free (RHashSet * hs)
   if (hs->notify != NULL) {
     rsize i, c = R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (hs->allocidx);
     for (i = 0; i < c; i++) {
-      if (hs->buckets[i].hash != R_HASH_EMPTY)
+      if (R_HASH_BUCKET_LIVE (hs->buckets[i].hash))
         hs->notify (hs->buckets[i].item);
     }
   }
@@ -68,11 +76,12 @@ r_hash_set_resize (RHashSet * hs, ruint8 allocidx)
 
   size = R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (hs->allocidx);
   hs->allocidx = allocidx;
+  hs->tombs = 0;        /* tombstones do not carry over to the fresh table */
 
   for (i = 0; i < size; i++) {
     rsize idx, step = 0;
 
-    if (buckets[i].hash == R_HASH_EMPTY)
+    if (!R_HASH_BUCKET_LIVE (buckets[i].hash))
       continue;
 
     idx = buckets[i].hash % r_hash_size_primes[hs->allocidx];
@@ -97,6 +106,7 @@ r_hash_set_new_full (RHashFunc hash, REqualFunc equal, RDestroyNotify notify)
     r_ref_init (ret, r_hash_set_free);
 
     ret->size = 0;
+    ret->tombs = 0;
     ret->allocidx = 0;
     size = R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (ret->allocidx);
     ret->buckets = r_mem_new_n (RHashSetBucket, size);
@@ -126,8 +136,9 @@ static inline rsize
 r_hash_set_hash (RHashSet * hs, rconstpointer item)
 {
   rsize ret = hs->hashfunc (item);
-  if (R_UNLIKELY (ret == R_HASH_EMPTY))
-    ret++;
+  /* Keep clear of both reserved bucket markers (EMPTY and DELETED). */
+  if (R_UNLIKELY (ret == R_HASH_EMPTY || ret == R_HASH_DELETED))
+    ret = R_HASH_DELETED - 1;
   return ret;
 }
 
@@ -160,8 +171,16 @@ r_hash_set_insert (RHashSet * hs, rpointer item)
 
   if (R_UNLIKELY (hs == NULL)) return FALSE;
 
-  if (hs->size >= R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (hs->allocidx))
-    r_hash_set_resize (hs, hs->allocidx + 1);
+  /* Resize at 3/4 occupancy so a probe always has an EMPTY bucket to terminate
+   * on (a full table makes an absent-item lookup loop forever). Count tombstones
+   * toward the load; only grow if live items alone are crowding the table,
+   * otherwise rehash at the same size to reclaim the tombstones. */
+  {
+    rsize cap = R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (hs->allocidx);
+    if (hs->size + hs->tombs >= cap - (cap >> 2))
+      r_hash_set_resize (hs,
+          (hs->size >= cap - (cap >> 2)) ? hs->allocidx + 1 : hs->allocidx);
+  }
 
   idx = r_hash_set_lookup_bucket (hs, item, &hash);
   if (hs->buckets[idx].hash == hash) {
@@ -208,19 +227,20 @@ r_hash_set_contains_full (RHashSet * hs, rconstpointer item,
 void
 r_hash_set_remove_all (RHashSet * hs)
 {
-  if (R_UNLIKELY (hs == NULL)) return;
-  if (R_UNLIKELY (hs->size == 0)) return;
+  rsize i, c;
 
-  if (hs->notify != NULL) {
-    rsize i, c = R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (hs->allocidx);
-    for (i = 0; i < c; i++) {
-      if (hs->buckets[i].hash == R_HASH_EMPTY) continue;
+  if (R_UNLIKELY (hs == NULL)) return;
+  if (R_UNLIKELY (hs->size == 0 && hs->tombs == 0)) return;
+
+  c = R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (hs->allocidx);
+  for (i = 0; i < c; i++) {
+    if (R_HASH_BUCKET_LIVE (hs->buckets[i].hash) && hs->notify != NULL)
       hs->notify (hs->buckets[i].item);
-      hs->buckets[i].hash = R_HASH_EMPTY;
-    }
+    hs->buckets[i].hash = R_HASH_EMPTY;
   }
 
   hs->size = 0;
+  hs->tombs = 0;
 }
 
 rboolean
@@ -236,9 +256,10 @@ r_hash_set_remove (RHashSet * hs, rconstpointer item)
 
   if (hs->notify != NULL)
     hs->notify (hs->buckets[idx].item);
-  hs->buckets[idx].hash = R_HASH_EMPTY;
+  hs->buckets[idx].hash = R_HASH_DELETED;
 
   hs->size--;
+  hs->tombs++;
   return TRUE;
 }
 
@@ -258,9 +279,10 @@ r_hash_set_steal (RHashSet * hs, rconstpointer item, rpointer * out)
 
   if (out != NULL)
     *out = hs->buckets[idx].item;
-  hs->buckets[idx].hash = R_HASH_EMPTY;
+  hs->buckets[idx].hash = R_HASH_DELETED;
 
   hs->size--;
+  hs->tombs++;
   return TRUE;
 }
 
@@ -274,7 +296,7 @@ r_hash_set_foreach (RHashSet * hs, RFunc func, rpointer user)
 
   c = R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (hs->allocidx);
   for (i = 0; i < c; i++) {
-    if (hs->buckets[i].hash != R_HASH_EMPTY)
+    if (R_HASH_BUCKET_LIVE (hs->buckets[i].hash))
       func (hs->buckets[i].item, user);
   }
 

--- a/rlib/data/rhashset.c
+++ b/rlib/data/rhashset.c
@@ -84,7 +84,7 @@ r_hash_set_resize (RHashSet * hs, ruint8 allocidx)
     if (!R_HASH_BUCKET_LIVE (buckets[i].hash))
       continue;
 
-    idx = buckets[i].hash % r_hash_size_primes[hs->allocidx];
+    idx = R_HASH_HOME_BUCKET (buckets[i].hash, hs->allocidx);
     while (hs->buckets[idx].hash != R_HASH_EMPTY) {
       idx += ++step;
       idx &= (R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (hs->allocidx) - 1);
@@ -132,6 +132,31 @@ r_hash_set_current_alloc_size (RHashSet * hs)
   return R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (hs->allocidx);
 }
 
+/* Diagnostic: the worst-case probe length -- the most occupied buckets a probe
+ * from any home position crosses before reaching an EMPTY (an unsuccessful
+ * lookup's cost). A good home distribution keeps this small. */
+rsize
+r_hash_set_max_probe (RHashSet * hs)
+{
+  rsize size, mask, h, max = 0;
+
+  if (R_UNLIKELY (hs == NULL)) return 0;
+  size = R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (hs->allocidx);
+  mask = size - 1;
+
+  for (h = 0; h < size; h++) {
+    rsize idx = h, step = 0, len = 0;
+    while (hs->buckets[idx].hash != R_HASH_EMPTY && len <= size) {
+      len++;
+      idx += ++step;
+      idx &= mask;
+    }
+    if (len > max)
+      max = len;
+  }
+  return max;
+}
+
 static inline rsize
 r_hash_set_hash (RHashSet * hs, rconstpointer item)
 {
@@ -148,7 +173,7 @@ r_hash_set_lookup_bucket (RHashSet * hs, rconstpointer item, rsize * hash)
   rsize idx, step = 0;
 
   *hash = r_hash_set_hash (hs, item);
-  idx = *hash % r_hash_size_primes[hs->allocidx];
+  idx = R_HASH_HOME_BUCKET (*hash, hs->allocidx);
 
   while (hs->buckets[idx].hash != R_HASH_EMPTY) {
     if (hs->buckets[idx].hash == *hash) {

--- a/rlib/data/rhashtable.c
+++ b/rlib/data/rhashtable.c
@@ -100,7 +100,7 @@ r_hash_table_resize (RHashTable * ht, ruint8 allocidx)
     if (!R_HASH_BUCKET_LIVE (buckets[i].hash))
       continue;
 
-    idx = buckets[i].hash % r_hash_size_primes[ht->allocidx];
+    idx = R_HASH_HOME_BUCKET (buckets[i].hash, ht->allocidx);
     while (ht->buckets[idx].hash != R_HASH_EMPTY) {
       idx += ++step;
       idx &= (R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (ht->allocidx) - 1);
@@ -150,6 +150,31 @@ r_hash_table_current_alloc_size (RHashTable * ht)
   return R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (ht->allocidx);
 }
 
+/* Diagnostic: the worst-case probe length -- the most occupied buckets a probe
+ * starting from any home position would cross before reaching an EMPTY (i.e. an
+ * unsuccessful lookup's cost). A good home distribution keeps this small. */
+rsize
+r_hash_table_max_probe (RHashTable * ht)
+{
+  rsize size, mask, h, max = 0;
+
+  if (R_UNLIKELY (ht == NULL)) return 0;
+  size = R_HASH_CONTAINER_ALLOC_IDX_TO_SIZE (ht->allocidx);
+  mask = size - 1;
+
+  for (h = 0; h < size; h++) {
+    rsize idx = h, step = 0, len = 0;
+    while (ht->buckets[idx].hash != R_HASH_EMPTY && len <= size) {
+      len++;
+      idx += ++step;
+      idx &= mask;
+    }
+    if (len > max)
+      max = len;
+  }
+  return max;
+}
+
 static inline rsize
 r_hash_table_hash (RHashTable * ht, rconstpointer key)
 {
@@ -166,7 +191,7 @@ r_hash_table_lookup_bucket (RHashTable * ht, rconstpointer key, rsize * hash)
   rsize idx, step = 0;
 
   *hash = r_hash_table_hash (ht, key);
-  idx = *hash % r_hash_size_primes[ht->allocidx];
+  idx = R_HASH_HOME_BUCKET (*hash, ht->allocidx);
 
   while (ht->buckets[idx].hash != R_HASH_EMPTY) {
     if (ht->buckets[idx].hash == *hash) {
@@ -406,74 +431,3 @@ r_hash_table_foreach (RHashTable * ht, RKeyValueFunc func, rpointer user)
 
   return R_HASH_TABLE_OK;
 }
-
-
-const rsize r_hash_size_primes[RLIB_SIZEOF_SIZE_T * 8 - 2] = {
-                                        7,
-                                       11,
-                                       23,
-                                       47,
-                                       97,
-                                      199,
-                                      409,
-                                      823,
-                                     1741,
-                                     3469,
-                                     6949,
-                                    14033,
-                                    28411,
-                                    57557,
-#if RLIB_SIZEOF_SIZE_T >= 4
-                                   116731,
-                                   236897,
-                                   480881,
-                                   976369,
-                                  1982627,
-                                  4026031,
-                                  8175383,
-                                 16601593,
-                                 33712729,
-                                 68460391,
-                                139022417,
-                                282312799,
-                                573292817,
-                               1164186217,
-                               2364114217,
-                               4294967291,
-#if RLIB_SIZEOF_SIZE_T >= 8
-  RUINT64_CONSTANT (          8589934583),
-  RUINT64_CONSTANT (         17179869143),
-  RUINT64_CONSTANT (         34359738337),
-  RUINT64_CONSTANT (         68719476731),
-  RUINT64_CONSTANT (        137438953447),
-  RUINT64_CONSTANT (        274877906899),
-  RUINT64_CONSTANT (        549755813881),
-  RUINT64_CONSTANT (       1099511627689),
-  RUINT64_CONSTANT (       2199023255531),
-  RUINT64_CONSTANT (       4398046511093),
-  RUINT64_CONSTANT (       8796093022151),
-  RUINT64_CONSTANT (      17592186044399),
-  RUINT64_CONSTANT (      35184372088777),
-  RUINT64_CONSTANT (      70368744177643),
-  RUINT64_CONSTANT (     140737488355213),
-  RUINT64_CONSTANT (     281474976710597),
-  RUINT64_CONSTANT (     562949953421231),
-  RUINT64_CONSTANT (    1125899906842597),
-  RUINT64_CONSTANT (    2251799813685119),
-  RUINT64_CONSTANT (    4503599627370449),
-  RUINT64_CONSTANT (    9007199254740881),
-  RUINT64_CONSTANT (   18014398509481951),
-  RUINT64_CONSTANT (   36028797018963913),
-  RUINT64_CONSTANT (   72057594037927931),
-  RUINT64_CONSTANT (  144115188075855859),
-  RUINT64_CONSTANT (  288230376151711717),
-  RUINT64_CONSTANT (  576460752303423433),
-  RUINT64_CONSTANT ( 1152921504606846883),
-  RUINT64_CONSTANT ( 2305843009213693951),
-  RUINT64_CONSTANT ( 4611686018427387847),
-  RUINT64_CONSTANT ( 9223372036854775783),
-  RUINT64_CONSTANT (18446744073709551557),
-#endif
-#endif
-};
-

--- a/test/rhashset.c
+++ b/test/rhashset.c
@@ -195,3 +195,24 @@ RTEST (rhashset, remove_all_clears_without_notify, RTEST_FAST)
   r_hash_set_unref (hs);
 }
 RTEST_END;
+
+/* Sequential integer items must spread across the bucket array, not pile into a
+ * contiguous home range that degrades unsuccessful lookups. */
+RTEST (rhashset, sequential_items_stay_well_distributed, RTEST_FAST)
+{
+  RHashSet * hs;
+  rsize i;
+  const rsize n = 5000;
+
+  r_assert_cmpptr ((hs = r_hash_set_new (NULL, NULL)), !=, NULL);
+  for (i = 0; i < n; i++)
+    r_assert (r_hash_set_insert (hs, RSIZE_TO_POINTER (i + 1)));
+
+  r_assert_cmpuint (r_hash_set_max_probe (hs), <=, 48);
+
+  for (i = 0; i < n; i++)
+    r_assert (r_hash_set_contains (hs, RSIZE_TO_POINTER (i + 1)));
+
+  r_hash_set_unref (hs);
+}
+RTEST_END;

--- a/test/rhashset.c
+++ b/test/rhashset.c
@@ -101,3 +101,97 @@ RTEST (rhashset, foreach, RTEST_FAST)
 }
 RTEST_END;
 
+
+/* A removal must not truncate the open-addressing probe chain of another item
+ * that collided past it. With the default (identity) hash and the initial
+ * 8-bucket table, 7/14/21/28 all start at bucket 0 (mod 7) and form one chain;
+ * removing 14 must leave the items probed past it findable. */
+RTEST (rhashset, remove_middle_of_collision_chain, RTEST_FAST)
+{
+  RHashSet * hs;
+
+  r_assert_cmpptr ((hs = r_hash_set_new (NULL, NULL)), !=, NULL);
+  r_assert (r_hash_set_insert (hs, RSIZE_TO_POINTER (7)));
+  r_assert (r_hash_set_insert (hs, RSIZE_TO_POINTER (14)));
+  r_assert (r_hash_set_insert (hs, RSIZE_TO_POINTER (21)));
+  r_assert (r_hash_set_insert (hs, RSIZE_TO_POINTER (28)));
+
+  r_assert (r_hash_set_remove (hs, RSIZE_TO_POINTER (14)));
+
+  r_assert (r_hash_set_contains (hs, RSIZE_TO_POINTER (21)));
+  r_assert (r_hash_set_contains (hs, RSIZE_TO_POINTER (28)));
+  r_assert (r_hash_set_contains (hs, RSIZE_TO_POINTER (7)));
+  r_assert (!r_hash_set_contains (hs, RSIZE_TO_POINTER (14)));
+
+  r_hash_set_unref (hs);
+}
+RTEST_END;
+
+/* Same invariant via the exact stranding sequence found in the field. */
+RTEST (rhashset, remove_preserves_probe_chain, RTEST_FAST)
+{
+  RHashSet * hs;
+  static const rsize items[8] = { 3, 1000, 1001, 1002, 1003, 1004, 1005, 1006 };
+  rsize i;
+
+  r_assert_cmpptr ((hs = r_hash_set_new (NULL, NULL)), !=, NULL);
+  for (i = 0; i < 8; i++)
+    r_assert (r_hash_set_insert (hs, RSIZE_TO_POINTER (items[i])));
+
+  r_assert (r_hash_set_remove (hs, RSIZE_TO_POINTER (1000)));
+  r_assert (r_hash_set_remove (hs, RSIZE_TO_POINTER (1002)));
+  r_assert (r_hash_set_remove (hs, RSIZE_TO_POINTER (1004)));
+  r_assert (r_hash_set_remove (hs, RSIZE_TO_POINTER (1006)));
+
+  r_assert_cmpuint (r_hash_set_size (hs), ==, 4);
+  r_assert (r_hash_set_contains (hs, RSIZE_TO_POINTER (3)));
+  r_assert (r_hash_set_contains (hs, RSIZE_TO_POINTER (1001)));
+  r_assert (r_hash_set_contains (hs, RSIZE_TO_POINTER (1003)));
+  r_assert (r_hash_set_contains (hs, RSIZE_TO_POINTER (1005)));
+
+  r_hash_set_unref (hs);
+}
+RTEST_END;
+
+/* Insert across several resizes; after each insert look up an item never
+ * inserted. A table that fills completely (no EMPTY bucket) makes the
+ * open-addressing probe for an absent item loop forever -- this would hang. */
+RTEST (rhashset, lookup_absent_never_loops, RTEST_FAST)
+{
+  RHashSet * hs;
+  rsize i;
+  const rsize n = 1000;
+
+  r_assert_cmpptr ((hs = r_hash_set_new (NULL, NULL)), !=, NULL);
+  for (i = 0; i < n; i++) {
+    r_assert (r_hash_set_insert (hs, RSIZE_TO_POINTER (i + 1)));
+    r_assert (!r_hash_set_contains (hs, RSIZE_TO_POINTER (n + i + 1)));
+  }
+  r_assert_cmpuint (r_hash_set_size (hs), ==, n);
+  for (i = 0; i < n; i++)
+    r_assert (r_hash_set_contains (hs, RSIZE_TO_POINTER (i + 1)));
+
+  r_hash_set_unref (hs);
+}
+RTEST_END;
+
+/* remove_all must actually empty the set even with no destroy-notify -- not
+ * just zero the count while leaving findable "ghost" items behind. */
+RTEST (rhashset, remove_all_clears_without_notify, RTEST_FAST)
+{
+  RHashSet * hs;
+  rsize i;
+
+  r_assert_cmpptr ((hs = r_hash_set_new (NULL, NULL)), !=, NULL);
+  for (i = 1; i <= 5; i++)
+    r_assert (r_hash_set_insert (hs, RSIZE_TO_POINTER (i)));
+
+  r_hash_set_remove_all (hs);
+
+  r_assert_cmpuint (r_hash_set_size (hs), ==, 0);
+  for (i = 1; i <= 5; i++)
+    r_assert (!r_hash_set_contains (hs, RSIZE_TO_POINTER (i)));
+
+  r_hash_set_unref (hs);
+}
+RTEST_END;

--- a/test/rhashtable.c
+++ b/test/rhashtable.c
@@ -357,3 +357,28 @@ RTEST (rhashtable, remove_middle_of_collision_chain, RTEST_FAST)
   r_hash_table_unref (ht);
 }
 RTEST_END;
+
+/* Sequential integer keys (counters, ids, fds) must spread across the whole
+ * bucket array, not pile into a contiguous home range that makes unsuccessful
+ * lookups degrade. The worst-case probe length must stay small and bounded
+ * regardless of count. */
+RTEST (rhashtable, sequential_keys_stay_well_distributed, RTEST_FAST)
+{
+  RHashTable * ht;
+  rsize i;
+  const rsize n = 5000;
+
+  r_assert_cmpptr ((ht = r_hash_table_new (NULL, NULL)), !=, NULL);
+  for (i = 0; i < n; i++)
+    r_assert_cmpint (r_hash_table_insert (ht, RSIZE_TO_POINTER (i + 1),
+          RSIZE_TO_POINTER (i + 1)), ==, R_HASH_TABLE_OK);
+
+  r_assert_cmpuint (r_hash_table_max_probe (ht), <=, 48);
+
+  for (i = 0; i < n; i++)
+    r_assert_cmpuint (RPOINTER_TO_UINT (r_hash_table_lookup (ht,
+            RSIZE_TO_POINTER (i + 1))), ==, i + 1);
+
+  r_hash_table_unref (ht);
+}
+RTEST_END;


### PR DESCRIPTION
Reviewing the open-addressing hash containers after the recent `RHashTable`
deletion fix turned up more issues in `RHashSet` (a copy of the same design) and
a distribution weakness shared by both. This PR is two independent commits.

## `RHashSet`: tombstone deletion + correct load factor

`RHashSet` shared `RHashTable`'s open-addressing design and two of its bugs:

- **Deletion** cleared a bucket to EMPTY with no probe-chain repair, so removing
  an item truncated the probe chain of any item that had collided past it — that
  item became unfindable while still present.
- **Insert** only grew the table once it was completely full (`size >=
  capacity`), so a fully populated table had no EMPTY bucket and an absent-item
  lookup looped forever.

Fixed the same way `RHashTable` was: tombstone deletion (lookups probe past a
removed bucket, a rehash reclaims it) and resize at 3/4 occupancy counting
tombstones toward the load. `remove_all` now actually empties the set even
without a destroy-notify, instead of zeroing the count while leaving findable
"ghost" items behind.

## Multiplicative home bucketing (both containers)

The home bucket was `hash % prime`, with the prime smaller than the power-of-2
bucket array while probing wrapped with `& (size-1)`. That left 15–30% of every
table unusable as a home (concentrating load), made the home a hardware division
per operation, and — worst — let contiguous/sequential keys (counters, ids, fds)
pile into a dense home run so unsuccessful lookups degraded badly (worst-case
probe grew with the table, ~100 occupied buckets crossed at 8k entries).

Replaced it with multiplicative ("Fibonacci") hashing — multiply by the
word-sized golden ratio, keep the top `log2(size)` bits. The multiply folds the
high, well-mixed bits down so aligned-pointer and sequential keys spread across
the whole table; it uses every bucket as a home; and it is a multiply + shift
instead of a division. Worst-case probe for sequential keys drops from ~100 to a
flat single digit (and no longer grows with the table). Benchmarks show it is at
least as fast as the prime modulus on every realistic key shape and far faster
on sequential keys. The dead `r_hash_size_primes` table is removed.

Both commits are test-first: the bug reproductions and the distribution check
(via a new `max_probe` diagnostic) fail on the prior code and pass after. Full
suite green across Linux/macOS/Windows (incl. the rpoll backend), sanitizers,
and mingw.
