### PR TITLE
net/tls: max_fragment_length negotiation and record fragmentation (RFC 6066)

### DIFF
--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -667,6 +667,19 @@ r_tls_server_write_hs_ext_alpn (const RTLSServer * server, ruint8 * ptr)
   return 7 + len;
 }
 
+static ruint16
+r_tls_server_write_hs_ext_max_fragment_length (const RTLSServer * server, ruint8 * ptr)
+{
+  if (server->max_fragment == 0)
+    return 0;
+
+  r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_MAX_FRAGMENT_LENGTH);
+  r_store_be16 (&ptr[2], 1);            /* extension_data is a single byte */
+  ptr[4] = server->max_fragment;        /* echo the negotiated value (1..4) */
+
+  return 5;
+}
+
 static RTLSError
 r_tls_server_write_hello (RTLSServer * server)
 {
@@ -721,6 +734,7 @@ r_tls_server_write_hello (RTLSServer * server)
     extsize += r_tls_server_write_hs_ext_ec_point_formats (server, ptr + 2 + extsize);
     extsize += r_tls_server_write_hs_ext_use_srtp (server, ptr + 2 + extsize);
     extsize += r_tls_server_write_hs_ext_alpn (server, ptr + 2 + extsize);
+    extsize += r_tls_server_write_hs_ext_max_fragment_length (server, ptr + 2 + extsize);
 
     if (extsize > 0) {
       r_store_be16 (ptr, extsize);
@@ -1461,6 +1475,7 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
   server->encrypt_then_mac = FALSE;
   server->dtls_srtp_profile = R_SRTP_CS_NONE;
   server->alpn_selected = NULL;
+  server->max_fragment = 0;
 
   for (r = r_tls_hello_msg_extension_first (&server->hello, &hsext);
       r == R_TLS_ERROR_OK;
@@ -1540,6 +1555,14 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
             server->alpn_selected_len = plen;
           }
         }
+        break;
+      case R_TLS_EXT_TYPE_MAX_FRAGMENT_LENGTH:
+        /* RFC 6066: a single byte, 1..4 -> 2^9..2^12. Any other value (or a
+         * malformed length) is illegal. The cap is echoed in the ServerHello
+         * and enforced on both directions. */
+        if (hsext.len != 1 || hsext.data[0] < 1 || hsext.data[0] > 4)
+          return R_TLS_ERROR_ILLEGAL_PARAMETER;
+        server->max_fragment = hsext.data[0];
         break;
       default:
         break;
@@ -2346,6 +2369,15 @@ r_tls_server_incoming_data (RTLSServer * server, RBuffer * buffer)
           r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_BAD_RECORD_MAC);
         continue;
       }
+    }
+
+    /* Honour a negotiated max_fragment_length: a plaintext fragment larger than
+     * the cap is a fatal record_overflow (RFC 6066). */
+    if (server->max_fragment != 0 &&
+        parser.fragment.size > ((rsize) 1u << (8 + server->max_fragment))) {
+      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_RECORD_OVERFLOW);
+      err = R_TLS_ERROR_RECORD_OVERFLOW;
+      break;
     }
 
     /* Count the accepted record. A ChangeCipherSpec resets the read counter

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -92,6 +92,7 @@ struct RTLSServer {
   rsize alpn_count;
   const rchar * alpn_selected;          /* negotiated protocol, points into alpn_protocols */
   rsize alpn_selected_len;
+  ruint8 max_fragment;                  /* negotiated max_fragment_length (RFC 6066): 0 none, else 1..4 */
   ruint8 * ticket;
   ruint16 ticketsize;
   RTLSSessionTicketKeys * ticket_keys;  /* shared STEK store; NULL disables tickets */
@@ -131,6 +132,23 @@ _r_write_u24 (ruint8 * ptr, ruint32 u24)
   *ptr++ = (ruint8)(u24 >> 16) & 0xff;
   *ptr++ = (ruint8)(u24 >>  8) & 0xff;
   *ptr++ = (ruint8)(u24      ) & 0xff;
