### PR TITLE
net/tls: send RFC 5246 alerts matching the failure

### DIFF
--- a/include/rlib/net/proto/rtls.h
+++ b/include/rlib/net/proto/rtls.h
@@ -347,6 +347,7 @@ typedef enum {
   R_TLS_ERROR_INVALID_MAC                               = -0x0e, /**< Record MAC verification failed. */
   R_TLS_ERROR_HS_VERIFICATION_FAILED                    = -0x0f, /**< Handshake verify-data check failed. */
   R_TLS_ERROR_ENCRYPTION_FAILED                         = -0x10, /**< Record encryption failed. */
+  R_TLS_ERROR_RECORD_OVERFLOW                           = -0x11, /**< Record fragment length exceeds the limit. */
 } RTLSError;
 
 /** @brief TLS record compression method (only @c NULL is supported / non-deprecated). */

--- a/rlib/net/proto/rtls.c
+++ b/rlib/net/proto/rtls.c
@@ -159,7 +159,7 @@ r_tls_parser_init_buffer (RTLSParser * parser, RBuffer * buf)
   }
 
   if ((fraglen & 0xc000) > 0) {
-    ret = R_TLS_ERROR_CORRUPT_RECORD;
+    ret = R_TLS_ERROR_RECORD_OVERFLOW;
     goto beach;
   }
   if (!r_buffer_map_byte_range (buf, parser->offset, (rssize)fraglen,

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -1023,7 +1023,9 @@ r_tls_client_incoming_data (RTLSClient * client, RBuffer * buffer)
     r_tls_client_state_appdata,
     r_tls_client_state_error,
   };
-  RTLSParser parser;
+  /* Zero-init: a record that fails init_buffer never sets parser.buf, and the
+   * post-loop r_tls_parser_clear must not free an uninitialised pointer. */
+  RTLSParser parser = R_TLS_PARSER_INIT;
   RTLSError err;
 
   if (R_UNLIKELY (client == NULL)) return FALSE;

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -1581,7 +1581,9 @@ r_tls_server_incoming_data (RTLSServer * server, RBuffer * buffer)
 
     r_tls_server_state_error,
   };
-  RTLSParser parser;
+  /* Zero-init: a record that fails init_buffer never sets parser.buf, and the
+   * post-loop r_tls_parser_clear must not free an uninitialised pointer. */
+  RTLSParser parser = R_TLS_PARSER_INIT;
   RTLSError err;
 
   if (R_UNLIKELY (server == NULL)) return FALSE;

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -1245,6 +1245,8 @@ r_tls_server_alert_for_error (RTLSError err)
     case R_TLS_ERROR_INVALID_RECORD:    /* malformed / out-of-spec message */
     case R_TLS_ERROR_CORRUPT_RECORD:
       return R_TLS_ALERT_TYPE_DECODE_ERROR;
+    case R_TLS_ERROR_RECORD_OVERFLOW:   /* fragment longer than the limit */
+      return R_TLS_ALERT_TYPE_RECORD_OVERFLOW;
     case R_TLS_ERROR_HS_VERIFICATION_FAILED:  /* could not verify Finished */
       return R_TLS_ALERT_TYPE_DECRYPT_ERROR;
     case R_TLS_ERROR_VERSION:
@@ -1655,6 +1657,18 @@ r_tls_server_incoming_data (RTLSServer * server, RBuffer * buffer)
   if (err >= R_TLS_ERROR_OK) {
     r_tls_server_send_out (server);
   } else {
+    /* A negative err here is a record-layer framing failure from
+     * init_buffer / init_next (a per-message error already sent its own alert
+     * and left err non-negative via the loop's re-init). BUF_TOO_SMALL just
+     * means the record is incomplete -- buffer it and wait for more. Otherwise
+     * surface the matching fatal alert, unless the session already failed. */
+    if (err != R_TLS_ERROR_BUF_TOO_SMALL && server->state != R_TLS_SERVER_ERROR) {
+      /* The failing record never reached the in-loop recordver update; take the
+       * version the parser read so the alert is framed correctly. */
+      if (parser.version != 0)
+        server->recordver = parser.version;
+      r_tls_server_send_alert (server, r_tls_server_alert_for_error (err));
+    }
     if (server->inbuf != NULL) {
       r_buffer_unref (server->inbuf);
       server->inbuf = NULL;

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -1225,6 +1225,34 @@ r_tls_server_send_alert (RTLSServer * server, RTLSAlertType alert)
   r_tls_server_change_state (server, R_TLS_SERVER_ERROR);
 }
 
+/* Map a handshake error to the alert the peer should receive (RFC 5246 7.2.2).
+ * Errors that reflect a local failure rather than peer behaviour (OOM, bad
+ * arguments, encryption failure) fall through to internal_error. */
+static RTLSAlertType
+r_tls_server_alert_for_error (RTLSError err)
+{
+  switch (err) {
+    case R_TLS_ERROR_WRONG_TYPE:        /* message out of turn for its type */
+    case R_TLS_ERROR_WRONG_STATE:       /* message arrived in the wrong state */
+      return R_TLS_ALERT_TYPE_UNEXPECTED_MESSAGE;
+    case R_TLS_ERROR_INVALID_MAC:       /* record MAC / AEAD tag check failed */
+      return R_TLS_ALERT_TYPE_BAD_RECORD_MAC;
+    case R_TLS_ERROR_NO_CERTIFICATE:    /* required client certificate missing */
+    case R_TLS_ERROR_HANDSHAKE_FAILURE:
+      return R_TLS_ALERT_TYPE_HANDSHAKE_FAILURE;
+    case R_TLS_ERROR_CORRUPT_CERTIFICATE:
+      return R_TLS_ALERT_TYPE_BAD_CERTIFICATE;
+    case R_TLS_ERROR_INVALID_RECORD:    /* malformed / out-of-spec message */
+    case R_TLS_ERROR_CORRUPT_RECORD:
+      return R_TLS_ALERT_TYPE_DECODE_ERROR;
+    case R_TLS_ERROR_HS_VERIFICATION_FAILED:  /* could not verify Finished */
+      return R_TLS_ALERT_TYPE_DECRYPT_ERROR;
+    case R_TLS_ERROR_VERSION:
+      return R_TLS_ALERT_TYPE_PROTOCOL_VERSION;
+    default:
+      return R_TLS_ALERT_TYPE_INTERNAL_ERROR;
+  }
+}
 
 static RTLSError
 r_tls_server_state_error (RTLSServer * server, const RTLSParser * parser)
@@ -1341,7 +1369,6 @@ r_tls_server_state_hello (RTLSServer * server, const RTLSParser * parser)
           R_TLS_SERVER_CHANGE_CIPHER : R_TLS_SERVER_CERTIFICATE);
   }
 
-  /* FIXME: Add proper alert codes for error scenarios */
   switch (err) {
     case R_TLS_ERROR_OK:
       R_LOG_TRACE ("Updating HS hash with ClientHello %u bytes",
@@ -1371,21 +1398,8 @@ r_tls_server_state_hello (RTLSServer * server, const RTLSParser * parser)
       if (r_tls_server_write_hello_done (server) == R_TLS_ERROR_OK)
         server->server.msgseq++;
       break;
-    case R_TLS_ERROR_WRONG_TYPE:
-      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_UNEXPECTED_MESSAGE);
-      break;
-    case R_TLS_ERROR_CORRUPT_RECORD:
-      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_DECODE_ERROR);
-      break;
-    case R_TLS_ERROR_HANDSHAKE_FAILURE:
-      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_HANDSHAKE_FAILURE);
-      break;
-    case R_TLS_ERROR_VERSION:
-      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_PROTOCOL_VERSION);
-      break;
-    case R_TLS_ERROR_WRONG_STATE:
     default:
-      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_INTERNAL_ERROR);
+      r_tls_server_send_alert (server, r_tls_server_alert_for_error (err));
       break;
   }
 
