### PR TITLE
net/tls: clean close_notify shutdown

### DIFF
--- a/include/rlib/net/rtlsclient.h
+++ b/include/rlib/net/rtlsclient.h
@@ -98,6 +98,16 @@ R_API RTLSError r_tls_client_start (RTLSClient * client, REvLoop * loop,
 R_API rboolean r_tls_client_incoming_data (RTLSClient * client, RBuffer * buffer);
 /** @brief Encrypt and send application data through the session. */
 R_API rboolean r_tls_client_send_appdata (RTLSClient * client, RBuffer * buffer);
+/**
+ * @brief Cleanly close an established session.
+ *
+ * Emits a warning @c close_notify alert to the peer and moves the session to
+ * its closed state; @ref r_tls_client_send_appdata refuses thereafter. Returns
+ * @c TRUE if the alert was emitted, @c FALSE if the session was not in its
+ * application-data state (so a second call is a no-op). This does not free the
+ * session — drop the reference with @ref r_tls_client_unref.
+ */
+R_API rboolean r_tls_client_close (RTLSClient * client);
 
 /** @brief Export RFC 5705 keying material for an application label / context. */
 R_API RTLSError r_tls_client_export_keying_material (const RTLSClient * client,

--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -103,6 +103,17 @@ typedef void (*RTLSErrorCb) (rpointer ctx, RTLSAlertType alert, rpointer session
  * well-formed certificate.
  */
 typedef rboolean (*RTLSCertVerifyCb) (rpointer ctx, RCryptoCert * const * chain, ruint count);
+/**
+ * @brief Callback fired when the peer cleanly closes the session.
+ *
+ * Invoked once when an inbound @c close_notify is received: the session has
+ * sent its own @c close_notify in reply and moved to its closed state, in
+ * which it accepts no further application data. Distinct from
+ * @ref RTLSErrorCb, which signals an aborted (fatal) session. May be @c NULL.
+ * @p session is the @ref RTLSServer or @ref RTLSClient the bundle is attached
+ * to.
+ */
+typedef void (*RTLSClosedCb) (rpointer ctx, rpointer session);
 
 /** @brief Callback bundle wiring a session to its transport and policy. */
 typedef struct {
@@ -112,6 +123,7 @@ typedef struct {
   RTLSBufferCb                  appdata;                 /**< Sink for decrypted application data. */
   RTLSErrorCb                   error;                   /**< Fired on a fatal alert; may be @c NULL. */
   RTLSCertVerifyCb              verify_cert;             /**< Verify the peer certificate chain; may be @c NULL. */
+  RTLSClosedCb                  closed;                  /**< Fired on a peer close_notify; may be @c NULL. */
 } RTLSCallbacks;
 
 /** @brief Create a TLS server with the given callbacks and user context. */
@@ -172,6 +184,16 @@ R_API RTLSError r_tls_server_start (RTLSServer * server, REvLoop * loop,
 R_API rboolean r_tls_server_incoming_data (RTLSServer * server, RBuffer * buffer);
 /** @brief Encrypt and send application data through the session. */
 R_API rboolean r_tls_server_send_appdata (RTLSServer * server, RBuffer * buffer);
+/**
+ * @brief Cleanly close an established session.
+ *
+ * Emits a warning @c close_notify alert to the peer and moves the session to
+ * its closed state; @ref r_tls_server_send_appdata refuses thereafter. Returns
+ * @c TRUE if the alert was emitted, @c FALSE if the session was not in its
+ * application-data state (so a second call is a no-op). This does not free the
+ * session — drop the reference with @ref r_tls_server_unref.
+ */
+R_API rboolean r_tls_server_close (RTLSServer * server);
 
 /** @brief Export RFC 5705 keying material for an application label / context. */
 R_API RTLSError r_tls_server_export_keying_material (const RTLSServer * server,

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -298,14 +298,14 @@ r_tls_client_send_out (RTLSClient * client)
   }
 }
 
-static void
-r_tls_client_send_alert (RTLSClient * client, RTLSAlertType alert)
+/* Build an alert record and queue it for sending; the caller flushes. */
+static RTLSError
+r_tls_client_emit_alert (RTLSClient * client, RTLSAlertLevel level,
+    RTLSAlertType alert)
 {
   RBuffer * buf;
   RTLSError ret = R_TLS_ERROR_OOM;
   RTLSVersion ver = (client->version != 0) ? client->version : client->recordver;
-
-  R_LOG_WARNING ("Sending alert: 0x%.2x in state (%d)", alert, client->state);
 
   if ((buf = r_tls_client_alloc_buffer (client)) != NULL) {
     RMemMapInfo info = R_MEM_MAP_INFO_INIT;
@@ -315,11 +315,9 @@ r_tls_client_send_alert (RTLSClient * client, RTLSAlertType alert)
 
       if (r_tls_version_is_dtls (ver))
         ret = r_dtls_write_alert (info.data, info.size, &sz, ver,
-            client->client.epoch, client->client.seqno,
-            R_TLS_ALERT_LEVEL_FATAL, alert);
+            client->client.epoch, client->client.seqno, level, alert);
       else
-        ret = r_tls_write_alert (info.data, info.size, &sz, ver,
-            R_TLS_ALERT_LEVEL_FATAL, alert);
+        ret = r_tls_write_alert (info.data, info.size, &sz, ver, level, alert);
       r_buffer_unmap (buf, &info);
 
       if (ret == R_TLS_ERROR_OK) {
@@ -330,7 +328,16 @@ r_tls_client_send_alert (RTLSClient * client, RTLSAlertType alert)
     r_buffer_unref (buf);
   }
 
-  if (ret == R_TLS_ERROR_OK)
+  return ret;
+}
+
+static void
+r_tls_client_send_alert (RTLSClient * client, RTLSAlertType alert)
+{
+  R_LOG_WARNING ("Sending alert: 0x%.2x in state (%d)", alert, client->state);
+
+  if (r_tls_client_emit_alert (client, R_TLS_ALERT_LEVEL_FATAL, alert)
+      == R_TLS_ERROR_OK)
     r_tls_client_send_out (client);
 
   if (client->cb.error != NULL)

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -38,6 +38,7 @@ typedef enum {
   R_TLS_CLIENT_CHANGE_CIPHER,       /* await server ChangeCipherSpec */
   R_TLS_CLIENT_FINISHED,            /* await server Finished */
   R_TLS_CLIENT_APPDATA,
+  R_TLS_CLIENT_CLOSED,
   R_TLS_CLIENT_ERROR,
 } RTLSClientState;
 
@@ -1116,6 +1117,14 @@ r_tls_client_state_error (RTLSClient * client, const RTLSParser * parser)
   return R_TLS_ERROR_OK;
 }
 
+/* Once closed (close_notify exchanged) any further record is dropped. */
+static RTLSError
+r_tls_client_state_closed (RTLSClient * client, const RTLSParser * parser)
+{
+  (void) client; (void) parser;
+  return R_TLS_ERROR_OK;
+}
+
 static RTLSError
 r_tls_client_state_server_hello (RTLSClient * client, const RTLSParser * parser)
 {
@@ -1424,6 +1433,7 @@ r_tls_client_incoming_data (RTLSClient * client, RBuffer * buffer)
     r_tls_client_state_change_cipher,
     r_tls_client_state_finished,
     r_tls_client_state_appdata,
+    r_tls_client_state_closed,
     r_tls_client_state_error,
   };
   /* Zero-init: a record that fails init_buffer never sets parser.buf, and the
@@ -1474,6 +1484,16 @@ r_tls_client_incoming_data (RTLSClient * client, RBuffer * buffer)
           if (client->cb.error != NULL)
             client->cb.error (client->userdata, atype, client);
           r_tls_client_change_state (client, R_TLS_CLIENT_ERROR);
+        } else if (atype == R_TLS_ALERT_TYPE_CLOSE_NOTIFY &&
+            client->state < R_TLS_CLIENT_CLOSED) {
+          /* Respond with our own close_notify (RFC 5246 7.2.1) and surface
+           * the orderly close to the application. */
+          if (r_tls_client_emit_alert (client, R_TLS_ALERT_LEVEL_WARNING,
+                R_TLS_ALERT_TYPE_CLOSE_NOTIFY) == R_TLS_ERROR_OK)
+            r_tls_client_send_out (client);
+          r_tls_client_change_state (client, R_TLS_CLIENT_CLOSED);
+          if (client->cb.closed != NULL)
+            client->cb.closed (client->userdata, client);
         }
       } else {
         r_tls_client_change_state (client, R_TLS_CLIENT_ERROR);
@@ -1543,6 +1563,23 @@ r_tls_client_send_appdata (RTLSClient * client, RBuffer * buffer)
     return FALSE;
 
   r_tls_client_send_out (client);
+  return TRUE;
+}
+
+rboolean
+r_tls_client_close (RTLSClient * client)
+{
+  if (R_UNLIKELY (client == NULL)) return FALSE;
+  /* Only an established session can be cleanly closed; a second call is a
+   * no-op (the state has already advanced past APPDATA). */
+  if (client->state != R_TLS_CLIENT_APPDATA) return FALSE;
+
+  if (r_tls_client_emit_alert (client, R_TLS_ALERT_LEVEL_WARNING,
+        R_TLS_ALERT_TYPE_CLOSE_NOTIFY) != R_TLS_ERROR_OK)
+    return FALSE;
+
+  r_tls_client_send_out (client);
+  r_tls_client_change_state (client, R_TLS_CLIENT_CLOSED);
   return TRUE;
 }
 

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -39,6 +39,7 @@ typedef enum {
   R_TLS_SERVER_CHANGE_CIPHER,
   R_TLS_SERVER_FINISHED,
   R_TLS_SERVER_APPDATA,
+  R_TLS_SERVER_CLOSED,
   R_TLS_SERVER_ERROR,
 } RTLSServerState;
 
@@ -1677,6 +1678,16 @@ r_tls_server_state_error (RTLSServer * server, const RTLSParser * parser)
   return R_TLS_ERROR_OK;
 }
 
+/* Once closed (close_notify exchanged) any further record is dropped. */
+static RTLSError
+r_tls_server_state_closed (RTLSServer * server, const RTLSParser * parser)
+{
+  (void) server;
+  (void) parser;
+
+  return R_TLS_ERROR_OK;
+}
+
 /* Attempt an abbreviated (RFC 5077) handshake from a ticket offered in the
  * ClientHello. On success the master secret and negotiated parameters have been
  * recovered from the ticket, the write keys are installed, and the server is
@@ -2026,6 +2037,7 @@ r_tls_server_incoming_data (RTLSServer * server, RBuffer * buffer)
     r_tls_server_state_change_cipher,
     r_tls_server_state_finished,
     r_tls_server_state_appdata,
+    r_tls_server_state_closed,
 
     r_tls_server_state_error,
   };
@@ -2083,8 +2095,19 @@ r_tls_server_incoming_data (RTLSServer * server, RBuffer * buffer)
       if ((err = r_tls_parser_parse_alert (&parser, &alevel, &atype)) == R_TLS_ERROR_OK) {
         R_LOG_WARNING ("Received Alert, %.2x %.2x", alevel, atype);
 
-        if (alevel == R_TLS_ALERT_LEVEL_FATAL)
+        if (alevel == R_TLS_ALERT_LEVEL_FATAL) {
           err = r_tls_server_change_state (server, R_TLS_SERVER_ERROR);
+        } else if (atype == R_TLS_ALERT_TYPE_CLOSE_NOTIFY &&
+            server->state < R_TLS_SERVER_CLOSED) {
+          /* Respond with our own close_notify (RFC 5246 7.2.1) and surface
+           * the orderly close to the application. */
+          if (r_tls_server_emit_alert (server, R_TLS_ALERT_LEVEL_WARNING,
+                R_TLS_ALERT_TYPE_CLOSE_NOTIFY) == R_TLS_ERROR_OK)
+            r_tls_server_send_out (server);
+          r_tls_server_change_state (server, R_TLS_SERVER_CLOSED);
+          if (server->cb.closed != NULL)
+            server->cb.closed (server->userdata, server);
+        }
       } else {
         R_LOG_WARNING ("Received Alert, unable to parse! %d", err);
 
@@ -2168,6 +2191,23 @@ r_tls_server_send_appdata (RTLSServer * server, RBuffer * buffer)
     return FALSE;
 
   r_tls_server_send_out (server);
+  return TRUE;
+}
+
+rboolean
+r_tls_server_close (RTLSServer * server)
+{
+  if (R_UNLIKELY (server == NULL)) return FALSE;
+  /* Only an established session can be cleanly closed; a second call is a
+   * no-op (the state has already advanced past APPDATA). */
+  if (server->state != R_TLS_SERVER_APPDATA) return FALSE;
+
+  if (r_tls_server_emit_alert (server, R_TLS_ALERT_LEVEL_WARNING,
+        R_TLS_ALERT_TYPE_CLOSE_NOTIFY) != R_TLS_ERROR_OK)
+    return FALSE;
+
+  r_tls_server_send_out (server);
+  r_tls_server_change_state (server, R_TLS_SERVER_CLOSED);
   return TRUE;
 }
 

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -1578,8 +1578,10 @@ r_tls_server_parse_finished (RTLSServer * server, const RTLSParser * parser)
 
 static void r_tls_server_send_out (RTLSServer * server);
 