+}
+
+static inline ruint32
+_r_read_u24 (const ruint8 * ptr)
+{
+  return ((ruint32)ptr[0] << 16) | ((ruint32)ptr[1] << 8) | (ruint32)ptr[2];
+}
+
+static inline void
+_r_write_u48 (ruint8 * ptr, ruint64 u48)
+{
+  *ptr++ = (ruint8)(u48 >> 40) & 0xff;
+  *ptr++ = (ruint8)(u48 >> 32) & 0xff;
+  *ptr++ = (ruint8)(u48 >> 24) & 0xff;
+  *ptr++ = (ruint8)(u48 >> 16) & 0xff;
+  *ptr++ = (ruint8)(u48 >>  8) & 0xff;
+  *ptr++ = (ruint8)(u48      ) & 0xff;
 }
 
 void
@@ -394,7 +412,7 @@ r_tls_server_cipher_encrypt (RTLSServer * server, RBuffer * buf)
 }
 
 static RTLSError
-r_tls_server_send_record (RTLSServer * server, RBuffer * buf)
+r_tls_server_send_record_one (RTLSServer * server, RBuffer * buf)
 {
   RTLSError ret;
   RBuffer * encbuf;
@@ -411,6 +429,130 @@ r_tls_server_send_record (RTLSServer * server, RBuffer * buf)
     ret = R_TLS_ERROR_ENCRYPTION_FAILED;
   }
 