@@ -1418,23 +1432,11 @@ r_tls_server_state_certificate (RTLSServer * server, const RTLSParser * parser)
       R_LOG_TRACE ("Updating HS hash with ClientCertificate %u bytes",
           (ruint)parser->fragment.size);
       r_msg_digest_update (server->hshash, parser->fragment.data, parser->fragment.size);
+      break;
     case R_TLS_ERROR_NOT_NEEDED:
       break;
-    case R_TLS_ERROR_NO_CERTIFICATE:
-      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_NO_CERTIFICATE);
-      break;
-    case R_TLS_ERROR_CORRUPT_CERTIFICATE:
-      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_BAD_CERTIFICATE);
-      break;
-    case R_TLS_ERROR_INVALID_MAC:
-      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_BAD_CERTIFICATE_HASH_VALUE);
-      break;
-    case R_TLS_ERROR_CORRUPT_RECORD:
-      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_DECODE_ERROR);
-      break;
-    case R_TLS_ERROR_WRONG_STATE:
     default:
-      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_INTERNAL_ERROR);
+      r_tls_server_send_alert (server, r_tls_server_alert_for_error (err));
       break;
   }
 
@@ -1450,7 +1452,6 @@ r_tls_server_state_key_exchange (RTLSServer * server, const RTLSParser * parser)
   if ((err = r_tls_server_parse_client_key_exchange (server, parser, pms)) == R_TLS_ERROR_OK)
     err = r_tls_server_change_state (server, R_TLS_SERVER_CHANGE_CIPHER);
 
-  /* FIXME: Add proper alert codes for error scenarios */
   switch (err) {
     case R_TLS_ERROR_OK:
       R_LOG_TRACE ("Updating HS hash with ClientKeyExchange %u bytes",
@@ -1461,12 +1462,8 @@ r_tls_server_state_key_exchange (RTLSServer * server, const RTLSParser * parser)
           (err = r_tls_server_expand_master_secret (server)) != R_TLS_ERROR_OK)
         r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_INTERNAL_ERROR);
       break;
-    case R_TLS_ERROR_CORRUPT_RECORD:
-      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_DECODE_ERROR);
-      break;
-    case R_TLS_ERROR_WRONG_STATE:
     default:
-      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_INTERNAL_ERROR);
+      r_tls_server_send_alert (server, r_tls_server_alert_for_error (err));
       break;
   }
 
@@ -1484,7 +1481,6 @@ r_tls_server_state_change_cipher (RTLSServer * server, const RTLSParser * parser
   else
     err = R_TLS_ERROR_WRONG_TYPE;
 
-  /* FIXME: Add proper alert codes for error scenarios */
   switch (err) {
     case R_TLS_ERROR_OK:
       /* enable cipher */
@@ -1493,12 +1489,8 @@ r_tls_server_state_change_cipher (RTLSServer * server, const RTLSParser * parser
       server->client.epoch++;
       server->client.seqno = 0;
       break;
-    case R_TLS_ERROR_CORRUPT_RECORD:
-      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_DECODE_ERROR);
-      break;
-    case R_TLS_ERROR_WRONG_STATE:
     default:
-      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_INTERNAL_ERROR);
+      r_tls_server_send_alert (server, r_tls_server_alert_for_error (err));
       break;
   }
 
@@ -1536,19 +1528,8 @@ r_tls_server_state_finished (RTLSServer * server, const RTLSParser * parser)
       if (server->cb.handshake_done != NULL)
         server->cb.handshake_done (server->userdata, server);
       break;
-    case R_TLS_ERROR_HANDSHAKE_FAILURE:
-    case R_TLS_ERROR_HS_VERIFICATION_FAILED:
-      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_HANDSHAKE_FAILURE);
-      break;
-    case R_TLS_ERROR_CORRUPT_RECORD:
-      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_DECODE_ERROR);
-      break;
-    case R_TLS_ERROR_WRONG_TYPE:
-      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_UNEXPECTED_MESSAGE);
-      break;
-    case R_TLS_ERROR_WRONG_STATE:
     default:
-      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_INTERNAL_ERROR);
+      r_tls_server_send_alert (server, r_tls_server_alert_for_error (err));
       break;
   }
 
@@ -1631,8 +1612,12 @@ r_tls_server_incoming_data (RTLSServer * server, RBuffer * buffer)
     if (!r_tls_parser_is_dtls (&parser) || parser.epoch == server->client.epoch) {
       if ((err = server->decrypt (&parser, server->client.cipher, server->client.hmac,
               server->encrypt_then_mac)) != R_TLS_ERROR_OK) {
-        /* A record that fails decrypt / MAC must not be processed. */
+        /* A record that fails decrypt / MAC must not be processed. TLS reports
+         * it as fatal bad_record_mac (RFC 5246 7.2.2); DTLS silently discards
+         * the record and keeps the association (RFC 6347 4.1.2.7). */
         R_LOG_WARNING ("Decryption returned: %d", err);
+        if (!r_tls_parser_is_dtls (&parser))
+          r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_BAD_RECORD_MAC);
         continue;
       }
     }

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -2230,3 +2230,37 @@ RTEST_F (rtlsserver, dtls_bad_record_silently_discarded, RTEST_FAST)
   r_memclear_secure (ms, sizeof (ms));
 }
 RTEST_END;
+
+/* A record whose fragment length exceeds the 2^14 limit is rejected at the
+ * record layer with a fatal record_overflow (RFC 5246 7.2.2). */
+RTEST_F (rtlsserver, tls_alert_record_overflow, RTEST_FAST)
+{
+  /* TLS 1.2 handshake record header claiming a 0x4000-byte fragment. */
+  static const ruint8 pkt[] = { 0x16, 0x03, 0x03, 0x40, 0x00 };
+  RBuffer * buf;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSAlertLevel alevel;
+  RTLSAlertType atype;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  /* A record-layer framing failure is fatal, so incoming_data reports it. */
+  r_assert_cmpptr ((buf = r_buffer_new_wrapped (R_MEM_FLAG_NONE, (rpointer)pkt,
+          sizeof (pkt), sizeof (pkt), 0, NULL, NULL)), !=, NULL);
+  r_assert (!r_tls_server_incoming_data (fixture->server, buf));
+  r_buffer_unref (buf);
+
+  r_assert (fixture->got_error);
+  r_assert_cmpuint (fixture->last_alert, ==, R_TLS_ALERT_TYPE_RECORD_OVERFLOW);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_ALERT);
+  r_assert_cmpint (r_tls_parser_parse_alert (&parser, &alevel, &atype), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (alevel, ==, R_TLS_ALERT_LEVEL_FATAL);
+  r_assert_cmpuint (atype, ==, R_TLS_ALERT_TYPE_RECORD_OVERFLOW);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+}
+RTEST_END;

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -2044,3 +2044,189 @@ RTEST_F (rtlsserver, dtls_session_resume, RTEST_FAST)
   r_tls_server_unref (srv2);
 }
 RTEST_END;