-static void
-r_tls_server_send_alert (RTLSServer * server, RTLSAlertType alert)
+/* Build an alert record and queue it for sending; the caller flushes. */
+static RTLSError
+r_tls_server_emit_alert (RTLSServer * server, RTLSAlertLevel level,
+    RTLSAlertType alert)
 {
   RBuffer * buf;
   RTLSError ret = R_TLS_ERROR_OOM;
@@ -1588,10 +1590,6 @@ r_tls_server_send_alert (RTLSServer * server, RTLSAlertType alert)
    * negotiation). */
   RTLSVersion ver = (server->version != 0) ? server->version : server->recordver;
 
-  R_LOG_WARNING ("Sending alert: 0x%.2x in state (%d)", alert, server->state);
-
-  /* Emit a fatal alert record to the peer. Best-effort: even if it
-   * cannot be built/sent we still report and move to the error state. */
   if ((buf = r_tls_server_alloc_buffer (server)) != NULL) {
     RMemMapInfo info = R_MEM_MAP_INFO_INIT;
 
@@ -1600,11 +1598,9 @@ r_tls_server_send_alert (RTLSServer * server, RTLSAlertType alert)
 
       if (r_tls_version_is_dtls (ver))
         ret = r_dtls_write_alert (info.data, info.size, &sz, ver,
-            server->server.epoch, server->server.seqno,
-            R_TLS_ALERT_LEVEL_FATAL, alert);
+            server->server.epoch, server->server.seqno, level, alert);
       else
