### PR TITLE
net: resume TLS/DTLS sessions from tickets

### DIFF
--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -34,6 +34,7 @@
 #include <rlib/crypto/rkey.h>
 #include <rlib/ev/revloop.h>
 #include <rlib/net/proto/rtls.h>
+#include <rlib/net/rtlssessiontickets.h>
 
 #include <rlib/rbuffer.h>
 #include <rlib/rref.h>
@@ -120,6 +121,15 @@ R_API RTLSServer * r_tls_server_new (const RTLSCallbacks * cb,
 /** @brief Set the server certificate and its private key. */
 R_API RTLSError r_tls_server_set_cert (RTLSServer * server,
     RCryptoCert * cert, RCryptoKey * privkey);
+/**
+ * @brief Attach the shared key store used to seal and open session tickets.
+ *
+ * The server takes a reference to @p keys, so one store can back many servers.
+ * With no store configured the server neither offers nor issues session
+ * tickets. See @ref r_tls_session_tickets.
+ */
+R_API RTLSError r_tls_server_set_session_ticket_keys (RTLSServer * server,
+    RTLSSessionTicketKeys * keys);
 /** @brief Override the server-random (testing / determinism). */
 R_API RTLSError r_tls_server_set_random (RTLSServer * server,
     const ruint8 servrandom[R_TLS_HELLO_RANDOM_BYTES]);

--- a/include/rlib/net/rtlssessiontickets.h
+++ b/include/rlib/net/rtlssessiontickets.h
@@ -1,0 +1,72 @@
+/* RLIB - Convenience library for useful things
+ * Copyright (C) 2026 Haakon Sporsheim <haakon.sporsheim@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ * See the COPYING file at the root of the source repository.
+ */
+#ifndef __R_NET_TLS_SESSION_TICKETS_H__
+#define __R_NET_TLS_SESSION_TICKETS_H__
+
+#if !defined(__RLIB_H_INCLUDE_GUARD__) && !defined(RLIB_COMPILATION)
+#error "#include <rlib.h> only please."
+#endif
+
+/**
+ * @file rlib/net/rtlssessiontickets.h
+ * @brief Shared key store for sealing TLS / DTLS session tickets.
+ */
+
+#include <rlib/rtypes.h>
+#include <rlib/rref.h>
+
+/**
+ * @defgroup r_tls_session_tickets TLS session-ticket keys
+ * @ingroup r_net
+ *
+ * @brief Server-held key material for RFC 5077 session tickets.
+ *
+ * A session ticket lets a TLS / DTLS server hand its session state to the
+ * client, sealed under a server-held key, so a later connection can resume
+ * without a full handshake. Because the resuming connection is a different
+ * @ref RTLSServer instance, the sealing key must be shared and outlive any
+ * single session: create one @ref RTLSSessionTicketKeys and attach it to
+ * every server that should issue and accept tickets with
+ * @ref r_tls_server_set_session_ticket_keys. A server with no key store
+ * configured neither offers nor issues tickets.
+ *
+ * @{
+ */
+
+R_BEGIN_DECLS
+
+/** @brief Opaque, refcounted session-ticket key store. */
+typedef struct RTLSSessionTicketKeys RTLSSessionTicketKeys;
+
+/**
+ * @brief Create a key store holding a fresh random key drawn from OS entropy.
+ *
+ * @return A new store (the caller owns one reference), or @c NULL if the OS
+ *   entropy source could not be read.
+ */
+R_API RTLSSessionTicketKeys * r_tls_session_ticket_keys_new (void) R_ATTR_MALLOC;
+/** @brief Increment the key store's refcount. */
+#define r_tls_session_ticket_keys_ref    r_ref_ref
+/** @brief Decrement the refcount; scrubs and frees the key material at zero. */
+#define r_tls_session_ticket_keys_unref  r_ref_unref
+
+R_END_DECLS
+
+/** @} */
+
+#endif /* __R_NET_TLS_SESSION_TICKETS_H__ */

--- a/include/rlib/rnet.h
+++ b/include/rlib/rnet.h
@@ -50,6 +50,7 @@
 #include <rlib/net/rhttpclient.h>
 #include <rlib/net/rhttpserver.h>
 #include <rlib/net/rsrtp.h>
+#include <rlib/net/rtlssessiontickets.h>
 #include <rlib/net/rtlsclient.h>
 #include <rlib/net/rtlsserver.h>
 #include <rlib/net/proto/rhttp.h>

--- a/rlib/meson.build
+++ b/rlib/meson.build
@@ -111,6 +111,7 @@ rlib_sources = [
   'net/rsrtp.c',
   'net/rtlsclient.c',
   'net/rtlsserver.c',
+  'net/rtlssessiontickets.c',
   'os/rproc.c',
   'os/rsignal.c',
   'os/rsys.c',

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -70,6 +70,9 @@ struct RTLSServer {
   ruint8 mastersecret[48];
   ruint8 servrandom[R_TLS_HELLO_RANDOM_BYTES];
   rboolean servrandompinned;
+  rboolean resumed;             /* abbreviated (RFC 5077) handshake in progress */
+  ruint8 session_id[32];        /* session id sent in the ServerHello on resume */
+  ruint8 session_id_len;
 
   RTLSVersion version;
   RTLSVersion recordver;        /* version of the last record seen, for pre-nego alerts */
@@ -360,8 +363,11 @@ r_tls_server_write_hs_ext_session_ticket (const RTLSServer * server, ruint8 * pt
   /* The ticket itself is minted in the final flight (it binds the master
    * secret), so this only signals that a NewSessionTicket will follow.
    * Without a key store the server can neither seal nor later open a ticket,
-   * so it makes no promise. */
-  if (!server->support_new_session_ticket || server->ticket_keys == NULL)
+   * so it makes no promise. On a resumed handshake no fresh ticket is issued,
+   * so the extension must not be echoed (RFC 5077 3.4) -- promising a ticket
+   * the abbreviated flight never sends would leave the client waiting. */
+  if (!server->support_new_session_ticket || server->ticket_keys == NULL ||
+      server->resumed)
     return 0;
 
   /* NewSessionTicket will come! */
@@ -417,7 +423,8 @@ r_tls_server_write_hello (RTLSServer * server)
           0, 0);
       ptr = info.data + hssize;
       ret = r_dtls_write_hs_server_hello (ptr, info.size - hssize, &size,
-          server->version, server->servrandom, NULL, 0,
+          server->version, server->servrandom,
+          server->session_id, server->session_id_len,
           server->csinfo->suite, server->comp);
       ptr += size;
       hdrsize = R_DTLS_RECORD_HDR_SIZE;
@@ -426,7 +433,8 @@ r_tls_server_write_hello (RTLSServer * server)
           server->version, R_TLS_HANDSHAKE_TYPE_SERVER_HELLO, 0);
       ptr = info.data + hssize;
       ret = r_tls_write_hs_server_hello (ptr, info.size - hssize, &size,
-          server->version, server->servrandom, NULL, 0,
+          server->version, server->servrandom,
+          server->session_id, server->session_id_len,
           server->csinfo->suite, server->comp);
       ptr += size;
       hdrsize = R_TLS_RECORD_HDR_SIZE;
@@ -744,6 +752,8 @@ r_tls_server_write_finished (RTLSServer * server)
   RTLSError ret;
   rsize size;
   RMemMapInfo info;
+  ruint8 hdrsize = r_tls_version_is_dtls (server->version) ?
+      R_DTLS_RECORD_HDR_SIZE : R_TLS_RECORD_HDR_SIZE;
 
   R_LOG_DEBUG ("%p - server finished", server);
 
@@ -753,9 +763,19 @@ r_tls_server_write_finished (RTLSServer * server)
   if (r_buffer_map (buf, &info, R_MEM_MAP_WRITE)) {
     rsize verifysize = 12, hashsize = r_msg_digest_size (server->hshash);
     ruint8 * hash = r_alloca (hashsize);
+    rboolean haveh;
 
-    if (r_msg_digest_finish (server->hshash) &&
-        r_msg_digest_get_data (server->hshash, hash, hashsize, NULL)) {
+    /* On a resumed handshake the server Finished is sent before the client's,
+     * so its verify_data covers the transcript so far and the digest must stay
+     * open to absorb the server Finished (below) for the client-Finished check.
+     * read it without finalizing. The full handshake sends its Finished last,
+     * so it may finalize the digest here. */
+    haveh = server->resumed ?
+        r_msg_digest_get_data (server->hshash, hash, hashsize, NULL) :
+        (r_msg_digest_finish (server->hshash) &&
+         r_msg_digest_get_data (server->hshash, hash, hashsize, NULL));
+
+    if (haveh) {
       if (r_tls_version_is_dtls (server->version)) {
         ret = r_dtls_write_handshake (info.data, info.size, &size,
             server->version, R_TLS_HANDSHAKE_TYPE_FINISHED, (ruint16)verifysize,
@@ -770,6 +790,12 @@ r_tls_server_write_finished (RTLSServer * server)
                               server->mastersecret, sizeof (server->mastersecret),
                               R_STR_WITH_SIZE_ARGS ("server finished"),
                               hash, hashsize, NULL)) == R_TLS_ERROR_OK) {
+        /* Fold the server Finished into the transcript the client Finished
+         * will be verified against (resume path only; the full path has
+         * already finalized the digest). */
+        if (server->resumed)
+          r_msg_digest_update (server->hshash, info.data + hdrsize,
+              (size + verifysize) - hdrsize);
         r_buffer_unmap (buf, &info);
         size += verifysize;
         r_buffer_set_size (buf, size);
@@ -1209,6 +1235,97 @@ r_tls_server_state_error (RTLSServer * server, const RTLSParser * parser)
   return R_TLS_ERROR_OK;
 }
 
+/* Attempt an abbreviated (RFC 5077) handshake from a ticket offered in the
+ * ClientHello. On success the master secret and negotiated parameters have been
+ * recovered from the ticket, the write keys are installed, and the server is
+ * ready to emit the resumed flight; returns TRUE. Any failure -- no / unopenable
+ * / expired ticket, or a suite no longer offered -- returns FALSE and leaves the
+ * caller to run a full handshake (which issues a fresh ticket). */
+static rboolean
+r_tls_server_try_resume (RTLSServer * server)
+{
+  RTLSHelloExt hsext = R_TLS_HELLO_EXT_INIT;
+  RTLSError r;
+  ruint8 plain[R_TLS_TICKET_STATE_SIZE];
+  rsize plainlen;
+  const ruint8 * ticket = NULL;
+  rsize ticketlen = 0;
+  RTLSVersion ver;
+  RTLSCipherSuite cs;
+  const RTLSCipherSuiteInfo * csinfo;
+  RClockTime issued_at, now;
+  rboolean ems;
+
+  if (server->ticket_keys == NULL)
+    return FALSE;
+
+  for (r = r_tls_hello_msg_extension_first (&server->hello, &hsext);
+      r == R_TLS_ERROR_OK;
+      r = r_tls_hello_msg_extension_next (&server->hello, &hsext)) {
+    if (hsext.type == R_TLS_EXT_TYPE_SESSION_TICKET) {
+      ticket = hsext.data;
+      ticketlen = hsext.len;
+      break;
+    }
+  }
+  if (ticket == NULL || ticketlen == 0)
+    return FALSE;
+
+  if (!r_tls_session_ticket_keys_open (server->ticket_keys, ticket, ticketlen,
+        plain, sizeof (plain), &plainlen))
+    return FALSE;
+  if (plainlen != sizeof (plain) || plain[0] != R_TLS_TICKET_STATE_VERSION) {
+    r_memclear_secure (plain, sizeof (plain));
+    return FALSE;
+  }
+
+  ver = (RTLSVersion) r_load_be16 (&plain[1]);
+  cs = (RTLSCipherSuite) r_load_be16 (&plain[3]);
+  ems = (plain[5] != 0);
+  issued_at = (RClockTime) r_load_be64 (&plain[6]);
+
+  /* Validate before adopting the recovered session: same version, not expired,
+   * the recovered suite must still be offered (RFC 5077), and the extended
+   * master secret state must match this ClientHello -- nego_hello has already
+   * set support_ext_master_secret from the offered extension, so resuming an
+   * EMS session without the extension (or vice versa) is refused as a downgrade
+   * (RFC 7627 5.3). */
+  now = r_time_get_ts_wallclock ();
+  if (ver != server->version ||
+      now < issued_at ||
+      now - issued_at > (RClockTime) R_TLS_SESSION_TICKET_LIFETIME * R_SECOND ||
+      ems != server->support_ext_master_secret ||
+      !r_tls_hello_msg_has_cipher_suite (&server->hello, cs) ||
+      (csinfo = r_tls_cipher_suite_get_info (cs)) == NULL) {
+    r_memclear_secure (plain, sizeof (plain));
+    return FALSE;
+  }
+
+  /* Adopt the resumed session: the suite comes from the ticket, not this
+   * ClientHello's preference-ordered negotiation (RFC 7627 5.1). */
+  server->csinfo = csinfo;
+  r_memcpy (server->mastersecret, &plain[14], sizeof (server->mastersecret));
+  r_memclear_secure (plain, sizeof (plain));
+
+  /* A fresh session id signals the resumed session to the client. Pin the
+   * server random now: key expansion below and the ServerHello both consume it,
+   * and they must agree. */
+  server->session_id_len = (ruint8) sizeof (server->session_id);
+  r_prng_fill (server->prng, server->session_id, server->session_id_len);
+  if (!server->servrandompinned) {
+    r_tls_generate_hello_random (server->servrandom, server->prng);
+    server->servrandompinned = TRUE;
+  }
+
+  /* The master secret comes from the ticket, so expand the key block directly
+   * (no derivation from a pre-master secret). */
+  if (r_tls_server_expand_master_secret (server) != R_TLS_ERROR_OK)
+    return FALSE;
+
+  server->resumed = TRUE;
+  return TRUE;
+}
+
 static RTLSError
 r_tls_server_state_hello (RTLSServer * server, const RTLSParser * parser)
 {
@@ -1220,7 +1337,8 @@ r_tls_server_state_hello (RTLSServer * server, const RTLSParser * parser)
     server->hellobuf = r_buffer_ref (parser->buf);
 
     if ((err = r_tls_server_nego_hello (server, parser->version, server->hello.version)) == R_TLS_ERROR_OK)
-      err = r_tls_server_change_state (server, R_TLS_SERVER_CERTIFICATE);
+      err = r_tls_server_change_state (server, r_tls_server_try_resume (server) ?
+          R_TLS_SERVER_CHANGE_CIPHER : R_TLS_SERVER_CERTIFICATE);
   }
 
   /* FIXME: Add proper alert codes for error scenarios */
@@ -1229,6 +1347,18 @@ r_tls_server_state_hello (RTLSServer * server, const RTLSParser * parser)
       R_LOG_TRACE ("Updating HS hash with ClientHello %u bytes",
           (ruint)parser->fragment.size);
       r_msg_digest_update (server->hshash, parser->fragment.data, parser->fragment.size);
+
+      if (server->resumed) {
+        /* Abbreviated flight: the server Finished is sent now, ahead of the
+         * client's. The client answers with its ChangeCipherSpec + Finished. */
+        if (r_tls_server_write_hello (server) == R_TLS_ERROR_OK)
+          server->server.msgseq++;
+        if (r_tls_server_write_change_cipher (server) == R_TLS_ERROR_OK)
+          server->encrypt = r_tls_server_cipher_encrypt;
+        if (r_tls_server_write_finished (server) == R_TLS_ERROR_OK)
+          server->server.msgseq++;
+        break;
+      }
 
       if (r_tls_server_write_hello (server) == R_TLS_ERROR_OK)
         server->server.msgseq++;
@@ -1388,14 +1518,18 @@ r_tls_server_state_finished (RTLSServer * server, const RTLSParser * parser)
           (ruint)parser->fragment.size);
       r_msg_digest_update (server->hshash, parser->fragment.data, parser->fragment.size);
 
-      if (r_tls_server_write_new_session_ticket (server) == R_TLS_ERROR_OK)
-        server->server.msgseq++;
-      if (r_tls_server_write_change_cipher (server) == R_TLS_ERROR_OK) {
-        /* enable cipher */
-        server->encrypt = r_tls_server_cipher_encrypt;
+      /* On a resumed handshake the server already sent its flight (Finished
+       * first) from state_hello; here it only verifies the client Finished. */
+      if (!server->resumed) {
+        if (r_tls_server_write_new_session_ticket (server) == R_TLS_ERROR_OK)
+          server->server.msgseq++;
+        if (r_tls_server_write_change_cipher (server) == R_TLS_ERROR_OK) {
+          /* enable cipher */
+          server->encrypt = r_tls_server_cipher_encrypt;
+        }
+        if (r_tls_server_write_finished (server) == R_TLS_ERROR_OK)
+          server->server.msgseq++;
       }
-      if (r_tls_server_write_finished (server) == R_TLS_ERROR_OK)
-        server->server.msgseq++;
 
       r_msg_digest_free (server->hshash);
       server->hshash = NULL;

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -19,14 +19,15 @@
 #include "config.h"
 #include "../rlib-private.h"
 #include <rlib/net/rtlsserver.h>
+#include "rtlssessiontickets-private.h"
 
-#include <rlib/crypto/raes.h>
 #include <rlib/crypto/rx509.h>
 
 #include <rlib/data/rqueue.h>
 
 #include <rlib/rmem.h>
 #include <rlib/rstr.h>
+#include <rlib/rtime.h>
 
 typedef enum {
   R_TLS_SERVER_INITIAL = 0,
@@ -83,8 +84,7 @@ struct RTLSServer {
   const ruint8 * srtp_mki;
   ruint8 * ticket;
   ruint16 ticketsize;
-  ruint8 ticket_key[16];        /* session-ticket encryption key (STEK) */
-  rboolean ticket_key_set;
+  RTLSSessionTicketKeys * ticket_keys;  /* shared STEK store; NULL disables tickets */
 
   RTLSConnectionState client;
   RTLSConnectionState server;
@@ -148,10 +148,11 @@ r_tls_server_free (RTLSServer * server)
   r_msg_digest_free (server->hshash);
 
   r_free (server->ticket);
+  if (server->ticket_keys != NULL)
+    r_tls_session_ticket_keys_unref (server->ticket_keys);
   r_queue_clear (&server->qsend, r_buffer_unref);
   /* Scrub key material before releasing the struct. */
   r_memclear_secure (server->mastersecret, sizeof (server->mastersecret));
-  r_memclear_secure (server->ticket_key, sizeof (server->ticket_key));
   r_free (server);
 }
 
@@ -220,6 +221,20 @@ r_tls_server_set_cert (RTLSServer * server,
 
   server->cert = r_crypto_cert_ref (cert);
   server->privkey = r_crypto_key_ref (privkey);
+
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_server_set_session_ticket_keys (RTLSServer * server,
+    RTLSSessionTicketKeys * keys)
+{
+  if (R_UNLIKELY (server == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (keys == NULL)) return R_TLS_ERROR_INVAL;
+
+  if (server->ticket_keys != NULL)
+    r_tls_session_ticket_keys_unref (server->ticket_keys);
+  server->ticket_keys = r_tls_session_ticket_keys_ref (keys);
 
   return R_TLS_ERROR_OK;
 }
@@ -343,8 +358,10 @@ static ruint16
 r_tls_server_write_hs_ext_session_ticket (const RTLSServer * server, ruint8 * ptr)
 {
   /* The ticket itself is minted in the final flight (it binds the master
-   * secret), so this only signals that a NewSessionTicket will follow. */
-  if (!server->support_new_session_ticket)
+   * secret), so this only signals that a NewSessionTicket will follow.
+   * Without a key store the server can neither seal nor later open a ticket,
+   * so it makes no promise. */
+  if (!server->support_new_session_ticket || server->ticket_keys == NULL)
     return 0;
 
   /* NewSessionTicket will come! */
@@ -616,53 +633,39 @@ r_tls_server_write_change_cipher (RTLSServer * server)
   return ret;
 }
 
+/* Serialized session state sealed inside a ticket (format version 2):
+ *   version(1) | protocol(2) | cipher_suite(2) | ems(1) | issued_at(8) | ms(48)
+ * issued_at is a wall-clock nanosecond stamp so the open side can enforce
+ * expiry. r_tls_server_open_session_ticket parses the same layout. */
+#define R_TLS_TICKET_STATE_VERSION    2
+#define R_TLS_TICKET_STATE_SIZE       (1 + 2 + 2 + 1 + 8 + 48)
+
 /* Mint the opaque session ticket: serialize the session state needed to resume
- * (format version, protocol version, cipher suite, EMS flag, master secret)
- * and seal it with AES-128-GCM under a per-server key generated lazily from OS
- * entropy. The ticket is nonce || ciphertext || tag; only this server can
- * decrypt it, so its contents stay opaque to the client. */
+ * and seal it under the shared key store. The ticket stays opaque to the
+ * client; only a server sharing the same RTLSSessionTicketKeys can open it. */
 static RTLSError
 r_tls_server_create_session_ticket (RTLSServer * server)
 {
-  ruint8 plain[1 + 2 + 2 + 1 + sizeof (server->mastersecret)];
-  ruint8 nonce[12];
+  ruint8 plain[R_TLS_TICKET_STATE_SIZE];
   ruint8 * ticket;
-  rsize ticketsize = sizeof (nonce) + sizeof (plain) + 16;
-  RCryptoCipher * cipher;
-  RCryptoCipherResult cr;
+  rsize ticketsize;
 
-  if (!server->ticket_key_set) {
-    if (!r_rand_entropy_fill (server->ticket_key, sizeof (server->ticket_key)))
-      return R_TLS_ERROR_HANDSHAKE_FAILURE;
-    server->ticket_key_set = TRUE;
-  }
-
-  plain[0] = 1;                                         /* ticket format version */
+  plain[0] = R_TLS_TICKET_STATE_VERSION;
   r_store_be16 (&plain[1], (ruint16)server->version);
   r_store_be16 (&plain[3], (ruint16)server->csinfo->suite);
   plain[5] = server->support_ext_master_secret ? 1 : 0;
-  r_memcpy (&plain[6], server->mastersecret, sizeof (server->mastersecret));
+  r_store_be64 (&plain[6], (ruint64)r_time_get_ts_wallclock ());
+  r_memcpy (&plain[14], server->mastersecret, sizeof (server->mastersecret));
 
-  if ((cipher = r_cipher_aes_128_gcm_new (server->ticket_key)) == NULL) {
+  if (!r_tls_session_ticket_keys_seal (server->ticket_keys, plain,
+        sizeof (plain), &ticket, &ticketsize)) {
     r_memclear_secure (plain, sizeof (plain));
-    return R_TLS_ERROR_OOM;
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
   }
-  if ((ticket = r_malloc (ticketsize)) == NULL) {
-    r_crypto_cipher_unref (cipher);
-    r_memclear_secure (plain, sizeof (plain));
-    return R_TLS_ERROR_OOM;
-  }
-
-  r_prng_fill (server->prng, nonce, sizeof (nonce));
-  r_memcpy (ticket, nonce, sizeof (nonce));
-  cr = r_crypto_cipher_encrypt_aead (cipher, ticket + sizeof (nonce),
-      sizeof (plain), plain, NULL, 0, nonce, sizeof (nonce),
-      ticket + sizeof (nonce) + sizeof (plain), 16);
-
-  r_crypto_cipher_unref (cipher);
   r_memclear_secure (plain, sizeof (plain));
 
-  if (cr != R_CRYPTO_CIPHER_OK) {
+  /* The NewSessionTicket carries the ticket length as a 16-bit field. */
+  if (ticketsize > RUINT16_MAX) {
     r_free (ticket);
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
   }
@@ -680,7 +683,7 @@ r_tls_server_write_new_session_ticket (RTLSServer * server)
   RTLSError ret;
   RMemMapInfo info;
 
-  if (!server->support_new_session_ticket)
+  if (!server->support_new_session_ticket || server->ticket_keys == NULL)
     return R_TLS_ERROR_NOT_NEEDED;
 
   if (server->ticketsize == 0 &&

--- a/rlib/net/rtlssessiontickets-private.h
+++ b/rlib/net/rtlssessiontickets-private.h
@@ -1,0 +1,51 @@
+/* RLIB - Convenience library for useful things
+ * Copyright (C) 2026 Haakon Sporsheim <haakon.sporsheim@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ * See the COPYING file at the root of the source repository.
+ */
+#ifndef __R_NET_TLS_SESSION_TICKETS_PRIV_H__
+#define __R_NET_TLS_SESSION_TICKETS_PRIV_H__
+
+#if !defined(RLIB_COMPILATION)
+#error "rtlssessiontickets-private.h should only be used internally in rlib!"
+#endif
+
+#include <rlib/net/rtlssessiontickets.h>
+#include <rlib/rtypes.h>
+
+R_BEGIN_DECLS
+
+/* Bytes a sealed ticket adds around the plaintext: key_name(16) + nonce(12)
+ * + GCM tag(16). The wire ticket is key_name || nonce || ciphertext || tag. */
+#define R_TLS_SESSION_TICKET_SEAL_OVERHEAD    (16 + 12 + 16)
+
+/* Seal @plain under @keys into a freshly allocated ticket; the caller frees
+ * @out. The key_name is authenticated (GCM AAD) so @ref
+ * r_tls_session_ticket_keys_open can reject tickets sealed by other keys
+ * before attempting to decrypt. Returns FALSE on entropy / cipher failure. */
+R_API_HIDDEN rboolean r_tls_session_ticket_keys_seal (RTLSSessionTicketKeys * keys,
+    const ruint8 * plain, rsize plainlen, ruint8 ** out, rsize * outlen);
+
+/* Open @ticket under @keys: reject unless the leading key_name matches and the
+ * AEAD tag verifies, then write the recovered plaintext into @plain_out (of
+ * capacity @cap) and its length to @plainlen_out. Returns FALSE on any size,
+ * key_name or tag mismatch. */
+R_API_HIDDEN rboolean r_tls_session_ticket_keys_open (RTLSSessionTicketKeys * keys,
+    const ruint8 * ticket, rsize len, ruint8 * plain_out, rsize cap,
+    rsize * plainlen_out);
+
+R_END_DECLS
+
+#endif /* __R_NET_TLS_SESSION_TICKETS_PRIV_H__ */

--- a/rlib/net/rtlssessiontickets.c
+++ b/rlib/net/rtlssessiontickets.c
@@ -1,0 +1,147 @@
+/* RLIB - Convenience library for useful things
+ * Copyright (C) 2026 Haakon Sporsheim <haakon.sporsheim@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ * See the COPYING file at the root of the source repository.
+ */
+
+#include "config.h"
+#include "rtlssessiontickets-private.h"
+
+#include <rlib/crypto/raes.h>
+#include <rlib/crypto/rcipher.h>
+
+#include <rlib/rmem.h>
+#include <rlib/rrand.h>
+
+#define R_TLS_STK_KEY_NAME_SIZE   16
+#define R_TLS_STK_KEY_SIZE        16
+#define R_TLS_STK_NONCE_SIZE      12
+#define R_TLS_STK_TAG_SIZE        16
+
+struct RTLSSessionTicketKeys {
+  RRef ref;
+  ruint8 key_name[R_TLS_STK_KEY_NAME_SIZE];
+  ruint8 key[R_TLS_STK_KEY_SIZE];
+};
+
+static void
+r_tls_session_ticket_keys_free (RTLSSessionTicketKeys * keys)
+{
+  r_memclear_secure (keys->key, sizeof (keys->key));
+  r_free (keys);
+}
+
+RTLSSessionTicketKeys *
+r_tls_session_ticket_keys_new (void)
+{
+  RTLSSessionTicketKeys * ret;
+
+  if ((ret = r_mem_new (RTLSSessionTicketKeys)) != NULL) {
+    if (!r_rand_entropy_fill (ret->key_name, sizeof (ret->key_name)) ||
+        !r_rand_entropy_fill (ret->key, sizeof (ret->key))) {
+      r_memclear_secure (ret->key, sizeof (ret->key));
+      r_free (ret);
+      return NULL;
+    }
+    r_ref_init (ret, r_tls_session_ticket_keys_free);
+  }
+
+  return ret;
+}
+
+rboolean
+r_tls_session_ticket_keys_seal (RTLSSessionTicketKeys * keys,
+    const ruint8 * plain, rsize plainlen, ruint8 ** out, rsize * outlen)
+{
+  RCryptoCipher * cipher;
+  ruint8 * ticket, * nonce, * ct, * tag;
+  rsize ticketlen = R_TLS_STK_KEY_NAME_SIZE + R_TLS_STK_NONCE_SIZE +
+      plainlen + R_TLS_STK_TAG_SIZE;
+  RCryptoCipherResult cr;
+
+  if (R_UNLIKELY (keys == NULL)) return FALSE;
+
+  if ((cipher = r_cipher_aes_128_gcm_new (keys->key)) == NULL)
+    return FALSE;
+  if ((ticket = r_malloc (ticketlen)) == NULL) {
+    r_crypto_cipher_unref (cipher);
+    return FALSE;
+  }
+
+  r_memcpy (ticket, keys->key_name, R_TLS_STK_KEY_NAME_SIZE);
+  nonce = ticket + R_TLS_STK_KEY_NAME_SIZE;
+  ct = nonce + R_TLS_STK_NONCE_SIZE;
+  tag = ct + plainlen;
+
+  if (!r_rand_entropy_fill (nonce, R_TLS_STK_NONCE_SIZE)) {
+    r_crypto_cipher_unref (cipher);
+    r_free (ticket);
+    return FALSE;
+  }
+
+  /* The key_name is authenticated (AAD) but not encrypted: it travels in the
+   * clear so the open side can pick the right key before decrypting. */
+  cr = r_crypto_cipher_encrypt_aead (cipher, ct, plainlen, plain,
+      keys->key_name, R_TLS_STK_KEY_NAME_SIZE, nonce, R_TLS_STK_NONCE_SIZE,
+      tag, R_TLS_STK_TAG_SIZE);
+  r_crypto_cipher_unref (cipher);
+
+  if (cr != R_CRYPTO_CIPHER_OK) {
+    r_free (ticket);
+    return FALSE;
+  }
+
+  *out = ticket;
+  *outlen = ticketlen;
+  return TRUE;
+}
+
+rboolean
+r_tls_session_ticket_keys_open (RTLSSessionTicketKeys * keys,
+    const ruint8 * ticket, rsize len, ruint8 * plain_out, rsize cap,
+    rsize * plainlen_out)
+{
+  RCryptoCipher * cipher;
+  const ruint8 * nonce, * ct, * tag;
+  rsize plainlen;
+  RCryptoCipherResult cr;
+
+  if (R_UNLIKELY (keys == NULL)) return FALSE;
+  if (len < R_TLS_SESSION_TICKET_SEAL_OVERHEAD)
+    return FALSE;
+  plainlen = len - R_TLS_SESSION_TICKET_SEAL_OVERHEAD;
+  if (plainlen > cap)
+    return FALSE;
+  /* Reject tickets sealed under a different key before touching the cipher. */
+  if (r_memcmp (ticket, keys->key_name, R_TLS_STK_KEY_NAME_SIZE) != 0)
+    return FALSE;
+
+  nonce = ticket + R_TLS_STK_KEY_NAME_SIZE;
+  ct = nonce + R_TLS_STK_NONCE_SIZE;
+  tag = ct + plainlen;
+
+  if ((cipher = r_cipher_aes_128_gcm_new (keys->key)) == NULL)
+    return FALSE;
+  cr = r_crypto_cipher_decrypt_aead (cipher, plain_out, plainlen, ct,
+      keys->key_name, R_TLS_STK_KEY_NAME_SIZE,
+      (ruint8 *) nonce, R_TLS_STK_NONCE_SIZE, (ruint8 *) tag, R_TLS_STK_TAG_SIZE);
+  r_crypto_cipher_unref (cipher);
+
+  if (cr != R_CRYPTO_CIPHER_OK)
+    return FALSE;
+
+  *plainlen_out = plainlen;
+  return TRUE;
+}

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -1425,3 +1425,622 @@ RTEST_F (rtlsserver, tls_session_ticket_issued, RTEST_FAST)
   r_crypto_key_unref (pk);
 }
 RTEST_END;
+
+/* Build a TLS 1.2 ClientHello offering @suite, empty renegotiation_info, and a
+ * session_ticket extension carrying @ticket (empty when @ticketlen is 0). The
+ * client random is captured into @crand. Returns the record length. */
+static rsize
+r_test_tls_build_client_hello (RPrng * prng, ruint8 * ch, rsize chcap,
+    RTLSCipherSuite suite, const ruint8 * ticket, rsize ticketlen, ruint8 * crand)
+{
+  ruint8 body[512];
+  ruint8 * p = body;
+  ruint8 * extlenp;
+  rsize bodylen, hssz;
+
+  *p++ = 0x03; *p++ = 0x03;
+  r_prng_fill (prng, p, R_TLS_HELLO_RANDOM_BYTES);
+  r_memcpy (crand, p, R_TLS_HELLO_RANDOM_BYTES); p += R_TLS_HELLO_RANDOM_BYTES;
+  *p++ = 0;                                  /* session id length */
+  r_store_be16 (p, 2); p += 2;               /* cipher-suites length */
+  r_store_be16 (p, (ruint16) suite); p += 2;
+  *p++ = 1; *p++ = 0;                        /* compression: null */
+  extlenp = p; p += 2;
+  r_store_be16 (p, (ruint16) R_TLS_EXT_TYPE_RENEGOTIATION_INFO); p += 2;
+  r_store_be16 (p, 1); p += 2; *p++ = 0;
+  r_store_be16 (p, (ruint16) R_TLS_EXT_TYPE_SESSION_TICKET); p += 2;
+  r_store_be16 (p, (ruint16) ticketlen); p += 2;
+  if (ticketlen > 0) { r_memcpy (p, ticket, ticketlen); p += ticketlen; }
+  r_store_be16 (extlenp, (ruint16) (p - (extlenp + 2)));
+  bodylen = (rsize) (p - body);
+
+  r_assert_cmpint (r_tls_write_handshake (ch, chcap, &hssz, R_TLS_VERSION_TLS_1_2,
+        R_TLS_HANDSHAKE_TYPE_CLIENT_HELLO, (ruint16) bodylen), ==, R_TLS_ERROR_OK);
+  r_memcpy (ch + hssz, body, bodylen);
+  return hssz + bodylen;
+}
+
+/* Create a server configured like the fixture's (same callbacks bound to @ctx,
+ * same cert), for the second connection in a resumption test. */
+static RTLSServer *
+r_test_tls_server_new_cfg (rpointer ctx)
+{
+  static const RTLSCallbacks cbs = {
+    NULL, r_tlsserver_test_hs_done, r_tlsserver_test_buffer_out,
+    r_tlsserver_test_buffer_appdata, r_tlsserver_test_error, NULL,
+  };
+  RTLSServer * srv;
+  RCryptoCert * cert;
+  RCryptoKey * pk;
+
+  r_assert_cmpptr ((srv = r_tls_server_new (&cbs, ctx, NULL)), !=, NULL);
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (testcertpem, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem, -1, NULL, 0)), !=, NULL);
+  r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_server_set_cert (srv, cert, pk));
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+  return srv;
+}
+
+/* Drive a full TLS 1.2 RSA handshake against @server to completion, returning
+ * the negotiated master secret in @ms and a malloc'd copy of the issued ticket
+ * in @ticket_out / @ticketlen_out (caller frees). */
+static void
+r_test_tls_client_issue (RTLSServer * server, RPrng * prng, RQueue * qout,
+    ruint8 ms[48], ruint8 ** ticket_out, rsize * ticketlen_out)
+{
+  RCryptoKey * pk;
+  RMsgDigest * md;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSHelloMsg hello;
+  RBuffer * buf, * plain, * enc;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  RCryptoCipher * ccipher;
+  RHmac * chmac;
+  RTLSHandshakeType hs;
+  ruint32 l;
+  ruint16 msgseq;
+  ruint8 ch[256];
+  ruint8 crand[R_TLS_HELLO_RANDOM_BYTES], srand[R_TLS_HELLO_RANDOM_BYTES];
+  ruint8 pms[48], kb[128], vd[12], iv[16], sh[64];
+  ruint8 encpms[512], cke[512], fin[64], ccs[16];
+  rsize chlen, hssz, enclen = sizeof (encpms), ckelen, finhs, ccslen, shlen;
+
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem, -1, NULL, 0)), !=, NULL);
+  r_assert_cmpptr ((md = r_msg_digest_new_sha256 ()), !=, NULL);
+
+  chlen = r_test_tls_build_client_hello (prng, ch, sizeof (ch),
+      R_TLS_CS_RSA_WITH_AES_128_CBC_SHA, NULL, 0, crand);
+  r_test_tls_server_feed (server, ch, chlen);
+  r_test_tls_hash_record (md, ch, chlen);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_msg_digest_update (md, parser.fragment.data, parser.fragment.size);
+  r_assert_cmpint (r_tls_parser_parse_hello (&parser, &hello), ==, R_TLS_ERROR_OK);
+  r_memcpy (srand, hello.random, sizeof (srand));
+  while (r_tls_parser_init_next (&parser, NULL) == R_TLS_ERROR_OK)
+    r_msg_digest_update (md, parser.fragment.data, parser.fragment.size);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+
+  pms[0] = 0x03; pms[1] = 0x03;
+  r_prng_fill (prng, pms + 2, sizeof (pms) - 2);
+  r_assert_cmpint (r_crypto_key_encrypt (pk, prng, pms, sizeof (pms), encpms, &enclen),
+      ==, R_CRYPTO_OK);
+  r_assert_cmpint (r_tls_write_handshake (cke, sizeof (cke), &hssz, R_TLS_VERSION_TLS_1_2,
+        R_TLS_HANDSHAKE_TYPE_CLIENT_KEY_EXCHANGE, (ruint16)(2 + enclen)), ==, R_TLS_ERROR_OK);
+  r_store_be16 (cke + hssz, (ruint16)enclen);
+  r_memcpy (cke + hssz + 2, encpms, enclen);
+  ckelen = hssz + 2 + enclen;
+  r_test_tls_hash_record (md, cke, ckelen);
+
+  shlen = r_msg_digest_size (md);
+  r_assert (r_msg_digest_get_data (md, sh, shlen, NULL));
+  r_assert_cmpint (r_tls_1_2_prf_sha256 (ms, 48, pms, sizeof (pms),
+        R_STR_WITH_SIZE_ARGS ("master secret"),
+        crand, sizeof (crand), srand, sizeof (srand), NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_1_2_prf_sha256 (kb, sizeof (kb), ms, 48,
+        R_STR_WITH_SIZE_ARGS ("key expansion"),
+        srand, sizeof (srand), crand, sizeof (crand), NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_1_2_prf_sha256 (vd, sizeof (vd), ms, 48,
+        R_STR_WITH_SIZE_ARGS ("client finished"), sh, shlen, NULL), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpptr ((ccipher = r_cipher_aes_128_cbc_new (kb + 40)), !=, NULL);
+  r_assert_cmpptr ((chmac = r_hmac_new (R_MSG_DIGEST_TYPE_SHA1, kb, 20)), !=, NULL);
+
+  r_assert_cmpint (r_tls_write_handshake (fin, sizeof (fin), &finhs, R_TLS_VERSION_TLS_1_2,
+        R_TLS_HANDSHAKE_TYPE_FINISHED, sizeof (vd)), ==, R_TLS_ERROR_OK);
+  r_memcpy (fin + finhs, vd, sizeof (vd));
+  r_assert_cmpptr ((plain = r_buffer_new_wrapped (R_MEM_FLAG_NONE, fin,
+          finhs + sizeof (vd), finhs + sizeof (vd), 0, NULL, NULL)), !=, NULL);
+  r_prng_fill (prng, iv, sizeof (iv));
+  r_assert_cmpptr ((enc = r_tls_encrypt_buffer (plain, 0, ccipher, iv, chmac, FALSE)), !=, NULL);
+  r_buffer_unref (plain);
+
+  r_assert_cmpint (r_tls_write_change_cipher (ccs, sizeof (ccs), &ccslen,
+        R_TLS_VERSION_TLS_1_2), ==, R_TLS_ERROR_OK);
+  r_test_tls_server_feed (server, cke, ckelen);
+  r_test_tls_server_feed (server, ccs, ccslen);
+  r_assert (r_buffer_map (enc, &info, R_MEM_MAP_READ));
+  r_test_tls_server_feed (server, info.data, info.size);
+  r_buffer_unmap (enc, &info);
+  r_buffer_unref (enc);
+
+  /* server 2nd flight: NewSessionTicket, CCS, Finished -- capture the ticket */
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_HANDSHAKE);
+  r_assert_cmpint (r_tls_parser_parse_handshake_full (&parser, &hs, &l,
+        &msgseq, NULL, NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmphex (hs, ==, R_TLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET);
+  {
+    ruint32 lifetime;
+    const ruint8 * ticket;
+    ruint16 ticketsize;
+
+    r_assert_cmpint (r_tls_parser_parse_new_session_ticket (&parser, &lifetime,
+          &ticket, &ticketsize), ==, R_TLS_ERROR_OK);
+    r_assert_cmpuint (ticketsize, >, 0);
+    *ticket_out = r_memdup (ticket, ticketsize);
+    *ticketlen_out = ticketsize;
+  }
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+
+  r_hmac_free (chmac);
+  r_crypto_cipher_unref (ccipher);
+  r_memclear_secure (pms, sizeof (pms));
+  r_memclear_secure (kb, sizeof (kb));
+  r_msg_digest_free (md);
+  r_crypto_key_unref (pk);
+}
+
+/* Present @ticket to @server (which must share the issuing key store) and drive
+ * the abbreviated handshake to completion: verify the server Finished over
+ * H(CH||SH), then send the client Finished over H(CH||SH||serverFinished). */
+static void
+r_test_tls_client_resume (RTLSServer * server, RPrng * prng, RQueue * qout,
+    const ruint8 ms[48], const ruint8 * ticket, rsize ticketlen)
+{
+  RMsgDigest * md;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSHelloMsg hello;
+  RBuffer * buf, * plain, * enc;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  RCryptoCipher * ccipher, * scipher;
+  RHmac * chmac, * shmac;
+  ruint8 ch[512];
+  ruint8 crand[R_TLS_HELLO_RANDOM_BYTES], srand[R_TLS_HELLO_RANDOM_BYTES];
+  ruint8 kb[128], vd[12], iv[16], hash[64], svd[12];
+  ruint8 fin[64], ccs[16];
+  rsize chlen, finhs, ccslen, hashsize;
+  const ruint8 * verify_data;
+  rsize verify_size;
+
+  r_assert_cmpptr ((md = r_msg_digest_new_sha256 ()), !=, NULL);
+
+  chlen = r_test_tls_build_client_hello (prng, ch, sizeof (ch),
+      R_TLS_CS_RSA_WITH_AES_128_CBC_SHA, ticket, ticketlen, crand);
+  r_test_tls_server_feed (server, ch, chlen);
+  r_test_tls_hash_record (md, ch, chlen);
+
+  /* resumed server flight: ServerHello, CCS, encrypted Finished (no Certificate) */
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_HANDSHAKE);
+  r_msg_digest_update (md, parser.fragment.data, parser.fragment.size);
+  r_assert_cmpint (r_tls_parser_parse_hello (&parser, &hello), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (hello.sidlen, >, 0);     /* a session id signals resumption */
+  r_memcpy (srand, hello.random, sizeof (srand));
+  {
+    /* No fresh ticket is issued on resume, so the ServerHello must not promise
+     * one with a session_ticket extension (RFC 5077 3.4). */
+    RTLSHelloExt ext;
+    RTLSError e;
+    for (e = r_tls_hello_msg_extension_first (&hello, &ext); e == R_TLS_ERROR_OK;
+        e = r_tls_hello_msg_extension_next (&hello, &ext))
+      r_assert_cmpuint (ext.type, !=, R_TLS_EXT_TYPE_SESSION_TICKET);
+  }
+
+  /* key block from the resumed master secret and the fresh randoms */
+  r_assert_cmpint (r_tls_1_2_prf_sha256 (kb, sizeof (kb), ms, 48,
+        R_STR_WITH_SIZE_ARGS ("key expansion"),
+        srand, sizeof (srand), crand, sizeof (crand), NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmpptr ((ccipher = r_cipher_aes_128_cbc_new (kb + 40)), !=, NULL);
+  r_assert_cmpptr ((chmac = r_hmac_new (R_MSG_DIGEST_TYPE_SHA1, kb, 20)), !=, NULL);
+  r_assert_cmpptr ((scipher = r_cipher_aes_128_cbc_new (kb + 56)), !=, NULL);
+  r_assert_cmpptr ((shmac = r_hmac_new (R_MSG_DIGEST_TYPE_SHA1, kb + 20, 20)), !=, NULL);
+
+  /* server verify_data is over the transcript through ServerHello */
+  hashsize = r_msg_digest_size (md);
+  r_assert (r_msg_digest_get_data (md, hash, hashsize, NULL));
+  r_assert_cmpint (r_tls_1_2_prf_sha256 (svd, sizeof (svd), ms, 48,
+        R_STR_WITH_SIZE_ARGS ("server finished"), hash, hashsize, NULL), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_parser_init_next (&parser, NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_CHANGE_CIPHER_SPEC);
+
+  r_assert_cmpint (r_tls_parser_init_next (&parser, NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_HANDSHAKE);
+  r_assert_cmpint (r_tls_parser_decrypt (&parser, scipher, shmac, FALSE), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_parser_parse_finished (&parser, &verify_data, &verify_size),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (verify_size, ==, 12);
+  r_assert_cmpint (r_memcmp (verify_data, svd, verify_size), ==, 0);
+  /* fold the server Finished so the client Finished covers it */
+  r_msg_digest_update (md, parser.fragment.data, parser.fragment.size);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+
+  hashsize = r_msg_digest_size (md);
+  r_assert (r_msg_digest_get_data (md, hash, hashsize, NULL));
+  r_assert_cmpint (r_tls_1_2_prf_sha256 (vd, sizeof (vd), ms, 48,
+        R_STR_WITH_SIZE_ARGS ("client finished"), hash, hashsize, NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_write_handshake (fin, sizeof (fin), &finhs, R_TLS_VERSION_TLS_1_2,
+        R_TLS_HANDSHAKE_TYPE_FINISHED, sizeof (vd)), ==, R_TLS_ERROR_OK);
+  r_memcpy (fin + finhs, vd, sizeof (vd));
+  r_assert_cmpptr ((plain = r_buffer_new_wrapped (R_MEM_FLAG_NONE, fin,
+          finhs + sizeof (vd), finhs + sizeof (vd), 0, NULL, NULL)), !=, NULL);
+  r_prng_fill (prng, iv, sizeof (iv));
+  r_assert_cmpptr ((enc = r_tls_encrypt_buffer (plain, 0, ccipher, iv, chmac, FALSE)), !=, NULL);
+  r_buffer_unref (plain);
+
+  r_assert_cmpint (r_tls_write_change_cipher (ccs, sizeof (ccs), &ccslen,
+        R_TLS_VERSION_TLS_1_2), ==, R_TLS_ERROR_OK);
+  r_test_tls_server_feed (server, ccs, ccslen);
+  r_assert (r_buffer_map (enc, &info, R_MEM_MAP_READ));
+  r_test_tls_server_feed (server, info.data, info.size);
+  r_buffer_unmap (enc, &info);
+  r_buffer_unref (enc);
+
+  r_hmac_free (chmac);
+  r_hmac_free (shmac);
+  r_crypto_cipher_unref (ccipher);
+  r_crypto_cipher_unref (scipher);
+  r_memclear_secure (kb, sizeof (kb));
+  r_msg_digest_free (md);
+}
+
+/* Feed a resume ClientHello (offering @suite + @ticket) and assert the server
+ * runs a full handshake -- a Certificate follows the ServerHello rather than a
+ * ChangeCipherSpec -- i.e. it declined to resume. */
+static void
+r_test_tls_client_resume_assert_full (RTLSServer * server, RPrng * prng,
+    RQueue * qout, RTLSCipherSuite suite, const ruint8 * ticket, rsize ticketlen)
+{
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSHelloMsg hello;
+  RBuffer * buf;
+  RTLSHandshakeType hs;
+  ruint32 l;
+  ruint16 msgseq;
+  ruint8 ch[512], crand[R_TLS_HELLO_RANDOM_BYTES];
+  rsize chlen;
+
+  chlen = r_test_tls_build_client_hello (prng, ch, sizeof (ch),
+      suite, ticket, ticketlen, crand);
+  r_test_tls_server_feed (server, ch, chlen);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_HANDSHAKE);
+  r_assert_cmpint (r_tls_parser_parse_hello (&parser, &hello), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_parser_init_next (&parser, NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_HANDSHAKE);
+  r_assert_cmpint (r_tls_parser_parse_handshake_full (&parser, &hs, &l,
+        &msgseq, NULL, NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmphex (hs, ==, R_TLS_HANDSHAKE_TYPE_CERTIFICATE);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+}
+
+/* End-to-end resumption: issue a ticket via a full handshake, then present it
+ * to a second server sharing the same key store and complete the abbreviated
+ * handshake, with the negotiated parameters preserved. */
+RTEST_F (rtlsserver, tls_session_resume, RTEST_FAST)
+{
+  RTLSServer * srv2;
+  ruint8 ms[48], * ticket = NULL;
+  rsize ticketlen = 0;
+  const RTLSCipherSuiteInfo * csinfo;
+
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (fixture->server,
+        fixture->ticket_keys), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_test_tls_client_issue (fixture->server, fixture->prng, &fixture->qout,
+      ms, &ticket, &ticketlen);
+  r_assert (fixture->hs_done);
+  r_assert_cmpuint (ticketlen, >, 0);
+
+  fixture->hs_done = FALSE;
+  r_queue_clear (&fixture->qout, r_buffer_unref);
+  r_assert_cmpptr ((srv2 = r_test_tls_server_new_cfg (fixture)), !=, NULL);
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (srv2, fixture->ticket_keys),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (srv2, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  r_test_tls_client_resume (srv2, fixture->prng, &fixture->qout, ms, ticket, ticketlen);
+  r_assert (fixture->hs_done);
+  r_assert_cmphex (r_tls_server_get_version (srv2), ==, R_TLS_VERSION_TLS_1_2);
+  r_assert_cmpptr ((csinfo = r_tls_server_get_cipher_suite (srv2)), !=, NULL);
+  r_assert_cmpstr (csinfo->str, ==, "TLS-RSA-WITH-AES-128-CBC-SHA");
+
+  r_free (ticket);
+  r_tls_server_unref (srv2);
+}
+RTEST_END;
+
+/* A ClientHello carrying an unopenable ticket falls back to a full handshake. */
+RTEST_F (rtlsserver, tls_session_resume_bad_ticket, RTEST_FAST)
+{
+  ruint8 garbage[80];
+
+  r_memset (garbage, 0xab, sizeof (garbage));
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (fixture->server,
+        fixture->ticket_keys), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  r_test_tls_client_resume_assert_full (fixture->server, fixture->prng, &fixture->qout,
+      R_TLS_CS_RSA_WITH_AES_128_CBC_SHA, garbage, sizeof (garbage));
+  r_assert (!fixture->hs_done);
+}
+RTEST_END;
+
+/* A ticket for a suite the resuming ClientHello no longer offers must not
+ * resume (RFC 5077); the server falls back to a full handshake. */
+RTEST_F (rtlsserver, tls_session_resume_suite_not_offered, RTEST_FAST)
+{
+  RTLSServer * srv2;
+  ruint8 ms[48], * ticket = NULL;
+  rsize ticketlen = 0;
+
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (fixture->server,
+        fixture->ticket_keys), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_test_tls_client_issue (fixture->server, fixture->prng, &fixture->qout,
+      ms, &ticket, &ticketlen);
+  r_assert (fixture->hs_done);
+
+  fixture->hs_done = FALSE;
+  r_queue_clear (&fixture->qout, r_buffer_unref);
+  r_assert_cmpptr ((srv2 = r_test_tls_server_new_cfg (fixture)), !=, NULL);
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (srv2, fixture->ticket_keys),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (srv2, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  /* the ticket is for RSA-AES128-CBC-SHA; this ClientHello offers only SHA256 */
+  r_test_tls_client_resume_assert_full (srv2, fixture->prng, &fixture->qout,
+      R_TLS_CS_RSA_WITH_AES_128_CBC_SHA256, ticket, ticketlen);
+
+  r_free (ticket);
+  r_tls_server_unref (srv2);
+}
+RTEST_END;
+
+/* Build a DTLS 1.2 ClientHello (message_seq 0) offering @suite, empty
+ * renegotiation_info, extended_master_secret (the issuing session used it) and
+ * a session_ticket extension carrying @ticket. Captures the client random. */
+static rsize
+r_test_tls_build_dtls_resume_hello (RPrng * prng, ruint8 * out, rsize outsz,
+    RTLSCipherSuite suite, const ruint8 * ticket, rsize ticketlen, ruint8 * crand)
+{
+  ruint8 body[256];
+  ruint8 * p = body;
+  ruint8 * extlenp;
+  rsize bodylen, hs;
+
+  *p++ = 0xfe; *p++ = 0xfd;                  /* client_version DTLS 1.2 */
+  r_prng_fill (prng, p, R_TLS_HELLO_RANDOM_BYTES);
+  r_memcpy (crand, p, R_TLS_HELLO_RANDOM_BYTES); p += R_TLS_HELLO_RANDOM_BYTES;
+  *p++ = 0;                                  /* session id length */
+  *p++ = 0;                                  /* cookie length */
+  r_store_be16 (p, 2); p += 2;               /* cipher-suites length */
+  r_store_be16 (p, (ruint16) suite); p += 2;
+  *p++ = 1; *p++ = 0;                        /* compression: null */
+  extlenp = p; p += 2;
+  r_store_be16 (p, (ruint16) R_TLS_EXT_TYPE_RENEGOTIATION_INFO); p += 2;
+  r_store_be16 (p, 1); p += 2; *p++ = 0;
+  r_store_be16 (p, (ruint16) R_TLS_EXT_TYPE_EXTENDED_MASTER_SECRET); p += 2;
+  r_store_be16 (p, 0); p += 2;
+  r_store_be16 (p, (ruint16) R_TLS_EXT_TYPE_SESSION_TICKET); p += 2;
+  r_store_be16 (p, (ruint16) ticketlen); p += 2;
+  if (ticketlen > 0) { r_memcpy (p, ticket, ticketlen); p += ticketlen; }
+  r_store_be16 (extlenp, (ruint16) (p - (extlenp + 2)));
+  bodylen = (rsize) (p - body);
+
+  r_assert_cmpint (r_dtls_write_handshake (out, outsz, &hs,
+        R_TLS_VERSION_DTLS_1_2, R_TLS_HANDSHAKE_TYPE_CLIENT_HELLO,
+        (ruint16) bodylen, 0, 0, 0, 0, (ruint32) bodylen), ==, R_TLS_ERROR_OK);
+  r_memcpy (out + hs, body, bodylen);
+  return hs + bodylen;
+}
+
+/* Present @ticket to a DTLS @server sharing the issuing key store and drive the
+ * abbreviated handshake to completion: verify the server Finished (epoch 1)
+ * over H(CH||SH), then send the client ChangeCipherSpec + Finished. */
+static void
+r_test_tls_dtls_client_resume (RTLSServer * server, RPrng * prng, RQueue * qout,
+    const ruint8 ms[48], const ruint8 * ticket, rsize ticketlen)
+{
+  RMsgDigest * md;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSHelloMsg hello;
+  RBuffer * buf, * plain, * encbuf;
+  RCryptoCipher * ccipher, * scipher;
+  RHmac * chmac, * shmac;
+  ruint8 ch[256];
+  ruint8 crand[R_TLS_HELLO_RANDOM_BYTES], srand[R_TLS_HELLO_RANDOM_BYTES];
+  ruint8 kb[128], vd[12], iv[16], hash[64], svd[12];
+  ruint8 finbuf[64], ccsbuf[32];
+  rsize chlen, finhs, ccslen, hashsize;
+  const ruint8 * verify_data;
+  rsize verify_size;
+
+  r_assert_cmpptr ((md = r_msg_digest_new_sha256 ()), !=, NULL);
+
+  chlen = r_test_tls_build_dtls_resume_hello (prng, ch, sizeof (ch),
+      R_TLS_CS_RSA_WITH_AES_128_CBC_SHA, ticket, ticketlen, crand);
+  r_test_tls_server_feed (server, ch, chlen);
+  r_test_tls_hash_record (md, ch, chlen);
+
+  /* resumed server flight: ServerHello, CCS (epoch 0), encrypted Finished
+   * (epoch 1); no Certificate. */
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_HANDSHAKE);
+  r_assert_cmpuint (parser.epoch, ==, 0);
+  r_msg_digest_update (md, parser.fragment.data, parser.fragment.size);
+  r_assert_cmpint (r_tls_parser_parse_hello (&parser, &hello), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (hello.sidlen, >, 0);     /* a session id signals resumption */
+  r_memcpy (srand, hello.random, sizeof (srand));
+  {
+    /* No fresh ticket is issued on resume, so the ServerHello must not promise
+     * one with a session_ticket extension (RFC 5077 3.4). */
+    RTLSHelloExt ext;
+    RTLSError e;
+    for (e = r_tls_hello_msg_extension_first (&hello, &ext); e == R_TLS_ERROR_OK;
+        e = r_tls_hello_msg_extension_next (&hello, &ext))
+      r_assert_cmpuint (ext.type, !=, R_TLS_EXT_TYPE_SESSION_TICKET);
+  }
+
+  r_assert_cmpint (r_tls_1_2_prf_sha256 (kb, sizeof (kb), ms, 48,
+        R_STR_WITH_SIZE_ARGS ("key expansion"),
+        srand, sizeof (srand), crand, sizeof (crand), NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmpptr ((ccipher = r_cipher_aes_128_cbc_new (kb + 40)), !=, NULL);
+  r_assert_cmpptr ((chmac = r_hmac_new (R_MSG_DIGEST_TYPE_SHA1, kb, 20)), !=, NULL);
+  r_assert_cmpptr ((scipher = r_cipher_aes_128_cbc_new (kb + 56)), !=, NULL);
+  r_assert_cmpptr ((shmac = r_hmac_new (R_MSG_DIGEST_TYPE_SHA1, kb + 20, 20)), !=, NULL);
+
+  hashsize = r_msg_digest_size (md);
+  r_assert (r_msg_digest_get_data (md, hash, hashsize, NULL));
+  r_assert_cmpint (r_tls_1_2_prf_sha256 (svd, sizeof (svd), ms, 48,
+        R_STR_WITH_SIZE_ARGS ("server finished"), hash, hashsize, NULL), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_parser_init_next (&parser, NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_CHANGE_CIPHER_SPEC);
+  r_assert_cmpuint (parser.epoch, ==, 0);
+
+  r_assert_cmpint (r_tls_parser_init_next (&parser, NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_HANDSHAKE);
+  r_assert_cmpuint (parser.epoch, ==, 1);
+  r_assert_cmpint (r_tls_parser_decrypt (&parser, scipher, shmac, FALSE), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_parser_parse_finished (&parser, &verify_data, &verify_size),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (verify_size, ==, 12);
+  r_assert_cmpint (r_memcmp (verify_data, svd, verify_size), ==, 0);
+  /* fold the server Finished so the client Finished covers it */
+  r_msg_digest_update (md, parser.fragment.data, parser.fragment.size);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+
+  hashsize = r_msg_digest_size (md);
+  r_assert (r_msg_digest_get_data (md, hash, hashsize, NULL));
+  r_assert_cmpint (r_tls_1_2_prf_sha256 (vd, sizeof (vd), ms, 48,
+        R_STR_WITH_SIZE_ARGS ("client finished"), hash, hashsize, NULL), ==, R_TLS_ERROR_OK);
+
+  /* client ChangeCipherSpec (epoch 0) + encrypted Finished (epoch 1, msg_seq 1) */
+  r_assert_cmpint (r_dtls_write_change_cipher (ccsbuf, sizeof (ccsbuf), &ccslen,
+        R_TLS_VERSION_DTLS_1_2, 0, 1), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_dtls_write_handshake (finbuf, sizeof (finbuf), &finhs,
+        R_TLS_VERSION_DTLS_1_2, R_TLS_HANDSHAKE_TYPE_FINISHED, sizeof (vd),
+        1, 0, 1, 0, sizeof (vd)), ==, R_TLS_ERROR_OK);
+  r_memcpy (finbuf + finhs, vd, sizeof (vd));
+  r_assert_cmpptr ((plain = r_buffer_new_wrapped (R_MEM_FLAG_NONE, finbuf,
+          finhs + sizeof (vd), finhs + sizeof (vd), 0, NULL, NULL)), !=, NULL);
+  r_prng_fill (prng, iv, sizeof (iv));
+  r_assert_cmpptr ((encbuf = r_dtls_encrypt_buffer (plain, ccipher, iv, chmac, FALSE)), !=, NULL);
+  r_buffer_unref (plain);
+
+  r_test_tls_server_feed (server, ccsbuf, ccslen);
+  r_assert (r_tls_server_incoming_data (server, encbuf));
+  r_buffer_unref (encbuf);
+
+  r_hmac_free (chmac);
+  r_hmac_free (shmac);
+  r_crypto_cipher_unref (ccipher);
+  r_crypto_cipher_unref (scipher);
+  r_memclear_secure (kb, sizeof (kb));
+  r_msg_digest_free (md);
+}
+
+/* End-to-end DTLS resumption: a full DTLS handshake issues a ticket, then a
+ * second server sharing the key store resumes from it through the abbreviated
+ * handshake (exercises the DTLS record-header transcript fold). */
+RTEST_F (rtlsserver, dtls_session_resume, RTEST_FAST)
+{
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RCryptoCipher * cipher = NULL;
+  RHmac * hmac = NULL;
+  RMsgDigest * hs_md = NULL;
+  RBuffer * buf;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  RTLSServer * srv2;
+  ruint8 ms[48], * ticket = NULL;
+  rsize ticketlen = 0;
+  RTLSHandshakeType hs;
+  ruint32 l;
+  ruint16 msgseq;
+
+  /* phase 1: full DTLS handshake issues a ticket */
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (fixture->server,
+        fixture->ticket_keys), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_test_tls_server_incoming_data (pkt_dtls_client_hallo);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert (r_buffer_map (buf, &info, R_MEM_MAP_READ));
+  r_test_tls_dtls_client_complete (fixture->server, fixture->prng,
+      pkt_dtls_client_hallo, sizeof (pkt_dtls_client_hallo), info.data, info.size,
+      TRUE, FALSE, &cipher, &hmac, &hs_md, ms);
+  r_buffer_unmap (buf, &info);
+  r_buffer_unref (buf);
+  r_assert (fixture->hs_done);
+
+  /* capture the issued ticket from the server's 2nd flight */
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_HANDSHAKE);
+  r_assert_cmpint (r_tls_parser_parse_handshake_full (&parser, &hs, &l,
+        &msgseq, NULL, NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmphex (hs, ==, R_TLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET);
+  {
+    ruint32 lifetime;
+    const ruint8 * tk;
+    ruint16 tksz;
+
+    r_assert_cmpint (r_tls_parser_parse_new_session_ticket (&parser, &lifetime,
+          &tk, &tksz), ==, R_TLS_ERROR_OK);
+    r_assert_cmpuint (tksz, >, 0);
+    ticket = r_memdup (tk, tksz);
+    ticketlen = tksz;
+  }
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+  r_msg_digest_free (hs_md);
+  r_hmac_free (hmac);
+  r_crypto_cipher_unref (cipher);
+
+  /* phase 2: resume on a second server sharing the key store */
+  fixture->hs_done = FALSE;
+  r_queue_clear (&fixture->qout, r_buffer_unref);
+  r_assert_cmpptr ((srv2 = r_test_tls_server_new_cfg (fixture)), !=, NULL);
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (srv2, fixture->ticket_keys),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (srv2, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  r_test_tls_dtls_client_resume (srv2, fixture->prng, &fixture->qout, ms, ticket, ticketlen);
+  r_assert (fixture->hs_done);
+  r_assert_cmphex (r_tls_server_get_version (srv2), ==, R_TLS_VERSION_DTLS_1_2);
+
+  r_free (ticket);
+  r_tls_server_unref (srv2);
+}
+RTEST_END;

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -55,6 +55,7 @@ const rchar testpkpem[] =
 RTEST_FIXTURE_STRUCT (rtlsserver)
 {
   RTLSServer * server;
+  RTLSSessionTicketKeys * ticket_keys;
   rboolean hs_done;
   rboolean got_error;
   RTLSAlertType last_alert;
@@ -132,10 +133,15 @@ RTEST_FIXTURE_SETUP (rtlsserver)
       r_tls_server_set_cert (fixture->server, cert, pk));
   r_crypto_key_unref (pk);
   r_crypto_cert_unref (cert);
+
+  /* Shared key store the ticket-issuing / resuming tests attach to a server;
+   * the fixture leaves it detached so the default server issues no tickets. */
+  r_assert_cmpptr ((fixture->ticket_keys = r_tls_session_ticket_keys_new ()), !=, NULL);
 }
 
 RTEST_FIXTURE_TEARDOWN (rtlsserver)
 {
+  r_tls_session_ticket_keys_unref (fixture->ticket_keys);
   r_tls_server_unref (fixture->server);
 
   r_queue_clear (&fixture->qout, r_buffer_unref);
@@ -450,6 +456,8 @@ RTEST_F (rtlsserver, dtls_srtp_valid_handshake, RTEST_FAST)
 
   r_assert_cmpint (r_tls_server_set_random (fixture->server, dtls_server_random),
       ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (fixture->server,
+        fixture->ticket_keys), ==, R_TLS_ERROR_OK);
   r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
       ==, R_TLS_ERROR_OK);
   r_assert (!fixture->hs_done);
@@ -660,6 +668,8 @@ RTEST_F (rtlsserver, dtls_session_ticket_extension_echoed, RTEST_FAST)
   ruint8 ch[256];
   rsize chlen;
 
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (fixture->server,
+        fixture->ticket_keys), ==, R_TLS_ERROR_OK);
   r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
       ==, R_TLS_ERROR_OK);
 
@@ -671,6 +681,25 @@ RTEST_F (rtlsserver, dtls_session_ticket_extension_echoed, RTEST_FAST)
 }
 RTEST_END;
 
+/* With no key store configured the server cannot seal a ticket, so even a
+ * ClientHello that offers session_ticket must not draw the extension. */
+RTEST_F (rtlsserver, dtls_session_ticket_no_keys_no_echo, RTEST_FAST)
+{
+  ruint8 ch[256];
+  rsize chlen;
+
+  /* deliberately no r_tls_server_set_session_ticket_keys */
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  chlen = r_test_tls_build_dtls_client_hello (fixture->prng, ch, sizeof (ch),
+      FALSE, FALSE, FALSE, TRUE, NULL, 0, TRUE);
+  r_test_tls_server_feed (fixture->server, ch, chlen);
+
+  r_test_tls_assert_session_ticket_ext (&fixture->qout, FALSE);
+}
+RTEST_END;
+
 /* A ClientHello that does not offer the session_ticket extension must not draw
  * one in the ServerHello. */
 RTEST_F (rtlsserver, dtls_session_ticket_extension_absent, RTEST_FAST)
@@ -678,6 +707,8 @@ RTEST_F (rtlsserver, dtls_session_ticket_extension_absent, RTEST_FAST)
   ruint8 ch[256];
   rsize chlen;
 
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (fixture->server,
+        fixture->ticket_keys), ==, R_TLS_ERROR_OK);
   r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
       ==, R_TLS_ERROR_OK);
 
@@ -1265,6 +1296,8 @@ RTEST_F (rtlsserver, tls_session_ticket_issued, RTEST_FAST)
   r_memcpy (ch + hssz, chbody, chbodylen);
   chlen = hssz + chbodylen;
 
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (fixture->server,
+        fixture->ticket_keys), ==, R_TLS_ERROR_OK);
   r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
       ==, R_TLS_ERROR_OK);
   r_test_tls_server_feed (fixture->server, ch, chlen);


### PR DESCRIPTION
Builds on the issue-side session tickets (#325): the server can now actually
resume from a ticket, which the previous per-instance ephemeral key made
impossible. Completes the resumption half of #219's session-ticket work.

## What it does
- **Shared key store.** A new refcounted `RTLSSessionTicketKeys` (created once,
  attached to any number of servers via `r_tls_server_set_session_ticket_keys`)
  seals and opens tickets with AES-128-GCM. Each ticket is
  `key_name || nonce || ciphertext || tag`, the key_name authenticated as AAD so
  the open side selects the key before decrypting. The sealed state gains an
  issued-at timestamp for expiry. A server with no store configured neither
  offers nor issues tickets (replacing the per-instance ephemeral key).
- **Abbreviated handshake.** When a ClientHello presents a ticket the server can
  open and accept, it recovers the master secret and parameters, derives fresh
  keys from new randoms, and runs the RFC 5077 abbreviated handshake —
  ServerHello (with a session id) + ChangeCipherSpec + Finished — skipping the
  Certificate and key exchange. Since the server Finished is sent first, the
  Finished writer reads the transcript hash without finalizing it and folds its
  own message back in for the later client-Finished verification.
- A ticket that cannot be opened, has expired, or is for a suite the ClientHello
  no longer offers is ignored and the server falls back to a full handshake.

## Validation
Resumption is refused on a version, cipher-suite, or extended-master-secret
mismatch (RFC 7627 5.3 downgrade), and no fresh ticket is promised in the
resumed ServerHello when none is sent (RFC 5077 3.4).

## Tests
TLS and DTLS resume round-trips (issue a real ticket, then resume on a second
server sharing the key store), verifying both Finished messages against an
independent transcript and asserting the negotiated parameters carry over;
plus fallbacks for an unopenable ticket and a suite no longer offered. Green
across the epoch/rpoll/ASan/UBSan/mingw matrix, leak- and UB-free.

## Deferred
No fresh ticket is re-issued on resumption (the original is reused until
expiry); single active key (the key_name reserves room for rotation); expiry
rejection is not yet covered by a deterministic test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)