### PR TITLE
net/tls: session-ticket resumption follow-ups

### DIFF
--- a/include/rlib/ev/revloop.h
+++ b/include/rlib/ev/revloop.h
@@ -89,6 +89,8 @@ R_API ruint r_ev_loop_run (REvLoop * loop, REvLoopRunMode mode);
 /** @brief Ask a running loop to stop (it returns from @ref r_ev_loop_run). */
 R_API void r_ev_loop_stop (REvLoop * loop);
 
+/** @brief The loop's clock (for timers); borrowed, owned by the loop. */
+R_API RClock * r_ev_loop_get_clock (const REvLoop * loop);
 /** @brief Total iterations the loop has run. */
 R_API rsize r_ev_loop_get_iterations (const REvLoop * loop);
 /** @brief Number of registered idle callbacks. */

--- a/rlib/ev/revloop.c
+++ b/rlib/ev/revloop.c
@@ -849,6 +849,12 @@ r_ev_loop_stop (REvLoop * loop)
   loop->stop_request = TRUE;
 }
 
+RClock *
+r_ev_loop_get_clock (const REvLoop * loop)
+{
+  return loop->clock;
+}
+
 rsize
 r_ev_loop_get_iterations (const REvLoop * loop)
 {

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -600,14 +600,12 @@ r_tls_server_write_hs_ext_encrypt_then_mac (const RTLSServer * server, ruint8 * 
 static ruint16
 r_tls_server_write_hs_ext_session_ticket (const RTLSServer * server, ruint8 * ptr)
 {
-  /* The ticket itself is minted in the final flight (it binds the master
-   * secret), so this only signals that a NewSessionTicket will follow.
-   * Without a key store the server can neither seal nor later open a ticket,
-   * so it makes no promise. On a resumed handshake no fresh ticket is issued,
-   * so the extension must not be echoed (RFC 5077 3.4) -- promising a ticket
-   * the abbreviated flight never sends would leave the client waiting. */
-  if (!server->support_new_session_ticket || server->ticket_keys == NULL ||
-      server->resumed)
+  /* Signals that a NewSessionTicket will follow (the ticket itself is minted in
+   * the flight, since it binds the master secret). Without a key store the
+   * server can neither seal nor open a ticket, so it makes no promise. On a
+   * resumed handshake a fresh ticket IS now issued (RFC 5077 3.4), so the
+   * extension is echoed there too. */
+  if (!server->support_new_session_ticket || server->ticket_keys == NULL)
     return 0;
 
   /* NewSessionTicket will come! */
@@ -1082,6 +1080,22 @@ r_tls_server_write_change_cipher (RTLSServer * server)
 #define R_TLS_TICKET_STATE_VERSION    2
 #define R_TLS_TICKET_STATE_SIZE       (1 + 2 + 2 + 1 + 8 + 48)
 
+/* Wall-clock 'now' for ticket issued-at / expiry. A synthetic loop clock drives
+ * it deterministically (tests advance it); a real loop clock is monotonic and
+ * unsuitable for cross-process ticket expiry, so production uses wall-clock. */
+static RClockTime
+r_tls_server_now (const RTLSServer * server)
+{
+  RClock * clock;
+
+  if (server->loop != NULL &&
+      (clock = r_ev_loop_get_clock (server->loop)) != NULL &&
+      r_clock_is_synthetic (clock))
+    return r_clock_get_time (clock);
+
+  return r_time_get_ts_wallclock ();
+}
+
 /* Mint the opaque session ticket: serialize the session state needed to resume
  * and seal it under the shared key store. The ticket stays opaque to the
  * client; only a server sharing the same RTLSSessionTicketKeys can open it. */
@@ -1096,7 +1110,7 @@ r_tls_server_create_session_ticket (RTLSServer * server)
   r_store_be16 (&plain[1], (ruint16)server->version);
   r_store_be16 (&plain[3], (ruint16)server->csinfo->suite);
   plain[5] = server->support_ext_master_secret ? 1 : 0;
-  r_store_be64 (&plain[6], (ruint64)r_time_get_ts_wallclock ());
+  r_store_be64 (&plain[6], (ruint64)r_tls_server_now (server));
   r_memcpy (&plain[14], server->mastersecret, sizeof (server->mastersecret));
 
   if (!r_tls_session_ticket_keys_seal (server->ticket_keys, plain,
@@ -1734,6 +1748,15 @@ r_tls_server_expand_master_secret (RTLSServer * server)
   ruint8 keyblock[256];
   RTLSError ret;
 
+  /* Idempotent: release any keys a prior call installed so a re-expansion
+   * (e.g. a full handshake after a failed resume) never leaks them. */
+  if (server->client.hmac != NULL) { r_hmac_free (server->client.hmac); server->client.hmac = NULL; }
+  if (server->server.hmac != NULL) { r_hmac_free (server->server.hmac); server->server.hmac = NULL; }
+  if (server->client.cipher != NULL) { r_crypto_cipher_unref (server->client.cipher); server->client.cipher = NULL; }
+  if (server->server.cipher != NULL) { r_crypto_cipher_unref (server->server.cipher); server->server.cipher = NULL; }
+  r_free (server->client.fixediv); server->client.fixediv = NULL;
+  r_free (server->server.fixediv); server->server.fixediv = NULL;
+
   if (server->prf (keyblock, sizeof (keyblock),
         server->mastersecret, sizeof (server->mastersecret),
         R_STR_WITH_SIZE_ARGS ("key expansion"),
@@ -1947,7 +1970,14 @@ r_tls_server_state_closed (RTLSServer * server, const RTLSParser * parser)
  * ready to emit the resumed flight; returns TRUE. Any failure -- no / unopenable
  * / expired ticket, or a suite no longer offered -- returns FALSE and leaves the
  * caller to run a full handshake (which issues a fresh ticket). */
-static rboolean
+/* Attempt to resume from a session ticket. Returns R_TLS_ERROR_NOT_NEEDED when
+ * the ClientHello is not resumable (no ticket, or a bad / expired / unusable
+ * one) and no server state was touched -- the caller runs a full handshake.
+ * R_TLS_ERROR_OK means the session was adopted. Any other (negative) result
+ * means a commit step failed after state was mutated: the caller must abort the
+ * handshake rather than fall back (a fallback would re-derive over half-adopted
+ * state). */
+static RTLSError
 r_tls_server_try_resume (RTLSServer * server)
 {
   RTLSHelloExt hsext = R_TLS_HELLO_EXT_INIT;
@@ -1963,7 +1993,7 @@ r_tls_server_try_resume (RTLSServer * server)
   rboolean ems;
 
   if (server->ticket_keys == NULL)
-    return FALSE;
+    return R_TLS_ERROR_NOT_NEEDED;
 
   for (r = r_tls_hello_msg_extension_first (&server->hello, &hsext);
       r == R_TLS_ERROR_OK;
@@ -1975,14 +2005,14 @@ r_tls_server_try_resume (RTLSServer * server)
     }
   }
   if (ticket == NULL || ticketlen == 0)
-    return FALSE;
+    return R_TLS_ERROR_NOT_NEEDED;
 
   if (!r_tls_session_ticket_keys_open (server->ticket_keys, ticket, ticketlen,
         plain, sizeof (plain), &plainlen))
-    return FALSE;
+    return R_TLS_ERROR_NOT_NEEDED;
   if (plainlen != sizeof (plain) || plain[0] != R_TLS_TICKET_STATE_VERSION) {
     r_memclear_secure (plain, sizeof (plain));
-    return FALSE;
+    return R_TLS_ERROR_NOT_NEEDED;
   }
 
   ver = (RTLSVersion) r_load_be16 (&plain[1]);
@@ -1995,8 +2025,8 @@ r_tls_server_try_resume (RTLSServer * server)
    * master secret state must match this ClientHello -- nego_hello has already
    * set support_ext_master_secret from the offered extension, so resuming an
    * EMS session without the extension (or vice versa) is refused as a downgrade
-   * (RFC 7627 5.3). */
-  now = r_time_get_ts_wallclock ();
+   * (RFC 7627 5.3). All these reject as "not resumable": no state mutated yet. */
+  now = r_tls_server_now (server);
   if (ver != server->version ||
       now < issued_at ||
       now - issued_at > (RClockTime) R_TLS_SESSION_TICKET_LIFETIME * R_SECOND ||
@@ -2004,14 +2034,27 @@ r_tls_server_try_resume (RTLSServer * server)
       !r_tls_hello_msg_has_cipher_suite (&server->hello, cs) ||
       (csinfo = r_tls_cipher_suite_get_info (cs)) == NULL) {
     r_memclear_secure (plain, sizeof (plain));
-    return FALSE;
+    return R_TLS_ERROR_NOT_NEEDED;
   }
+
+  /* --- Commit: server state is mutated past here. A failure now aborts the
+   * handshake (returned to the caller), it does not fall back. --- */
 
   /* Adopt the resumed session: the suite comes from the ticket, not this
    * ClientHello's preference-ordered negotiation (RFC 7627 5.1). */
   server->csinfo = csinfo;
   r_memcpy (server->mastersecret, &plain[14], sizeof (server->mastersecret));
   r_memclear_secure (plain, sizeof (plain));
+
+  /* Re-select the PRF and transcript hash for the recovered suite: nego_hello
+   * derived them from the negotiated suite, which the ticket suite may differ
+   * from. The ClientHello is fed to hshash only after this returns (state_hello),
+   * so swapping the hash here is transcript-safe; free the old one first. */
+  if (server->hshash != NULL)
+    r_msg_digest_free (server->hshash);
+  server->hshash = NULL;
+  if (!r_tls_prf_and_hash_for (csinfo->prf, &server->prf, &server->hshash))
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
 
   /* A fresh session id signals the resumed session to the client. Pin the
    * server random now: key expansion below and the ServerHello both consume it,
@@ -2025,11 +2068,11 @@ r_tls_server_try_resume (RTLSServer * server)
 
   /* The master secret comes from the ticket, so expand the key block directly
    * (no derivation from a pre-master secret). */
-  if (r_tls_server_expand_master_secret (server) != R_TLS_ERROR_OK)
-    return FALSE;
+  if ((r = r_tls_server_expand_master_secret (server)) != R_TLS_ERROR_OK)
+    return r;
 
   server->resumed = TRUE;
-  return TRUE;
+  return R_TLS_ERROR_OK;
 }
 
 static RTLSError
@@ -2042,9 +2085,15 @@ r_tls_server_state_hello (RTLSServer * server, const RTLSParser * parser)
         server, parser->version, server->hello.version);
     server->hellobuf = r_buffer_ref (parser->buf);
 
-    if ((err = r_tls_server_nego_hello (server, parser->version, server->hello.version)) == R_TLS_ERROR_OK)
-      err = r_tls_server_change_state (server, r_tls_server_try_resume (server) ?
-          R_TLS_SERVER_CHANGE_CIPHER : R_TLS_SERVER_CERTIFICATE);
+    if ((err = r_tls_server_nego_hello (server, parser->version, server->hello.version)) == R_TLS_ERROR_OK) {
+      RTLSError rr = r_tls_server_try_resume (server);
+      if (rr == R_TLS_ERROR_OK)
+        err = r_tls_server_change_state (server, R_TLS_SERVER_CHANGE_CIPHER);
+      else if (rr == R_TLS_ERROR_NOT_NEEDED)
+        err = r_tls_server_change_state (server, R_TLS_SERVER_CERTIFICATE);
+      else
+        err = rr;   /* resume committed then failed: abort, do not fall back */
+    }
   }
 
   switch (err) {
@@ -2055,8 +2104,13 @@ r_tls_server_state_hello (RTLSServer * server, const RTLSParser * parser)
 
       if (server->resumed) {
         /* Abbreviated flight: the server Finished is sent now, ahead of the
-         * client's. The client answers with its ChangeCipherSpec + Finished. */
+         * client's. A fresh NewSessionTicket is reissued to refresh the
+         * lifetime (RFC 5077), before the ChangeCipherSpec so it is plaintext
+         * and folded into the server Finished's transcript. The client answers
+         * with its ChangeCipherSpec + Finished. */
         if (r_tls_server_write_hello (server) == R_TLS_ERROR_OK)
+          server->server.msgseq++;
+        if (r_tls_server_write_new_session_ticket (server) == R_TLS_ERROR_OK)
           server->server.msgseq++;
         if (r_tls_server_write_change_cipher (server) == R_TLS_ERROR_OK)
           server->encrypt = r_tls_server_cipher_encrypt;

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -2267,14 +2267,36 @@ r_test_tls_client_resume (RTLSServer * server, RPrng * prng, RQueue * qout,
   r_assert_cmpuint (hello.sidlen, >, 0);     /* a session id signals resumption */
   r_memcpy (srand, hello.random, sizeof (srand));
   {
-    /* No fresh ticket is issued on resume, so the ServerHello must not promise
-     * one with a session_ticket extension (RFC 5077 3.4). */
+    /* A fresh ticket is reissued on resume, so the ServerHello advertises a
+     * session_ticket extension (RFC 5077 3.4). */
     RTLSHelloExt ext;
     RTLSError e;
+    rboolean seen_st = FALSE;
     for (e = r_tls_hello_msg_extension_first (&hello, &ext); e == R_TLS_ERROR_OK;
         e = r_tls_hello_msg_extension_next (&hello, &ext))
-      r_assert_cmpuint (ext.type, !=, R_TLS_EXT_TYPE_SESSION_TICKET);
+      if (ext.type == R_TLS_EXT_TYPE_SESSION_TICKET)
+        seen_st = TRUE;
+    r_assert (seen_st);
   }
+
+  /* The reissued NewSessionTicket precedes the ChangeCipherSpec; fold it into
+   * the transcript so the server Finished (and ours) cover it. */
+  r_assert_cmpint (r_tls_parser_init_next (&parser, NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_HANDSHAKE);
+  {
+    RTLSHandshakeType hs;
+    ruint32 l, lifetime;
+    ruint16 mseq, nstlen;
+    const ruint8 * nst;
+
+    r_assert_cmpint (r_tls_parser_parse_handshake_full (&parser, &hs, &l, &mseq,
+          NULL, NULL), ==, R_TLS_ERROR_OK);
+    r_assert_cmphex (hs, ==, R_TLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET);
+    r_assert_cmpint (r_tls_parser_parse_new_session_ticket (&parser, &lifetime,
+          &nst, &nstlen), ==, R_TLS_ERROR_OK);
+    r_assert_cmpuint (nstlen, >, 0);          /* a real ticket was reissued */
+  }
+  r_msg_digest_update (md, parser.fragment.data, parser.fragment.size);
 
   /* key block from the resumed master secret and the fresh randoms */
   r_assert_cmpint (r_tls_1_2_prf_sha256 (kb, sizeof (kb), ms, 48,
@@ -2285,7 +2307,7 @@ r_test_tls_client_resume (RTLSServer * server, RPrng * prng, RQueue * qout,
   r_assert_cmpptr ((scipher = r_cipher_aes_128_cbc_new (kb + 56)), !=, NULL);
   r_assert_cmpptr ((shmac = r_hmac_new (R_MSG_DIGEST_TYPE_SHA1, kb + 20, 20)), !=, NULL);
 
-  /* server verify_data is over the transcript through ServerHello */
+  /* server verify_data is over the transcript through the NewSessionTicket */
   hashsize = r_msg_digest_size (md);
   r_assert (r_msg_digest_get_data (md, hash, hashsize, NULL));
   r_assert_cmpint (r_tls_1_2_prf_sha256 (svd, sizeof (svd), ms, 48,
@@ -2456,6 +2478,46 @@ RTEST_F (rtlsserver, tls_session_resume_suite_not_offered, RTEST_FAST)
 }
 RTEST_END;
 
+/* A ticket older than its lifetime must not resume; the server falls back to a
+ * full handshake. The fixture's synthetic loop clock drives the ticket's
+ * issued-at and the expiry check, so advancing it past the lifetime forces the
+ * rejection deterministically. */
+RTEST_F (rtlsserver, tls_session_resume_expired, RTEST_FAST)
+{
+  RTLSServer * srv2;
+  ruint8 ms[48], * ticket = NULL;
+  rsize ticketlen = 0;
+
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (fixture->server,
+        fixture->ticket_keys), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_test_tls_client_issue (fixture->server, fixture->prng, &fixture->qout,
+      ms, &ticket, &ticketlen);   /* issued at clock time 0 */
+  r_assert (fixture->hs_done);
+  r_assert_cmpuint (ticketlen, >, 0);
+
+  /* Advance the synthetic clock just past the ticket lifetime. */
+  r_assert (r_test_clock_update_time (fixture->clock,
+        (RClockTime) (R_TLS_SESSION_TICKET_LIFETIME + 1) * R_SECOND));
+
+  fixture->hs_done = FALSE;
+  r_queue_clear (&fixture->qout, r_buffer_unref);
+  r_assert_cmpptr ((srv2 = r_test_tls_server_new_cfg (fixture)), !=, NULL);
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (srv2, fixture->ticket_keys),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (srv2, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  r_test_tls_client_resume_assert_full (srv2, fixture->prng, &fixture->qout,
+      R_TLS_CS_RSA_WITH_AES_128_CBC_SHA, ticket, ticketlen);
+  r_assert (!fixture->hs_done);
+
+  r_free (ticket);
+  r_tls_server_unref (srv2);
+}
+RTEST_END;
+
 /* Build a DTLS 1.2 ClientHello (message_seq 0) offering @suite, empty
  * renegotiation_info, extended_master_secret (the issuing session used it) and
  * a session_ticket extension carrying @ticket. Captures the client random. */
@@ -2533,14 +2595,37 @@ r_test_tls_dtls_client_resume (RTLSServer * server, RPrng * prng, RQueue * qout,
   r_assert_cmpuint (hello.sidlen, >, 0);     /* a session id signals resumption */
   r_memcpy (srand, hello.random, sizeof (srand));
   {
-    /* No fresh ticket is issued on resume, so the ServerHello must not promise
-     * one with a session_ticket extension (RFC 5077 3.4). */
+    /* A fresh ticket is reissued on resume, so the ServerHello advertises a
+     * session_ticket extension (RFC 5077 3.4). */
     RTLSHelloExt ext;
     RTLSError e;
+    rboolean seen_st = FALSE;
     for (e = r_tls_hello_msg_extension_first (&hello, &ext); e == R_TLS_ERROR_OK;
         e = r_tls_hello_msg_extension_next (&hello, &ext))
-      r_assert_cmpuint (ext.type, !=, R_TLS_EXT_TYPE_SESSION_TICKET);
+      if (ext.type == R_TLS_EXT_TYPE_SESSION_TICKET)
+        seen_st = TRUE;
+    r_assert (seen_st);
   }
+
+  /* The reissued NewSessionTicket (epoch 0) precedes the ChangeCipherSpec; fold
+   * it into the transcript so the server Finished (and ours) cover it. */
+  r_assert_cmpint (r_tls_parser_init_next (&parser, NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_HANDSHAKE);
+  r_assert_cmpuint (parser.epoch, ==, 0);
+  {
+    RTLSHandshakeType hs;
+    ruint32 l, lifetime;
+    ruint16 mseq, nstlen;
+    const ruint8 * nst;
+
+    r_assert_cmpint (r_tls_parser_parse_handshake_full (&parser, &hs, &l, &mseq,
+          NULL, NULL), ==, R_TLS_ERROR_OK);
+    r_assert_cmphex (hs, ==, R_TLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET);
+    r_assert_cmpint (r_tls_parser_parse_new_session_ticket (&parser, &lifetime,
+          &nst, &nstlen), ==, R_TLS_ERROR_OK);
+    r_assert_cmpuint (nstlen, >, 0);
+  }
+  r_msg_digest_update (md, parser.fragment.data, parser.fragment.size);
 
   r_assert_cmpint (r_tls_1_2_prf_sha256 (kb, sizeof (kb), ms, 48,
         R_STR_WITH_SIZE_ARGS ("key expansion"),


### PR DESCRIPTION
Four refinements to TLS/DTLS session-ticket resumption (the remaining #327 items;
key rotation is tracked separately). All live in the same resume path.

## Re-issue a fresh ticket on resumption
The abbreviated flight now sends a NewSessionTicket so the ticket lifetime
refreshes (RFC 5077) instead of expiring at the original issue time. It is sent
before the ChangeCipherSpec (plaintext) and folded into the server Finished's
transcript, and the resumed ServerHello advertises the session_ticket extension.

## Re-select PRF / transcript hash from the ticket suite
`try_resume` adopted the ticket's cipher suite but kept the PRF/hash `nego_hello`
derived from the negotiated suite. It now re-derives them from the recovered
suite (transcript-safe: the ClientHello is hashed after the swap). Latent today
since both TLS 1.2 suites use the SHA-256 PRF; correct once that stops holding.

## Transactional resumption
`try_resume` validates fully before mutating any state and now distinguishes
"not resumable" (fall back to a full handshake) from a post-commit failure
(abort — never re-derive over half-adopted state). `expand_master_secret` is
idempotent (frees any prior install), so a re-expansion can't leak keys.

## Deterministic expiry
The ticket issued-at / expiry time is read from the server's loop clock when
that clock is synthetic, else wall-clock — production is unchanged (real clocks
aren't synthetic), and a test can advance a synthetic clock past the lifetime to
exercise rejection. A new test does exactly that.

Adds a small `r_ev_loop_get_clock` accessor (separate commit). Green across the
epoch/rpoll/ASan/UBSan/mingw matrix (leak-free) and under Wine; doxygen clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)