### PR TITLE
net/tls: remaining RFC 5246 7.2.2 alerts (no_renegotiation, illegal_parameter)

### DIFF
--- a/include/rlib/net/proto/rtls.h
+++ b/include/rlib/net/proto/rtls.h
@@ -348,6 +348,7 @@ typedef enum {
   R_TLS_ERROR_HS_VERIFICATION_FAILED                    = -0x0f, /**< Handshake verify-data check failed. */
   R_TLS_ERROR_ENCRYPTION_FAILED                         = -0x10, /**< Record encryption failed. */
   R_TLS_ERROR_RECORD_OVERFLOW                           = -0x11, /**< Record fragment length exceeds the limit. */
+  R_TLS_ERROR_ILLEGAL_PARAMETER                         = -0x12, /**< Field value well-formed but out of range. */
 } RTLSError;
 
 /** @brief TLS record compression method (only @c NULL is supported / non-deprecated). */

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -1153,7 +1153,21 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
   for (i = 0; i < count; i++)
     incoming[i] = (RTLSCipherSuite) r_load_be16 (server->hello.cs + i * sizeof (ruint16));
 
-  /* Compression */
+  /* Compression: we only support null, but the client MUST offer it
+   * (RFC 5246 7.4.1.4). An empty list is malformed; a non-empty list without
+   * null is a well-formed-but-illegal parameter. */
+  {
+    ruint16 ncomp = r_tls_hello_msg_compression_count (&server->hello), c;
+
+    if (ncomp == 0)
+      return R_TLS_ERROR_CORRUPT_RECORD;
+    for (c = 0; c < ncomp; c++) {
+      if (r_tls_hello_msg_compression_method (&server->hello, c) == R_TLS_COMPRESSION_NULL)
+        break;
+    }
+    if (c == ncomp)
+      return R_TLS_ERROR_ILLEGAL_PARAMETER;
+  }
   server->comp = R_TLS_COMPRESSION_NULL;
 
   /* Cipher suite */
@@ -1660,6 +1674,8 @@ r_tls_server_alert_for_error (RTLSError err)
       return R_TLS_ALERT_TYPE_DECODE_ERROR;
     case R_TLS_ERROR_RECORD_OVERFLOW:   /* fragment longer than the limit */
       return R_TLS_ALERT_TYPE_RECORD_OVERFLOW;
+    case R_TLS_ERROR_ILLEGAL_PARAMETER: /* field value out of range */
+      return R_TLS_ALERT_TYPE_ILLEGAL_PARAMETER;
     case R_TLS_ERROR_HS_VERIFICATION_FAILED:  /* could not verify Finished */
       return R_TLS_ALERT_TYPE_DECRYPT_ERROR;
     case R_TLS_ERROR_VERSION:

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -2006,6 +2006,18 @@ r_tls_server_state_appdata (RTLSServer * server, const RTLSParser * parser)
     } else {
       R_LOG_WARNING ("Unable to create view of TLS appdata buffer");
     }
+  } else if (parser->content == R_TLS_CONTENT_TYPE_HANDSHAKE) {
+    RTLSHandshakeType hstype;
+
+    /* A post-handshake ClientHello is a renegotiation attempt. We do not
+     * renegotiate; decline with a warning and keep the session running
+     * (RFC 5246 7.2.1). The caller flushes via send_out after dispatch. */
+    if (r_tls_parser_parse_handshake_peek_type (parser, &hstype) == R_TLS_ERROR_OK &&
+        hstype == R_TLS_HANDSHAKE_TYPE_CLIENT_HELLO)
+      r_tls_server_emit_alert (server, R_TLS_ALERT_LEVEL_WARNING,
+          R_TLS_ALERT_TYPE_NO_RENEGOTIATION);
+    else
+      R_LOG_WARNING ("Received non-app-data record");
   } else {
     R_LOG_WARNING ("Received non-app-data record");
   }

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -1278,6 +1278,57 @@ RTEST_F (rtlsserver, dtls_no_renegotiation_warning, RTEST_FAST)
 }
 RTEST_END;
 
