### PR TITLE
net/http: optional TLS (HTTPS) termination

### DIFF
--- a/include/rlib/net/rhttpserver.h
+++ b/include/rlib/net/rhttpserver.h
@@ -35,6 +35,8 @@
 #include <rlib/ev/revloop.h>
 
 #include <rlib/net/rsocketaddress.h>
+#include <rlib/crypto/rcert.h>
+#include <rlib/crypto/rkey.h>
 
 /**
  * @defgroup r_http_server HTTP server
@@ -44,7 +46,7 @@
  * dispatches requests to pattern-matched handlers.
  *
  * Register one or more handlers with @ref r_http_server_set_handler
- * (each bound to a path pattern), then @ref r_http_server_listen on a
+ * (each bound to a path pattern), then @ref r_http_server_add_listen_addr on a
  * socket address. Each request invokes the matching
  * @ref RHttpRequestHandler, which returns the @ref RHttpResponse to
  * send. Requests can also be injected directly via
@@ -94,8 +96,20 @@ R_API rboolean r_http_server_set_handler (RHttpServer * server,
   const rchar * pattern, rssize size, RHttpRequestHandler handler,
   rpointer data, RDestroyNotify notify);
 
-/** @brief Start accepting connections on @p addr. */
-R_API rboolean r_http_server_listen (RHttpServer * server, RSocketAddress * addr);
+/** @brief Add a plaintext (HTTP) listening address; may be called repeatedly. */
+R_API rboolean r_http_server_add_listen_addr (RHttpServer * server,
+    RSocketAddress * addr);
+/**
+ * @brief Add a TLS (HTTPS) listening address terminated with @p cert / @p privkey.
+ *
+ * Each accepted connection runs a per-connection TLS handshake before any HTTP
+ * is parsed. @p cert and @p privkey are referenced and apply to this listener
+ * only, so distinct addresses may serve distinct certificates. May be combined
+ * freely with @ref r_http_server_add_listen_addr on one server (e.g. HTTP on
+ * port 80 and HTTPS on port 443).
+ */
+R_API rboolean r_http_server_add_tls_listen_addr (RHttpServer * server,
+    RSocketAddress * addr, RCryptoCert * cert, RCryptoKey * privkey);
 /**
  * @brief Local address of the server's first listener.
  *

--- a/rlib/net/rhttpserver.c
+++ b/rlib/net/rhttpserver.c
@@ -22,10 +22,12 @@
 #include <rlib/net/rhttpserver.h>
 
 #include <rlib/ev/revtcp.h>
+#include <rlib/net/rtlsserver.h>
 
 #include <rlib/data/rdirtree.h>
 #include <rlib/data/rptrarray.h>
 
+#include <rlib/rrand.h>
 #include <rlib/rmem.h>
 #include <rlib/rstr.h>
 
@@ -37,12 +39,19 @@ struct RHttpServer {
 
   RPtrArray * clients;
   RPtrArray * listen;
+
+  /* Per-listener TLS config (cert/key) for HTTPS listeners, plus the shared
+   * PRNG every per-connection RTLSServer draws from. */
+  RPtrArray * tls_listeners;
+  RPrng * prng;
 };
 
 typedef struct {
   RRef ref;
   RHttpServer * server;
   REvTCP * evtcp;
+
+  RTLSServer * tls;     /* per-connection TLS engine; NULL for plaintext */
 
   RHttpRequest * req;
   rssize bodysize;
@@ -69,6 +78,8 @@ r_http_client_ctx_free (RHttpClientCtx * ctx)
     r_buffer_unref (ctx->inbuf);
   if (ctx->req != NULL)
     r_http_request_unref (ctx->req);
+  if (ctx->tls != NULL)
+    r_tls_server_unref (ctx->tls);
 
   r_ev_tcp_unref (ctx->evtcp);
   r_http_server_unref (ctx->server);
@@ -141,7 +152,17 @@ r_http_client_ctx_tcp_response_ready (rpointer data, RHttpResponse * res,
         server, buf, R_EV_IO_ARGS (ctx->evtcp), ctx->keepalive ? "keepalive" : "close");
     R_LOG_BUF_DUMP (R_LOG_LEVEL_TRACE, buf);
 
-    if (!ctx->keepalive) {
+    if (ctx->tls != NULL) {
+      /* send_appdata flushes encrypted records via the out callback. On close,
+       * the queued response + close_notify drain through r_ev_tcp_close's
+       * graceful flush before the FIN. This runs from the deferred handler
+       * callback, not the recv chain, so closing here is safe. */
+      r_tls_server_send_appdata (ctx->tls, buf);
+      if (!ctx->keepalive) {
+        r_tls_server_close (ctx->tls);
+        r_http_client_ctx_close (ctx, NULL, NULL);
+      }
+    } else if (!ctx->keepalive) {
       r_ev_tcp_send (ctx->evtcp, buf, r_http_client_ctx_response_sent,
           r_ref_ref (ctx), r_ref_unref);
     } else {
@@ -313,6 +334,9 @@ r_http_server_free (RHttpServer * server)
   r_ev_loop_unref (server->loop);
   r_ptr_array_unref (server->clients);
   r_ptr_array_unref (server->listen);
+  r_ptr_array_unref (server->tls_listeners);
+  if (server->prng != NULL)
+    r_prng_unref (server->prng);
   r_free (server);
 }
 
@@ -332,6 +356,9 @@ r_http_server_new (REvLoop * loop)
 
     ret->clients = r_ptr_array_new_sized (1024);
     ret->listen = r_ptr_array_new ();
+
+    ret->tls_listeners = r_ptr_array_new ();
+    ret->prng = NULL;
 
     R_LOG_INFO ("New HTTP server %p", ret);
   } else {
@@ -491,6 +518,126 @@ r_http_server_process_request (RHttpServer * server,
   return FALSE;
 }
 
+/* --- TLS termination (HTTPS) ---------------------------------------------
+ * A per-connection RTLSServer sits between the socket and the HTTP parser:
+ *   socket recv -> r_tls_server_incoming_data -> appdata -> the HTTP parser;
+ *   HTTP response -> r_tls_server_send_appdata -> out -> socket send.
+ * The bundle's userdata is the RHttpClientCtx (a back-pointer; the ctx owns the
+ * RTLSServer, hence a NULL destroy-notify on r_tls_server_new). */
+
+/* Cert/key for one HTTPS listener; the server owns these in tls_listeners and
+ * passes one (borrowed) as the accept callback's data. */
+typedef struct {
+  RHttpServer * server;
+  RCryptoCert * cert;
+  RCryptoKey * privkey;
+} RHttpTLSListener;
+
+static void
+r_http_tls_listener_free (rpointer data)
+{
+  RHttpTLSListener * l = data;
+  r_crypto_cert_unref (l->cert);
+  r_crypto_key_unref (l->privkey);
+  r_free (l);
+}
+
+static rboolean
+r_http_client_ctx_tls_out (rpointer data, RBuffer * buf, rpointer session)
+{
+  RHttpClientCtx * ctx = data;
+  (void) session;
+
+  /* Borrowed buffer: the send path queues its own reference. */
+  r_ev_tcp_send_and_forget (ctx->evtcp, buf);
+  return TRUE;
+}
+
+static rboolean
+r_http_client_ctx_tls_appdata (rpointer data, RBuffer * buf, rpointer session)
+{
+  RHttpClientCtx * ctx = data;
+  (void) session;
+
+  /* Decrypted bytes flow into the same parser the plaintext path uses. */
+  r_http_client_ctx_tcp_recv (ctx, buf, ctx->evtcp);
+  return TRUE;
+}
+
+static void
+r_http_client_ctx_tls_error (rpointer data, RTLSAlertType alert, rpointer session)
+{
+  RHttpClientCtx * ctx = data;
+  (void) alert;
+  (void) session;
+
+  r_http_client_ctx_close (ctx, NULL, NULL);
+}
+
+static void
+r_http_client_ctx_tls_closed (rpointer data, rpointer session)
+{
+  RHttpClientCtx * ctx = data;
+  (void) session;
+
+  r_http_client_ctx_close (ctx, NULL, NULL);
+}
+
+static const RTLSCallbacks g__r_http_tls_callbacks = {
+  NULL,                              /* preferred_cipher_suites (defaults) */
+  NULL,                              /* handshake_done (appdata drives parsing) */
+  r_http_client_ctx_tls_out,         /* out */
+  r_http_client_ctx_tls_appdata,     /* appdata */
+  r_http_client_ctx_tls_error,       /* error */
+  NULL,                              /* verify_cert (no client cert) */
+  r_http_client_ctx_tls_closed,      /* closed */
+};
+
+static void
+r_http_client_ctx_tls_recv (rpointer data, RBuffer * buf, REvTCP * evtcp)
+{
+  RHttpClientCtx * ctx = data;
+  (void) evtcp;
+
+  if (buf == NULL) {
+    r_http_client_ctx_close (ctx, NULL, NULL);
+    return;
+  }
+
+  /* incoming_data synchronously fires out (handshake records) and appdata
+   * (decrypted bytes -> parser), and may tear the connection down via the
+   * error/closed callbacks; hold a reference so the ctx survives the chain. */
+  r_ref_ref (ctx);
+  r_tls_server_incoming_data (ctx->tls, buf);
+  r_ref_unref (ctx);
+}
+
+static void
+r_http_server_tcp_connection_ready_tls (rpointer data,
+    REvTCP * newtcp, REvTCP * listening)
+{
+  RHttpTLSListener * l = data;
+  RHttpServer * server = l->server;
+  RHttpClientCtx * ctx;
+
+  if ((ctx = r_http_client_ctx_new (server, newtcp)) != NULL &&
+      (ctx->tls = r_tls_server_new (&g__r_http_tls_callbacks, ctx, NULL)) != NULL &&
+      r_tls_server_set_cert (ctx->tls, l->cert, l->privkey) == R_TLS_ERROR_OK &&
+      r_tls_server_start (ctx->tls, server->loop, server->prng) == R_TLS_ERROR_OK &&
+      r_ev_tcp_recv_start (newtcp, NULL, r_http_client_ctx_tls_recv, ctx, NULL)) {
+    R_LOG_TRACE ("%p: New TLS connection "R_EV_IO_FORMAT" on "R_EV_IO_FORMAT,
+        server, R_EV_IO_ARGS (newtcp), R_EV_IO_ARGS (listening));
+    r_ptr_array_add (server->clients, ctx, r_ref_unref);
+  } else if (ctx != NULL) {
+    R_LOG_WARNING ("%p: New TLS connection "R_EV_IO_FORMAT" setup failed",
+        server, R_EV_IO_ARGS (newtcp));
+    r_ref_unref (ctx);
+  } else {
+    R_LOG_WARNING ("%p: New TLS connection "R_EV_IO_FORMAT" OOM", server,
+        R_EV_IO_ARGS (newtcp));
+  }
+}
+
 static void
 r_http_server_tcp_connection_ready (rpointer data,
     REvTCP * newtcp, REvTCP * listening)
@@ -517,8 +664,12 @@ r_http_server_tcp_connection_ready (rpointer data,
   }
 }
 
-rboolean
-r_http_server_listen (RHttpServer * server, RSocketAddress * addr)
+/* @accept_data is borrowed by the accept callback; the caller keeps it alive
+ * for as long as the listener (the server owns plaintext data implicitly and
+ * TLS listener configs via tls_listeners). */
+static rboolean
+r_http_server_do_listen (RHttpServer * server, RSocketAddress * addr,
+    REvTCPConnectionReadyFunc accept_cb, rpointer accept_data)
 {
   REvTCP * tcp;
   rchar * addrstr;
@@ -527,7 +678,7 @@ r_http_server_listen (RHttpServer * server, RSocketAddress * addr)
 
   if ((tcp = r_ev_tcp_new_bind (addr, server->loop)) != NULL) {
     if (r_ev_tcp_listen (tcp, R_SOCKET_DEFAULT_BACKLOG,
-          r_http_server_tcp_connection_ready, server, NULL) >= R_SOCKET_OK) {
+          accept_cb, accept_data, NULL) >= R_SOCKET_OK) {
       if (r_ptr_array_add (server->listen, tcp, r_ev_tcp_unref) != R_PTR_ARRAY_INVALID_IDX) {
         R_LOG_INFO ("%p: TCP listen %s", server, addrstr);
         r_free (addrstr);
@@ -541,6 +692,44 @@ r_http_server_listen (RHttpServer * server, RSocketAddress * addr)
   R_LOG_ERROR ("%p: Failed for %s", server, addrstr);
   r_free (addrstr);
   return FALSE;
+}
+
+rboolean
+r_http_server_add_listen_addr (RHttpServer * server, RSocketAddress * addr)
+{
+  return r_http_server_do_listen (server, addr,
+      r_http_server_tcp_connection_ready, server);
+}
+
+rboolean
+r_http_server_add_tls_listen_addr (RHttpServer * server, RSocketAddress * addr,
+    RCryptoCert * cert, RCryptoKey * privkey)
+{
+  RHttpTLSListener * l;
+
+  if (R_UNLIKELY (server == NULL)) return FALSE;
+  if (R_UNLIKELY (cert == NULL || privkey == NULL)) {
+    R_LOG_ERROR ("%p: add_tls_listen_addr needs a cert and key", server);
+    return FALSE;
+  }
+
+  if (server->prng == NULL && (server->prng = r_prng_new_mt ()) == NULL)
+    return FALSE;
+
+  if ((l = r_mem_new (RHttpTLSListener)) == NULL)
+    return FALSE;
+  l->server = server;
+  l->cert = r_crypto_cert_ref (cert);
+  l->privkey = r_crypto_key_ref (privkey);
+
+  if (!r_http_server_do_listen (server, addr,
+        r_http_server_tcp_connection_ready_tls, l)) {
+    r_http_tls_listener_free (l);
+    return FALSE;
+  }
+
+  r_ptr_array_add (server->tls_listeners, l, r_http_tls_listener_free);
+  return TRUE;
 }
 
 RSocketAddress *

--- a/test/rhttpclient.c
+++ b/test/rhttpclient.c
@@ -100,7 +100,7 @@ r_test_http_listen_ephemeral (RHttpServer * srv)
 
   r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)),
       !=, NULL);
