### PR TITLE
crypto: zero the LE->BE scratch buffer in the Edwards/Ed loaders

### DIFF
--- a/rlib/crypto/recurve-edwards.c
+++ b/rlib/crypto/recurve-edwards.c
@@ -176,7 +176,7 @@ static const REdwardsParams g__edwards_params[] = {
 static void
 r_edwards_mpint_init_from_le (rmpint * mp, const ruint8 * le, rsize n)
 {
-  ruint8 be[64];
+  ruint8 be[64] = { 0 };
   rsize i;
   for (i = 0; i < n; i++)
     be[i] = le[n - 1 - i];

--- a/rlib/crypto/red25519.c
+++ b/rlib/crypto/red25519.c
@@ -72,7 +72,7 @@ static const RCryptoAlgoInfo g_ed25519_priv_key_info = {
 static void
 r_ed25519_le_to_mpint (rmpint * mp, const ruint8 * le, rsize n)
 {
-  ruint8 be[64];
+  ruint8 be[64] = { 0 };
   rsize i;
   for (i = 0; i < n; i++)
     be[i] = le[n - 1 - i];

--- a/rlib/crypto/red448.c
+++ b/rlib/crypto/red448.c
@@ -82,7 +82,7 @@ static const RCryptoAlgoInfo g_ed448_priv_key_info = {
 static void
 r_ed448_le_to_mpint (rmpint * mp, const ruint8 * le, rsize n)
 {
-  ruint8 be[128];
+  ruint8 be[128] = { 0 };
   rsize i;
   for (i = 0; i < n; i++)
     be[i] = le[n - 1 - i];


### PR DESCRIPTION
`r_edwards_mpint_init_from_le` (recurve-edwards), `r_ed25519_le_to_mpint`
(red25519) and `r_ed448_le_to_mpint` (red448) are the same helper: fill a stack
scratch buffer `be[0..n)` by byte-reversing the little-endian input, read exactly
that range via `r_mpint_init_binary(mp, be, n)`, then securely clear it. The
optimiser cannot correlate the fill-loop bound with the read length, so it flags
the read as `'be' may be used uninitialized` — observed in the ASan build tier
for the first; the other two share the identical pattern and are fixed for
robustness across compilers / optimisation levels.

There is no real uninitialised read (the bytes read are exactly the bytes the
loop wrote), so this defines the scratch buffer fully up front (`= { 0 }`) — the
buffer is securely cleared after use regardless, so the change is purely
defensive and behaviour-neutral.

Green across the epoch/rpoll/ASan/UBSan/mingw matrix and under Wine; doxygen
clean. The Ed25519/Ed448 test suites exercise all three loaders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)