+/* A ClientHello whose compression list omits null compression is well-formed
+ * but illegal (RFC 5246 7.4.1.4): the server aborts with illegal_parameter. */
+RTEST_F (rtlsserver, dtls_clienthello_no_null_compression, RTEST_FAST)
+{
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RBuffer * buf;
+  RTLSAlertLevel level = 0;
+  RTLSAlertType type = 0;
+  ruint8 body[128], ch[256];
+  ruint8 * p = body;
+  ruint8 * extlenp;
+  rsize bodylen, hs;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  /* DTLS 1.2 ClientHello, compression = [deflate] only (no null). */
+  *p++ = 0xfe; *p++ = 0xfd;
+  r_prng_fill (fixture->prng, p, R_TLS_HELLO_RANDOM_BYTES); p += R_TLS_HELLO_RANDOM_BYTES;
+  *p++ = 0;                                  /* session id length */
+  *p++ = 0;                                  /* cookie length (DTLS) */
+  r_store_be16 (p, (ruint16) sizeof (ruint16)); p += 2;
+  r_store_be16 (p, (ruint16) R_TLS_CS_RSA_WITH_AES_128_CBC_SHA); p += 2;
+  *p++ = 1; *p++ = 1;                        /* compression: deflate only, no null */
+  extlenp = p; p += 2;
+  r_store_be16 (p, (ruint16) R_TLS_EXT_TYPE_RENEGOTIATION_INFO); p += 2;
+  r_store_be16 (p, 1); p += 2; *p++ = 0;
+  r_store_be16 (extlenp, (ruint16) (p - (extlenp + 2)));
+  bodylen = (rsize) (p - body);
+
+  r_assert_cmpint (r_dtls_write_handshake (ch, sizeof (ch), &hs,
+        R_TLS_VERSION_DTLS_1_2, R_TLS_HANDSHAKE_TYPE_CLIENT_HELLO,
+        (ruint16) bodylen, 0, 0, 0, 0, (ruint32) bodylen), ==, R_TLS_ERROR_OK);
+  r_memcpy (ch + hs, body, bodylen);
+  r_test_tls_server_feed (fixture->server, ch, hs + bodylen);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_ALERT);
+  r_assert_cmpint (r_tls_parser_parse_alert (&parser, &level, &type), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (level, ==, R_TLS_ALERT_LEVEL_FATAL);
+  r_assert_cmpuint (type, ==, R_TLS_ALERT_TYPE_ILLEGAL_PARAMETER);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+
+  r_assert (!fixture->hs_done);
+  r_assert (fixture->got_error);
+  r_assert_cmpuint (fixture->last_alert, ==, R_TLS_ALERT_TYPE_ILLEGAL_PARAMETER);
+}
+RTEST_END;
+
 /* Over a (non-DTLS) TLS connection the record sequence number is implicit and
  * must advance per record: the client Finished is read seqno 0, the first
  * application_data record is seqno 1. A regression where the server MAC'd

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -335,7 +335,8 @@ static void
 r_test_tls_dtls_client_complete (RTLSServer * server, RPrng * prng,
     const ruint8 * ch, rsize chlen, const ruint8 * srvflight, rsize srvlen,
     rboolean ems, rboolean etm, RCryptoCipher ** srv_cipher, RHmac ** srv_hmac,
-    RMsgDigest ** hs_md, ruint8 * ms_out)
+    RMsgDigest ** hs_md, ruint8 * ms_out,
+    RCryptoCipher ** cli_cipher, RHmac ** cli_hmac)
 {
   RCryptoKey * pk;
   RBuffer * buf;
@@ -442,8 +443,15 @@ r_test_tls_dtls_client_complete (RTLSServer * server, RPrng * prng,
   r_prng_fill (prng, iv, sizeof (iv));
   r_assert_cmpptr ((encbuf = r_dtls_encrypt_buffer (plain, cipher, iv, hmac, etm)), !=, NULL);
   r_buffer_unref (plain);
-  r_hmac_free (hmac);
-  r_crypto_cipher_unref (cipher);
+  /* Hand the client write keys back so the caller can encrypt a later record
+   * (e.g. a renegotiation ClientHello), else free them. */
+  if (cli_cipher != NULL) {
+    *cli_cipher = cipher;
+    *cli_hmac = hmac;
+  } else {
+    r_hmac_free (hmac);
+    r_crypto_cipher_unref (cipher);
+  }
 
   /* ChangeCipherSpec (epoch 0) */
   r_assert_cmpint (r_dtls_write_change_cipher (ccsbuf, sizeof (ccsbuf), &ccslen,
@@ -587,7 +595,7 @@ RTEST_F (rtlsserver, dtls_srtp_valid_handshake, RTEST_FAST)
   r_assert (r_buffer_map (buf, &info, R_MEM_MAP_READ));
   r_test_tls_dtls_client_complete (fixture->server, fixture->prng,
       pkt_dtls_client_hallo, sizeof (pkt_dtls_client_hallo), info.data, info.size,
-      TRUE, FALSE, &cipher, &hmac, &hs_md, ms);
+      TRUE, FALSE, &cipher, &hmac, &hs_md, ms, NULL, NULL);
   r_buffer_unmap (buf, &info);
   r_buffer_unref (buf);
   r_assert (fixture->hs_done);
@@ -800,7 +808,7 @@ RTEST_F (rtlsserver, dtls_handshake_without_ems, RTEST_FAST)
 
   r_assert (r_buffer_map (buf, &info, R_MEM_MAP_READ));
   r_test_tls_dtls_client_complete (fixture->server, fixture->prng,
-      ch, chlen, info.data, info.size, FALSE, FALSE, &cipher, &hmac, NULL, NULL);
+      ch, chlen, info.data, info.size, FALSE, FALSE, &cipher, &hmac, NULL, NULL, NULL, NULL);
   r_buffer_unmap (buf, &info);
   r_buffer_unref (buf);
 