-  if (r_http_server_listen (srv, addr))
+  if (r_http_server_add_listen_addr (srv, addr))
     bound = r_http_server_get_local_address (srv);
   r_socket_address_unref (addr);
 

--- a/test/rhttpserver.c
+++ b/test/rhttpserver.c
@@ -1,5 +1,56 @@
 #include <rlib/rnet.h>
 #include <rlib/rev.h>
+#include <rlib/rcrypto.h>
+
+static const rchar testcertpem[] =
+  "-----BEGIN CERTIFICATE-----\r\n"
+  "MIIC8TCCAdmgAwIBAgIJALoi/+XOQDHjMA0GCSqGSIb3DQEBCwUAMA8xDTALBgNV\r\n"
+  "BAMMBHJsaWIwHhcNMTYxMTE1MTMzNjI0WhcNMTcxMTE1MTMzNjI0WjAPMQ0wCwYD\r\n"
+  "VQQDDARybGliMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwjolUmQU\r\n"
+  "r9Q2FZ7O3qau+Z6+VvuJROvxzjt1aIQLLO/hF0Ya56BZCZD5aKyqQM//fTm97VTb\r\n"
+  "CQYBaNg03D20XPDIWmr7EdHxYK+YI+jz7DrWqhM4jwSvvteXXXWD7bVdCq+RyveD\r\n"
+  "NrgoGZqL5UCiWS1BWkB9nS/KQtgxrT3hWSOlG1xRh6hfeIy4H2CB3Qk/Q3PHjMcH\r\n"
+  "7CKhCj+ctbqR3r2K3BLL3fgZKnfQdCPsZplN8Ey4hSOc/67NQK/yn/S0JgeHmjb8\r\n"
+  "D5xbaDiOloOHJJg6dm1QU0UuEpiK2Uda0VR6TGu9Ci05h5U3HoV9CbyAGQhmFSem\r\n"
+  "NreAELYv89sMgwIDAQABo1AwTjAdBgNVHQ4EFgQUXFVr3x4Bcglp/MP0ZFEk/Ntz\r\n"
+  "wJYwHwYDVR0jBBgwFoAUXFVr3x4Bcglp/MP0ZFEk/NtzwJYwDAYDVR0TBAUwAwEB\r\n"
+  "/zANBgkqhkiG9w0BAQsFAAOCAQEAL4ZKyDRXP3+Jr/GN+p6WbFW3tHuhxWxy8rMy\r\n"
+  "W7OHX/sHASzJiaEmjtIlPx/7uFFowktEmXyybEmBvYp64UZ2mo2v+CCm+236wPTS\r\n"
+  "gGfpcp9nP2RI0VFdJLHuqWapa5CQJZISRAO/tj7UqflOWBohm04EvmJe53JGEq+4\r\n"
+  "Dk41kC+z3jVPGHG+jR3uYOw7JCmFT+bt4P5EDxGAKe9eoweLHBJ8vlJ7cUdHhBv1\r\n"
+  "BUCMVR86kPZFzHKVQtWNXt26H/khgz7RA/qUSJA17Nk2h0h60b1AbkljkduWWIMZ\r\n"
+  "5B2DUz4MEDUHjppHF9+A2q5ZN+25eOYbrkS5Dq50VPNrvd8dSQ==\r\n"
+  "-----END CERTIFICATE-----\r\n";
+
+static const rchar testpkpem[] =
+  "-----BEGIN PRIVATE KEY-----\r\n"
+  "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDCOiVSZBSv1DYV\r\n"
+  "ns7epq75nr5W+4lE6/HOO3VohAss7+EXRhrnoFkJkPlorKpAz/99Ob3tVNsJBgFo\r\n"
+  "2DTcPbRc8MhaavsR0fFgr5gj6PPsOtaqEziPBK++15dddYPttV0Kr5HK94M2uCgZ\r\n"
+  "movlQKJZLUFaQH2dL8pC2DGtPeFZI6UbXFGHqF94jLgfYIHdCT9Dc8eMxwfsIqEK\r\n"
+  "P5y1upHevYrcEsvd+Bkqd9B0I+xmmU3wTLiFI5z/rs1Ar/Kf9LQmB4eaNvwPnFto\r\n"
+  "OI6Wg4ckmDp2bVBTRS4SmIrZR1rRVHpMa70KLTmHlTcehX0JvIAZCGYVJ6Y2t4AQ\r\n"
+  "ti/z2wyDAgMBAAECggEABJZzAzsx8eVFUcVqhX/SajsBq/RNDb+0+nYVE97qlKkl\r\n"
+  "2/Lf99ClycAO5BYP/2/qTP7sKYrzkYb+yYcx2HHsrLVTRi94trcKyIndQhvihxXs\r\n"
+  "tB+4Gki2Df/xp1d7QkYiaHo1K2IlS0mWSOSJoWShcRHMlWEolmnmkSWiJsFrbTuL\r\n"
+  "sxB/6lVmD6Bbez/ob5JzK4QBAEREd0QbUCQiDssFvf0nlDmtKrxosLFuu86z0nIR\r\n"
+  "3OKyr9n6IW64r7x7Ccv/5pY3Cmkg0/knF4bi60ssm2byY2TW3wnOT0inVrp0UUQP\r\n"
+  "ex9Dse3izVyMLaeqLh6GCQhLFROE85qslLmOYb56YQKBgQD7HHWdsrNDtkHkXvyz\r\n"
+  "TWi8dPVMVk4/X/G3vPr2nBRHj9MzXX/ZgoFpklMsR/EtKh9LBBh9vY9YnXhIGUrc\r\n"
+  "vwt1PSUIsjUuHBfhxnHxcZEu2ROw18LJmSRp6duZADFcH8ApPFg1dVZ2APyHyS4J\r\n"
+  "tTL/DIeQ6ASq0EENjuO5VgM5PwKBgQDGAiz9c3/1OPZNiENyCYbrqOzduzkoisX7\r\n"
+  "yGYFiJpLdsmrRsztqJktwiDEYYrJoV+AHmKa79Iexp6vvq9gQFN3XvFw6U1XXF5D\r\n"
+  "RtLHHqWgoj9yFIpmVXfcdFICfNdPcVn7NAE0CQBRNgBJGSvRoSeTpOyjVmF9Mu18\r\n"
+  "h2wUK0L3vQKBgBms7kXCmNvKjfA42iPHPXdPiilVBckrGT8NPqfqi5RJm3G8FK97\r\n"
+  "zZmq0YBMltdkYDC+aXap5DdOWpccpu/tRNGm/9tkxVVCoBqAvPPQBeVBYucJGKye\r\n"
+  "UP/XXpHFWEawJGjS9733knCcZzXHF0L82QsFD/N8FcYVZyFow9YWelvnAoGAIj8o\r\n"
+  "FuIOJJSojPpfZ+7b5hB+f08tcKSn34dmldhtj1XJRZVmRkidzbtAvZZ9UahWgys+\r\n"
+  "NLv75JTHx2+8l3IovYGvUq8XUF/Kcepi9EuJrAHD5XBGC7MGmxuHP6Tl/HiHbpot\r\n"
+  "Bxnzcxha7kmrOYOc+71PrGR5UhUn3Bz0BX0CBSUCgYAKxDbgtJ1NZgf33yMQb1BG\r\n"
+  "vgLQWiysO9t1dXFN9YiPsZ1Rkyj9iOdROG47T1ifcrCw45mqBF71COM23zplWz64\r\n"
+  "wUg8Baom8FExrgLtVDeyQO7qkiOoP96r9Fm34Y4Sgv1/oiO9f5KYckMcSig9zCQA\r\n"
+  "VFwqM04nD9RsYGRKy6NhrA==\r\n"
+  "-----END PRIVATE KEY-----\r\n";
 
 static void
 r_test_http_server_stop (rpointer data, REvLoop * loop)
