### PR TITLE
net/tls: bound hello-extension list accessors by the extension length

### DIFF
--- a/include/rlib/net/proto/rtls.h
+++ b/include/rlib/net/proto/rtls.h
@@ -588,9 +588,15 @@ R_API RTLSError r_tls_hello_msg_extension_next (const RTLSHelloMsg * msg, RTLSHe
 
 /** @name signature_algorithms extension accessors
  *  @{ */
-/** @brief Number of signature schemes in the signature_algorithms extension @p ext. */
+/** @brief Number of signature schemes in the signature_algorithms extension @p ext,
+ * clamped to what @p ext's length can hold (so a bogus inner length is safe). */
 static inline ruint16 r_tls_hello_ext_sign_scheme_count (const RTLSHelloExt * ext)
-{ return r_load_be16 (ext->data) / sizeof (ruint16); }
+{
+  ruint16 avail;
+  if (ext->len < sizeof (ruint16)) return 0;
+  avail = (ruint16) ((ext->len - sizeof (ruint16)) / sizeof (ruint16));
+  return MIN ((ruint16) (r_load_be16 (ext->data) / sizeof (ruint16)), avail);
+}
 /** @brief Return the @p n th signature scheme in @p ext. */
 static inline RTLSSignatureScheme r_tls_hello_ext_sign_scheme (const RTLSHelloExt * ext, int n)
 { return (RTLSSignatureScheme) r_load_be16 (ext->data + (n + 1) * sizeof (ruint16)); }
@@ -598,9 +604,13 @@ static inline RTLSSignatureScheme r_tls_hello_ext_sign_scheme (const RTLSHelloEx
 
 /** @name ec_point_format extension accessors
  *  @{ */
-/** @brief Number of point formats in the ec_point_format extension @p ext. */
+/** @brief Number of point formats in the ec_point_format extension @p ext,
+ * clamped to what @p ext's length can hold (1-byte list prefix). */
 static inline ruint16 r_tls_hello_ext_ec_point_format_count (const RTLSHelloExt * ext)
-{ return ext->data[0]; }
+{
+  if (ext->len < sizeof (ruint8)) return 0;
+  return MIN ((ruint16) ext->data[0], (ruint16) (ext->len - sizeof (ruint8)));
+}
 /** @brief Return the @p n th EC point format in @p ext. */
 static inline RTLSEcPointFormat r_tls_hello_ext_ec_point_format (const RTLSHelloExt * ext, int n)
 { return (RTLSEcPointFormat)ext->data[n+1]; }
@@ -608,9 +618,15 @@ static inline RTLSEcPointFormat r_tls_hello_ext_ec_point_format (const RTLSHello
 
 /** @name supported_groups / elliptic_curves extension accessors
  *  @{ */
-/** @brief Number of named groups in the supported_groups extension @p ext. */
+/** @brief Number of named groups in the supported_groups extension @p ext,
+ * clamped to what @p ext's length can hold. */
 static inline ruint16 r_tls_hello_ext_supported_groups_count (const RTLSHelloExt * ext)
-{ return r_load_be16 (ext->data) / sizeof (ruint16); }
+{
+  ruint16 avail;
+  if (ext->len < sizeof (ruint16)) return 0;
+  avail = (ruint16) ((ext->len - sizeof (ruint16)) / sizeof (ruint16));
+  return MIN ((ruint16) (r_load_be16 (ext->data) / sizeof (ruint16)), avail);
+}
 /** @brief Return the @p n th named group in @p ext. */
 static inline RTLSSupportedGroup r_tls_hello_ext_supported_group (const RTLSHelloExt * ext, int n)
 { return (RTLSSupportedGroup) r_load_be16 (ext->data + (n + 1) * sizeof (ruint16)); }
@@ -618,9 +634,15 @@ static inline RTLSSupportedGroup r_tls_hello_ext_supported_group (const RTLSHell
 
 /** @name use_srtp extension accessors
  *  @{ */
-/** @brief Number of SRTP protection profiles in the use_srtp extension @p ext. */
+/** @brief Number of SRTP protection profiles in the use_srtp extension @p ext,
+ * clamped to what @p ext's length can hold. */
 static inline ruint16 r_tls_hello_ext_use_srtp_profile_count (const RTLSHelloExt * ext)
-{ return r_load_be16 (ext->data) / sizeof (ruint16); }
+{
+  ruint16 avail;
+  if (ext->len < sizeof (ruint16)) return 0;
+  avail = (ruint16) ((ext->len - sizeof (ruint16)) / sizeof (ruint16));
+  return MIN ((ruint16) (r_load_be16 (ext->data) / sizeof (ruint16)), avail);
+}
 /** @brief Return the @p n th SRTP protection profile in @p ext. */
 static inline RSRTPCipherSuite r_tls_hello_ext_use_srtp_profile(const RTLSHelloExt * ext, int n)
 { return (RSRTPCipherSuite) r_load_be16 (ext->data + (n + 1) * sizeof (ruint16)); }

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -1265,18 +1265,6 @@ r_tls_server_default_cipher_suites (rpointer ctx, RTLSVersion ver,
   return TRUE;
 }
 
-/* Clamp the attacker-declared entry count of a hello-extension list to what the
- * extension body can actually hold, so a bogus inner length can't drive reads
- * past ext->data[ext->len]. @hdr is the list-length prefix (1 or 2 bytes),
- * @esz the per-entry size. */
-static ruint16
-r_tls_ext_list_count (const RTLSHelloExt * ext, ruint16 declared,
-    rsize hdr, rsize esz)
-{
-  rsize avail = (ext->len > hdr) ? (ext->len - hdr) / esz : 0;
-  return ((rsize)declared < avail) ? declared : (ruint16)avail;
-}
-
 /* Pick a named curve for ECDHE from the ClientHello's supported_groups, gated
  * by the curves we implement. A Weierstrass curve additionally needs the peer
  * to accept uncompressed points (ec_point_formats); per RFC 4492 5.1 an absent
@@ -1296,8 +1284,7 @@ r_tls_server_nego_ecdhe_curve (RTLSServer * server, REcurveID * out)
       r = r_tls_hello_msg_extension_next (&server->hello, &ext)) {
     if (ext.type == R_TLS_EXT_TYPE_EC_POINT_FORMATS) {
       have_uncompressed = FALSE;
-      n = r_tls_ext_list_count (&ext, r_tls_hello_ext_ec_point_format_count (&ext),
-          sizeof (ruint8), sizeof (ruint8));
+      n = r_tls_hello_ext_ec_point_format_count (&ext);
       for (i = 0; i < n; i++) {
         if (r_tls_hello_ext_ec_point_format (&ext, i) ==
             R_TLS_EC_POINT_FORMAT_UNCOMPRESSED) {
@@ -1313,8 +1300,7 @@ r_tls_server_nego_ecdhe_curve (RTLSServer * server, REcurveID * out)
       r == R_TLS_ERROR_OK;
       r = r_tls_hello_msg_extension_next (&server->hello, &ext)) {
     if (ext.type == R_TLS_EXT_TYPE_SUPPORTED_GROUPS) {
-      n = r_tls_ext_list_count (&ext, r_tls_hello_ext_supported_groups_count (&ext),
-          sizeof (ruint16), sizeof (ruint16));
+      n = r_tls_hello_ext_supported_groups_count (&ext);
       for (i = 0; i < n; i++) {
         REcurveID c;
         if (r_tls_ecdhe_group_to_curve (r_tls_hello_ext_supported_group (&ext, i), &c) &&
@@ -1496,8 +1482,7 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
         break;
       case R_TLS_EXT_TYPE_USE_SRTP:
         /* FIXME: Use SRTP cipher suite API */
-        count = r_tls_ext_list_count (&hsext,
-            r_tls_hello_ext_use_srtp_profile_count (&hsext), sizeof (ruint16), sizeof (ruint16));
+        count = r_tls_hello_ext_use_srtp_profile_count (&hsext);
         for (i = 0; i < count; i++) {
           if (r_tls_hello_ext_use_srtp_profile (&hsext, i) == R_SRTP_CS_AES_128_CM_HMAC_SHA1_80) {
             server->dtls_srtp_profile = R_SRTP_CS_AES_128_CM_HMAC_SHA1_80;
@@ -1525,18 +1510,11 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
           RTLSSignatureScheme want = r_tls_sign_scheme_for_key (server->privkey);
           rboolean ok = FALSE;
 
-          /* Bound the scheme count by the actual extension length: the inner
-           * list-length word is attacker-controlled, so it must not drive reads
-           * past hsext.data[hsext.len]. */
-          if (hsext.len >= sizeof (ruint16)) {
-            count = r_tls_hello_ext_sign_scheme_count (&hsext);
-            if (count > (hsext.len - sizeof (ruint16)) / sizeof (ruint16))
-              count = (hsext.len - sizeof (ruint16)) / sizeof (ruint16);
-            for (i = 0; i < count; i++) {
-              if (r_tls_hello_ext_sign_scheme (&hsext, i) == want) {
-                ok = TRUE;
-                break;
-              }
+          count = r_tls_hello_ext_sign_scheme_count (&hsext);
+          for (i = 0; i < count; i++) {
+            if (r_tls_hello_ext_sign_scheme (&hsext, i) == want) {
+              ok = TRUE;
+              break;
             }
           }
           if (!ok)

--- a/test/rtls.c
+++ b/test/rtls.c
@@ -1271,3 +1271,53 @@ RTEST (rtls, parse_client_key_exchange_ecdhe, RTEST_FAST)
   r_tls_parser_clear (&parser);
 }
 RTEST_END;
+
+/* The hello-extension list accessors must clamp their entry count to the
+ * extension's own length, so a bogus inner list-length cannot drive a
+ * consumer's loop past ext->data[ext->len] (ASan would catch the over-read). */
+RTEST (rtls, hello_ext_list_bounds, RTEST_FAST)
+{
+  RTLSHelloExt ext = R_TLS_HELLO_EXT_INIT;
+  ruint16 i, n;
+  /* uint16 list-length prefix declaring 0x7ffe entries, but the extension only
+   * holds two 2-byte entries after the prefix. */
+  static const ruint8 over16[] = { 0xff, 0xfe, 0x00, 0x01, 0x00, 0x02 };
+  /* uint8 list-length prefix declaring 255 formats, only two present. */
+  static const ruint8 over8[] = { 0xff, 0x00, 0x01 };
+  /* A well-formed list that under-declares relative to the buffer. */
+  static const ruint8 fits[] = { 0x00, 0x02, 0x00, 0x01, 0xde, 0xad };
+
+  ext.data = over16;
+  ext.len = sizeof (over16);
+  r_assert_cmpuint (r_tls_hello_ext_sign_scheme_count (&ext), ==, 2);
+  r_assert_cmpuint (r_tls_hello_ext_supported_groups_count (&ext), ==, 2);
+  r_assert_cmpuint (r_tls_hello_ext_use_srtp_profile_count (&ext), ==, 2);
+  /* Looping the getter over the clamped count stays in bounds. */
+  n = r_tls_hello_ext_sign_scheme_count (&ext);
+  for (i = 0; i < n; i++) {
+    (void) r_tls_hello_ext_sign_scheme (&ext, i);
+    (void) r_tls_hello_ext_supported_group (&ext, i);
+    (void) r_tls_hello_ext_use_srtp_profile (&ext, i);
+  }
+
+  ext.data = over8;
+  ext.len = sizeof (over8);
+  n = r_tls_hello_ext_ec_point_format_count (&ext);
+  r_assert_cmpuint (n, ==, 2);
+  for (i = 0; i < n; i++)
+    (void) r_tls_hello_ext_ec_point_format (&ext, i);
+
+  /* A buffer shorter than the length prefix yields zero, not an over-read. */
+  ext.data = over16;
+  ext.len = 0;
+  r_assert_cmpuint (r_tls_hello_ext_sign_scheme_count (&ext), ==, 0);
+  ext.len = 1;
+  r_assert_cmpuint (r_tls_hello_ext_sign_scheme_count (&ext), ==, 0);
+  r_assert_cmpuint (r_tls_hello_ext_ec_point_format_count (&ext), ==, 0);
+
+  /* Well-formed: the declared count is returned, not over-trimmed. */
+  ext.data = fits;
+  ext.len = sizeof (fits);
+  r_assert_cmpuint (r_tls_hello_ext_sign_scheme_count (&ext), ==, 1);
+}
+RTEST_END;


### PR DESCRIPTION
The hello-extension list accessors (`signature_algorithms`, `supported_groups`,
`ec_point_formats`, `use_srtp`) derived their entry count from a length word
*inside* the extension body without reference to the extension's own `len`. A
consumer looping `for (i = 0; i < count; i++) accessor(ext, i)` over a malformed
ClientHello whose inner list-length over-declares its contents would read past
`ext->data[ext->len]`.

There was no live over-read — every consumer clamped at the call site (via
`r_tls_ext_list_count` or an inline check). This makes the accessors safe by
construction instead: each `_count` now returns `MIN(declared, what ext->len
holds)` and 0 when the extension is shorter than the length prefix, so a new
consumer written the obvious way is safe. The now-redundant call-site clamps and
the `r_tls_ext_list_count` helper are removed. No behaviour change for
well-formed input.

A `test/rtls.c` unit test builds extensions whose inner length over-declares the
contents and asserts each `_count` clamps, looping the getter over the clamped
count so ASan proves no over-read; it also covers truncated and well-formed
under-declared extensions. Green across the epoch/rpoll/ASan/UBSan/mingw matrix,
ASan-clean; doxygen clean.

Filed during the ECDHE_ECDSA audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)