+  return ret;
+}
+
+/* Build and send one record (content type @ct) carrying @body[@bodylen], which
+ * already fits the fragment cap. Uses the current write seqno (DTLS records
+ * carry it in the header; send_record_one then advances it). */
+static RTLSError
+r_tls_server_send_slice (RTLSServer * server, rboolean dtls, ruint8 ct,
+    ruint16 ver, ruint16 epoch, const ruint8 * body, rsize bodylen)
+{
+  RBuffer * rec;
+  RMemMapInfo out = R_MEM_MAP_INFO_INIT;
+  rsize hdrlen = dtls ? R_DTLS_RECORD_HDR_SIZE : R_TLS_RECORD_HDR_SIZE;
+  RTLSError ret = R_TLS_ERROR_OOM;
+
+  if ((rec = r_buffer_new_alloc (NULL, hdrlen + bodylen, NULL)) == NULL)
+    return R_TLS_ERROR_OOM;
+
+  if (r_buffer_map (rec, &out, R_MEM_MAP_WRITE)) {
+    ruint8 * p = out.data;
+
+    p[0] = ct;
+    r_store_be16 (&p[1], ver);
+    if (dtls) {
+      r_store_be16 (&p[3], epoch);
+      _r_write_u48 (&p[5], server->server.seqno);
+      r_store_be16 (&p[11], (ruint16) bodylen);
+    } else {
+      r_store_be16 (&p[3], (ruint16) bodylen);
+    }
+    r_memcpy (p + hdrlen, body, bodylen);
+    r_buffer_unmap (rec, &out);
+    r_buffer_set_size (rec, hdrlen + bodylen);
+    ret = r_tls_server_send_record_one (server, rec);
+  }
+
+  r_buffer_unref (rec);
+  return ret;
+}
+
+/* Send a complete plaintext record, honouring a negotiated max_fragment_length
+ * (RFC 6066): a payload larger than the cap is split into multiple <=cap records
+ * before encryption, each with its own write sequence number. With no cap (or a
+ * record that already fits) the buffer is encrypted and queued unchanged. */
+static RTLSError
+r_tls_server_send_record (RTLSServer * server, RBuffer * buf)
+{
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  rboolean dtls = r_tls_version_is_dtls (server->version);
+  rsize hdrlen = dtls ? R_DTLS_RECORD_HDR_SIZE : R_TLS_RECORD_HDR_SIZE;
+  rsize cap = server->max_fragment ? ((rsize) 1u << (8 + server->max_fragment)) : 0;
+  RTLSError ret;
+  ruint8 ct;
+  ruint16 ver, epoch = 0;
+  const ruint8 * pay;
+  rsize paylen, off;
+
+  /* Fast path: no cap negotiated, or the record payload already fits. */
+  if (cap == 0 || r_buffer_get_size (buf) <= hdrlen + cap)
+    return r_tls_server_send_record_one (server, buf);
+
+  if (!r_buffer_map (buf, &info, R_MEM_MAP_READ))
+    return R_TLS_ERROR_OOM;
+  ct = info.data[0];
+  ver = r_load_be16 (&info.data[1]);
+  if (dtls)
+    epoch = r_load_be16 (&info.data[3]);
+  pay = info.data + hdrlen;
+  paylen = info.size - hdrlen;
+  ret = R_TLS_ERROR_OK;
+
+  if (dtls && ct == R_TLS_CONTENT_TYPE_HANDSHAKE) {
+    /* DTLS handshake messages are not a byte stream: reframe into <=cap
+     * fragments, each repeating the handshake header with its own
+     * fragment_offset / fragment_length (same message sequence). */
+    const ruint8 * hs = pay;
+    ruint8 hstype = hs[0];
+    ruint32 msglen = _r_read_u24 (&hs[1]);
+    ruint16 msgseq = r_load_be16 (&hs[4]);
+    const ruint8 * mbody = hs + R_DTLS_HS_HDR_SIZE;
+    rsize chunkmax = cap - R_DTLS_HS_HDR_SIZE;
+    ruint32 foff;
+
+    for (foff = 0; foff < msglen && ret == R_TLS_ERROR_OK; foff += (ruint32) chunkmax) {
+      rsize chunk = MIN (chunkmax, msglen - foff);
+      RBuffer * rec;
+      RMemMapInfo out = R_MEM_MAP_INFO_INIT;
+      rsize reclen = R_DTLS_RECORD_HDR_SIZE + R_DTLS_HS_HDR_SIZE + chunk;
+
+      ret = R_TLS_ERROR_OOM;
+      if ((rec = r_buffer_new_alloc (NULL, reclen, NULL)) != NULL) {
+        if (r_buffer_map (rec, &out, R_MEM_MAP_WRITE)) {
+          ruint8 * p = out.data;
+
+          /* Record header: the record carries only this fragment's bytes. */
+          p[0] = R_TLS_CONTENT_TYPE_HANDSHAKE;
+          r_store_be16 (&p[1], ver);
+          r_store_be16 (&p[3], epoch);
+          _r_write_u48 (&p[5], server->server.seqno);
+          r_store_be16 (&p[11], (ruint16) (R_DTLS_HS_HDR_SIZE + chunk));
+          /* Handshake header: the length is the whole message; this fragment
+           * covers [foff, foff+chunk). */
+          p[13] = hstype;
+          _r_write_u24 (&p[14], msglen);
+          r_store_be16 (&p[17], msgseq);
+          _r_write_u24 (&p[19], foff);
+          _r_write_u24 (&p[22], (ruint32) chunk);
+          r_memcpy (p + R_DTLS_RECORD_HDR_SIZE + R_DTLS_HS_HDR_SIZE, mbody + foff, chunk);
+          r_buffer_unmap (rec, &out);
+          r_buffer_set_size (rec, reclen);
+          ret = r_tls_server_send_record_one (server, rec);
+        }
+        r_buffer_unref (rec);
+      }
+    }
+  } else {
+    /* TLS (any content type, a record-layer byte stream) and DTLS
+     * application data: slice the payload into <=cap records. */
+    for (off = 0; off < paylen && ret == R_TLS_ERROR_OK; off += cap)
+      ret = r_tls_server_send_slice (server, dtls, ct, ver, epoch,
+          pay + off, MIN (cap, paylen - off));
+  }
+
+  r_buffer_unmap (buf, &info);
   return ret;
 }
 

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -360,6 +360,39 @@ r_test_tls_build_dtls_client_hello_alpn (RPrng * prng, ruint8 * out, rsize outsz
   return hs + bodylen;
 }
 
