### PR TITLE
net/tls: mutual TLS (client-certificate authentication)

### DIFF
--- a/include/rlib/net/proto/rtls.h
+++ b/include/rlib/net/proto/rtls.h
@@ -745,6 +745,53 @@ R_API RTLSError r_tls_write_hs_new_session_ticket (rpointer buf, rsize size, rsi
 /** @brief DTLS alias for @ref r_tls_write_hs_new_session_ticket. */
 #define r_dtls_write_hs_new_session_ticket r_tls_write_hs_new_session_ticket
 
+/**
+ * @brief Write a CertificateRequest handshake-message body into @p buf.
+ * @param buf Destination buffer.
+ * @param size Capacity of @p buf in bytes.
+ * @param out Out: bytes written.
+ * @param certtypes Accepted certificate types (@ref RTLSClientCertificateType).
+ * @param ncerttypes Number of certificate types.
+ * @param signschemes Accepted signature schemes (@ref RTLSSignatureScheme).
+ * @param nsignschemes Number of signature schemes.
+ * @param ca Concatenated accepted-CA distinguished names, or @c NULL.
+ * @param casize Length of @p ca in bytes (0 for an empty CA list).
+ */
+R_API RTLSError r_tls_write_hs_certificate_request (rpointer buf, rsize size, rsize * out,
+    const ruint8 * certtypes, ruint8 ncerttypes,
+    const RTLSSignatureScheme * signschemes, ruint16 nsignschemes,
+    const ruint8 * ca, ruint16 casize);
+/** @brief DTLS alias for @ref r_tls_write_hs_certificate_request. */
+#define r_dtls_write_hs_certificate_request r_tls_write_hs_certificate_request
+
+/**
+ * @brief Write a CertificateVerify handshake-message body into @p buf.
+ * @param buf Destination buffer.
+ * @param size Capacity of @p buf in bytes.
+ * @param out Out: bytes written.
+ * @param sigscheme Signature scheme of @p sig (@ref RTLSSignatureScheme).
+ * @param sig Signature bytes.
+ * @param sigsize Signature length in bytes.
+ */
+R_API RTLSError r_tls_write_hs_certificate_verify (rpointer buf, rsize size, rsize * out,
+    RTLSSignatureScheme sigscheme, const ruint8 * sig, ruint16 sigsize);
+/** @brief DTLS alias for @ref r_tls_write_hs_certificate_verify. */
+#define r_dtls_write_hs_certificate_verify r_tls_write_hs_certificate_verify
+
+/**
+ * @brief Write a Certificate handshake-message body carrying a single
+ * end-entity certificate (or an empty list when @p der is @c NULL).
+ * @param buf Destination buffer.
+ * @param size Capacity of @p buf in bytes.
+ * @param out Out: bytes written.
+ * @param der DER-encoded certificate, or @c NULL for an empty Certificate.
+ * @param dersize Length of @p der in bytes.
+ */
+R_API RTLSError r_tls_write_hs_certificate (rpointer buf, rsize size, rsize * out,
+    const ruint8 * der, rsize dersize);
+/** @brief DTLS alias for @ref r_tls_write_hs_certificate. */
+#define r_dtls_write_hs_certificate r_tls_write_hs_certificate
+
 
 /** @brief Write a TLS ChangeCipherSpec record into @p data. */
 R_API RTLSError r_tls_write_change_cipher (rpointer data, rsize size,

--- a/include/rlib/net/rtlsclient.h
+++ b/include/rlib/net/rtlsclient.h
@@ -73,6 +73,16 @@ R_API RTLSClient * r_tls_client_new (const RTLSCallbacks * cb,
 /** @brief Drop a reference (alias for @ref r_ref_unref). */
 #define r_tls_client_unref  r_ref_unref
 
+/**
+ * @brief Set the client certificate and private key for mutual TLS.
+ *
+ * When the server sends a CertificateRequest the client presents @p cert and
+ * proves possession of it with @p privkey; without this the client answers a
+ * CertificateRequest with an empty certificate. RSA keys with
+ * rsa_pkcs1_sha256 are supported.
+ */
+R_API RTLSError r_tls_client_set_cert (RTLSClient * client,
+    RCryptoCert * cert, RCryptoKey * privkey);
 /** @brief Override the client-random (testing / determinism). */
 R_API RTLSError r_tls_client_set_random (RTLSClient * client,
     const ruint8 clirandom[R_TLS_HELLO_RANDOM_BYTES]);

--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -95,8 +95,12 @@ typedef void (*RTLSErrorCb) (rpointer ctx, RTLSAlertType alert, rpointer session
  * and for verifying out of band (e.g. SDP fingerprint) after the
  * handshake. The certificates are borrowed; do not unref them.
  *
- * Used by @ref RTLSClient to validate the server certificate (and, in
- * future, by the server for client-certificate / mTLS checks).
+ * Used by @ref RTLSClient to validate the server certificate, and by the
+ * server to validate a client certificate under mutual TLS (see
+ * @ref r_tls_server_set_client_cert_mode). This callback is the trust
+ * decision: the library only checks proof-of-possession (the
+ * CertificateVerify signature), so a @c NULL callback authenticates any
+ * well-formed certificate.
  */
 typedef rboolean (*RTLSCertVerifyCb) (rpointer ctx, RCryptoCert * const * chain, ruint count);
 
@@ -118,9 +122,36 @@ R_API RTLSServer * r_tls_server_new (const RTLSCallbacks * cb,
 /** @brief Drop a reference (alias for @ref r_ref_unref). */
 #define r_tls_server_unref  r_ref_unref
 
+/**
+ * @brief Client-certificate (mutual-TLS) policy.
+ *
+ * Selects whether the server asks the client for a certificate and whether one
+ * is mandatory. When a certificate is presented it is delivered to the
+ * @ref RTLSCertVerifyCb for validation and its CertificateVerify signature is
+ * checked; the verified leaf is then available via
+ * @ref r_tls_server_get_peer_cert.
+ */
+typedef enum {
+  R_TLS_CLIENT_CERT_MODE_NONE = 0,   /**< Do not request a client certificate (default). */
+  R_TLS_CLIENT_CERT_MODE_REQUEST,    /**< Request one; an empty/absent certificate is accepted. */
+  R_TLS_CLIENT_CERT_MODE_REQUIRE,    /**< Require one; an empty/absent certificate aborts the handshake. */
+} RTLSClientCertMode;
+
 /** @brief Set the server certificate and its private key. */
 R_API RTLSError r_tls_server_set_cert (RTLSServer * server,
     RCryptoCert * cert, RCryptoKey * privkey);
+/**
+ * @brief Set the client-certificate (mutual-TLS) policy; defaults to
+ * @ref R_TLS_CLIENT_CERT_MODE_NONE. Must be set before the handshake starts.
+ */
+R_API RTLSError r_tls_server_set_client_cert_mode (RTLSServer * server,
+    RTLSClientCertMode mode);
+/**
+ * @brief The peer (client) leaf certificate presented during a mutual-TLS
+ * handshake, or @c NULL if none was presented. The reference is borrowed
+ * (owned by the session); ref it to outlive the session.
+ */
+R_API RCryptoCert * r_tls_server_get_peer_cert (const RTLSServer * server);
 /**
  * @brief Attach the shared key store used to seal and open session tickets.
  *

--- a/rlib/net/proto/rtls.c
+++ b/rlib/net/proto/rtls.c
@@ -1406,6 +1406,86 @@ r_tls_write_hs_new_session_ticket (rpointer data, rsize size, rsize * out,
 }
 
 RTLSError
+r_tls_write_hs_certificate_request (rpointer data, rsize size, rsize * out,
+    const ruint8 * certtypes, ruint8 ncerttypes,
+    const RTLSSignatureScheme * signschemes, ruint16 nsignschemes,
+    const ruint8 * ca, ruint16 casize)
+{
+  ruint8 * p = data;
+  rsize need = sizeof (ruint8) + (rsize)ncerttypes +
+      sizeof (ruint16) + (rsize)nsignschemes * sizeof (ruint16) +
+      sizeof (ruint16) + (rsize)casize;
+  ruint16 i;
+
+  if (R_UNLIKELY (data == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (size < need)) return R_TLS_ERROR_BUF_TOO_SMALL;
+
+  *p++ = ncerttypes;
+  if (ncerttypes > 0) { r_memcpy (p, certtypes, ncerttypes); p += ncerttypes; }
+
+  r_store_be16 (p, (ruint16)(nsignschemes * sizeof (ruint16))); p += sizeof (ruint16);
+  for (i = 0; i < nsignschemes; i++) {
+    r_store_be16 (p, (ruint16)signschemes[i]); p += sizeof (ruint16);
+  }
+
+  r_store_be16 (p, casize); p += sizeof (ruint16);
+  if (casize > 0) { r_memcpy (p, ca, casize); p += casize; }
+
+  if (out != NULL)
+    *out = need;
+
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_write_hs_certificate_verify (rpointer data, rsize size, rsize * out,
+    RTLSSignatureScheme sigscheme, const ruint8 * sig, ruint16 sigsize)
+{
+  ruint8 * p = data;
+  rsize need = sizeof (ruint16) + sizeof (ruint16) + (rsize)sigsize;
+
+  if (R_UNLIKELY (data == NULL || sig == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (size < need)) return R_TLS_ERROR_BUF_TOO_SMALL;
+
+  r_store_be16 (p, (ruint16)sigscheme); p += sizeof (ruint16);
+  r_store_be16 (p, sigsize); p += sizeof (ruint16);
+  r_memcpy (p, sig, sigsize);
+
+  if (out != NULL)
+    *out = need;
+
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_write_hs_certificate (rpointer data, rsize size, rsize * out,
+    const ruint8 * der, rsize dersize)
+{
+  ruint8 * p = data;
+  rsize entrylen = (der != NULL && dersize > 0) ? (3 + dersize) : 0;
+  rsize need = 3 + entrylen;
+
+  if (R_UNLIKELY (data == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (size < need)) return R_TLS_ERROR_BUF_TOO_SMALL;
+
+  /* certificate_list<0..2^24-1> */
+  *p++ = (ruint8)((entrylen >> 16) & 0xff);
+  *p++ = (ruint8)((entrylen >>  8) & 0xff);
+  *p++ = (ruint8)((entrylen      ) & 0xff);
+  if (entrylen > 0) {
+    *p++ = (ruint8)((dersize >> 16) & 0xff);
+    *p++ = (ruint8)((dersize >>  8) & 0xff);
+    *p++ = (ruint8)((dersize      ) & 0xff);
+    r_memcpy (p, der, dersize);
+  }
+
+  if (out != NULL)
+    *out = need;
+
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
 r_tls_write_change_cipher (rpointer data, rsize size,
     rsize * out, RTLSVersion ver)
 {

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -90,6 +90,10 @@ struct RTLSClient {
   RPrng * prng;
   RCryptoCert * peer_cert;
 
+  RCryptoCert * cert;          /* own certificate for mTLS, or NULL */
+  RCryptoKey * privkey;        /* own private key for mTLS, or NULL */
+  rboolean cert_requested;     /* server sent a CertificateRequest */
+
   RBuffer * inbuf;
   RQueue qsend;
 };
@@ -115,6 +119,10 @@ r_tls_client_free (RTLSClient * client)
     r_prng_unref (client->prng);
   if (client->peer_cert != NULL)
     r_crypto_cert_unref (client->peer_cert);
+  if (client->cert != NULL)
+    r_crypto_cert_unref (client->cert);
+  if (client->privkey != NULL)
+    r_crypto_key_unref (client->privkey);
   if (client->client.hmac != NULL)
     r_hmac_free (client->client.hmac);
   if (client->client.cipher != NULL)
@@ -178,6 +186,23 @@ r_tls_client_change_state (RTLSClient * client, RTLSClientState state)
   }
 
   return R_TLS_ERROR_WRONG_STATE;
+}
+
+RTLSError
+r_tls_client_set_cert (RTLSClient * client, RCryptoCert * cert, RCryptoKey * privkey)
+{
+  if (R_UNLIKELY (client == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (cert == NULL || privkey == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (client->state != R_TLS_CLIENT_INITIAL)) return R_TLS_ERROR_WRONG_STATE;
+
+  if (client->cert != NULL)
+    r_crypto_cert_unref (client->cert);
+  if (client->privkey != NULL)
+    r_crypto_key_unref (client->privkey);
+  client->cert = r_crypto_cert_ref (cert);
+  client->privkey = r_crypto_key_ref (privkey);
+
+  return R_TLS_ERROR_OK;
 }
 
 RTLSError
@@ -584,6 +609,124 @@ r_tls_client_expand_master_secret (RTLSClient * client)
 }
 
 static RTLSError
+r_tls_client_send_certificate (RTLSClient * client)
+{
+  RBuffer * buf, * certder = NULL;
+  RTLSError ret;
+  RMemMapInfo info, dinfo = R_MEM_MAP_INFO_INIT;
+  const ruint8 * der = NULL;
+  rsize dersize = 0;
+
+  if (client->cert != NULL) {
+    if ((certder = r_crypto_cert_get_data_buffer (client->cert)) == NULL)
+      return R_TLS_ERROR_NO_CERTIFICATE;
+    if (!r_buffer_map (certder, &dinfo, R_MEM_MAP_READ)) {
+      r_buffer_unref (certder);
+      return R_TLS_ERROR_OOM;
+    }
+    der = dinfo.data;
+    dersize = dinfo.size;
+  }
+
+  if ((buf = r_tls_client_alloc_buffer (client)) == NULL) {
+    if (certder != NULL) { r_buffer_unmap (certder, &dinfo); r_buffer_unref (certder); }
+    return R_TLS_ERROR_OOM;
+  }
+
+  if (r_buffer_map (buf, &info, R_MEM_MAP_WRITE)) {
+    rsize hssize, bodylen;
+    ruint8 hdrsize;
+    rsize totalbody = 3 + ((der != NULL && dersize > 0) ? (3 + dersize) : 0);
+
+    if (r_tls_version_is_dtls (client->version)) {
+      ret = r_dtls_write_handshake (info.data, info.size, &hssize,
+          client->version, R_TLS_HANDSHAKE_TYPE_CERTIFICATE, (ruint16)totalbody,
+          client->client.epoch, client->client.seqno, client->client.msgseq,
+          0, (ruint32)totalbody);
+      hdrsize = R_DTLS_RECORD_HDR_SIZE;
+    } else {
+      ret = r_tls_write_handshake (info.data, info.size, &hssize,
+          client->version, R_TLS_HANDSHAKE_TYPE_CERTIFICATE, (ruint16)totalbody);
+      hdrsize = R_TLS_RECORD_HDR_SIZE;
+    }
+
+    if (ret == R_TLS_ERROR_OK &&
+        (ret = r_tls_write_hs_certificate (info.data + hssize, info.size - hssize,
+            &bodylen, der, dersize)) == R_TLS_ERROR_OK) {
+      r_msg_digest_update (client->hshash, info.data + hdrsize,
+          (hssize + bodylen) - hdrsize);
+      r_buffer_unmap (buf, &info);
+      r_buffer_set_size (buf, hssize + bodylen);
+      ret = r_tls_client_send_record (client, buf);
+    } else {
+      r_buffer_unmap (buf, &info);
+    }
+  } else {
+    ret = R_TLS_ERROR_OOM;
+  }
+
+  r_buffer_unref (buf);
+  if (certder != NULL) { r_buffer_unmap (certder, &dinfo); r_buffer_unref (certder); }
+  return ret;
+}
+
+static RTLSError
+r_tls_client_send_certificate_verify (RTLSClient * client)
+{
+  RBuffer * buf;
+  RTLSError ret;
+  RMemMapInfo info;
+  ruint8 hash[64], sig[512];
+  rsize hashsize = r_msg_digest_size (client->hshash);
+  rsize sigsize = sizeof (sig);
+
+  /* Sign the transcript through ClientKeyExchange (current hshash). */
+  if (!r_msg_digest_get_data (client->hshash, hash, hashsize, NULL))
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  if (r_crypto_key_sign (client->privkey, client->prng, R_MSG_DIGEST_TYPE_SHA256,
+        hash, hashsize, sig, &sigsize) != R_CRYPTO_OK)
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
+  if ((buf = r_tls_client_alloc_buffer (client)) == NULL)
+    return R_TLS_ERROR_OOM;
+
+  if (r_buffer_map (buf, &info, R_MEM_MAP_WRITE)) {
+    rsize hssize, bodylen;
+    ruint8 hdrsize;
+    rsize totalbody = sizeof (ruint16) + sizeof (ruint16) + sigsize;
+
+    if (r_tls_version_is_dtls (client->version)) {
+      ret = r_dtls_write_handshake (info.data, info.size, &hssize,
+          client->version, R_TLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY, (ruint16)totalbody,
+          client->client.epoch, client->client.seqno, client->client.msgseq,
+          0, (ruint32)totalbody);
+      hdrsize = R_DTLS_RECORD_HDR_SIZE;
+    } else {
+      ret = r_tls_write_handshake (info.data, info.size, &hssize,
+          client->version, R_TLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY, (ruint16)totalbody);
+      hdrsize = R_TLS_RECORD_HDR_SIZE;
+    }
+
+    if (ret == R_TLS_ERROR_OK &&
+        (ret = r_tls_write_hs_certificate_verify (info.data + hssize, info.size - hssize,
+            &bodylen, R_TLS_SIGN_SCHEME_RSA_PKCS1_SHA256, sig, (ruint16)sigsize)) == R_TLS_ERROR_OK) {
+      r_msg_digest_update (client->hshash, info.data + hdrsize,
+          (hssize + bodylen) - hdrsize);
+      r_buffer_unmap (buf, &info);
+      r_buffer_set_size (buf, hssize + bodylen);
+      ret = r_tls_client_send_record (client, buf);
+    } else {
+      r_buffer_unmap (buf, &info);
+    }
+  } else {
+    ret = R_TLS_ERROR_OOM;
+  }
+
+  r_buffer_unref (buf);
+  return ret;
+}
+
+static RTLSError
 r_tls_client_send_key_exchange (RTLSClient * client, ruint8 pms[48])
 {
   RBuffer * buf;
@@ -775,10 +918,18 @@ r_tls_client_parse_finished (RTLSClient * client, const RTLSParser * parser)
 static RTLSError
 r_tls_client_send_flight (RTLSClient * client)
 {
-  RTLSError ret;
+  RTLSError ret = R_TLS_ERROR_OK;
   ruint8 pms[48];
 
-  if ((ret = r_tls_client_send_key_exchange (client, pms)) == R_TLS_ERROR_OK)
+  /* mTLS: a Certificate (the configured one, or empty) precedes the
+   * ClientKeyExchange when the server requested one. */
+  if (client->cert_requested) {
+    if ((ret = r_tls_client_send_certificate (client)) == R_TLS_ERROR_OK)
+      client->client.msgseq++;
+  }
+
+  if (ret == R_TLS_ERROR_OK &&
+      (ret = r_tls_client_send_key_exchange (client, pms)) == R_TLS_ERROR_OK)
     client->client.msgseq++;
 
   if (ret == R_TLS_ERROR_OK)
@@ -786,6 +937,13 @@ r_tls_client_send_flight (RTLSClient * client)
   r_memclear_secure (pms, sizeof (pms));
   if (ret == R_TLS_ERROR_OK)
     ret = r_tls_client_expand_master_secret (client);
+
+  /* mTLS: prove possession of the certificate's private key, but only when a
+   * real certificate was sent. */
+  if (ret == R_TLS_ERROR_OK && client->cert_requested && client->cert != NULL) {
+    if ((ret = r_tls_client_send_certificate_verify (client)) == R_TLS_ERROR_OK)
+      client->client.msgseq++;
+  }
 
   if (ret == R_TLS_ERROR_OK)
     ret = r_tls_client_send_change_cipher (client);
@@ -907,8 +1065,13 @@ r_tls_client_state_server_hello_done (RTLSClient * client, const RTLSParser * pa
   if ((err = r_tls_parser_parse_handshake_peek_type (parser, &type)) == R_TLS_ERROR_OK) {
     if (type == R_TLS_HANDSHAKE_TYPE_SERVER_HELLO_DONE) {
       err = R_TLS_ERROR_OK;
-    } else if (type == R_TLS_HANDSHAKE_TYPE_SERVER_KEY_EXCHANGE ||
-        type == R_TLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST) {
+    } else if (type == R_TLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST) {
+      /* Remember to present a (configured or empty) certificate in our flight;
+       * fold into the transcript and keep waiting for ServerHelloDone. */
+      client->cert_requested = TRUE;
+      r_msg_digest_update (client->hshash, parser->fragment.data, parser->fragment.size);
+      return R_TLS_ERROR_OK;
+    } else if (type == R_TLS_HANDSHAKE_TYPE_SERVER_KEY_EXCHANGE) {
       /* Not used by the RSA path; fold into the transcript and keep waiting. */
       r_msg_digest_update (client->hshash, parser->fragment.data, parser->fragment.size);
       return R_TLS_ERROR_OK;

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -34,6 +34,7 @@ typedef enum {
   R_TLS_SERVER_HELLO,
   R_TLS_SERVER_CERTIFICATE,
   R_TLS_SERVER_KEY_EXCHANGE,
+  R_TLS_SERVER_CERTIFICATE_VERIFY,
   R_TLS_SERVER_CHANGE_CIPHER,
   R_TLS_SERVER_FINISHED,
   R_TLS_SERVER_APPDATA,
@@ -101,6 +102,11 @@ struct RTLSServer {
   RCryptoCert * cert;
   RCryptoKey * privkey;
 
+  RTLSClientCertMode client_cert_mode;  /* mTLS policy; default NONE */
+  rboolean client_cert_received;        /* a non-empty client cert was parsed */
+  RCryptoCert * peer_cert;              /* client leaf cert, ref'd; NULL if none */
+  RCryptoKey * peer_pubkey;             /* client leaf public key, for CertificateVerify */
+
   RBuffer * inbuf;
   RQueue qsend;
 };
@@ -138,6 +144,10 @@ r_tls_server_free (RTLSServer * server)
     r_crypto_cert_unref (server->cert);
   if (server->privkey != NULL)
     r_crypto_key_unref (server->privkey);
+  if (server->peer_cert != NULL)
+    r_crypto_cert_unref (server->peer_cert);
+  if (server->peer_pubkey != NULL)
+    r_crypto_key_unref (server->peer_pubkey);
   if (server->client.hmac != NULL)
     r_hmac_free (server->client.hmac);
   if (server->client.cipher != NULL)
@@ -226,6 +236,24 @@ r_tls_server_set_cert (RTLSServer * server,
   server->privkey = r_crypto_key_ref (privkey);
 
   return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_server_set_client_cert_mode (RTLSServer * server, RTLSClientCertMode mode)
+{
+  if (R_UNLIKELY (server == NULL)) return R_TLS_ERROR_INVAL;
+  /* The mode drives the ServerHello flight (CertificateRequest); fix it first. */
+  if (R_UNLIKELY (server->state > R_TLS_SERVER_HELLO)) return R_TLS_ERROR_WRONG_STATE;
+
+  server->client_cert_mode = mode;
+  return R_TLS_ERROR_OK;
+}
+
+RCryptoCert *
+r_tls_server_get_peer_cert (const RTLSServer * server)
+{
+  if (R_UNLIKELY (server == NULL)) return NULL;
+  return server->peer_cert;
 }
 
 RTLSError
@@ -598,9 +626,57 @@ r_tls_server_write_key_exchange (RTLSServer * server)
 static RTLSError
 r_tls_server_write_cert_req (RTLSServer * server)
 {
-  /* FIXME: Request certificate? */
-  (void) server;
-  return R_TLS_ERROR_NOT_NEEDED;
+  static const ruint8 certtypes[] = { R_TLS_CLIENT_CERT_TYPE_RSA_SIGN };
+  static const RTLSSignatureScheme schemes[] = { R_TLS_SIGN_SCHEME_RSA_PKCS1_SHA256 };
+  RBuffer * buf;
+  RTLSError ret;
+  RMemMapInfo info;
+
+  /* Only request a client certificate when mutual TLS is configured. */
+  if (server->client_cert_mode == R_TLS_CLIENT_CERT_MODE_NONE)
+    return R_TLS_ERROR_NOT_NEEDED;
+
+  R_LOG_DEBUG ("%p - server certificate request", server);
+
+  if ((buf = r_tls_server_alloc_buffer (server)) == NULL)
+    return R_TLS_ERROR_OOM;
+
+  if (r_buffer_map (buf, &info, R_MEM_MAP_WRITE)) {
+    rsize hssize, bodylen;
+    ruint8 hdrsize = r_tls_version_is_dtls (server->version) ?
+        R_DTLS_RECORD_HDR_SIZE : R_TLS_RECORD_HDR_SIZE;
+
+    /* cert-type count(1) + types + sig-scheme len(2) + schemes + CA len(2) */
+    bodylen = 1 + R_N_ELEMENTS (certtypes) +
+        2 + R_N_ELEMENTS (schemes) * sizeof (ruint16) + 2;
+    if (r_tls_version_is_dtls (server->version)) {
+      ret = r_dtls_write_handshake (info.data, info.size, &hssize,
+          server->version, R_TLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST, (ruint16)bodylen,
+          server->server.epoch, server->server.seqno, server->server.msgseq,
+          0, (ruint32)bodylen);
+    } else {
+      ret = r_tls_write_handshake (info.data, info.size, &hssize,
+          server->version, R_TLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST, (ruint16)bodylen);
+    }
+
+    if (ret == R_TLS_ERROR_OK &&
+        (ret = r_tls_write_hs_certificate_request (info.data + hssize,
+            info.size - hssize, &bodylen, certtypes, R_N_ELEMENTS (certtypes),
+            schemes, R_N_ELEMENTS (schemes), NULL, 0)) == R_TLS_ERROR_OK) {
+      r_msg_digest_update (server->hshash, info.data + hdrsize,
+          (hssize + bodylen) - hdrsize);
+      r_buffer_unmap (buf, &info);
+      r_buffer_set_size (buf, hssize + bodylen);
+      ret = r_tls_server_send_record (server, buf);
+    } else {
+      r_buffer_unmap (buf, &info);
+    }
+  } else {
+    ret = R_TLS_ERROR_OOM;
+  }
+
+  r_buffer_unref (buf);
+  return ret;
 }
 
 static RTLSError
@@ -1007,10 +1083,91 @@ static RTLSError
 r_tls_server_parse_client_certificate (RTLSServer * server,
     const RTLSParser * parser)
 {
-  /* TODO: implement */
-  (void) server;
-  (void) parser;
-  return R_TLS_ERROR_NO_CERTIFICATE;
+  RCryptoCert * chain[16];
+  RTLSCertificate tlscert = R_TLS_CERTIFICATE_INIT;
+  ruint n = 0, i;
+  RTLSError err = R_TLS_ERROR_OK;
+
+  while (n < R_N_ELEMENTS (chain) &&
+      r_tls_parser_parse_certificate_next (parser, &tlscert) == R_TLS_ERROR_OK) {
+    if ((chain[n] = r_tls_certificate_get_cert (&tlscert)) != NULL)
+      n++;
+  }
+
+  if (n == 0) {
+    /* TLS 1.2: a client with no suitable certificate sends an empty list rather
+     * than the SSLv3 no_certificate alert. */
+    if (server->client_cert_mode == R_TLS_CLIENT_CERT_MODE_REQUIRE)
+      return R_TLS_ERROR_NO_CERTIFICATE;          /* -> handshake_failure */
+    server->client_cert_received = FALSE;          /* REQUEST: proceed unauthenticated */
+    return R_TLS_ERROR_OK;
+  }
+
+  /* Trust/chain validation is delegated to the caller's verify_cert callback
+   * (as on the client side); keep the leaf for the CertificateVerify check. */
+  if (server->cb.verify_cert != NULL &&
+      !server->cb.verify_cert (server->userdata, chain, n)) {
+    err = R_TLS_ERROR_CORRUPT_CERTIFICATE;         /* -> bad_certificate */
+  } else if ((server->peer_pubkey = r_crypto_cert_get_public_key (chain[0])) == NULL) {
+    err = R_TLS_ERROR_CORRUPT_CERTIFICATE;
+  } else {
+    server->peer_cert = r_crypto_cert_ref (chain[0]);
+    server->client_cert_received = TRUE;
+  }
+
+  for (i = 0; i < n; i++)
+    r_crypto_cert_unref (chain[i]);
+
+  return err;
+}
+
+/* This cut supports RSA client certs with rsa_pkcs1_sha256, whose hash matches
+ * the transcript digest of the supported suites. */
+static rboolean
+r_tls_sign_scheme_to_md (RTLSSignatureScheme scheme, RMsgDigestType * md)
+{
+  switch (scheme) {
+    case R_TLS_SIGN_SCHEME_RSA_PKCS1_SHA256:
+      *md = R_MSG_DIGEST_TYPE_SHA256;
+      return TRUE;
+    default:
+      return FALSE;
+  }
+}
+
+/* Verify the client's CertificateVerify: its signature covers the handshake
+ * transcript through ClientKeyExchange (a snapshot of hshash, taken before this
+ * message is folded in). */
+static RTLSError
+r_tls_server_parse_certificate_verify (RTLSServer * server, const RTLSParser * parser)
+{
+  RTLSSignatureScheme scheme;
+  const ruint8 * sig;
+  ruint16 sigsize;
+  RMsgDigestType md;
+  RTLSError err;
+  rsize hashsize;
+  ruint8 * hash;
+
+  if (R_UNLIKELY (server->peer_pubkey == NULL))   /* CertVerify with no cert */
+    return R_TLS_ERROR_WRONG_STATE;
+
+  if ((err = r_tls_parser_parse_certificate_verify (parser, &scheme, &sig, &sigsize))
+        != R_TLS_ERROR_OK)
+    return err;
+  if (!r_tls_sign_scheme_to_md (scheme, &md))
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
+  hashsize = r_msg_digest_size (server->hshash);
+  hash = r_alloca (hashsize);
+  if (!r_msg_digest_get_data (server->hshash, hash, hashsize, NULL))
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
+  if (r_crypto_key_verify (server->peer_pubkey, md, hash, hashsize, sig, sigsize)
+        != R_CRYPTO_OK)
+    return R_TLS_ERROR_HS_VERIFICATION_FAILED;     /* -> decrypt_error */
+
+  return R_TLS_ERROR_OK;
 }
 
 static RTLSError
@@ -1416,13 +1573,13 @@ r_tls_server_state_certificate (RTLSServer * server, const RTLSParser * parser)
   RTLSHandshakeType type;
   if ((err = r_tls_parser_parse_handshake_peek_type (parser, &type)) == R_TLS_ERROR_OK) {
     if (type == R_TLS_HANDSHAKE_TYPE_CERTIFICATE) {
-      if ((err = r_tls_server_parse_client_certificate (server, parser)) == R_TLS_ERROR_OK) {
+      if ((err = r_tls_server_parse_client_certificate (server, parser)) == R_TLS_ERROR_OK)
         err = r_tls_server_change_state (server, R_TLS_SERVER_KEY_EXCHANGE);
-      } else {
-        /* FIXME Error? */
-      }
     } else if (type == R_TLS_HANDSHAKE_TYPE_CLIENT_KEY_EXCHANGE) {
-      if ((err = r_tls_server_change_state (server, R_TLS_SERVER_KEY_EXCHANGE)) == R_TLS_ERROR_OK)
+      /* Client sent no Certificate at all; fatal when one is required. */
+      if (server->client_cert_mode == R_TLS_CLIENT_CERT_MODE_REQUIRE)
+        err = R_TLS_ERROR_NO_CERTIFICATE;
+      else if ((err = r_tls_server_change_state (server, R_TLS_SERVER_KEY_EXCHANGE)) == R_TLS_ERROR_OK)
         err = R_TLS_ERROR_NOT_NEEDED;
     } else {
       err = R_TLS_ERROR_WRONG_TYPE;
@@ -1452,7 +1609,8 @@ r_tls_server_state_key_exchange (RTLSServer * server, const RTLSParser * parser)
   ruint8 pms[48];
 
   if ((err = r_tls_server_parse_client_key_exchange (server, parser, pms)) == R_TLS_ERROR_OK)
-    err = r_tls_server_change_state (server, R_TLS_SERVER_CHANGE_CIPHER);
+    err = r_tls_server_change_state (server, server->client_cert_received ?
+        R_TLS_SERVER_CERTIFICATE_VERIFY : R_TLS_SERVER_CHANGE_CIPHER);
 
   switch (err) {
     case R_TLS_ERROR_OK:
@@ -1470,6 +1628,37 @@ r_tls_server_state_key_exchange (RTLSServer * server, const RTLSParser * parser)
   }
 
   r_memclear_secure (pms, sizeof (pms));
+  return err;
+}
+
+static RTLSError
+r_tls_server_state_certificate_verify (RTLSServer * server, const RTLSParser * parser)
+{
+  RTLSError err;
+  RTLSHandshakeType type;
+
+  if ((err = r_tls_parser_parse_handshake_peek_type (parser, &type)) == R_TLS_ERROR_OK) {
+    if (type == R_TLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY) {
+      if ((err = r_tls_server_parse_certificate_verify (server, parser)) == R_TLS_ERROR_OK)
+        err = r_tls_server_change_state (server, R_TLS_SERVER_CHANGE_CIPHER);
+    } else {
+      err = R_TLS_ERROR_WRONG_TYPE;
+    }
+  }
+
+  switch (err) {
+    case R_TLS_ERROR_OK:
+      R_LOG_TRACE ("Updating HS hash with CertificateVerify %u bytes",
+          (ruint)parser->fragment.size);
+      /* Fold only after verifying its own signature, so the client Finished
+       * (which covers CertificateVerify) still checks out. */
+      r_msg_digest_update (server->hshash, parser->fragment.data, parser->fragment.size);
+      break;
+    default:
+      r_tls_server_send_alert (server, r_tls_server_alert_for_error (err));
+      break;
+  }
+
   return err;
 }
 
@@ -1577,6 +1766,7 @@ r_tls_server_incoming_data (RTLSServer * server, RBuffer * buffer)
     r_tls_server_state_hello,
     r_tls_server_state_certificate,
     r_tls_server_state_key_exchange,
+    r_tls_server_state_certificate_verify,
     r_tls_server_state_change_cipher,
     r_tls_server_state_finished,
     r_tls_server_state_appdata,

--- a/test/rtls.c
+++ b/test/rtls.c
@@ -943,6 +943,103 @@ RTEST (rtls, write_dtls_change_cipher, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rtls, write_certificate_request, RTEST_FAST)
+{
+  static const ruint8 certtypes[] = { R_TLS_CLIENT_CERT_TYPE_RSA_SIGN };
+  static const RTLSSignatureScheme schemes[] = { R_TLS_SIGN_SCHEME_RSA_PKCS1_SHA256 };
+  ruint8 body[64], rec[96];
+  rsize bodylen = sizeof (body), hs, reclen;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSHandshakeType hstype;
+  ruint32 hslen;
+  RTLSCertReq req;
+
+  r_assert_cmpint (r_tls_write_hs_certificate_request (body, sizeof (body), &bodylen,
+        certtypes, R_N_ELEMENTS (certtypes), schemes, R_N_ELEMENTS (schemes), NULL, 0),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_write_handshake (rec, sizeof (rec), &hs, R_TLS_VERSION_TLS_1_2,
+        R_TLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST, (ruint16)bodylen), ==, R_TLS_ERROR_OK);
+  r_memcpy (rec + hs, body, bodylen);
+  reclen = hs + bodylen;
+
+  r_assert_cmpint (r_tls_parser_init (&parser, rec, reclen), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_parser_parse_handshake (&parser, &hstype, &hslen), ==, R_TLS_ERROR_OK);
+  r_assert_cmphex (hstype, ==, R_TLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST);
+  r_assert_cmpint (r_tls_parser_parse_certificate_request (&parser, &req), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (req.certtypecount, ==, 1);
+  r_assert_cmphex (r_tls_cert_req_cert_type (&req, 0), ==, R_TLS_CLIENT_CERT_TYPE_RSA_SIGN);
+  r_assert_cmpuint (req.signschemecount, ==, 1);
+  r_assert_cmphex (r_tls_cert_req_sign_scheme (&req, 0), ==, R_TLS_SIGN_SCHEME_RSA_PKCS1_SHA256);
+  r_assert_cmpuint (req.cacount, ==, 0);
+  r_tls_parser_clear (&parser);
+}
+RTEST_END;
+
+RTEST (rtls, write_certificate_verify, RTEST_FAST)
+{
+  static const ruint8 sigbytes[] = { 0xde, 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03 };
+  ruint8 body[64], rec[96];
+  rsize bodylen = sizeof (body), hs, reclen;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSHandshakeType hstype;
+  ruint32 hslen;
+  RTLSSignatureScheme scheme;
+  const ruint8 * sig;
+  ruint16 sigsize;
+
+  r_assert_cmpint (r_tls_write_hs_certificate_verify (body, sizeof (body), &bodylen,
+        R_TLS_SIGN_SCHEME_RSA_PKCS1_SHA256, sigbytes, sizeof (sigbytes)), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_write_handshake (rec, sizeof (rec), &hs, R_TLS_VERSION_TLS_1_2,
+        R_TLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY, (ruint16)bodylen), ==, R_TLS_ERROR_OK);
+  r_memcpy (rec + hs, body, bodylen);
+  reclen = hs + bodylen;
+
+  r_assert_cmpint (r_tls_parser_init (&parser, rec, reclen), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_parser_parse_handshake (&parser, &hstype, &hslen), ==, R_TLS_ERROR_OK);
+  r_assert_cmphex (hstype, ==, R_TLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY);
+  r_assert_cmpint (r_tls_parser_parse_certificate_verify (&parser, &scheme, &sig, &sigsize),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmphex (scheme, ==, R_TLS_SIGN_SCHEME_RSA_PKCS1_SHA256);
+  r_assert_cmpuint (sigsize, ==, sizeof (sigbytes));
+  r_assert_cmpmem (sig, ==, sigbytes, sigsize);
+  r_tls_parser_clear (&parser);
+}
+RTEST_END;
+
+RTEST (rtls, write_certificate, RTEST_FAST)
+{
+  static const ruint8 der[] = { 0x30, 0x05, 0x02, 0x03, 0x0a, 0x0b, 0x0c };
+  ruint8 body[64], rec[96];
+  rsize bodylen = sizeof (body), hs, reclen;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSHandshakeType hstype;
+  ruint32 hslen;
+  RTLSCertificate tlscert = R_TLS_CERTIFICATE_INIT;
+
+  r_assert_cmpint (r_tls_write_hs_certificate (body, sizeof (body), &bodylen,
+        der, sizeof (der)), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_write_handshake (rec, sizeof (rec), &hs, R_TLS_VERSION_TLS_1_2,
+        R_TLS_HANDSHAKE_TYPE_CERTIFICATE, (ruint16)bodylen), ==, R_TLS_ERROR_OK);
+  r_memcpy (rec + hs, body, bodylen);
+  reclen = hs + bodylen;
+
+  r_assert_cmpint (r_tls_parser_init (&parser, rec, reclen), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_parser_parse_handshake (&parser, &hstype, &hslen), ==, R_TLS_ERROR_OK);
+  r_assert_cmphex (hstype, ==, R_TLS_HANDSHAKE_TYPE_CERTIFICATE);
+  r_assert_cmpint (r_tls_parser_parse_certificate_next (&parser, &tlscert), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (tlscert.len, ==, sizeof (der));
+  r_assert_cmpmem (tlscert.cert, ==, der, sizeof (der));
+  r_assert_cmpint (r_tls_parser_parse_certificate_next (&parser, &tlscert), ==, R_TLS_ERROR_EOB);
+  r_tls_parser_clear (&parser);
+
+  /* An empty Certificate is just the 3-byte zero certificate_list length. */
+  bodylen = sizeof (body);
+  r_assert_cmpint (r_tls_write_hs_certificate (body, sizeof (body), &bodylen, NULL, 0),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (bodylen, ==, 3);
+}
+RTEST_END;
+
 RTEST (rtls, dtls_encrypt, RTEST_FAST)
 {
   static const ruint8 aes_128_cbc_key[] = {

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -334,3 +334,69 @@ RTEST_F (rtlsclient, tls_verify_cert_reject, RTEST_FAST)
   r_assert (fixture->cli_error);
 }
 RTEST_END;
+
+/* Mutual TLS: the server requires a client certificate, the client presents
+ * one, and the handshake completes with each side holding the other's leaf. */
+static void
+r_test_tls_mtls_loopback (RTEST_FIXTURE_STRUCT (rtlsclient) * fixture, RTLSVersion version)
+{
+  RCryptoCert * cert;
+  RCryptoKey * pk;
+
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (testcertpem, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem, -1, NULL, 0)), !=, NULL);
+  r_assert_cmpint (r_tls_client_set_cert (fixture->client, cert, pk), ==, R_TLS_ERROR_OK);
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+
+  r_assert_cmpint (r_tls_server_set_client_cert_mode (fixture->server,
+        R_TLS_CLIENT_CERT_MODE_REQUIRE), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng, version),
+      ==, R_TLS_ERROR_OK);
+
+  r_test_tls_loopback_pump (fixture);
+
+  r_assert (fixture->cli_hs_done);
+  r_assert (fixture->srv_hs_done);
+  r_assert (!fixture->cli_error);
+  r_assert (!fixture->srv_error);
+  /* Each side validated and kept the other's leaf certificate. */
+  r_assert_cmpptr (r_tls_server_get_peer_cert (fixture->server), !=, NULL);
+  r_assert_cmpptr (r_tls_client_get_peer_cert (fixture->client), !=, NULL);
+}
+
+RTEST_F (rtlsclient, tls_mtls_loopback, RTEST_FAST)
+{
+  r_test_tls_mtls_loopback (fixture, R_TLS_VERSION_TLS_1_2);
+}
+RTEST_END;
+
+RTEST_F (rtlsclient, dtls_mtls_loopback, RTEST_FAST)
+{
+  r_test_tls_mtls_loopback (fixture, R_TLS_VERSION_DTLS_1_2);
+}
+RTEST_END;
+
+/* The server requires a client certificate but the client has none: it answers
+ * with an empty Certificate and the server aborts the handshake. */
+RTEST_F (rtlsclient, tls_mtls_require_no_client_cert, RTEST_FAST)
+{
+  r_assert_cmpint (r_tls_server_set_client_cert_mode (fixture->server,
+        R_TLS_CLIENT_CERT_MODE_REQUIRE), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_2), ==, R_TLS_ERROR_OK);
+
+  r_test_tls_loopback_pump (fixture);
+
+  r_assert (!fixture->srv_hs_done);
+  r_assert (!fixture->cli_hs_done);
+  r_assert (fixture->srv_error);
+  r_assert_cmpptr (r_tls_server_get_peer_cert (fixture->server), ==, NULL);
+}
+RTEST_END;

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -59,6 +59,8 @@ RTEST_FIXTURE_STRUCT (rtlsserver)
   rboolean hs_done;
   rboolean got_error;
   RTLSAlertType last_alert;
+  ruint peer_cert_seen;        /* times verify_cert was invoked */
+  rboolean reject_peer_cert;   /* make verify_cert reject the chain */
 
   RClock * clock;
   REvLoop * evloop;
@@ -83,6 +85,16 @@ r_tlsserver_test_error (rpointer ctx, RTLSAlertType alert, rpointer session)
   (void) session;
   fixture->got_error = TRUE;
   fixture->last_alert = alert;
+}
+
+static rboolean
+r_tlsserver_test_verify_cert (rpointer ctx, RCryptoCert * const * chain, ruint count)
+{
+  RTEST_FIXTURE_STRUCT (rtlsserver) * fixture = ctx;
+  (void) chain;
+  (void) count;
+  fixture->peer_cert_seen++;
+  return !fixture->reject_peer_cert;
 }
 
 static rboolean
@@ -111,7 +123,7 @@ RTEST_FIXTURE_SETUP (rtlsserver)
     r_tlsserver_test_buffer_out,
     r_tlsserver_test_buffer_appdata,
     r_tlsserver_test_error,
-    NULL,
+    r_tlsserver_test_verify_cert,
   };
   RCryptoCert * cert;
   RCryptoKey * pk;
@@ -122,6 +134,8 @@ RTEST_FIXTURE_SETUP (rtlsserver)
   fixture->hs_done = FALSE;
   fixture->got_error = FALSE;
   fixture->last_alert = R_TLS_ALERT_TYPE_CLOSE_NOTIFY;
+  fixture->peer_cert_seen = 0;
+  fixture->reject_peer_cert = FALSE;
 
   r_queue_init (&fixture->qout);
   r_queue_init (&fixture->qapp);
@@ -2262,5 +2276,257 @@ RTEST_F (rtlsserver, tls_alert_record_overflow, RTEST_FAST)
   r_assert_cmpuint (atype, ==, R_TLS_ALERT_TYPE_RECORD_OVERFLOW);
   r_tls_parser_clear (&parser);
   r_buffer_unref (buf);
+}
+RTEST_END;
+
+/* How the in-test mTLS client presents its certificate. */
+typedef enum {
+  R_TEST_MTLS_CERT,    /* send a real client Certificate + CertificateVerify */
+  R_TEST_MTLS_EMPTY,   /* send an empty Certificate (no CertificateVerify) */
+} RTestMtlsCert;
+
+/* Drive a full TLS 1.2 RSA handshake presenting a client certificate, so the
+ * server's mutual-TLS path runs. @certmode picks a real or empty client
+ * Certificate; @tamper_cv flips a byte of the CertificateVerify signature. The
+ * caller inspects the fixture (hs_done / got_error / last_alert). */
+static void
+r_test_tls_client_mtls (RTLSServer * server, RPrng * prng, RQueue * qout,
+    RTestMtlsCert certmode, rboolean tamper_cv)
+{
+  RCryptoKey * pk;
+  RCryptoCert * clientcert = NULL;
+  RBuffer * certder = NULL;
+  RMsgDigest * md;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSHelloMsg hello;
+  RBuffer * buf, * plain, * enc;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  RCryptoCipher * ccipher;
+  RHmac * chmac;
+  ruint8 ch[256];
+  ruint8 crand[R_TLS_HELLO_RANDOM_BYTES], srand[R_TLS_HELLO_RANDOM_BYTES];
+  ruint8 pms[48], kb[128], vd[12], iv[16], sh[64], sig[512];
+  ruint8 encpms[512], certmsg[2048], cke[512], cvmsg[600], fin[64], ccs[16];
+  rsize chlen, hssz, enclen = sizeof (encpms), ckelen, finhs, ccslen, shlen;
+  rsize sigsize = sizeof (sig);
+
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem, -1, NULL, 0)), !=, NULL);
+  r_assert_cmpptr ((md = r_msg_digest_new_sha256 ()), !=, NULL);
+
+  chlen = r_test_tls_build_client_hello (prng, ch, sizeof (ch),
+      R_TLS_CS_RSA_WITH_AES_128_CBC_SHA, NULL, 0, crand);
+  r_test_tls_server_feed (server, ch, chlen);
+  r_test_tls_hash_record (md, ch, chlen);
+
+  /* server flight: ServerHello + Certificate + CertificateRequest + HelloDone */
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_msg_digest_update (md, parser.fragment.data, parser.fragment.size);
+  r_assert_cmpint (r_tls_parser_parse_hello (&parser, &hello), ==, R_TLS_ERROR_OK);
+  r_memcpy (srand, hello.random, sizeof (srand));
+  while (r_tls_parser_init_next (&parser, NULL) == R_TLS_ERROR_OK)
+    r_msg_digest_update (md, parser.fragment.data, parser.fragment.size);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+
+  /* Client Certificate (before ClientKeyExchange). */
+  {
+    const ruint8 * der = NULL;
+    rsize dersize = 0, hs;
+    ruint8 cbody[2048];
+    rsize cbodylen = sizeof (cbody), certmsglen;
+
+    if (certmode == R_TEST_MTLS_CERT) {
+      r_assert_cmpptr ((clientcert = r_pem_parse_cert_from_data (testcertpem, -1)), !=, NULL);
+      r_assert_cmpptr ((certder = r_crypto_cert_get_data_buffer (clientcert)), !=, NULL);
+      r_assert (r_buffer_map (certder, &info, R_MEM_MAP_READ));
+      der = info.data; dersize = info.size;
+    }
+    r_assert_cmpint (r_tls_write_hs_certificate (cbody, sizeof (cbody), &cbodylen,
+          der, dersize), ==, R_TLS_ERROR_OK);
+    if (certder != NULL) r_buffer_unmap (certder, &info);
+    r_assert_cmpint (r_tls_write_handshake (certmsg, sizeof (certmsg), &hs,
+          R_TLS_VERSION_TLS_1_2, R_TLS_HANDSHAKE_TYPE_CERTIFICATE, (ruint16)cbodylen),
+        ==, R_TLS_ERROR_OK);
+    r_memcpy (certmsg + hs, cbody, cbodylen);
+    certmsglen = hs + cbodylen;
+    r_test_tls_server_feed (server, certmsg, certmsglen);
+    r_test_tls_hash_record (md, certmsg, certmsglen);
+  }
+
+  /* ClientKeyExchange */
+  pms[0] = 0x03; pms[1] = 0x03;
+  r_prng_fill (prng, pms + 2, sizeof (pms) - 2);
+  r_assert_cmpint (r_crypto_key_encrypt (pk, prng, pms, sizeof (pms), encpms, &enclen),
+      ==, R_CRYPTO_OK);
+  r_assert_cmpint (r_tls_write_handshake (cke, sizeof (cke), &hssz, R_TLS_VERSION_TLS_1_2,
+        R_TLS_HANDSHAKE_TYPE_CLIENT_KEY_EXCHANGE, (ruint16)(2 + enclen)), ==, R_TLS_ERROR_OK);
+  r_store_be16 (cke + hssz, (ruint16)enclen);
+  r_memcpy (cke + hssz + 2, encpms, enclen);
+  ckelen = hssz + 2 + enclen;
+  r_test_tls_server_feed (server, cke, ckelen);
+  r_test_tls_hash_record (md, cke, ckelen);
+
+  /* master secret + key block (legacy seed; the ClientHello offered no EMS).
+   * The client Finished verify_data must cover CertificateVerify, so it is
+   * computed at the end of this block, after that message is folded. */
+  {
+    ruint8 ms[48];
+    r_assert_cmpint (r_tls_1_2_prf_sha256 (ms, sizeof (ms), pms, sizeof (pms),
+          R_STR_WITH_SIZE_ARGS ("master secret"),
+          crand, sizeof (crand), srand, sizeof (srand), NULL), ==, R_TLS_ERROR_OK);
+    r_assert_cmpint (r_tls_1_2_prf_sha256 (kb, sizeof (kb), ms, sizeof (ms),
+          R_STR_WITH_SIZE_ARGS ("key expansion"),
+          srand, sizeof (srand), crand, sizeof (crand), NULL), ==, R_TLS_ERROR_OK);
+
+    /* CertificateVerify (after CKE): sign the transcript through CKE. */
+    if (certmode == R_TEST_MTLS_CERT) {
+      ruint8 cvhash[64];
+      rsize cvhashlen = r_msg_digest_size (md), hs, cvbodylen;
+      ruint8 cvbody[600];
+
+      r_assert (r_msg_digest_get_data (md, cvhash, cvhashlen, NULL));
+      r_assert_cmpint (r_crypto_key_sign (pk, prng, R_MSG_DIGEST_TYPE_SHA256,
+            cvhash, cvhashlen, sig, &sigsize), ==, R_CRYPTO_OK);
+      if (tamper_cv)
+        sig[0] ^= 0xff;
+      cvbodylen = sizeof (cvbody);
+      r_assert_cmpint (r_tls_write_hs_certificate_verify (cvbody, sizeof (cvbody),
+            &cvbodylen, R_TLS_SIGN_SCHEME_RSA_PKCS1_SHA256, sig, (ruint16)sigsize),
+          ==, R_TLS_ERROR_OK);
+      r_assert_cmpint (r_tls_write_handshake (cvmsg, sizeof (cvmsg), &hs,
+            R_TLS_VERSION_TLS_1_2, R_TLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY,
+            (ruint16)cvbodylen), ==, R_TLS_ERROR_OK);
+      r_memcpy (cvmsg + hs, cvbody, cvbodylen);
+      r_test_tls_server_feed (server, cvmsg, hs + cvbodylen);
+      r_test_tls_hash_record (md, cvmsg, hs + cvbodylen);
+    }
+
+    /* client Finished over the full transcript */
+    shlen = r_msg_digest_size (md);
+    r_assert (r_msg_digest_get_data (md, sh, shlen, NULL));
+    r_assert_cmpint (r_tls_1_2_prf_sha256 (vd, sizeof (vd), ms, sizeof (ms),
+          R_STR_WITH_SIZE_ARGS ("client finished"), sh, shlen, NULL), ==, R_TLS_ERROR_OK);
+    r_memclear_secure (ms, sizeof (ms));
+  }
+
+  r_assert_cmpptr ((ccipher = r_cipher_aes_128_cbc_new (kb + 40)), !=, NULL);
+  r_assert_cmpptr ((chmac = r_hmac_new (R_MSG_DIGEST_TYPE_SHA1, kb, 20)), !=, NULL);
+  r_assert_cmpint (r_tls_write_handshake (fin, sizeof (fin), &finhs, R_TLS_VERSION_TLS_1_2,
+        R_TLS_HANDSHAKE_TYPE_FINISHED, sizeof (vd)), ==, R_TLS_ERROR_OK);
+  r_memcpy (fin + finhs, vd, sizeof (vd));
+  r_assert_cmpptr ((plain = r_buffer_new_wrapped (R_MEM_FLAG_NONE, fin,
+          finhs + sizeof (vd), finhs + sizeof (vd), 0, NULL, NULL)), !=, NULL);
+  r_prng_fill (prng, iv, sizeof (iv));
+  r_assert_cmpptr ((enc = r_tls_encrypt_buffer (plain, 0, ccipher, iv, chmac, FALSE)), !=, NULL);
+  r_buffer_unref (plain);
+
+  r_assert_cmpint (r_tls_write_change_cipher (ccs, sizeof (ccs), &ccslen,
+        R_TLS_VERSION_TLS_1_2), ==, R_TLS_ERROR_OK);
+  r_test_tls_server_feed (server, ccs, ccslen);
+  r_assert (r_buffer_map (enc, &info, R_MEM_MAP_READ));
+  r_test_tls_server_feed (server, info.data, info.size);
+  r_buffer_unmap (enc, &info);
+  r_buffer_unref (enc);
+
+  r_hmac_free (chmac);
+  r_crypto_cipher_unref (ccipher);
+  if (certder != NULL) r_buffer_unref (certder);
+  if (clientcert != NULL) r_crypto_cert_unref (clientcert);
+  r_memclear_secure (pms, sizeof (pms));
+  r_memclear_secure (kb, sizeof (kb));
+  r_msg_digest_free (md);
+  r_crypto_key_unref (pk);
+}
+
+/* REQUIRE mode, client presents a valid cert: the handshake completes, the
+ * verify_cert callback saw the chain, and get_peer_cert returns the leaf. */
+RTEST_F (rtlsserver, tls_mtls_require_roundtrip, RTEST_FAST)
+{
+  r_assert_cmpint (r_tls_server_set_client_cert_mode (fixture->server,
+        R_TLS_CLIENT_CERT_MODE_REQUIRE), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  r_test_tls_client_mtls (fixture->server, fixture->prng, &fixture->qout,
+      R_TEST_MTLS_CERT, FALSE);
+
+  r_assert (fixture->hs_done);
+  r_assert (!fixture->got_error);
+  r_assert_cmpuint (fixture->peer_cert_seen, ==, 1);
+  r_assert_cmpptr (r_tls_server_get_peer_cert (fixture->server), !=, NULL);
+}
+RTEST_END;
+
+/* REQUEST mode, client sends an empty Certificate: the handshake completes
+ * unauthenticated and there is no peer cert. */
+RTEST_F (rtlsserver, tls_mtls_request_no_cert, RTEST_FAST)
+{
+  r_assert_cmpint (r_tls_server_set_client_cert_mode (fixture->server,
+        R_TLS_CLIENT_CERT_MODE_REQUEST), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  r_test_tls_client_mtls (fixture->server, fixture->prng, &fixture->qout,
+      R_TEST_MTLS_EMPTY, FALSE);
+
+  r_assert (fixture->hs_done);
+  r_assert (!fixture->got_error);
+  r_assert_cmpptr (r_tls_server_get_peer_cert (fixture->server), ==, NULL);
+}
+RTEST_END;
+
+/* REQUIRE mode, client sends an empty Certificate: fatal handshake_failure. */
+RTEST_F (rtlsserver, tls_mtls_require_no_cert, RTEST_FAST)
+{
+  r_assert_cmpint (r_tls_server_set_client_cert_mode (fixture->server,
+        R_TLS_CLIENT_CERT_MODE_REQUIRE), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  r_test_tls_client_mtls (fixture->server, fixture->prng, &fixture->qout,
+      R_TEST_MTLS_EMPTY, FALSE);
+
+  r_assert (!fixture->hs_done);
+  r_assert (fixture->got_error);
+  r_assert_cmpuint (fixture->last_alert, ==, R_TLS_ALERT_TYPE_HANDSHAKE_FAILURE);
+}
+RTEST_END;
+
+/* A CertificateVerify whose signature does not check out is a failed handshake
+ * cryptographic operation: decrypt_error. */
+RTEST_F (rtlsserver, tls_mtls_bad_certificate_verify, RTEST_FAST)
+{
+  r_assert_cmpint (r_tls_server_set_client_cert_mode (fixture->server,
+        R_TLS_CLIENT_CERT_MODE_REQUIRE), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  r_test_tls_client_mtls (fixture->server, fixture->prng, &fixture->qout,
+      R_TEST_MTLS_CERT, TRUE);
+
+  r_assert (!fixture->hs_done);
+  r_assert (fixture->got_error);
+  r_assert_cmpuint (fixture->last_alert, ==, R_TLS_ALERT_TYPE_DECRYPT_ERROR);
+}
+RTEST_END;
+
+/* When the verify_cert callback rejects the chain, the server aborts with
+ * bad_certificate. */
+RTEST_F (rtlsserver, tls_mtls_verify_cert_rejects, RTEST_FAST)
+{
+  fixture->reject_peer_cert = TRUE;
+  r_assert_cmpint (r_tls_server_set_client_cert_mode (fixture->server,
+        R_TLS_CLIENT_CERT_MODE_REQUIRE), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  r_test_tls_client_mtls (fixture->server, fixture->prng, &fixture->qout,
+      R_TEST_MTLS_CERT, FALSE);
+
+  r_assert (!fixture->hs_done);
+  r_assert (fixture->got_error);
+  r_assert_cmpuint (fixture->peer_cert_seen, ==, 1);
+  r_assert_cmpuint (fixture->last_alert, ==, R_TLS_ALERT_TYPE_BAD_CERTIFICATE);
 }
 RTEST_END;


### PR DESCRIPTION
Implements client-certificate authentication on both the TLS/DTLS server and
client — the last of #219's handshake features. RSA client certs with
rsa_pkcs1_sha256 (whose hash matches the suites' SHA-256 transcript); trust is
delegated to the existing `verify_cert` callback, as the client already does for
the server certificate.

## Server (`r_tls_server_set_client_cert_mode`)
- NONE (default, unchanged), REQUEST (ask; an empty/absent client cert is
  accepted), REQUIRE (ask; an empty/absent cert aborts).
- Emits a CertificateRequest in its flight; parses the client chain and hands it
  to `verify_cert`; verifies the CertificateVerify signature against a snapshot
  of the transcript through ClientKeyExchange (taken before that message is
  folded). A new CERTIFICATE_VERIFY state runs only when a non-empty client cert
  was presented. The verified leaf is exposed via `r_tls_server_get_peer_cert`.
- Alerts: unsupported scheme -> handshake_failure, bad signature ->
  decrypt_error, rejected chain -> bad_certificate, required-but-absent ->
  handshake_failure.

## Client (`r_tls_client_set_cert`)
- On a CertificateRequest, presents the configured certificate (or an empty one)
  before ClientKeyExchange and, when a real cert was sent, a CertificateVerify
  signed over the transcript.

## Proto
New `r_tls_write_hs_certificate_request` / `_certificate_verify` / `_certificate`
writers (the parsers already existed).

## Tests
Proto round-trips; server-side coverage via a hand-rolled client for the
negatives (require-no-cert -> handshake_failure, tampered CertificateVerify ->
decrypt_error, verify_cert reject -> bad_certificate); and a real
RTLSClient <-> RTLSServer mutual handshake completing for both TLS and DTLS, plus
a require-but-client-has-no-cert negative. Green across the
epoch/rpoll/ASan/UBSan/mingw matrix, leak- and UB-free; doxygen clean.

## Scope / follow-up
RSA + rsa_pkcs1_sha256 only; ECDSA and other schemes can follow. The remaining
#219 bullet — version handling beyond 1.2 — is the TLS 1.3 / multi-version effort
tracked in #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)