@@ -24,7 +75,7 @@ RTEST (rhttpserver, listen, RTEST_FAST)
    * in TIME_WAIT (notably under meson test --repeat). */
   r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
 
-  r_assert (r_http_server_listen (srv, addr));
+  r_assert (r_http_server_add_listen_addr (srv, addr));
   r_socket_address_unref (addr);
 
   r_ev_loop_add_callback (loop, FALSE, r_test_http_server_stop,
@@ -209,7 +260,7 @@ RTEST (rhttpserver, keepalive_default_http11, RTEST_FAST | RTEST_SYSTEM)
         RUINT_TO_POINTER (R_HTTP_STATUS_OK), NULL));
   r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)),
       !=, NULL);
-  r_assert (r_http_server_listen (srv, addr));
+  r_assert (r_http_server_add_listen_addr (srv, addr));
   r_socket_address_unref (addr);
   r_assert_cmpptr ((addr = r_http_server_get_local_address (srv)), !=, NULL);
 
@@ -224,6 +275,244 @@ RTEST (rhttpserver, keepalive_default_http11, RTEST_FAST | RTEST_SYSTEM)
   r_thread_join (thread);
   r_thread_unref (thread);
   r_assert_cmpint (c.responses, ==, 2);   /* connection persisted across requests */
+
+  r_http_server_stop (srv, NULL, NULL, NULL);
+  r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
+  r_http_server_unref (srv);
+  r_socket_address_unref (addr);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+
+/* A TLS client driven over a real loopback REvTCP, all on one event loop: it
+ * connects, runs the handshake, sends one GET on handshake completion and
+ * captures the decrypted HTTP response. */
+typedef struct {
+  REvLoop * loop;
+  REvTCP * tcp;
+  RTLSClient * tls;
+  RPrng * prng;
+  RBuffer * resp;            /* decrypted response bytes, accumulated */
+  RTLSVersion version;
+  const RTLSCipherSuiteInfo * cipher;
+  rboolean got_response;
+  rboolean eos;
+} RTestTLSClient;
+
+static rboolean
+r_test_tls_client_out (rpointer data, RBuffer * buf, rpointer session)
+{
+  RTestTLSClient * c = data;
+  (void) session;
+  /* Borrowed buffer: the send path queues its own reference. */
+  r_ev_tcp_send_and_forget (c->tcp, buf);
+  return TRUE;
+}
+
+static void
+r_test_tls_client_hs_done (rpointer data, rpointer session)
+{
+  static const rchar req[] =
+      "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
+  RTestTLSClient * c = data;
+  RBuffer * buf;
+  (void) session;
+
+  c->version = r_tls_client_get_version (c->tls);
+  c->cipher = r_tls_client_get_cipher_suite (c->tls);
+
+  r_assert_cmpptr ((buf = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer) req, sizeof (req) - 1, sizeof (req) - 1, 0, NULL, NULL)),
+      !=, NULL);
+  r_tls_client_send_appdata (c->tls, buf);
+  r_buffer_unref (buf);
+}
+
+static rboolean
+r_test_tls_client_appdata (rpointer data, RBuffer * buf, rpointer session)
+{
+  RTestTLSClient * c = data;
+  (void) session;
+
+  r_buffer_append_mem_from_buffer (c->resp, buf);
+  if (r_buffer_get_size (c->resp) >= 12 &&
+      r_buffer_memcmp (c->resp, 0, "HTTP/1.1 200", 12) == 0)
+    c->got_response = TRUE;
+  return TRUE;
+}
+
+static const RTLSCallbacks g_test_tls_client_cbs = {
+  NULL, r_test_tls_client_hs_done, r_test_tls_client_out,
+  r_test_tls_client_appdata, NULL, NULL, NULL,
+};
+
+static void
+r_test_tls_client_recv (rpointer data, RBuffer * buf, REvTCP * evtcp)
+{
+  RTestTLSClient * c = data;
+  (void) evtcp;
+
+  if (buf == NULL) {
+    c->eos = TRUE;
+    return;
+  }
+  r_tls_client_incoming_data (c->tls, buf);
+}
+
+static void
+r_test_tls_client_connected (rpointer data, REvTCP * evtcp, int status)
+{
+  RTestTLSClient * c = data;
+  (void) evtcp;
+
+  r_assert_cmpint (status, ==, R_SOCKET_OK);
+  r_assert_cmpint (R_TLS_ERROR_OK, ==,
+      r_tls_client_start (c->tls, c->loop, c->prng, R_TLS_VERSION_TLS_1_2));
+  r_assert (r_ev_tcp_recv_start (c->tcp, NULL, r_test_tls_client_recv, c, NULL));
+}
+
+RTEST (rhttpserver, https_get, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RHttpServer * srv;
+  RSocketAddress * addr;
+  RCryptoCert * cert;
+  RCryptoKey * pk;
+  RTestTLSClient c = { NULL, NULL, NULL, NULL, NULL, R_TLS_VERSION_UNKNOWN, NULL, FALSE, FALSE };
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((srv = r_http_server_new (loop)), !=, NULL);
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (testcertpem, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem, -1, NULL, 0)), !=, NULL);
+
+  r_assert (r_http_server_set_handler (srv, "/", -1,
+        r_test_http_simple_status_handler,
+        RUINT_TO_POINTER (R_HTTP_STATUS_OK), NULL));
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
+  r_assert (r_http_server_add_tls_listen_addr (srv, addr, cert, pk));
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_http_server_get_local_address (srv)), !=, NULL);
+
+  r_assert_cmpptr ((c.prng = r_prng_new_mt ()), !=, NULL);
+  r_assert_cmpptr ((c.resp = r_buffer_new ()), !=, NULL);
+  r_assert_cmpptr ((c.tls = r_tls_client_new (&g_test_tls_client_cbs, &c, NULL)), !=, NULL);
+  c.loop = loop;
+  r_assert_cmpptr ((c.tcp = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpint (r_ev_tcp_connect (c.tcp, addr,
+        r_test_tls_client_connected, &c, NULL), >=, R_SOCKET_OK);
+
+  while (!c.got_response && !c.eos)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE);
+
+  r_assert (c.got_response);
+  r_assert_cmpint (c.version, ==, R_TLS_VERSION_TLS_1_2);
+  r_assert_cmpptr (c.cipher, !=, NULL);
+
+  r_ev_tcp_close (c.tcp, NULL, NULL, NULL);
+  r_ev_tcp_unref (c.tcp);
+  r_tls_client_unref (c.tls);
+  r_buffer_unref (c.resp);
+  r_prng_unref (c.prng);
+
+  r_http_server_stop (srv, NULL, NULL, NULL);
+  r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
+  r_http_server_unref (srv);
+  r_socket_address_unref (addr);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+/* A plaintext HTTP request against a TLS listener: the bytes are not a valid
+ * TLS record, so the server aborts the connection rather than answering. */
+typedef struct {
+  REvTCP * tcp;
+  RBuffer * resp;
+  rboolean got_response;
+  rboolean eos;
+} RTestPlainClient;
+
+static void
+r_test_plain_client_recv (rpointer data, RBuffer * buf, REvTCP * evtcp)
+{
+  RTestPlainClient * c = data;
+  (void) evtcp;
+
+  if (buf == NULL) {
+    c->eos = TRUE;
+    return;
+  }
+  r_buffer_append_mem_from_buffer (c->resp, buf);
+  if (r_buffer_get_size (c->resp) >= 12 &&
+      r_buffer_memcmp (c->resp, 0, "HTTP/1.1 200", 12) == 0)
+    c->got_response = TRUE;
+}
+
+static void
+r_test_plain_client_connected (rpointer data, REvTCP * evtcp, int status)
+{
+  static const rchar req[] = "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n";
+  RTestPlainClient * c = data;
+  RBuffer * buf;
+  (void) evtcp;
+
+  r_assert_cmpint (status, ==, R_SOCKET_OK);
+  r_assert (r_ev_tcp_recv_start (c->tcp, NULL, r_test_plain_client_recv, c, NULL));
+  r_assert_cmpptr ((buf = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer) req, sizeof (req) - 1, sizeof (req) - 1, 0, NULL, NULL)),
+      !=, NULL);
+  r_ev_tcp_send_and_forget (c->tcp, buf);
+  r_buffer_unref (buf);
+}
+
+RTEST (rhttpserver, https_rejects_plaintext, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RHttpServer * srv;
+  RSocketAddress * addr;
+  RCryptoCert * cert;
+  RCryptoKey * pk;
+  RTestPlainClient c = { NULL, NULL, FALSE, FALSE };
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((srv = r_http_server_new (loop)), !=, NULL);
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (testcertpem, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem, -1, NULL, 0)), !=, NULL);
+
+  r_assert (r_http_server_set_handler (srv, "/", -1,
+        r_test_http_simple_status_handler,
+        RUINT_TO_POINTER (R_HTTP_STATUS_OK), NULL));
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
+  r_assert (r_http_server_add_tls_listen_addr (srv, addr, cert, pk));
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_http_server_get_local_address (srv)), !=, NULL);
+
+  r_assert_cmpptr ((c.resp = r_buffer_new ()), !=, NULL);
+  r_assert_cmpptr ((c.tcp = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpint (r_ev_tcp_connect (c.tcp, addr,
+        r_test_plain_client_connected, &c, NULL), >=, R_SOCKET_OK);
+
+  while (!c.eos)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE);
+
+  r_assert (c.eos);                 /* server dropped the connection */
+  r_assert (!c.got_response);       /* never answered the plaintext request */
+
+  r_ev_tcp_close (c.tcp, NULL, NULL, NULL);
+  r_ev_tcp_unref (c.tcp);
+  r_buffer_unref (c.resp);
 
   r_http_server_stop (srv, NULL, NULL, NULL);
   r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);