+/* A DTLS 1.2 ClientHello (null compression, empty renegotiation_info) carrying
+ * a max_fragment_length extension with the 1-byte @value. */
+static rsize
+r_test_tls_build_dtls_client_hello_mfl (RPrng * prng, ruint8 * out, rsize outsz,
+    ruint8 value)
+{
+  ruint8 body[256];
+  ruint8 * p = body;
+  ruint8 * extlenp;
+  rsize bodylen, hs;
+
+  *p++ = 0xfe; *p++ = 0xfd;
+  r_prng_fill (prng, p, R_TLS_HELLO_RANDOM_BYTES); p += R_TLS_HELLO_RANDOM_BYTES;
+  *p++ = 0;                                  /* session id length */
+  *p++ = 0;                                  /* cookie length (DTLS) */
+  r_store_be16 (p, (ruint16) sizeof (ruint16)); p += 2;
+  r_store_be16 (p, (ruint16) R_TLS_CS_RSA_WITH_AES_128_CBC_SHA); p += 2;
+  *p++ = 1; *p++ = 0;                        /* compression: null */
+  extlenp = p; p += 2;
+  r_store_be16 (p, (ruint16) R_TLS_EXT_TYPE_RENEGOTIATION_INFO); p += 2;
+  r_store_be16 (p, 1); p += 2; *p++ = 0;
+  r_store_be16 (p, (ruint16) R_TLS_EXT_TYPE_MAX_FRAGMENT_LENGTH); p += 2;
+  r_store_be16 (p, 1); p += 2; *p++ = value;
+  r_store_be16 (extlenp, (ruint16) (p - (extlenp + 2)));
+  bodylen = (rsize) (p - body);
+
+  r_assert_cmpint (r_dtls_write_handshake (out, outsz, &hs,
+        R_TLS_VERSION_DTLS_1_2, R_TLS_HANDSHAKE_TYPE_CLIENT_HELLO,
+        (ruint16) bodylen, 0, 0, 0, 0, (ruint32) bodylen), ==, R_TLS_ERROR_OK);
+  r_memcpy (out + hs, body, bodylen);
+  return hs + bodylen;
+}
+
 /* Minimal DTLS 1.2 RSA client completing a handshake against the server
  * under test. It mirrors the server's transcript hashing by feeding the
  * same handshake-message fragments, derives the master secret per RFC 7627
@@ -1485,6 +1518,216 @@ RTEST_F (rtlsserver, dtls_alpn_not_configured_ignored, RTEST_FAST)
   r_assert_cmpptr (r_tls_server_get_alpn_selected (fixture->server, &sel), ==, NULL);
   r_assert_cmpuint (sel, ==, 0);
   r_test_tls_assert_alpn_ext (&fixture->qout, NULL, 0);
+}
+RTEST_END;
+
+/* A negotiated max_fragment_length is echoed verbatim in the ServerHello. */
+RTEST_F (rtlsserver, dtls_max_fragment_echoed, RTEST_FAST)
+{
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RBuffer * buf;
+  RTLSHelloMsg msg;
+  RTLSHelloExt ext;
+  RTLSError e;
+  rboolean seen = FALSE;
+  ruint8 ch[256];
+  rsize chlen;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  chlen = r_test_tls_build_dtls_client_hello_mfl (fixture->prng, ch, sizeof (ch), 2);
+  r_test_tls_server_feed (fixture->server, ch, chlen);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_parser_parse_hello (&parser, &msg), ==, R_TLS_ERROR_OK);
+  for (e = r_tls_hello_msg_extension_first (&msg, &ext); e == R_TLS_ERROR_OK;
+      e = r_tls_hello_msg_extension_next (&msg, &ext)) {
+    if (ext.type == R_TLS_EXT_TYPE_MAX_FRAGMENT_LENGTH) {
+      seen = TRUE;
+      r_assert_cmpuint (ext.len, ==, 1);
+      r_assert_cmpuint (ext.data[0], ==, 2);
+    }
+  }
+  r_assert (seen);
+  r_assert (!fixture->got_error);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
+/* An out-of-range max_fragment_length value aborts with illegal_parameter. */
+RTEST_F (rtlsserver, dtls_max_fragment_invalid_value, RTEST_FAST)
+{
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RBuffer * buf;
+  RTLSAlertLevel level = 0;
+  RTLSAlertType type = 0;
+  ruint8 ch[256];
+  rsize chlen;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  chlen = r_test_tls_build_dtls_client_hello_mfl (fixture->prng, ch, sizeof (ch), 5);
+  r_test_tls_server_feed (fixture->server, ch, chlen);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_ALERT);
+  r_assert_cmpint (r_tls_parser_parse_alert (&parser, &level, &type), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (level, ==, R_TLS_ALERT_LEVEL_FATAL);
+  r_assert_cmpuint (type, ==, R_TLS_ALERT_TYPE_ILLEGAL_PARAMETER);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+
+  r_assert (!fixture->hs_done);
+  r_assert (fixture->got_error);
+}
+RTEST_END;
+
+/* With a 512-byte cap negotiated, the 757-byte server Certificate must be
+ * fragmented: no emitted record exceeds the cap, and the Certificate message is
+ * split into contiguous fragments (same msgseq) that reassemble to its full
+ * length. */
+RTEST_F (rtlsserver, dtls_max_fragment_fragments_handshake, RTEST_FAST)
+{
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RBuffer * buf;
+  ruint8 ch[256];
+  rsize chlen;
+  RTLSError e;
+  ruint32 cert_msglen = 0, cert_next_off = 0;
+  ruint cert_frags = 0;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  chlen = r_test_tls_build_dtls_client_hello_mfl (fixture->prng, ch, sizeof (ch), 1);
+  r_test_tls_server_feed (fixture->server, ch, chlen);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  for (e = r_tls_parser_init_buffer (&parser, buf); e == R_TLS_ERROR_OK;
+      e = r_tls_parser_init_next (&parser, NULL)) {
+    r_assert_cmpuint (parser.fragment.size, <=, 512);
+    if (parser.content == R_TLS_CONTENT_TYPE_HANDSHAKE) {
+      RTLSHandshakeType t;
+      ruint32 mlen = 0, foff = 0, flen = 0;
+      ruint16 mseq = 0;
+
+      if (r_tls_parser_parse_handshake_full (&parser, &t, &mlen, &mseq, &foff, &flen)
+            == R_TLS_ERROR_OK && t == R_TLS_HANDSHAKE_TYPE_CERTIFICATE) {
+        if (cert_frags == 0)
+          cert_msglen = mlen;
+        r_assert_cmpuint (mlen, ==, cert_msglen);     /* same total length */
+        r_assert_cmpuint (foff, ==, cert_next_off);   /* contiguous */
+        cert_next_off += flen;
+        cert_frags++;
+      }
+    }
+  }
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+
+  r_assert_cmpuint (cert_frags, >, 1);                /* it was split */
+  r_assert_cmpuint (cert_next_off, ==, cert_msglen);  /* and reassembles */
+  r_assert (!fixture->got_error);
+}
+RTEST_END;
+
+/* Application data larger than the negotiated cap is split into multiple <=cap
+ * records that reassemble to the original payload. */
+RTEST_F (rtlsserver, dtls_max_fragment_fragments_appdata, RTEST_FAST)
+{
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RCryptoCipher * cipher = NULL;
+  RHmac * hmac = NULL;
+  RBuffer * buf, * app;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  ruint8 ch[256], payload[5000], got[5200];
+  rsize chlen, gotlen = 0, i;
+  ruint nrec = 0;
+  RTLSError e;
+
+  for (i = 0; i < sizeof (payload); i++)
+    payload[i] = (ruint8) (i & 0xff);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  /* Cap 4096: the handshake flight fits (no handshake fragmentation), so the
+   * in-test client completes normally; the 5000-byte appdata then splits. */
+  chlen = r_test_tls_build_dtls_client_hello_mfl (fixture->prng, ch, sizeof (ch), 4);
+  r_test_tls_server_feed (fixture->server, ch, chlen);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert (r_buffer_map (buf, &info, R_MEM_MAP_READ));
+  r_test_tls_dtls_client_complete (fixture->server, fixture->prng,
+      ch, chlen, info.data, info.size, FALSE, FALSE, &cipher, &hmac, NULL, NULL, NULL, NULL);
+  r_buffer_unmap (buf, &info);
+  r_buffer_unref (buf);
+  r_assert (fixture->hs_done);
+
+  /* Drop the server's ChangeCipherSpec + Finished flight. */
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_buffer_unref (buf);
+
+  r_assert_cmpptr ((app = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          payload, sizeof (payload), sizeof (payload), 0, NULL, NULL)), !=, NULL);
+  r_assert (r_tls_server_send_appdata (fixture->server, app));
+  r_buffer_unref (app);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  for (e = r_tls_parser_init_buffer (&parser, buf); e == R_TLS_ERROR_OK;
+      e = r_tls_parser_init_next (&parser, NULL)) {
+    r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_APPLICATION_DATA);
+    r_assert_cmpint (r_tls_parser_decrypt (&parser, cipher, hmac, FALSE, NULL), ==, R_TLS_ERROR_OK);
+    r_assert_cmpuint (parser.fragment.size, <=, 4096);
+    r_assert_cmpuint (gotlen + parser.fragment.size, <=, sizeof (got));
+    r_memcpy (got + gotlen, parser.fragment.data, parser.fragment.size);
+    gotlen += parser.fragment.size;
+    nrec++;
+  }
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+
+  r_assert_cmpuint (nrec, >, 1);
+  r_assert_cmpuint (gotlen, ==, sizeof (payload));
+  r_assert_cmpint (r_memcmp (got, payload, sizeof (payload)), ==, 0);
+
+  r_hmac_free (hmac);
+  r_crypto_cipher_unref (cipher);
+}
+RTEST_END;
+
+/* An incoming record whose plaintext exceeds the negotiated cap is rejected
+ * with a fatal record_overflow. */
+RTEST_F (rtlsserver, dtls_max_fragment_incoming_overflow, RTEST_FAST)
+{
+  ruint8 ch[256], big[R_DTLS_RECORD_HDR_SIZE + 600];
+  rsize chlen;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  chlen = r_test_tls_build_dtls_client_hello_mfl (fixture->prng, ch, sizeof (ch), 1);
+  r_test_tls_server_feed (fixture->server, ch, chlen);
+
+  /* A 600-byte epoch-0 record exceeds the negotiated 512-byte cap. Feed it
+   * directly (r_test_tls_server_feed asserts a TRUE return, but an over-cap
+   * record is rejected, so incoming_data returns FALSE). */
+  r_memclear (big, sizeof (big));
+  big[0] = R_TLS_CONTENT_TYPE_HANDSHAKE;
+  big[1] = 0xfe; big[2] = 0xfd;              /* DTLS 1.2 */
+  big[3] = 0; big[4] = 0;                    /* epoch 0 */
+  big[10] = 1;                               /* sequence number 1 */
+  r_store_be16 (&big[11], 600);              /* fragment length */
+  {
+    RBuffer * rec = r_buffer_new_wrapped (R_MEM_FLAG_NONE, big, sizeof (big),
+        sizeof (big), 0, NULL, NULL);
+    r_assert_cmpptr (rec, !=, NULL);
+    r_tls_server_incoming_data (fixture->server, rec);
+    r_buffer_unref (rec);
+  }
+
+  r_assert (fixture->got_error);
+  r_assert_cmpuint (fixture->last_alert, ==, R_TLS_ALERT_TYPE_RECORD_OVERFLOW);
 }
 RTEST_END;
 