-        ret = r_tls_write_alert (info.data, info.size, &sz, ver,
-            R_TLS_ALERT_LEVEL_FATAL, alert);
+        ret = r_tls_write_alert (info.data, info.size, &sz, ver, level, alert);
       r_buffer_unmap (buf, &info);
 
       if (ret == R_TLS_ERROR_OK) {
@@ -1615,7 +1611,20 @@ r_tls_server_send_alert (RTLSServer * server, RTLSAlertType alert)
     r_buffer_unref (buf);
   }
 
-  if (ret != R_TLS_ERROR_OK)
+  return ret;
+}
+
+static void
+r_tls_server_send_alert (RTLSServer * server, RTLSAlertType alert)
+{
+  RTLSError ret;
+
+  R_LOG_WARNING ("Sending alert: 0x%.2x in state (%d)", alert, server->state);
+
+  /* Emit a fatal alert record to the peer. Best-effort: even if it
+   * cannot be built/sent we still report and move to the error state. */
+  if ((ret = r_tls_server_emit_alert (server, R_TLS_ALERT_LEVEL_FATAL, alert))
+      != R_TLS_ERROR_OK)
     R_LOG_WARNING ("Failed to emit alert 0x%.2x: %d", alert, ret);
   else
     /* Flush now: the caller returns an error, skipping the normal

--- a/rlib/rtc/rrtcdtlstransport.c
+++ b/rlib/rtc/rrtcdtlstransport.c
@@ -219,6 +219,7 @@ r_rtc_crypto_transport_new_dtls (RRtcIceTransport * ice, RPrng * prng,
     r_rtc_dtls_srv_buffer_appdata,
     NULL,
     NULL,
+    NULL,
   };
 
   if (R_UNLIKELY (ice == NULL)) return NULL;

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -82,6 +82,7 @@ RTEST_FIXTURE_STRUCT (rtlsclient)
 
   rboolean srv_hs_done, cli_hs_done;
   rboolean srv_error, cli_error;
+  rboolean srv_closed, cli_closed;
   ruint verify_calls;
   rboolean verify_result;
   RTLSCipherSuite force_suite;   /* pin both endpoints to one suite; NONE = defaults */
@@ -139,6 +140,22 @@ r_tlsclient_test_cli_error (rpointer ctx, RTLSAlertType alert, rpointer session)
   fixture->cli_error = TRUE;
 }
 