@@ -853,7 +861,7 @@ RTEST_F (rtlsserver, dtls_encrypt_then_mac_handshake, RTEST_FAST)
    * hs_done implies the server accepted the EtM-protected client Finished. */
   r_assert (r_buffer_map (buf, &info, R_MEM_MAP_READ));
   r_test_tls_dtls_client_complete (fixture->server, fixture->prng,
-      ch, chlen, info.data, info.size, FALSE, TRUE, &cipher, &hmac, NULL, NULL);
+      ch, chlen, info.data, info.size, FALSE, TRUE, &cipher, &hmac, NULL, NULL, NULL, NULL);
   r_buffer_unmap (buf, &info);
   r_buffer_unref (buf);
   r_assert (fixture->hs_done);
@@ -1109,7 +1117,7 @@ RTEST_F (rtlsserver, dtls_send_appdata, RTEST_FAST)
   r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
   r_assert (r_buffer_map (buf, &info, R_MEM_MAP_READ));
   r_test_tls_dtls_client_complete (fixture->server, fixture->prng,
-      ch, chlen, info.data, info.size, FALSE, FALSE, &cipher, &hmac, NULL, NULL);
+      ch, chlen, info.data, info.size, FALSE, FALSE, &cipher, &hmac, NULL, NULL, NULL, NULL);
   r_buffer_unmap (buf, &info);
   r_buffer_unref (buf);
   r_assert (fixture->hs_done);
@@ -1166,7 +1174,7 @@ RTEST_F (rtlsserver, dtls_server_close_emits_close_notify, RTEST_FAST)
   r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
   r_assert (r_buffer_map (buf, &info, R_MEM_MAP_READ));
   r_test_tls_dtls_client_complete (fixture->server, fixture->prng,
-      ch, chlen, info.data, info.size, FALSE, FALSE, &cipher, &hmac, NULL, NULL);
+      ch, chlen, info.data, info.size, FALSE, FALSE, &cipher, &hmac, NULL, NULL, NULL, NULL);
   r_buffer_unmap (buf, &info);
   r_buffer_unref (buf);
   r_assert (fixture->hs_done);
@@ -1201,6 +1209,72 @@ RTEST_F (rtlsserver, dtls_server_close_emits_close_notify, RTEST_FAST)
 
   r_hmac_free (hmac);
   r_crypto_cipher_unref (cipher);
