### PR TITLE
net/tls: ALPN negotiation on the server

### DIFF
--- a/include/rlib/net/proto/rtls.h
+++ b/include/rlib/net/proto/rtls.h
@@ -157,6 +157,7 @@ typedef enum {
   R_TLS_ALERT_TYPE_BAD_CERTIFICATE_STATUS_RESPONSE      = 0x71, /* [RFC6066] */
   R_TLS_ALERT_TYPE_BAD_CERTIFICATE_HASH_VALUE           = 0x72, /* [RFC6066] */
   R_TLS_ALERT_TYPE_UNKNOWN_PSK_IDENTITY                 = 0x73, /* [RFC4279] */
+  R_TLS_ALERT_TYPE_NO_APPLICATION_PROTOCOL              = 0x78, /* [RFC7301] */
 } RTLSAlertType;
 
 /** @brief Handshake message type (IANA TLS HandshakeType). */
@@ -349,6 +350,7 @@ typedef enum {
   R_TLS_ERROR_ENCRYPTION_FAILED                         = -0x10, /**< Record encryption failed. */
   R_TLS_ERROR_RECORD_OVERFLOW                           = -0x11, /**< Record fragment length exceeds the limit. */
   R_TLS_ERROR_ILLEGAL_PARAMETER                         = -0x12, /**< Field value well-formed but out of range. */
+  R_TLS_ERROR_NO_APPLICATION_PROTOCOL                   = -0x13, /**< No ALPN protocol in common with the peer. */
 } RTLSError;
 
 /** @brief TLS record compression method (only @c NULL is supported / non-deprecated). */