+static void
+r_tlsclient_test_srv_closed (rpointer ctx, rpointer session)
+{
+  RTEST_FIXTURE_STRUCT (rtlsclient) * fixture = ctx;
+  (void) session;
+  fixture->srv_closed = TRUE;
+}
+
+static void
+r_tlsclient_test_cli_closed (rpointer ctx, rpointer session)
+{
+  RTEST_FIXTURE_STRUCT (rtlsclient) * fixture = ctx;
+  (void) session;
+  fixture->cli_closed = TRUE;
+}
+
 static rboolean
 r_tlsclient_test_srv_out (rpointer ctx, RBuffer * buf, rpointer session)
 {
@@ -189,6 +206,7 @@ RTEST_FIXTURE_SETUP (rtlsclient)
     r_tlsclient_test_srv_app,
     r_tlsclient_test_srv_error,
     NULL,
+    r_tlsclient_test_srv_closed,
   };
   static RTLSCallbacks clicbs = {
     r_tlsclient_test_prefer_ecdhe,
@@ -197,6 +215,7 @@ RTEST_FIXTURE_SETUP (rtlsclient)
     r_tlsclient_test_cli_app,
     r_tlsclient_test_cli_error,
     r_tlsclient_test_verify_cert,
+    r_tlsclient_test_cli_closed,
   };
   RCryptoCert * cert;
   RCryptoKey * pk;