+}
+RTEST_END;
+
+/* A post-handshake ClientHello is a renegotiation attempt: the server declines
+ * with a warning no_renegotiation (RFC 5246 7.2.1) and keeps the session up. */
+RTEST_F (rtlsserver, dtls_no_renegotiation_warning, RTEST_FAST)
+{
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RCryptoCipher * scipher = NULL, * ccipher = NULL;
+  RHmac * shmac = NULL, * chmac = NULL;
+  RBuffer * buf, * plain, * enc;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  ruint8 ch[256], reneg[64], iv[16];
+  rsize chlen, hslen;
+  RTLSAlertLevel level = 0;
+  RTLSAlertType type = 0;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  chlen = r_test_tls_build_dtls_client_hello (fixture->prng, ch, sizeof (ch),
+      FALSE, FALSE, FALSE, TRUE, NULL, 0, FALSE);
+  r_test_tls_server_feed (fixture->server, ch, chlen);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert (r_buffer_map (buf, &info, R_MEM_MAP_READ));
+  r_test_tls_dtls_client_complete (fixture->server, fixture->prng,
+      ch, chlen, info.data, info.size, FALSE, FALSE, &scipher, &shmac, NULL, NULL,
+      &ccipher, &chmac);
+  r_buffer_unmap (buf, &info);
+  r_buffer_unref (buf);
+  r_assert (fixture->hs_done);
+
+  /* Drop the server's ChangeCipherSpec + Finished flight. */
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_buffer_unref (buf);
+
+  /* Encrypt a minimal renegotiation ClientHello (epoch 1) and feed it. The
+   * appdata handler only peeks the handshake type, so an empty body suffices. */
+  r_assert_cmpint (r_dtls_write_handshake (reneg, sizeof (reneg), &hslen,
+        R_TLS_VERSION_DTLS_1_2, R_TLS_HANDSHAKE_TYPE_CLIENT_HELLO, 0,
+        1, 1, 3, 0, 0), ==, R_TLS_ERROR_OK);
+  r_assert_cmpptr ((plain = r_buffer_new_wrapped (R_MEM_FLAG_NONE, reneg, hslen,
+          hslen, 0, NULL, NULL)), !=, NULL);
+  r_prng_fill (fixture->prng, iv, sizeof (iv));
+  r_assert_cmpptr ((enc = r_dtls_encrypt_buffer (plain, ccipher, iv, chmac, FALSE)), !=, NULL);
+  r_buffer_unref (plain);
+  r_assert (r_tls_server_incoming_data (fixture->server, enc));
+  r_buffer_unref (enc);
+
+  /* The reply is an encrypted warning no_renegotiation and the session lives on. */
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_ALERT);
+  r_assert_cmpint (r_tls_parser_decrypt (&parser, scipher, shmac, FALSE, NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_parser_parse_alert (&parser, &level, &type), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (level, ==, R_TLS_ALERT_LEVEL_WARNING);
+  r_assert_cmpuint (type, ==, R_TLS_ALERT_TYPE_NO_RENEGOTIATION);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+
+  r_assert (fixture->hs_done);
+  r_assert (!fixture->got_error);
+
+  r_hmac_free (shmac); r_crypto_cipher_unref (scipher);
+  r_hmac_free (chmac); r_crypto_cipher_unref (ccipher);
 }
 RTEST_END;
 
@@ -2104,7 +2178,7 @@ RTEST_F (rtlsserver, dtls_session_resume, RTEST_FAST)
   r_assert (r_buffer_map (buf, &info, R_MEM_MAP_READ));
   r_test_tls_dtls_client_complete (fixture->server, fixture->prng,
       pkt_dtls_client_hallo, sizeof (pkt_dtls_client_hallo), info.data, info.size,
-      TRUE, FALSE, &cipher, &hmac, &hs_md, ms);
+      TRUE, FALSE, &cipher, &hmac, &hs_md, ms, NULL, NULL);
   r_buffer_unmap (buf, &info);
   r_buffer_unref (buf);
   r_assert (fixture->hs_done);
@@ -2311,7 +2385,7 @@ RTEST_F (rtlsserver, dtls_bad_record_silently_discarded, RTEST_FAST)
   r_assert (r_buffer_map (buf, &info, R_MEM_MAP_READ));
   r_test_tls_dtls_client_complete (fixture->server, fixture->prng,
       pkt_dtls_client_hallo, sizeof (pkt_dtls_client_hallo), info.data, info.size,
-      TRUE, FALSE, &cipher, &hmac, &hs_md, ms);
+      TRUE, FALSE, &cipher, &hmac, &hs_md, ms, NULL, NULL);
   r_buffer_unmap (buf, &info);
   r_buffer_unref (buf);
   r_assert (fixture->hs_done);


### PR DESCRIPTION
Implements the two §7.2.2 alerts the server still never sent. Both build on the
warning-level alert path added with close_notify.

## no_renegotiation (warning)
A ClientHello received in the application-data state is a renegotiation attempt.
The server does not renegotiate; rather than silently dropping it, it now
declines with a warning no_renegotiation and keeps the session running
(RFC 5246 7.2.1) — so a peer learns its request was refused instead of stalling.

## illegal_parameter (47)
RFC 5246 7.4.1.4 requires the client to offer the null compression method; the
negotiation ignored the offered list entirely. A well-formed list that omits
null is now rejected with a new R_TLS_ERROR_ILLEGAL_PARAMETER mapped to the
illegal_parameter alert. An empty list remains a decode_error, keeping the
malformed-vs-out-of-range distinction. Scope is deliberately limited to this one
RFC-mandated check; the existing handshake_failure / decode_error
classifications are left untouched.

## Tests
A DTLS test encrypts a renegotiation ClientHello with the client write keys
(the test client helper now hands them back) and asserts the server replies with
an encrypted warning no_renegotiation while the session stays up; another feeds
a ClientHello whose compression list omits null and asserts a fatal
illegal_parameter abort. Green across the epoch/rpoll/ASan/UBSan/mingw matrix,
leak- and UB-free; doxygen clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)