+
+/* How r_test_tls_drive_bad_finished should break the client Finished. */
+typedef enum {
+  R_TEST_FIN_BAD_VERIFY,   /* valid record, wrong verify_data -> decrypt_error */
+  R_TEST_FIN_BAD_MAC,      /* tampered ciphertext -> bad_record_mac */
+} RTestFinBreak;
+
+/* Drive a TLS 1.2 RSA handshake against @server up to the client Finished, then
+ * send a deliberately broken Finished so the server emits the corresponding
+ * fatal alert (asserted by the caller via the fixture's error callback). */
+static void
+r_test_tls_drive_bad_finished (RTLSServer * server, RPrng * prng, RQueue * qout,
+    RTestFinBreak how)
+{
+  RCryptoKey * pk;
+  RMsgDigest * md;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSHelloMsg hello;
+  RBuffer * buf, * plain, * enc;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  RCryptoCipher * ccipher;
+  RHmac * chmac;
+  ruint8 ch[256], rec[128];
+  ruint8 crand[R_TLS_HELLO_RANDOM_BYTES], srand[R_TLS_HELLO_RANDOM_BYTES];
+  ruint8 pms[48], ms[48], kb[128], vd[12], iv[16], sh[64];
+  ruint8 encpms[512], cke[512], fin[64], ccs[16];
+  rsize chlen, hssz, enclen = sizeof (encpms), ckelen, finhs, ccslen, shlen;
+
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem, -1, NULL, 0)), !=, NULL);
+  r_assert_cmpptr ((md = r_msg_digest_new_sha256 ()), !=, NULL);
+
+  chlen = r_test_tls_build_client_hello (prng, ch, sizeof (ch),
+      R_TLS_CS_RSA_WITH_AES_128_CBC_SHA, NULL, 0, crand);
+  r_test_tls_server_feed (server, ch, chlen);
+  r_test_tls_hash_record (md, ch, chlen);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_msg_digest_update (md, parser.fragment.data, parser.fragment.size);
+  r_assert_cmpint (r_tls_parser_parse_hello (&parser, &hello), ==, R_TLS_ERROR_OK);
+  r_memcpy (srand, hello.random, sizeof (srand));
+  while (r_tls_parser_init_next (&parser, NULL) == R_TLS_ERROR_OK)
+    r_msg_digest_update (md, parser.fragment.data, parser.fragment.size);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+
+  pms[0] = 0x03; pms[1] = 0x03;
+  r_prng_fill (prng, pms + 2, sizeof (pms) - 2);
+  r_assert_cmpint (r_crypto_key_encrypt (pk, prng, pms, sizeof (pms), encpms, &enclen),
+      ==, R_CRYPTO_OK);
+  r_assert_cmpint (r_tls_write_handshake (cke, sizeof (cke), &hssz, R_TLS_VERSION_TLS_1_2,
+        R_TLS_HANDSHAKE_TYPE_CLIENT_KEY_EXCHANGE, (ruint16)(2 + enclen)), ==, R_TLS_ERROR_OK);
+  r_store_be16 (cke + hssz, (ruint16)enclen);
+  r_memcpy (cke + hssz + 2, encpms, enclen);
+  ckelen = hssz + 2 + enclen;
+  r_test_tls_hash_record (md, cke, ckelen);
+
+  shlen = r_msg_digest_size (md);
+  r_assert (r_msg_digest_get_data (md, sh, shlen, NULL));
+  r_assert_cmpint (r_tls_1_2_prf_sha256 (ms, 48, pms, sizeof (pms),
+        R_STR_WITH_SIZE_ARGS ("master secret"),
+        crand, sizeof (crand), srand, sizeof (srand), NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_1_2_prf_sha256 (kb, sizeof (kb), ms, 48,
+        R_STR_WITH_SIZE_ARGS ("key expansion"),
+        srand, sizeof (srand), crand, sizeof (crand), NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_1_2_prf_sha256 (vd, sizeof (vd), ms, 48,
+        R_STR_WITH_SIZE_ARGS ("client finished"), sh, shlen, NULL), ==, R_TLS_ERROR_OK);
+
+  /* A wrong verify_data still MACs and decrypts cleanly, so the server reaches
+   * the Finished check and rejects it with decrypt_error. */
+  if (how == R_TEST_FIN_BAD_VERIFY)
+    vd[0] ^= 0xff;
+
+  r_assert_cmpptr ((ccipher = r_cipher_aes_128_cbc_new (kb + 40)), !=, NULL);
+  r_assert_cmpptr ((chmac = r_hmac_new (R_MSG_DIGEST_TYPE_SHA1, kb, 20)), !=, NULL);
+  r_assert_cmpint (r_tls_write_handshake (fin, sizeof (fin), &finhs, R_TLS_VERSION_TLS_1_2,
+        R_TLS_HANDSHAKE_TYPE_FINISHED, sizeof (vd)), ==, R_TLS_ERROR_OK);
+  r_memcpy (fin + finhs, vd, sizeof (vd));
+  r_assert_cmpptr ((plain = r_buffer_new_wrapped (R_MEM_FLAG_NONE, fin,
+          finhs + sizeof (vd), finhs + sizeof (vd), 0, NULL, NULL)), !=, NULL);
+  r_prng_fill (prng, iv, sizeof (iv));
+  r_assert_cmpptr ((enc = r_tls_encrypt_buffer (plain, 0, ccipher, iv, chmac, FALSE)), !=, NULL);
+  r_buffer_unref (plain);
+
+  r_assert_cmpint (r_tls_write_change_cipher (ccs, sizeof (ccs), &ccslen,
+        R_TLS_VERSION_TLS_1_2), ==, R_TLS_ERROR_OK);
+  r_test_tls_server_feed (server, cke, ckelen);
+  r_test_tls_server_feed (server, ccs, ccslen);
+
+  r_assert (r_buffer_map (enc, &info, R_MEM_MAP_READ));
+  r_assert_cmpuint (info.size, <=, sizeof (rec));
+  r_memcpy (rec, info.data, info.size);
+  /* Flipping a ciphertext byte breaks the record MAC -> bad_record_mac. */
+  if (how == R_TEST_FIN_BAD_MAC)
+    rec[info.size - 1] ^= 0xff;
+  r_test_tls_server_feed (server, rec, info.size);
+  r_buffer_unmap (enc, &info);
+  r_buffer_unref (enc);
+
+  r_hmac_free (chmac);
+  r_crypto_cipher_unref (ccipher);
+  r_memclear_secure (pms, sizeof (pms));
+  r_memclear_secure (ms, sizeof (ms));
+  r_memclear_secure (kb, sizeof (kb));
+  r_msg_digest_free (md);
+  r_crypto_key_unref (pk);
+}
+
+/* A client Finished that decrypts cleanly but carries the wrong verify_data is
+ * a failed handshake cryptographic check -> decrypt_error (RFC 5246 7.2.2). */
+RTEST_F (rtlsserver, tls_alert_finished_decrypt_error, RTEST_FAST)
+{
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  r_test_tls_drive_bad_finished (fixture->server, fixture->prng, &fixture->qout,
+      R_TEST_FIN_BAD_VERIFY);
+
+  r_assert (fixture->got_error);
+  r_assert (!fixture->hs_done);
+  r_assert_cmpuint (fixture->last_alert, ==, R_TLS_ALERT_TYPE_DECRYPT_ERROR);
+}
+RTEST_END;
+
+/* A TLS record that fails decryption / MAC is fatal: bad_record_mac. */
+RTEST_F (rtlsserver, tls_alert_bad_record_mac, RTEST_FAST)
+{
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  r_test_tls_drive_bad_finished (fixture->server, fixture->prng, &fixture->qout,
+      R_TEST_FIN_BAD_MAC);
+
+  r_assert (fixture->got_error);
+  r_assert (!fixture->hs_done);
+  r_assert_cmpuint (fixture->last_alert, ==, R_TLS_ALERT_TYPE_BAD_RECORD_MAC);
+}
+RTEST_END;
+
+/* Unlike TLS, a DTLS record that fails decryption / MAC is silently discarded
+ * and the association survives (RFC 6347 4.1.2.7): no alert, no error. */
+RTEST_F (rtlsserver, dtls_bad_record_silently_discarded, RTEST_FAST)
+{
+  RCryptoCipher * cipher = NULL;
+  RHmac * hmac = NULL;
+  RMsgDigest * hs_md = NULL;
+  RBuffer * buf;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  ruint8 ms[48];
+  /* DTLS application_data record, epoch 1, seqno 1, with a 32-byte body that
+   * is not a valid ciphertext under the negotiated keys. */
+  ruint8 rec[13 + 32];
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_test_tls_server_incoming_data (pkt_dtls_client_hallo);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert (r_buffer_map (buf, &info, R_MEM_MAP_READ));
+  r_test_tls_dtls_client_complete (fixture->server, fixture->prng,
+      pkt_dtls_client_hallo, sizeof (pkt_dtls_client_hallo), info.data, info.size,
+      TRUE, FALSE, &cipher, &hmac, &hs_md, ms);
+  r_buffer_unmap (buf, &info);
+  r_buffer_unref (buf);
+  r_assert (fixture->hs_done);
+  r_msg_digest_free (hs_md);
+  r_hmac_free (hmac);
+  r_crypto_cipher_unref (cipher);
+
+  /* Drain the server's flight, then feed the bogus epoch-1 record. */
+  r_queue_clear (&fixture->qout, r_buffer_unref);
+  r_memset (rec, 0, sizeof (rec));
+  rec[0] = R_TLS_CONTENT_TYPE_APPLICATION_DATA;
+  rec[1] = 0xfe; rec[2] = 0xfd;              /* DTLS 1.2 */
+  rec[3] = 0x00; rec[4] = 0x01;              /* epoch 1 */
+  rec[10] = 0x01;                            /* sequence number 1 (48-bit) */
+  rec[11] = 0x00; rec[12] = 0x20;            /* length 32 */
+  r_memset (rec + 13, 0xab, 32);             /* garbage ciphertext */
+  r_test_tls_server_feed (fixture->server, rec, sizeof (rec));
+
+  r_assert (!fixture->got_error);
+  r_assert_cmpptr (r_test_tls_server_queue_agg (&fixture->qout), ==, NULL);
+
+  r_memclear_secure (ms, sizeof (ms));
+}
+RTEST_END;


### PR DESCRIPTION
Audits the server's error-to-alert behaviour against RFC 5246 §7.2.2 and fixes
the cases that sent a wrong, over-generic, or missing alert.

## Alert mapping
Centralised in one `alert_for_error()` helper that every state's failure path
routes through, so the peer always sees the alert that matches the failure:
- a Finished that fails to verify -> `decrypt_error` (was `handshake_failure`);
- a message arriving in the wrong state -> `unexpected_message` (was `internal_error`);
- a record MAC failure -> `bad_record_mac` (was a misplaced `bad_certificate_hash_value`);
- a missing required client certificate -> `handshake_failure` (was the SSLv3-reserved `no_certificate`).

## Record layer
- A record failing decryption/MAC now sends a fatal `bad_record_mac` on TLS
  (RFC 5246 §7.2.2); DTLS keeps silently discarding it (RFC 6347 §4.1.2.7).
- A record that fails the framing checks (over-length, malformed, bad content
  type) previously dropped silently with no alert; it now draws
  `record_overflow` (over-length, via a dedicated `R_TLS_ERROR_RECORD_OVERFLOW`)
  or `decode_error`.

## Latent crash fixed
Exercising the first-record framing-failure path exposed an uninitialised
`RTLSParser` in both the server and client incoming-data loops: a record that
fails `init_buffer` never sets `parser.buf`, so the post-loop
`r_tls_parser_clear()` freed stack garbage. Both loops now zero-initialise the
parser. (Crashed in plain builds, masked under ASan; never reached before
because nothing fed a first record that fails framing.)

## Tests
New per-scenario assertions on the exact alert byte (or silence, for DTLS):
bad Finished -> decrypt_error, tampered TLS record -> bad_record_mac, DTLS bad
record -> silently discarded, over-length record -> record_overflow. Green
across the epoll/rpoll/ASan/UBSan/mingw matrix, leak- and UB-free.

## Not covered (tracked separately)
Alerts that need detection we don't have yet: `no_renegotiation` /
`illegal_parameter` (#330), certificate alerts + CertificateVerify `decrypt_error`
(mTLS, #219), `inappropriate_fallback` / version completeness (multi-version /
TLS 1.3, #329).

🤖 Generated with [Claude Code](https://claude.com/claude-code)