@@ -207,6 +226,7 @@ RTEST_FIXTURE_SETUP (rtlsclient)
 
   fixture->srv_hs_done = fixture->cli_hs_done = FALSE;
   fixture->srv_error = fixture->cli_error = FALSE;
+  fixture->srv_closed = fixture->cli_closed = FALSE;
   fixture->verify_calls = 0;
   fixture->verify_result = TRUE;
   fixture->force_suite = R_TLS_CS_NONE;
@@ -301,6 +321,76 @@ r_test_tls_assert_appdata (RQueue * q, const ruint8 * data, rsize size)
   r_buffer_unref (buf);
 }
 
+/* Assert @buf is an alert record. The close_notify is emitted post-handshake,
+ * so its body is encrypted (only the record content type is in the clear); the
+ * decrypted warning/close_notify bytes are asserted in the rtlsserver suite. */
+static void
+r_test_tls_assert_alert_record (RBuffer * buf)
+{
+  RTLSParser parser = R_TLS_PARSER_INIT;
+
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_ALERT);
+  r_tls_parser_clear (&parser);
+}
+
+/* Drive a handshake, then have one endpoint cleanly close: it emits a warning
+ * close_notify, the peer auto-responds (RFC 5246 7.2.1) and reports the orderly
+ * close through its closed callback, and neither side accepts further app data.
+ * The initiator is not itself notified (it requested the close). */
+static void
+r_test_tls_close_notify (RTEST_FIXTURE_STRUCT (rtlsclient) * fixture,
+    RTLSVersion version, rboolean server_initiates)
+{
+  static const ruint8 payload[] = { 'x' };
+  RBuffer * buf;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng, version),
+      ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->cli_hs_done);
+  r_assert (fixture->srv_hs_done);
+
+  if (server_initiates) {
+    r_assert (r_tls_server_close (fixture->server));
+    r_assert (!r_tls_server_close (fixture->server));  /* idempotent: a no-op */
+    /* The server queued exactly its warning close_notify; deliver it. */
+    r_assert_cmpptr ((buf = r_queue_pop (&fixture->srv_out)), !=, NULL);
+    r_test_tls_assert_alert_record (buf);
+    r_tls_client_incoming_data (fixture->client, buf);
+    r_buffer_unref (buf);
+    r_assert (fixture->cli_closed);
+    r_assert (!fixture->cli_error);
+    r_assert (!fixture->srv_closed);                   /* initiator not notified */
+    /* The client auto-responded with its own warning close_notify. */
+    r_assert_cmpptr ((buf = r_queue_pop (&fixture->cli_out)), !=, NULL);
+    r_test_tls_assert_alert_record (buf);
+    r_buffer_unref (buf);
+  } else {
+    r_assert (r_tls_client_close (fixture->client));
+    r_assert (!r_tls_client_close (fixture->client));  /* idempotent: a no-op */
+    r_assert_cmpptr ((buf = r_queue_pop (&fixture->cli_out)), !=, NULL);
+    r_test_tls_assert_alert_record (buf);
+    r_tls_server_incoming_data (fixture->server, buf);
+    r_buffer_unref (buf);
+    r_assert (fixture->srv_closed);
+    r_assert (!fixture->srv_error);
+    r_assert (!fixture->cli_closed);                   /* initiator not notified */
+    r_assert_cmpptr ((buf = r_queue_pop (&fixture->srv_out)), !=, NULL);
+    r_test_tls_assert_alert_record (buf);
+    r_buffer_unref (buf);
+  }
+
+  /* A closed session refuses application data in either direction. */
+  r_assert_cmpptr ((buf = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)payload, sizeof (payload), sizeof (payload), 0, NULL, NULL)), !=, NULL);
+  r_assert (!r_tls_client_send_appdata (fixture->client, buf));
+  r_assert (!r_tls_server_send_appdata (fixture->server, buf));
+  r_buffer_unref (buf);
+}
+
 static void
 r_test_tls_loopback (RTEST_FIXTURE_STRUCT (rtlsclient) * fixture, RTLSVersion version)
 {
@@ -354,6 +444,30 @@ RTEST_END;
 RTEST_F (rtlsclient, dtls_loopback, RTEST_FAST)
 {
   r_test_tls_loopback (fixture, R_TLS_VERSION_DTLS_1_2);
+}
+RTEST_END;
+
+RTEST_F (rtlsclient, tls_close_notify_client, RTEST_FAST)
+{
+  r_test_tls_close_notify (fixture, R_TLS_VERSION_TLS_1_2, FALSE);
+}
+RTEST_END;
+
+RTEST_F (rtlsclient, dtls_close_notify_client, RTEST_FAST)
+{
+  r_test_tls_close_notify (fixture, R_TLS_VERSION_DTLS_1_2, FALSE);
+}
+RTEST_END;
+
+RTEST_F (rtlsclient, tls_close_notify_server, RTEST_FAST)
+{
+  r_test_tls_close_notify (fixture, R_TLS_VERSION_TLS_1_2, TRUE);
+}
+RTEST_END;
+
+RTEST_F (rtlsclient, dtls_close_notify_server, RTEST_FAST)
+{
+  r_test_tls_close_notify (fixture, R_TLS_VERSION_DTLS_1_2, TRUE);
 }
 RTEST_END;
 

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -58,6 +58,7 @@ RTEST_FIXTURE_STRUCT (rtlsserver)
   RTLSSessionTicketKeys * ticket_keys;
   rboolean hs_done;
   rboolean got_error;
+  rboolean closed;
   RTLSAlertType last_alert;
   ruint peer_cert_seen;        /* times verify_cert was invoked */
   rboolean reject_peer_cert;   /* make verify_cert reject the chain */
@@ -103,6 +104,14 @@ r_tlsserver_test_error (rpointer ctx, RTLSAlertType alert, rpointer session)
   fixture->last_alert = alert;
 }
 