### PR DESCRIPTION
Negotiates the `max_fragment_length` extension and honours the cap in both
directions for TLS and DTLS. Per RFC 6066 §4 a negotiated cap applies to *every*
record including handshake messages, so this is the substantive piece the issue
flagged: real outgoing record fragmentation, which the server previously lacked.

## Negotiation
The client's 1-byte value (1..4 → 2^9..2^12) is stored and echoed in the
ServerHello; any other value is `illegal_parameter`. With nothing negotiated the
server behaves exactly as before.

## Outgoing fragmentation
`r_tls_server_send_record` is the single chokepoint every record passes through
(both `send_appdata` and the handshake `write_*` functions), so fragmentation
lives there: a payload over the cap is split into multiple ≤cap records, each
encrypted with its own sequence number. TLS records (a byte stream — handshake or
application data) and DTLS application data are sliced; DTLS handshake messages
are reframed, repeating the handshake header with per-fragment
`fragment_offset`/`fragment_length` and the same message sequence. The handshake
transcript hash is fed the full messages before this layer, so it is unaffected.

## Incoming
A decrypted plaintext fragment larger than the negotiated cap draws a fatal
`record_overflow`.

## Tests
Server-side over DTLS: the value is echoed; an out-of-range value aborts with
`illegal_parameter`; with a 512-byte cap the 757-byte Certificate is reframed
into contiguous ≤cap fragments that reassemble to the full message; application
data larger than the cap is split into ≤cap records that reassemble to the
original payload; and an over-cap incoming record draws `record_overflow`. Green
across the epoch/rpoll/ASan/UBSan/mingw matrix, leak- and UB-free; doxygen clean.

The fragmentation engine lands as its own commit (inert until negotiation
activates it), so it is bisectable as a no-op rework of the send path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)