### PR DESCRIPTION
Adds server-side TLS termination to `RHttpServer`, wiring a per-connection `RTLSServer` as a transparent filter between the accepted socket (ciphertext) and the existing HTTP request parser (plaintext).

## API
- `r_http_server_add_listen_addr(server, addr)` — add a plaintext (HTTP) listener; may be called repeatedly.
- `r_http_server_add_tls_listen_addr(server, addr, cert, key)` — add a TLS (HTTPS) listener terminated with `cert`/`key`. The cert/key are **per-listener**, so distinct addresses may serve distinct certificates, and TLS and plaintext listeners coexist freely on one server (e.g. HTTP on :80 and HTTPS on :443).

This renames the previous `r_http_server_listen` to `r_http_server_add_listen_addr` — a server now carries a *set* of listeners rather than a single one. The shape mirrors Go's `ListenAndServe` / `ListenAndServeTLS` and the per-listener cert model used by nginx/Beast.

## Data flow
```
socket recv -> r_tls_server_incoming_data -> appdata -> existing HTTP parser
HTTP response -> r_tls_server_send_appdata -> out -> socket send
```
On a non-keepalive response the encrypted body and a `close_notify` are queued, then `r_ev_tcp_close`'s graceful flush delivers them before the FIN. The recv path holds a reference across `r_tls_server_incoming_data` so a teardown triggered from inside the synchronous decrypt→parse→close chain cannot free the connection mid-call. Per-listener cert/key live in a server-owned array (freed at teardown) and are passed as borrowed data to the accept callback.

Scope is MVP server-side termination; ALPN, mutual-TLS, cipher-suite policy, and SNI (multiple certs on one port) are deferred — SNI in particular would arrive as a cert-selection callback on the `RTLSServer` layer, additive to this `(addr, cert, key)` signature.

## Testing
- End-to-end: an `RTLSClient` over a real loopback `REvTCP` against an HTTPS listener (single event loop) — handshake, GET, decrypted 200, asserting negotiated TLS 1.2 + cipher suite.
- Negative: a plaintext request to the TLS listener is dropped without an answer.
- Full matrix green: `_build_linux`, `_build_rpoll`, `_build_asan`, `_build_asan_rpoll`, `_build_ubsan`; mingw compile-clean both backends; full suite under Wine; doxygen clean.

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)