+static void
+r_tlsserver_test_closed (rpointer ctx, rpointer session)
+{
+  RTEST_FIXTURE_STRUCT (rtlsserver) * fixture = ctx;
+  (void) session;
+  fixture->closed = TRUE;
+}
+
 static rboolean
 r_tlsserver_test_verify_cert (rpointer ctx, RCryptoCert * const * chain, ruint count)
 {
@@ -140,6 +149,7 @@ RTEST_FIXTURE_SETUP (rtlsserver)
     r_tlsserver_test_buffer_appdata,
     r_tlsserver_test_error,
     r_tlsserver_test_verify_cert,
+    r_tlsserver_test_closed,
   };
   RCryptoCert * cert;
   RCryptoKey * pk;
@@ -149,6 +159,7 @@ RTEST_FIXTURE_SETUP (rtlsserver)
   r_assert_cmpptr ((fixture->evloop = r_ev_loop_new_full (fixture->clock, NULL)), !=, NULL);
   fixture->hs_done = FALSE;
   fixture->got_error = FALSE;
+  fixture->closed = FALSE;
   fixture->last_alert = R_TLS_ALERT_TYPE_CLOSE_NOTIFY;
   fixture->peer_cert_seen = 0;
   fixture->reject_peer_cert = FALSE;
@@ -1129,6 +1140,70 @@ RTEST_F (rtlsserver, dtls_send_appdata, RTEST_FAST)
 }
 RTEST_END;
 