@@ -629,6 +631,17 @@ static inline ruint8 r_tls_hello_ext_use_srtp_mki_size (const RTLSHelloExt * ext
 static inline const ruint8 * r_tls_hello_ext_use_srtp_mki (const RTLSHelloExt * ext)
 { return &ext->data[sizeof (ruint16) + r_load_be16 (ext->data) + sizeof (ruint8)]; }
 /** @} */
+
+/**
+ * @brief Whether the ALPN extension @p ext advertises the protocol @p name.
+ *
+ * Walks the ALPN @c ProtocolNameList (RFC 7301) strictly within @p ext's
+ * declared length, so a malformed or over-long list never reads past the
+ * extension and simply yields @c FALSE. @p len is the protocol-name length
+ * (1..255).
+ */
+R_API rboolean r_tls_hello_ext_alpn_contains (const RTLSHelloExt * ext,
+    const ruint8 * name, ruint8 len);
 
 
 /** @brief Decode the certificate entry @p cert into an @c RCryptoCert (caller owns the result). */

--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -173,6 +173,21 @@ R_API RCryptoCert * r_tls_server_get_peer_cert (const RTLSServer * server);
  */
 R_API RTLSError r_tls_server_set_session_ticket_keys (RTLSServer * server,
     RTLSSessionTicketKeys * keys);
+/**
+ * @brief Configure the application protocols the server supports for ALPN
+ * (RFC 7301), in descending order of preference.
+ *
+ * Each @p protocols entry is a NUL-terminated protocol name (e.g. @c "h2",
+ * @c "http/1.1"); names are copied. When a client offers ALPN the server picks
+ * the first configured protocol the client also lists (server preference) and
+ * echoes it in the ServerHello; if none match the handshake aborts with a fatal
+ * @c no_application_protocol alert. With no protocols configured (the default)
+ * the server does not negotiate ALPN. Must be set before the handshake starts.
+ * Returns @c R_TLS_ERROR_INVAL if any name is empty or longer than 255 bytes.
+ * Call with @p count 0 to clear a previously configured list.
+ */
+R_API RTLSError r_tls_server_set_alpn_protocols (RTLSServer * server,
+    const rchar * const * protocols, rsize count);
 /** @brief Override the server-random (testing / determinism). */
 R_API RTLSError r_tls_server_set_random (RTLSServer * server,
     const ruint8 servrandom[R_TLS_HELLO_RANDOM_BYTES]);
@@ -209,6 +224,13 @@ R_API const RTLSCipherSuiteInfo * r_tls_server_get_cipher_suite (const RTLSServe
 R_API RSRTPCipherSuite r_tls_server_get_dtls_srtp_profile (const RTLSServer * server);
 /** @brief Negotiated DTLS-SRTP MKI; @p size receives its byte length. */
 R_API const ruint8 * r_tls_server_get_dtls_srtp_mki (const RTLSServer * server, ruint8 * size);
+/**
+ * @brief Negotiated ALPN protocol, or @c NULL if none was negotiated.
+ *
+ * Returns the protocol selected during the handshake (NUL-terminated); @p len,
+ * when non-@c NULL, receives its length. See @ref r_tls_server_set_alpn_protocols.
+ */
+R_API const rchar * r_tls_server_get_alpn_selected (const RTLSServer * server, rsize * len);
 
 R_END_DECLS
 

--- a/rlib/net/proto/rtls.c
+++ b/rlib/net/proto/rtls.c
@@ -1470,6 +1470,37 @@ r_tls_hello_msg_extension_next (const RTLSHelloMsg * msg, RTLSHelloExt * ext)
   return R_TLS_ERROR_OK;
 }
 
+rboolean
+r_tls_hello_ext_alpn_contains (const RTLSHelloExt * ext,
+    const ruint8 * name, ruint8 len)
+{
+  const ruint8 * p, * end;
+  ruint16 listlen;
+
+  if (R_UNLIKELY (ext == NULL || name == NULL || len == 0))
+    return FALSE;
+  /* ProtocolNameList: uint16 list_len, then { uint8 name_len, name }*.
+   * Keep every step inside the declared extension length. */
+  if (ext->len < sizeof (ruint16))
+    return FALSE;
+  listlen = r_load_be16 (ext->data);
+  if ((rsize) listlen + sizeof (ruint16) > ext->len)
+    return FALSE;
+
+  p = ext->data + sizeof (ruint16);
+  end = p + listlen;
+  while (p < end) {
+    ruint8 nlen = *p++;
+    if (nlen == 0 || p + nlen > end)
+      return FALSE;
+    if (nlen == len && r_memcmp (p, name, len) == 0)
+      return TRUE;
+    p += nlen;
+  }
+
+  return FALSE;
+}
+
 RCryptoCert *
 r_tls_certificate_get_cert (const RTLSCertificate * cert)
 {

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -88,6 +88,10 @@ struct RTLSServer {
   RSRTPCipherSuite dtls_srtp_profile;
   ruint8 srtp_mki_size;
   const ruint8 * srtp_mki;
+  rchar ** alpn_protocols;              /* configured supported protocols (owned) */
+  rsize alpn_count;
+  const rchar * alpn_selected;          /* negotiated protocol, points into alpn_protocols */
+  rsize alpn_selected_len;
   ruint8 * ticket;
   ruint16 ticketsize;
   RTLSSessionTicketKeys * ticket_keys;  /* shared STEK store; NULL disables tickets */
@@ -156,6 +160,12 @@ r_tls_server_free (RTLSServer * server)
     r_crypto_key_unref (server->peer_pubkey);
   if (server->ecdhe_key != NULL)
     r_crypto_key_unref (server->ecdhe_key);
+  if (server->alpn_protocols != NULL) {
+    rsize i;
+    for (i = 0; i < server->alpn_count; i++)
+      r_free (server->alpn_protocols[i]);
+    r_free (server->alpn_protocols);
+  }
   if (server->client.hmac != NULL)
     r_hmac_free (server->client.hmac);
   if (server->client.cipher != NULL)
@@ -275,6 +285,49 @@ r_tls_server_set_session_ticket_keys (RTLSServer * server,
   if (server->ticket_keys != NULL)
     r_tls_session_ticket_keys_unref (server->ticket_keys);
   server->ticket_keys = r_tls_session_ticket_keys_ref (keys);
+
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_server_set_alpn_protocols (RTLSServer * server,
+    const rchar * const * protocols, rsize count)
+{
+  rchar ** copy;
+  rsize i;
+
+  if (R_UNLIKELY (server == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (protocols == NULL && count > 0)) return R_TLS_ERROR_INVAL;
+  /* ALPN protocol names are opaque<1..255> (RFC 7301). */
+  for (i = 0; i < count; i++) {
+    rsize len = (protocols[i] != NULL) ? r_strlen (protocols[i]) : 0;
+    if (len == 0 || len > 255)
+      return R_TLS_ERROR_INVAL;
+  }
+
+  /* Replace any previously configured list. */
+  if (server->alpn_protocols != NULL) {
+    for (i = 0; i < server->alpn_count; i++)
+      r_free (server->alpn_protocols[i]);
+    r_free (server->alpn_protocols);
+    server->alpn_protocols = NULL;
+    server->alpn_count = 0;
+  }
+  if (count == 0)
+    return R_TLS_ERROR_OK;
+
+  if ((copy = r_mem_new_n (rchar *, count)) == NULL)
+    return R_TLS_ERROR_OOM;
+  for (i = 0; i < count; i++) {
+    if ((copy[i] = r_strdup (protocols[i])) == NULL) {
+      while (i > 0)
+        r_free (copy[--i]);
+      r_free (copy);
+      return R_TLS_ERROR_OOM;
+    }
+  }
+  server->alpn_protocols = copy;
+  server->alpn_count = count;
 
   return R_TLS_ERROR_OK;
 }
@@ -454,6 +507,24 @@ r_tls_server_write_hs_ext_use_srtp (const RTLSServer * server, ruint8 * ptr)
   return 9 + server->srtp_mki_size;
 }
 
+static ruint16
+r_tls_server_write_hs_ext_alpn (const RTLSServer * server, ruint8 * ptr)
+{
+  ruint8 len;
+
+  if (server->alpn_selected == NULL)
+    return 0;
+
+  len = (ruint8) server->alpn_selected_len;
+  r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_APPLICATION_LAYER_PROTOCOL_NEGOTIATION);
+  r_store_be16 (&ptr[2], (ruint16)(3 + len));  /* ProtocolNameList: list_len(2) + name_len(1) + name */
+  r_store_be16 (&ptr[4], (ruint16)(1 + len));  /* list_len: one name_len(1) + name */
+  ptr[6] = len;
+  r_memcpy (&ptr[7], server->alpn_selected, len);
+
+  return 7 + len;
+}
+
 static RTLSError
 r_tls_server_write_hello (RTLSServer * server)
 {
@@ -507,6 +578,7 @@ r_tls_server_write_hello (RTLSServer * server)
     extsize += r_tls_server_write_hs_ext_session_ticket (server, ptr + 2 + extsize);
     extsize += r_tls_server_write_hs_ext_ec_point_formats (server, ptr + 2 + extsize);
     extsize += r_tls_server_write_hs_ext_use_srtp (server, ptr + 2 + extsize);
+    extsize += r_tls_server_write_hs_ext_alpn (server, ptr + 2 + extsize);
 
     if (extsize > 0) {
       r_store_be16 (ptr, extsize);
@@ -1108,6 +1180,7 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
   RTLSHelloExt hsext = R_TLS_HELLO_EXT_INIT;
   RTLSError r;
   ruint16 count, i;
+  rboolean alpn_offered = FALSE;
   RTLSCipherSuite preferred[] = {
     R_TLS_CS_NONE, R_TLS_CS_NONE, R_TLS_CS_NONE, R_TLS_CS_NONE, R_TLS_CS_NONE, R_TLS_CS_NONE, R_TLS_CS_NONE, R_TLS_CS_NONE,
     R_TLS_CS_NONE, R_TLS_CS_NONE, R_TLS_CS_NONE, R_TLS_CS_NONE, R_TLS_CS_NONE, R_TLS_CS_NONE, R_TLS_CS_NONE, R_TLS_CS_NONE,
@@ -1245,6 +1318,7 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
   server->support_ext_master_secret = FALSE;
   server->encrypt_then_mac = FALSE;
   server->dtls_srtp_profile = R_SRTP_CS_NONE;
+  server->alpn_selected = NULL;
 
   for (r = r_tls_hello_msg_extension_first (&server->hello, &hsext);
       r == R_TLS_ERROR_OK;
@@ -1312,10 +1386,28 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
             return R_TLS_ERROR_HANDSHAKE_FAILURE;
         }
         break;
+      case R_TLS_EXT_TYPE_APPLICATION_LAYER_PROTOCOL_NEGOTIATION:
+        /* Select the first of our configured protocols the client also offered
+         * (server preference). With nothing configured we do not participate. */
+        alpn_offered = TRUE;
+        for (i = 0; i < server->alpn_count && server->alpn_selected == NULL; i++) {
+          rsize plen = r_strlen (server->alpn_protocols[i]);
+          if (r_tls_hello_ext_alpn_contains (&hsext,
+                (const ruint8 *) server->alpn_protocols[i], (ruint8) plen)) {
+            server->alpn_selected = server->alpn_protocols[i];
+            server->alpn_selected_len = plen;
+          }
+        }
+        break;
       default:
         break;
     }
   }
+
+  /* The client offered ALPN and we have protocols configured but none matched:
+   * abort (RFC 7301 3.2). With no protocols configured we simply ignore it. */
+  if (alpn_offered && server->alpn_count > 0 && server->alpn_selected == NULL)
+    return R_TLS_ERROR_NO_APPLICATION_PROTOCOL;
 
   /* RFC 5746 3.6: the SCSV signals secure-renegotiation support just like
    * an empty renegotiation_info extension. */
@@ -1676,6 +1768,8 @@ r_tls_server_alert_for_error (RTLSError err)
       return R_TLS_ALERT_TYPE_RECORD_OVERFLOW;
     case R_TLS_ERROR_ILLEGAL_PARAMETER: /* field value out of range */
       return R_TLS_ALERT_TYPE_ILLEGAL_PARAMETER;
+    case R_TLS_ERROR_NO_APPLICATION_PROTOCOL: /* no ALPN protocol in common */
+      return R_TLS_ALERT_TYPE_NO_APPLICATION_PROTOCOL;
     case R_TLS_ERROR_HS_VERIFICATION_FAILED:  /* could not verify Finished */
       return R_TLS_ALERT_TYPE_DECRYPT_ERROR;
     case R_TLS_ERROR_VERSION:
@@ -2287,5 +2381,14 @@ r_tls_server_get_dtls_srtp_mki (const RTLSServer * server, ruint8 * size)
     *size = server->srtp_mki_size;
 
   return server->srtp_mki;
+}
+
+const rchar *
+r_tls_server_get_alpn_selected (const RTLSServer * server, rsize * len)
+{
+  if (len != NULL)
+    *len = (server != NULL) ? server->alpn_selected_len : 0;
+
+  return (server != NULL) ? server->alpn_selected : NULL;
 }
 

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -319,6 +319,47 @@ r_test_tls_build_dtls_client_hello (RPrng * prng, ruint8 * out, rsize outsz,
   return hs + bodylen;
 }
 
+/* A DTLS 1.2 ClientHello (null compression, empty renegotiation_info) carrying
+ * an ALPN extension advertising @protos (n names). */
+static rsize
+r_test_tls_build_dtls_client_hello_alpn (RPrng * prng, ruint8 * out, rsize outsz,
+    const rchar * const * protos, rsize n)
+{
+  ruint8 body[256];
+  ruint8 * p = body;
+  ruint8 * extlenp, * alpnlenp, * listlenp;
+  rsize bodylen, hs, i;
+
+  *p++ = 0xfe; *p++ = 0xfd;
+  r_prng_fill (prng, p, R_TLS_HELLO_RANDOM_BYTES); p += R_TLS_HELLO_RANDOM_BYTES;
+  *p++ = 0;                                  /* session id length */
+  *p++ = 0;                                  /* cookie length (DTLS) */
+  r_store_be16 (p, (ruint16) sizeof (ruint16)); p += 2;
+  r_store_be16 (p, (ruint16) R_TLS_CS_RSA_WITH_AES_128_CBC_SHA); p += 2;
+  *p++ = 1; *p++ = 0;                        /* compression: null */
+  extlenp = p; p += 2;
+  r_store_be16 (p, (ruint16) R_TLS_EXT_TYPE_RENEGOTIATION_INFO); p += 2;
+  r_store_be16 (p, 1); p += 2; *p++ = 0;
+  r_store_be16 (p, (ruint16) R_TLS_EXT_TYPE_APPLICATION_LAYER_PROTOCOL_NEGOTIATION); p += 2;
+  alpnlenp = p; p += 2;                       /* ALPN ext data length */
+  listlenp = p; p += 2;                       /* ProtocolNameList length */
+  for (i = 0; i < n; i++) {
+    ruint8 l = (ruint8) r_strlen (protos[i]);
+    *p++ = l;
+    r_memcpy (p, protos[i], l); p += l;
+  }
+  r_store_be16 (listlenp, (ruint16) (p - (listlenp + 2)));
+  r_store_be16 (alpnlenp, (ruint16) (p - (alpnlenp + 2)));
+  r_store_be16 (extlenp, (ruint16) (p - (extlenp + 2)));
+  bodylen = (rsize) (p - body);
+
+  r_assert_cmpint (r_dtls_write_handshake (out, outsz, &hs,
+        R_TLS_VERSION_DTLS_1_2, R_TLS_HANDSHAKE_TYPE_CLIENT_HELLO,
+        (ruint16) bodylen, 0, 0, 0, 0, (ruint32) bodylen), ==, R_TLS_ERROR_OK);
+  r_memcpy (out + hs, body, bodylen);
+  return hs + bodylen;
+}
+
 /* Minimal DTLS 1.2 RSA client completing a handshake against the server
  * under test. It mirrors the server's transcript hashing by feeding the
  * same handshake-message fragments, derives the master secret per RFC 7627
@@ -706,6 +747,37 @@ r_test_tls_assert_session_ticket_ext (RQueue * qout, rboolean expect)
     }
   }
   r_assert_cmpint (seen, ==, expect);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+}
+
+/* Assert the ServerHello in @qout carries an ALPN extension selecting @expected
+ * (@len bytes), or no ALPN extension at all when @expected is NULL. */
+static void
+r_test_tls_assert_alpn_ext (RQueue * qout, const rchar * expected, rsize len)
+{
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RBuffer * buf;
+  RTLSHelloMsg msg;
+  RTLSHelloExt ext;
+  RTLSError e;
+  rboolean seen = FALSE;
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_parser_parse_hello (&parser, &msg), ==, R_TLS_ERROR_OK);
+  for (e = r_tls_hello_msg_extension_first (&msg, &ext); e == R_TLS_ERROR_OK;
+      e = r_tls_hello_msg_extension_next (&msg, &ext)) {
+    if (ext.type == R_TLS_EXT_TYPE_APPLICATION_LAYER_PROTOCOL_NEGOTIATION) {
+      seen = TRUE;
+      /* ProtocolNameList: list_len(2) + name_len(1) + name. */
+      r_assert_cmpuint (ext.len, ==, 3 + len);
+      r_assert_cmpuint (r_load_be16 (ext.data), ==, 1 + len);
+      r_assert_cmpuint (ext.data[2], ==, len);
+      r_assert_cmpint (r_memcmp (&ext.data[3], expected, len), ==, 0);
+    }
+  }
+  r_assert_cmpint (seen, ==, (expected != NULL));
   r_tls_parser_clear (&parser);
   r_buffer_unref (buf);
 }
@@ -1326,6 +1398,93 @@ RTEST_F (rtlsserver, dtls_clienthello_no_null_compression, RTEST_FAST)
   r_assert (!fixture->hs_done);
   r_assert (fixture->got_error);
   r_assert_cmpuint (fixture->last_alert, ==, R_TLS_ALERT_TYPE_ILLEGAL_PARAMETER);
+}
+RTEST_END;
+
+/* The server selects the first of its own configured ALPN protocols that the
+ * client also offered (server preference), not the client's first choice, and
+ * echoes it in the ServerHello. */
+RTEST_F (rtlsserver, dtls_alpn_selects_server_preference, RTEST_FAST)
+{
+  static const rchar * srv[] = { "h2", "http/1.1" };
+  static const rchar * cli[] = { "http/1.1", "h2" };
+  ruint8 ch[256];
+  rsize chlen, sel = 0;
+  const rchar * p;
+
+  r_assert_cmpint (r_tls_server_set_alpn_protocols (fixture->server, srv,
+        R_N_ELEMENTS (srv)), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  chlen = r_test_tls_build_dtls_client_hello_alpn (fixture->prng, ch, sizeof (ch),
+      cli, R_N_ELEMENTS (cli));
+  r_test_tls_server_feed (fixture->server, ch, chlen);
+
+  r_assert (!fixture->got_error);
+  r_assert_cmpptr ((p = r_tls_server_get_alpn_selected (fixture->server, &sel)), !=, NULL);
+  r_assert_cmpuint (sel, ==, 2);
+  r_assert_cmpint (r_memcmp (p, "h2", 2), ==, 0);
+  r_test_tls_assert_alpn_ext (&fixture->qout, "h2", 2);
+}
+RTEST_END;
+
+/* The client offers ALPN but shares no protocol with the configured server:
+ * the handshake aborts with a fatal no_application_protocol alert. */
+RTEST_F (rtlsserver, dtls_alpn_no_overlap_fatal, RTEST_FAST)
+{
+  static const rchar * srv[] = { "h2" };
+  static const rchar * cli[] = { "http/1.1" };
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RBuffer * buf;
+  RTLSAlertLevel level = 0;
+  RTLSAlertType type = 0;
+  ruint8 ch[256];
+  rsize chlen;
+
+  r_assert_cmpint (r_tls_server_set_alpn_protocols (fixture->server, srv,
+        R_N_ELEMENTS (srv)), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  chlen = r_test_tls_build_dtls_client_hello_alpn (fixture->prng, ch, sizeof (ch),
+      cli, R_N_ELEMENTS (cli));
+  r_test_tls_server_feed (fixture->server, ch, chlen);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_ALERT);
+  r_assert_cmpint (r_tls_parser_parse_alert (&parser, &level, &type), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (level, ==, R_TLS_ALERT_LEVEL_FATAL);
+  r_assert_cmpuint (type, ==, R_TLS_ALERT_TYPE_NO_APPLICATION_PROTOCOL);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+
+  r_assert (!fixture->hs_done);
+  r_assert (fixture->got_error);
+  r_assert_cmpuint (fixture->last_alert, ==, R_TLS_ALERT_TYPE_NO_APPLICATION_PROTOCOL);
+}
+RTEST_END;
+
+/* With no ALPN configured the server ignores the client's offer: no extension
+ * is echoed and the handshake proceeds. */
+RTEST_F (rtlsserver, dtls_alpn_not_configured_ignored, RTEST_FAST)
+{
+  static const rchar * cli[] = { "h2" };
+  ruint8 ch[256];
+  rsize chlen, sel = 1;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  chlen = r_test_tls_build_dtls_client_hello_alpn (fixture->prng, ch, sizeof (ch),
+      cli, R_N_ELEMENTS (cli));
+  r_test_tls_server_feed (fixture->server, ch, chlen);
+
+  r_assert (!fixture->got_error);
+  r_assert_cmpptr (r_tls_server_get_alpn_selected (fixture->server, &sel), ==, NULL);
+  r_assert_cmpuint (sel, ==, 0);
+  r_test_tls_assert_alpn_ext (&fixture->qout, NULL, 0);
 }
 RTEST_END;
 


### PR DESCRIPTION
Adds server-side ALPN (application_layer_protocol_negotiation, RFC 7301) for TLS
and DTLS, so a server can select an application protocol (e.g. `h2` vs
`http/1.1`) from the client's offer. This is the negotiation an HTTPS server
(#255) needs.

## API
- `r_tls_server_set_alpn_protocols(server, protocols, count)` configures an
  ordered list of supported protocol names (copied). Consistent with the other
  `r_tls_server_set_*` config setters.
- `r_tls_server_get_alpn_selected(server, &len)` returns the negotiated protocol,
  or NULL if none.

## Behaviour
When a client offers ALPN, the server selects the first of *its* configured
protocols the client also lists (server preference, as cipher suites do) and
echoes it in the ServerHello. If the client offers ALPN but shares no protocol
with the configured server, the handshake aborts with a fatal
`no_application_protocol` alert (RFC 7301 §3.2). With no protocols configured
(the default) the server does not participate and existing handshakes are
unchanged.

The client's offered ProtocolNameList is parsed by a bounded helper
(`r_tls_hello_ext_alpn_contains`) that stays strictly within the extension, so a
malformed or over-long list can never read past it.

Scope is the server side (the issue); the client does not send ALPN. Tests drive
the server over DTLS with a crafted ClientHello: server-preference selection +
ServerHello echo, the no-overlap fatal alert, and the unconfigured-ignored case.
Green across the epoch/rpoll/ASan/UBSan/mingw matrix, leak- and UB-free; doxygen
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)