### PR TITLE
rmem: release wrapped data when r_mem_new_wrapped fails

### DIFF
--- a/include/rlib/rbuffer.h
+++ b/include/rlib/rbuffer.h
@@ -83,10 +83,16 @@ R_API RBuffer * r_buffer_new_alloc (RMemAllocator * allocator, rsize allocsize,
  * @param user        Opaque pointer forwarded to @p usernotify.
  * @param usernotify  Destructor called when the wrapping segment
  *                    is freed; receives @p user.
+ *
+ * @p usernotify runs exactly once whether the buffer is created or creation
+ * fails (so a non-@c NULL @p usernotify must not be paired with the caller
+ * freeing @p data on a @c NULL return).
  */
 R_API RBuffer * r_buffer_new_wrapped (RMemFlags flags, rpointer data,
     rsize allocsize, rsize size, rsize offset, rpointer user, RDestroyNotify usernotify);
-/** @brief Wrap @p data and free it with @ref r_free when the segment dies. */
+/** @brief Wrap @p data and free it with @ref r_free when the segment dies.
+ * Ownership transfers unconditionally: @p data is freed even if creation fails,
+ * so the caller must not free it on a @c NULL return. */
 static inline RBuffer * r_buffer_new_take (rpointer data, rsize size)
 { return r_buffer_new_wrapped (R_MEM_FLAG_NONE, data, size, size, 0, data, r_free); }
 /** @brief Allocate-and-copy @p data, returning a wrapping buffer. */

--- a/include/rlib/rmemallocator.h
+++ b/include/rlib/rmemallocator.h
@@ -167,6 +167,11 @@ typedef struct {
  * @param user       Cookie passed to @p usernotify on free.
  * @param usernotify Destroy callback (may be @c NULL for borrowed memory).
  * @return New @c RMem reference, or @c NULL on allocation failure.
+ *
+ * Ownership of @p data transfers on entry: @p usernotify is invoked exactly
+ * once whether the wrapper is created (when the last reference drops) or
+ * creation fails (before returning @c NULL). Callers must therefore not free
+ * @p data themselves on a @c NULL return.
  */
 R_API RMem * r_mem_new_wrapped (RMemFlags flags, rpointer data, rsize allocsize,
     rsize size, rsize offset, rpointer user, RDestroyNotify usernotify) R_ATTR_WARN_UNUSED_RESULT;
@@ -179,7 +184,9 @@ R_API RMem * r_mem_new_wrapped (RMemFlags flags, rpointer data, rsize allocsize,
  * obtained from @c r_malloc: when the last reference drops the
  * wrapper calls @c r_free on @p data. Equivalent to
  * @c r_mem_new_wrapped @c (flags, data, allocsize, size, offset,
- * data, r_free).
+ * data, r_free). Ownership transfers unconditionally — @p data is
+ * @c r_free'd even if creation fails, so the caller must not free it on a
+ * @c NULL return.
  */
 static inline RMem * r_mem_new_take(RMemFlags flags, rpointer data,
     rsize allocsize, rsize size, rsize offset)

--- a/rlib/net/proto/rhttp.c
+++ b/rlib/net/proto/rhttp.c
@@ -416,10 +416,8 @@ r_http_msg_add_header (RHttpMsg * msg, const rchar * field, rssize fsize,
   if (R_UNLIKELY (vsize == 0)) return FALSE;
 
   if ((line = r_strprintf ("%.*s: %.*s\r\n\r\n", (int)fsize, field, (int)vsize, value)) == NULL ||
-      (hdr = r_buffer_new_take (line, fsize + 2 + vsize + 4)) == NULL) {
-    r_free (line);
-    return FALSE;
-  }
+      (hdr = r_buffer_new_take (line, fsize + 2 + vsize + 4)) == NULL)
+    return FALSE;   /* line is NULL, or r_buffer_new_take owns it even on failure */
 
   if (msg->hdr != NULL) {
     RBuffer * buf;

--- a/rlib/net/proto/rrtcp.c
+++ b/rlib/net/proto/rrtcp.c
@@ -439,10 +439,8 @@ r_rtcp_append (RBuffer * buf, ruint8 pt, ruint8 count,
   if (bodylen > 0 && body != NULL)
     r_memcpy (pkt + sizeof (ruint32), body, bodylen);
 
-  if (R_UNLIKELY ((mem = r_mem_new_take (R_MEM_FLAG_NONE, pkt, total, total, 0)) == NULL)) {
-    r_free (pkt);
-    return FALSE;
-  }
+  if (R_UNLIKELY ((mem = r_mem_new_take (R_MEM_FLAG_NONE, pkt, total, total, 0)) == NULL))
+    return FALSE;   /* r_mem_new_take owns pkt, even on failure */
   res = r_buffer_mem_append (buf, mem);
   r_mem_unref (mem);
   return res;

--- a/rlib/net/proto/rrtp.c
+++ b/rlib/net/proto/rrtp.c
@@ -102,10 +102,8 @@ r_rtp_new (RBuffer * payload, ruint8 pad, ruint8 cc, rboolean ext,
     hdr->p = pad > 0 ? 1 : 0;
     hdr->x = ext ? 1 : 0;
     hdr->cc = cc;
-    if (R_UNLIKELY ((mem = r_mem_new_take (R_MEM_FLAG_NONE, hdr, size, size, 0)) == NULL)) {
-      r_free (hdr);
-      goto error;
-    }
+    if (R_UNLIKELY ((mem = r_mem_new_take (R_MEM_FLAG_NONE, hdr, size, size, 0)) == NULL))
+      goto error;   /* r_mem_new_take owns hdr, even on failure */
 
     res = r_buffer_mem_append (ret, mem);
     r_mem_unref (mem);
@@ -125,10 +123,8 @@ r_rtp_new (RBuffer * payload, ruint8 pad, ruint8 cc, rboolean ext,
       if (extsize > 0 && extdata != NULL)
         r_memcpy (e + sizeof (ruint32), extdata, extsize);
 
-      if (R_UNLIKELY ((mem = r_mem_new_take (R_MEM_FLAG_NONE, e, size, size, 0)) == NULL)) {
-        r_free (e);
-        goto error;
-      }
+      if (R_UNLIKELY ((mem = r_mem_new_take (R_MEM_FLAG_NONE, e, size, size, 0)) == NULL))
+        goto error;   /* r_mem_new_take owns e, even on failure */
 
       res = r_buffer_mem_append (ret, mem);
       r_mem_unref (mem);
@@ -147,10 +143,8 @@ r_rtp_new (RBuffer * payload, ruint8 pad, ruint8 cc, rboolean ext,
         goto error;
 
       data[size - 1] = pad;
-      if (R_UNLIKELY ((mem = r_mem_new_take (R_MEM_FLAG_NONE, data, size, size, 0)) == NULL)) {
-        r_free (data);
-        goto error;
-      }
+      if (R_UNLIKELY ((mem = r_mem_new_take (R_MEM_FLAG_NONE, data, size, size, 0)) == NULL))
+        goto error;   /* r_mem_new_take owns data, even on failure */
 
       res = r_buffer_mem_append (ret, mem);
       r_mem_unref (mem);

--- a/rlib/rmemallocator.c
+++ b/rlib/rmemallocator.c
@@ -365,15 +365,24 @@ r_mem_new_wrapped (RMemFlags flags, rpointer data, rsize allocsize,
 {
   RSystemMem * sysmem;
 
-  if (R_UNLIKELY (data == NULL)) return NULL;
-  if (R_UNLIKELY (size + offset > allocsize)) return NULL;
+  if (R_UNLIKELY (data == NULL || size + offset > allocsize))
+    goto fail;
 
-  if ((sysmem = r_mem_new (RSystemMem)) != NULL) {
-    r_system_mem_init (sysmem, flags, &g__r_mem_allocator_system, NULL,
-        allocsize, size, 0, offset, data, user, usernotify);
-  }
+  if (R_UNLIKELY ((sysmem = r_mem_new (RSystemMem)) == NULL))
+    goto fail;
+
+  r_system_mem_init (sysmem, flags, &g__r_mem_allocator_system, NULL,
+      allocsize, size, 0, offset, data, user, usernotify);
 
   return (RMem *) sysmem;
+
+fail:
+  /* Ownership of @data transferred to us on entry; release it via the notify
+   * even when the wrapper cannot be created, so a "take" caller (which does not
+   * free on a NULL return) never leaks. */
+  if (usernotify != NULL)
+    usernotify (user);
+  return NULL;
 }
 
 RMem *

--- a/test/rmem.c
+++ b/test/rmem.c
@@ -339,3 +339,47 @@ RTEST (rmem, memclear_secure, RTEST_FAST)
 }
 RTEST_END;
 
+static ruint g__r_test_wrap_notify;
+static void
+r_test_wrap_notify (rpointer user)
+{
+  (void) user;
+  g__r_test_wrap_notify++;
+}
+
+/* r_mem_new_wrapped takes ownership of @data on entry, so the destroy notify
+ * must run exactly once whether the wrapper is created or creation fails -- a
+ * "take" caller does not free on a NULL return, so a missed notify leaks. */
+RTEST (rmem, new_wrapped_releases_on_failure, RTEST_FAST)
+{
+  ruint8 buf[8];
+  RMem * mem;
+
+  /* size + offset exceeds allocsize: creation fails, ownership still released. */
+  g__r_test_wrap_notify = 0;
+  r_assert_cmpptr (r_mem_new_wrapped (R_MEM_FLAG_NONE, buf, sizeof (buf),
+        sizeof (buf), 4, buf, r_test_wrap_notify), ==, NULL);
+  r_assert_cmpuint (g__r_test_wrap_notify, ==, 1);
+
+  /* NULL data is rejected too; the notify still runs (user may be NULL). */
+  g__r_test_wrap_notify = 0;
+  r_assert_cmpptr (r_mem_new_wrapped (R_MEM_FLAG_NONE, NULL, 0, 0, 0,
+        NULL, r_test_wrap_notify), ==, NULL);
+  r_assert_cmpuint (g__r_test_wrap_notify, ==, 1);
+
+  /* A NULL notify (borrowed memory) is simply not called on failure. */
+  g__r_test_wrap_notify = 0;
+  r_assert_cmpptr (r_mem_new_wrapped (R_MEM_FLAG_NONE, buf, sizeof (buf),
+        sizeof (buf), 4, buf, NULL), ==, NULL);
+  r_assert_cmpuint (g__r_test_wrap_notify, ==, 0);
+
+  /* Success path: the notify fires exactly once, at unref -- not twice. */
+  g__r_test_wrap_notify = 0;
+  r_assert_cmpptr ((mem = r_mem_new_wrapped (R_MEM_FLAG_NONE, buf, sizeof (buf),
+        sizeof (buf), 0, buf, r_test_wrap_notify)), !=, NULL);
+  r_assert_cmpuint (g__r_test_wrap_notify, ==, 0);
+  r_mem_unref (mem);
+  r_assert_cmpuint (g__r_test_wrap_notify, ==, 1);
+}
+RTEST_END;
+

--- a/test/rmemallocator.c
+++ b/test/rmemallocator.c
@@ -241,12 +241,15 @@ RTEST (rmem, wrapped, RTEST_FAST)
   rsize allocsize = 42;
   rpointer data = r_malloc0 (allocsize);
 
+  /* Bad parameters return NULL. Pass a NULL notify so these probes do not
+   * release data -- ownership transfers on entry, so r_free would consume it
+   * (the dedicated release-on-failure behaviour is covered in test/rmem.c). */
   r_assert_cmpptr (r_mem_new_wrapped (R_MEM_FLAG_NONE, NULL, allocsize,
-          24, 4, data, r_free), ==, NULL);
+          24, 4, data, NULL), ==, NULL);
   r_assert_cmpptr (r_mem_new_wrapped (R_MEM_FLAG_NONE, data, 0,
-          24, 4, data, r_free), ==, NULL);
+          24, 4, data, NULL), ==, NULL);
   r_assert_cmpptr (r_mem_new_wrapped (R_MEM_FLAG_NONE, data, allocsize,
-          24, 24, data, r_free), ==, NULL);
+          24, 24, data, NULL), ==, NULL);
   /* This is really just the same as r_mem_new_take () */
   r_assert_cmpptr ((mem = r_mem_new_wrapped (R_MEM_FLAG_NONE, data, allocsize,
           24, 4, data, r_free)), !=, NULL);


### PR DESCRIPTION
`r_mem_new_wrapped` takes ownership of the wrapped buffer on entry, but on its
own allocation failure (or a rejected argument) it returned NULL without
invoking the destroy notify — so a "take" caller, which correctly does not free
on a NULL return, leaked the buffer (OOM-only, but library-wide).

## The fix
Make ownership transfer unconditional: the notify runs exactly once, whether the
wrapper is created (when the last reference drops) or creation fails (before
returning NULL). This is what the `r_mem_new_take` / `r_buffer_new_take`
documentation already implied ("ownership transferred").

## Reconciling the callers
The contract was used inconsistently in-tree, so the fix is not a one-liner:
- Callers that **freed** the buffer on a NULL return (`rrtp` ×3, `rrtcp`,
  `rhttp`) would now double-free — their redundant `r_free` is dropped.
- Callers that **relied on take** (`rjson`, `rsdp`, the X.509 cert path,
  `r_ev_udp/tcp_send`, the TLS parser) were the ones leaking on OOM — now fixed.

The contract is documented on `r_mem_new_wrapped` / `_take` and
`r_buffer_new_wrapped` / `_take` so new callers don't reintroduce a free-on-NULL.

## Tests
A new `test/rmem.c` case asserts the notify fires exactly once on a failed wrap
(bad size, NULL data), is not called for borrowed memory (NULL notify), and
fires once at unref on success. The existing `/rmem/wrapped` test reused one
buffer across several failing probes with an `r_free` notify — valid under the
old contract, a use-after-free under the new one — so its probes now pass a NULL
notify. Green across the epoch/rpoll/ASan/UBSan/mingw matrix (ASan-clean, no
double-free) and under Wine; doxygen clean.

Found while auditing the ECDHE_ECDSA work (the cert-PEM path is one caller).

🤖 Generated with [Claude Code](https://claude.com/claude-code)