+/* r_tls_server_close cleanly shuts an established session down: it emits an
+ * (encrypted) warning close_notify, refuses further application data, and does
+ * not fire the closed callback (that signals a peer-initiated close). */
+RTEST_F (rtlsserver, dtls_server_close_emits_close_notify, RTEST_FAST)
+{
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RCryptoCipher * cipher = NULL;
+  RHmac * hmac = NULL;
+  RBuffer * buf, * app;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  ruint8 ch[256];
+  rsize chlen;
+  RTLSAlertLevel level = 0;
+  RTLSAlertType type = 0;
+  static const ruint8 payload[] = { 'x' };
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  chlen = r_test_tls_build_dtls_client_hello (fixture->prng, ch, sizeof (ch),
+      FALSE, FALSE, FALSE, TRUE, NULL, 0, FALSE);
+  r_test_tls_server_feed (fixture->server, ch, chlen);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert (r_buffer_map (buf, &info, R_MEM_MAP_READ));
+  r_test_tls_dtls_client_complete (fixture->server, fixture->prng,
+      ch, chlen, info.data, info.size, FALSE, FALSE, &cipher, &hmac, NULL, NULL);
+  r_buffer_unmap (buf, &info);
+  r_buffer_unref (buf);
+  r_assert (fixture->hs_done);
+
+  /* Drop the server's ChangeCipherSpec + Finished flight. */
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_buffer_unref (buf);
+
+  /* Cleanly close; a second call is a no-op. */
+  r_assert (r_tls_server_close (fixture->server));
+  r_assert (!r_tls_server_close (fixture->server));
+
+  /* The emitted record is an encrypted warning close_notify at epoch 1. */
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_ALERT);
+  r_assert_cmpuint (parser.epoch, ==, 1);
+  r_assert_cmpint (r_tls_parser_decrypt (&parser, cipher, hmac, FALSE, NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_parser_parse_alert (&parser, &level, &type), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (level, ==, R_TLS_ALERT_LEVEL_WARNING);
+  r_assert_cmpuint (type, ==, R_TLS_ALERT_TYPE_CLOSE_NOTIFY);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+
+  /* Closed: no further application data, and we initiated so closed never fired. */
+  r_assert_cmpptr ((app = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)payload, sizeof (payload), sizeof (payload), 0, NULL, NULL)), !=, NULL);
+  r_assert (!r_tls_server_send_appdata (fixture->server, app));
+  r_buffer_unref (app);
+  r_assert (!fixture->closed);
+  r_assert (!fixture->got_error);
+
+  r_hmac_free (hmac);
+  r_crypto_cipher_unref (cipher);
+}
+RTEST_END;
+
 /* Over a (non-DTLS) TLS connection the record sequence number is implicit and
  * must advance per record: the client Finished is read seqno 0, the first
  * application_data record is seqno 1. A regression where the server MAC'd
@@ -1498,7 +1573,7 @@ r_test_tls_server_new_cfg (rpointer ctx)
 {
   static const RTLSCallbacks cbs = {
     NULL, r_tlsserver_test_hs_done, r_tlsserver_test_buffer_out,
-    r_tlsserver_test_buffer_appdata, r_tlsserver_test_error, NULL,
+    r_tlsserver_test_buffer_appdata, r_tlsserver_test_error, NULL, NULL,
   };
   RTLSServer * srv;
   RCryptoCert * cert;


### PR DESCRIPTION
Gives the TLS/DTLS server and client an orderly shutdown path (TLS 1.2 +
DTLS 1.2). Until now both endpoints could only emit *fatal* alerts -- nothing
sent a warning close_notify -- and an inbound close_notify was logged and
ignored, so a peer could not distinguish an orderly close from a truncated or
aborted connection.

## Closing
`r_tls_server_close` / `r_tls_client_close` emit a warning close_notify and move
the session to a new closed state in which it refuses further application data.
A second call is a no-op; closing does not free the session.

## Inbound close_notify
A received close_notify is now answered with our own close_notify (RFC 5246
7.2.1), the session moves to the closed state, and the orderly close is surfaced
through a new RTLSClosedCb callback -- distinct from the fatal-alert error
callback, so the application can tell a clean close from an aborted one. The
initiator is not itself notified (it requested the close).

The closed state slots between the application-data and error states so a fatal
alert can still escalate a closed session; the existing alert record writers
already take the level parameter, so there is no record-layer change. The fatal
alert path is refactored to share the record-building helper but is otherwise
byte-for-byte unchanged.

## Tests
Loopback close over TLS and DTLS, for both a client- and a server-initiated
close: the peer reports the orderly close, auto-responds, and both ends then
refuse application data; the initiator is not notified and a second close is a
no-op. A server-direct test decrypts the emitted record to confirm it is a
warning close_notify. Green across the epoch/rpoll/ASan/UBSan/mingw matrix,
leak- and UB-free; doxygen clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)