### PR TITLE
net/http: HTTPS support in the HTTP client

### DIFF
--- a/include/rlib/net/rhttpclient.h
+++ b/include/rlib/net/rhttpclient.h
@@ -48,12 +48,17 @@
  * callback on the loop thread. For blocking use without managing a loop,
  * see @ref RHttpClientSync, which owns a private loop and an @ref RHttpClient.
  *
- * Scope is plaintext HTTP/1.1, either to an explicit @ref RSocketAddress or
- * to the host/port derived from the request URI (@ref r_http_client_request),
- * with response bodies framed by @c Content-Length, chunked transfer-encoding
- * or connection close. Persistent connections are reused via a small per-client
- * pool (@ref r_http_client_set_keepalive). Built on the @ref r_http_proto wire
- * codec and @ref r_evtcp.
+ * Scope is HTTP/1.1 over plaintext (@c http) or TLS (@c https), either to an
+ * explicit @ref RSocketAddress or to the host/port derived from the request URI
+ * (@ref r_http_client_request), with response bodies framed by @c Content-Length,
+ * chunked transfer-encoding or connection close. Persistent connections are
+ * reused via a small per-client pool (@ref r_http_client_set_keepalive). Built
+ * on the @ref r_http_proto wire codec and @ref r_evtcp.
+ *
+ * @warning HTTPS is not yet authenticated: the server certificate is accepted
+ * unconditionally (rlib has no certificate trust store or hostname matching),
+ * so the connection is encrypted but open to an active man-in-the-middle. Do
+ * not use it to carry secrets over an untrusted network.
  *
  * @{
  */
@@ -71,6 +76,7 @@ typedef enum {
   R_HTTP_CLIENT_SEND_FAILED,    /**< Could not send the request. */
   R_HTTP_CLIENT_RECV_FAILED,    /**< Transport error, or closed before the body completed. */
   R_HTTP_CLIENT_PARSE_FAILED,   /**< Malformed response, or unsupported framing (chunked / tunnel). */
+  R_HTTP_CLIENT_TLS_FAILED,     /**< TLS handshake failed or the session was aborted by an alert. */
 } RHttpClientResult;
 
 /**
@@ -115,8 +121,14 @@ R_API RClockTimeDiff r_http_client_get_idle_timeout (RHttpClient * client);
 
 /**
  * @brief Asynchronously send @p req to @p addr and deliver the response.
+ *
+ * The connection target is @p addr, but TLS is selected by @p req's URI scheme:
+ * an @c https request is terminated with TLS (see the group warning on
+ * certificate verification), an @c http request is plaintext. @p addr chooses
+ * where to connect; the scheme chooses whether to encrypt.
+ *
  * @param client The client.
- * @param req    The request to send.
+ * @param req    The request to send; its URI scheme selects plaintext vs TLS.
  * @param addr   Peer address to connect to.
  * @param cb     Invoked with the outcome on the loop thread.
  * @param data   User pointer passed to @p cb.
@@ -135,10 +147,11 @@ R_API rboolean r_http_client_request_to_addr (RHttpClient * client, RHttpRequest
  *
  * Derives the host and port from the request URI (@ref r_http_request_get_uri),
  * resolves them on the loop via the asynchronous resolver (never blocking the
- * loop thread), then connects to the first resolved address. The port defaults
- * to 80 for the @c http scheme when the URI omits it. Only plaintext targets
- * are supported: a missing host, or a URI with no port and a non-@c http
- * scheme, is rejected.
+ * loop thread), then connects to the first resolved address. An @c https scheme
+ * terminates the connection with TLS (see the group warning on certificate
+ * verification). When the URI omits the port it defaults to 80 for @c http and
+ * 443 for @c https; a missing host, or a URI with no port and a scheme that is
+ * neither @c http nor @c https, is rejected.
  *
  * @param client The client.
  * @param req    The request to send; its URI selects the target.
@@ -183,8 +196,12 @@ R_API RClockTimeDiff r_http_client_sync_get_idle_timeout (RHttpClientSync * clie
 
 /**
  * @brief Send @p req to @p addr and block until the response arrives.
+ *
+ * As with @ref r_http_client_request_to_addr, @p addr is the connection target
+ * while @p req's URI scheme selects plaintext (@c http) vs TLS (@c https).
+ *
  * @param client The blocking client.
- * @param req    The request to send.
+ * @param req    The request to send; its URI scheme selects plaintext vs TLS.
  * @param addr   Peer address to connect to.
  * @param result If non-@c NULL, receives the request outcome.
  * @return The response (caller @ref r_http_response_unref's it) on success,

--- a/rlib/net/rhttpclient.c
+++ b/rlib/net/rhttpclient.c
@@ -24,8 +24,10 @@
 #include <rlib/ev/revresolve.h>
 
 #include <rlib/net/rsocket.h>
+#include <rlib/net/rtlsclient.h>
 #include <rlib/data/rptrarray.h>
 
+#include <rlib/rrand.h>
 #include <rlib/ruri.h>
 #include <rlib/rmem.h>
 #include <rlib/rstr.h>
@@ -49,6 +51,7 @@ struct RHttpClient {
   RPtrArray * idle;     /* idle RHttpClientConn, scanned by destination addr */
   rboolean keepalive;
   RClockTimeDiff idle_timeout;
+  RPrng * prng;         /* lazily created on the first HTTPS request */
 };
 
 struct RHttpClientReqCtx {
@@ -69,6 +72,7 @@ struct RHttpClientReqCtx {
   RDestroyNotify notify;
 
   RSocketAddress * dest;  /* connect target; keys reuse and drives the retry */
+  rboolean tls;           /* HTTPS: terminate the connection with TLS */
   rboolean reused;        /* running on a pooled connection */
   rboolean retried;       /* a stale-connection retry has already happened */
   rboolean finished;
@@ -82,6 +86,7 @@ struct RHttpClientConn {
   RRef ref;
   RHttpClient * client;       /* borrowed */
   REvTCP * evtcp;
+  RTLSClient * tls;           /* per-connection TLS engine; NULL for plaintext */
   RSocketAddress * addr;      /* destination key */
   RHttpClientReqCtx * req;    /* current request, or NULL when idle */
   RClockEntry * timer;        /* idle-eviction timer, set only when idle */
@@ -154,6 +159,8 @@ r_http_client_conn_free (RHttpClientConn * conn)
       r_ev_tcp_abort (conn->evtcp, NULL, NULL, NULL);
     r_ev_tcp_unref (conn->evtcp);
   }
+  if (conn->tls != NULL)
+    r_tls_client_unref (conn->tls);
   if (conn->addr != NULL)
     r_socket_address_unref (conn->addr);
   r_free (conn);
@@ -222,18 +229,38 @@ r_http_client_conn_idle_timeout (rpointer data, REvLoop * loop)
  * connection is idle in the pool -- treated as a peer close that evicts it. */
 static void r_http_client_req_recv_data (RHttpClientReqCtx * ctx, RBuffer * buf);
 
+/* Route one plaintext/decrypted chunk (or EOS, @buf == NULL) to the current
+ * request, or -- on a parked connection the peer is done with -- evict it. */
+static void
+r_http_client_conn_deliver (RHttpClientConn * conn, RBuffer * buf)
+{
+  if (conn->req == NULL || conn->req->finished) {
+    r_http_client_conn_evict (conn);
+    return;
+  }
+  r_http_client_req_recv_data (conn->req, buf);
+}
+
 static void
 r_http_client_conn_recv (rpointer data, RBuffer * buf, REvTCP * evtcp)
 {
   RHttpClientConn * conn = data;
   (void) evtcp;
 
-  if (conn->req == NULL || conn->req->finished) {
-    /* Bytes or EOF on a parked connection: the peer is done with it. */
-    r_http_client_conn_evict (conn);
-    return;
+  if (conn->tls != NULL) {
+    if (buf == NULL) {
+      r_http_client_conn_deliver (conn, NULL);   /* transport end-of-stream */
+      return;
+    }
+    /* Ciphertext: incoming_data synchronously fires appdata (-> parser) and may
+     * tear the connection down via the error/closed callbacks; hold a reference
+     * so the conn survives the chain. */
+    r_http_client_conn_ref (conn);
+    r_tls_client_incoming_data (conn->tls, buf);
+    r_http_client_conn_unref (conn);
+  } else {
+    r_http_client_conn_deliver (conn, buf);
   }
-  r_http_client_req_recv_data (conn->req, buf);
 }
 
 static void
@@ -265,11 +292,111 @@ r_http_client_conn_connected (rpointer data, REvTCP * evtcp, int status)
     return;
   }
 
+  if (conn->tls != NULL) {
+    /* Arm recv before the handshake so the server's records are received, then
+     * drive the ClientHello; the request is sent once handshake_done fires. */
+    if (!conn->recving) {
+      if (!r_ev_tcp_recv_start (conn->evtcp, NULL, r_http_client_conn_recv,
+              conn, NULL)) {
+        r_http_client_req_fail (conn->req, R_HTTP_CLIENT_RECV_FAILED, TRUE);
+        return;
+      }
+      conn->recving = TRUE;
+    }
+    if (r_tls_client_start (conn->tls, conn->client->loop, conn->client->prng,
+            R_TLS_VERSION_TLS_1_2) != R_TLS_ERROR_OK) {
+      r_http_client_req_fail (conn->req, R_HTTP_CLIENT_TLS_FAILED, TRUE);
+      return;
+    }
+    return;
+  }
+
   r_http_client_req_send (conn->req, TRUE);
 }
 
+/* --- TLS termination (HTTPS) ---------------------------------------------
+ * A per-connection RTLSClient filters the socket: ciphertext recv ->
+ * incoming_data -> appdata (decrypted) -> the existing response parser; the
+ * serialized request -> send_appdata -> out -> socket send. The callback
+ * userdata is the RHttpClientConn (a back-pointer; the conn owns the
+ * RTLSClient, hence the NULL destroy-notify on r_tls_client_new). */
+
+static rboolean
+r_http_client_tls_out (rpointer data, RBuffer * buf, rpointer session)
+{
+  RHttpClientConn * conn = data;
+  (void) session;
+
+  /* Borrowed buffer: the send path queues its own reference. */
+  r_ev_tcp_send_and_forget (conn->evtcp, buf);
+  return TRUE;
+}
+
+static void
+r_http_client_tls_handshake_done (rpointer data, rpointer session)
+{
+  RHttpClientConn * conn = data;
+  (void) session;
+
+  if (conn->req != NULL)
+    r_http_client_req_send (conn->req, TRUE);
+}
+
+static rboolean
+r_http_client_tls_appdata (rpointer data, RBuffer * buf, rpointer session)
+{
+  RHttpClientConn * conn = data;
+  (void) session;
+
+  r_http_client_conn_deliver (conn, buf);
+  return TRUE;
+}
+
+static void
+r_http_client_tls_error (rpointer data, RTLSAlertType alert, rpointer session)
+{
+  RHttpClientConn * conn = data;
+  (void) alert;
+  (void) session;
+
+  if (conn->req != NULL)
+    r_http_client_req_fail (conn->req, R_HTTP_CLIENT_TLS_FAILED, TRUE);
+  else
+    r_http_client_conn_evict (conn);
+}
+
+static void
+r_http_client_tls_closed (rpointer data, rpointer session)
+{
+  RHttpClientConn * conn = data;
+  (void) session;
+
+  r_http_client_conn_deliver (conn, NULL);   /* close_notify == end-of-stream */
+}
+
+/*
+ * ============================ SECURITY TODO =============================
+ * verify_cert is NULL, so the server certificate is accepted UNCONDITIONALLY:
+ * the handshake is not authenticated -- any certificate (self-signed, expired,
+ * wrong host) is trusted, leaving HTTPS open to active man-in-the-middle.
+ * rlib has no certificate trust store and no hostname matching yet; this is a
+ * functional-only HTTPS client. Before this is fit for untrusted networks, a
+ * trust store (CA bundle / system trust) plus RFC 6125 hostname verification
+ * must be wired into verify_cert.
+ * ========================================================================
+ */
+static const RTLSCallbacks g__r_http_client_tls_callbacks = {
+  NULL,                                  /* preferred_cipher_suites (defaults) */
+  r_http_client_tls_handshake_done,      /* handshake_done */
+  r_http_client_tls_out,                 /* out */
+  r_http_client_tls_appdata,             /* appdata */
+  r_http_client_tls_error,               /* error */
+  NULL,                                  /* verify_cert -- see SECURITY TODO */
+  r_http_client_tls_closed,              /* closed */
+};
+
 static RHttpClientConn *
-r_http_client_conn_new (RHttpClient * client, RSocketAddress * addr)
+r_http_client_conn_new (RHttpClient * client, RSocketAddress * addr, rboolean tls)
 {
   RHttpClientConn * conn;
 
@@ -283,6 +410,11 @@ r_http_client_conn_new (RHttpClient * client, RSocketAddress * addr)
     r_http_client_conn_unref (conn);
     return NULL;
   }
+  if (tls && (conn->tls = r_tls_client_new (&g__r_http_client_tls_callbacks,
+          conn, NULL)) == NULL) {
+    r_http_client_conn_unref (conn);
+    return NULL;
+  }
   r_ev_tcp_set_error_handler (conn->evtcp, r_http_client_conn_error, conn, NULL);
   return conn;
 }
@@ -290,14 +422,16 @@ r_http_client_conn_new (RHttpClient * client, RSocketAddress * addr)
 /* Take a live pooled connection to @addr out of the pool for reuse, or NULL.
  * The returned connection carries the reference the pool held. */
 static RHttpClientConn *
-r_http_client_pool_acquire (RHttpClient * client, const RSocketAddress * addr)
+r_http_client_pool_acquire (RHttpClient * client, const RSocketAddress * addr,
+    rboolean tls)
 {
   rsize i = 0;
 
   while (i < r_ptr_array_size (client->idle)) {
     RHttpClientConn * conn = r_ptr_array_get (client->idle, i);
 
-    if (conn->closing || !r_socket_address_is_equal (conn->addr, addr)) {
+    if (conn->closing || (conn->tls != NULL) != tls ||
+        !r_socket_address_is_equal (conn->addr, addr)) {
       i++;
       continue;
     }
@@ -538,7 +672,10 @@ r_http_client_req_send (RHttpClientReqCtx * ctx, rboolean defer)
     r_http_client_req_fail (ctx, R_HTTP_CLIENT_SEND_FAILED, defer);
     return;
   }
-  r_ev_tcp_send_and_forget (conn->evtcp, buf);
+  if (conn->tls != NULL)
+    r_tls_client_send_appdata (conn->tls, buf);   /* encrypt -> out -> socket */
+  else
+    r_ev_tcp_send_and_forget (conn->evtcp, buf);
   r_buffer_unref (buf);
 
   /* The recv watch is bound to the connection for its whole life; a reused
@@ -560,7 +697,13 @@ r_http_client_req_connect (RHttpClientReqCtx * ctx, rboolean defer)
   RHttpClientConn * conn;
 
   ctx->reused = FALSE;
-  if ((conn = r_http_client_conn_new (ctx->client, ctx->dest)) == NULL) {
+  /* The TLS handshake draws randomness from a lazily created, client-owned PRNG. */
+  if (ctx->tls && ctx->client->prng == NULL &&
+      (ctx->client->prng = r_prng_new_mt ()) == NULL) {
+    r_http_client_req_complete (ctx, R_HTTP_CLIENT_TLS_FAILED, defer);
+    return;
+  }
+  if ((conn = r_http_client_conn_new (ctx->client, ctx->dest, ctx->tls)) == NULL) {
     r_http_client_req_complete (ctx, R_HTTP_CLIENT_CONNECT_FAILED, defer);
     return;
   }
@@ -575,7 +718,8 @@ r_http_client_req_connect (RHttpClientReqCtx * ctx, rboolean defer)
 static void
 r_http_client_req_dispatch (RHttpClientReqCtx * ctx, rboolean defer)
 {
-  RHttpClientConn * conn = r_http_client_pool_acquire (ctx->client, ctx->dest);
+  RHttpClientConn * conn = r_http_client_pool_acquire (ctx->client, ctx->dest,
+      ctx->tls);
 
   if (conn != NULL) {
     ctx->conn = conn;   /* acquire transferred the pool's reference to us */
@@ -608,6 +752,24 @@ r_http_client_req_ctx_new (RHttpClient * client, RHttpRequest * req,
   return ctx;
 }
 
+/* TRUE if the request URI's scheme is https (selects TLS termination). */
+static rboolean
+r_http_request_uri_is_https (RHttpRequest * req)
+{
+  RUri * uri;
+  rchar * scheme;
+  rboolean tls = FALSE;
+
+  if ((uri = r_http_request_get_uri (req)) != NULL) {
+    if ((scheme = r_uri_get_scheme (uri)) != NULL) {
+      tls = (r_strcasecmp (scheme, "https") == 0);
+      r_free (scheme);
+    }
+    r_uri_unref (uri);
+  }
+  return tls;
+}
+
 rboolean
 r_http_client_request_to_addr (RHttpClient * client, RHttpRequest * req,
     const RSocketAddress * addr,
@@ -620,6 +782,7 @@ r_http_client_request_to_addr (RHttpClient * client, RHttpRequest * req,
 
   if ((ctx = r_http_client_req_ctx_new (client, req, cb, data, notify)) == NULL)
     return FALSE;
+  ctx->tls = r_http_request_uri_is_https (req);
   if ((ctx->dest = r_socket_address_copy (addr)) == NULL) {
     ctx->cb = NULL;     /* not committed: notify must not run */
     ctx->notify = NULL;
@@ -668,6 +831,7 @@ r_http_client_request (RHttpClient * client, RHttpRequest * req,
   RUri * uri;
   rchar * host, * scheme;
   ruint16 port;
+  rboolean tls;
   rchar service[8];
   RResolveHints hints = { R_SOCKET_FAMILY_NONE, R_SOCKET_TYPE_STREAM,
       R_SOCKET_PROTOCOL_DEFAULT };
@@ -683,9 +847,14 @@ r_http_client_request (RHttpClient * client, RHttpRequest * req,
   port = r_uri_get_port (uri);
   r_uri_unref (uri);
 
-  /* Fall back to the scheme's default port; only plaintext http is targeted. */
-  if (port == 0 && scheme != NULL && r_strcasecmp (scheme, "http") == 0)
-    port = 80;
+  /* http and https are supported; fall back to the scheme's default port. */
+  tls = (scheme != NULL && r_strcasecmp (scheme, "https") == 0);
+  if (port == 0 && scheme != NULL) {
+    if (tls)
+      port = 443;
+    else if (r_strcasecmp (scheme, "http") == 0)
+      port = 80;
+  }
   r_free (scheme);
   if (R_UNLIKELY (host == NULL || port == 0)) {
     r_free (host);
@@ -697,6 +866,7 @@ r_http_client_request (RHttpClient * client, RHttpRequest * req,
     r_free (host);
     return FALSE;
   }
+  ctx->tls = tls;
 
   /* Committed: the array owns ctx and every outcome is delivered via cb. */
   r_ptr_array_add (client->reqs, ctx, r_ref_unref);
@@ -727,6 +897,8 @@ r_http_client_free (RHttpClient * client)
    * (conn_free, synchronous close -- we are not inside an io callback here). */
   r_ptr_array_unref (client->idle);
   r_ptr_array_unref (client->reqs);
+  if (client->prng != NULL)
+    r_prng_unref (client->prng);
   r_ev_loop_unref (client->loop);
   r_free (client);
 }
@@ -747,6 +919,7 @@ r_http_client_new (REvLoop * loop)
     ret->idle = r_ptr_array_new ();
     ret->keepalive = TRUE;
     ret->idle_timeout = R_HTTP_CLIENT_IDLE_TIMEOUT;
+    ret->prng = NULL;
 
     R_LOG_INFO ("New HTTP client %p", ret);
   } else {

--- a/test/rhttpclient.c
+++ b/test/rhttpclient.c
@@ -226,8 +226,9 @@ RTEST (rhttpclient, request_get_uri, RTEST_FAST | RTEST_SYSTEM)
 }
 RTEST_END;
 
-/* A non-http scheme with no explicit port has no usable target: the request
- * is rejected before it starts (FALSE), so notify is never called. */
+/* A scheme that is neither http nor https with no explicit port has no usable
+ * target: the request is rejected before it starts (FALSE), so notify is never
+ * called. */
 RTEST (rhttpclient, request_uri_unsupported, RTEST_FAST | RTEST_SYSTEM)
 {
   REvLoop * loop;
@@ -241,7 +242,7 @@ RTEST (rhttpclient, request_uri_unsupported, RTEST_FAST | RTEST_SYSTEM)
 
   r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
   r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
-          "https://127.0.0.1/", NULL, NULL)), !=, NULL);
+          "ftp://127.0.0.1/", NULL, NULL)), !=, NULL);
 
   r_assert (!r_http_client_request (client, req, r_test_http_send_cb, NULL, NULL));
 

--- a/test/rhttpclient.c
+++ b/test/rhttpclient.c
@@ -1,11 +1,62 @@
 #include <rlib/rnet.h>
 #include <rlib/rev.h>
+#include <rlib/rcrypto.h>
 
 /* Servers here bind an ephemeral port (0) and read back the OS-assigned port
  * (see r_test_http_listen_ephemeral): a fixed port collides with a previous
  * run's socket still in TIME_WAIT -- notably under meson test --repeat, and on
  * Windows where rtest runs single-process. */
 #define R_TEST_HTTP_CLIENT_BODY   "hello from rlib"
+
+static const rchar testcertpem[] =
+  "-----BEGIN CERTIFICATE-----\r\n"
+  "MIIC8TCCAdmgAwIBAgIJALoi/+XOQDHjMA0GCSqGSIb3DQEBCwUAMA8xDTALBgNV\r\n"
+  "BAMMBHJsaWIwHhcNMTYxMTE1MTMzNjI0WhcNMTcxMTE1MTMzNjI0WjAPMQ0wCwYD\r\n"
+  "VQQDDARybGliMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwjolUmQU\r\n"
+  "r9Q2FZ7O3qau+Z6+VvuJROvxzjt1aIQLLO/hF0Ya56BZCZD5aKyqQM//fTm97VTb\r\n"
+  "CQYBaNg03D20XPDIWmr7EdHxYK+YI+jz7DrWqhM4jwSvvteXXXWD7bVdCq+RyveD\r\n"
+  "NrgoGZqL5UCiWS1BWkB9nS/KQtgxrT3hWSOlG1xRh6hfeIy4H2CB3Qk/Q3PHjMcH\r\n"
+  "7CKhCj+ctbqR3r2K3BLL3fgZKnfQdCPsZplN8Ey4hSOc/67NQK/yn/S0JgeHmjb8\r\n"
+  "D5xbaDiOloOHJJg6dm1QU0UuEpiK2Uda0VR6TGu9Ci05h5U3HoV9CbyAGQhmFSem\r\n"
+  "NreAELYv89sMgwIDAQABo1AwTjAdBgNVHQ4EFgQUXFVr3x4Bcglp/MP0ZFEk/Ntz\r\n"
+  "wJYwHwYDVR0jBBgwFoAUXFVr3x4Bcglp/MP0ZFEk/NtzwJYwDAYDVR0TBAUwAwEB\r\n"
+  "/zANBgkqhkiG9w0BAQsFAAOCAQEAL4ZKyDRXP3+Jr/GN+p6WbFW3tHuhxWxy8rMy\r\n"
+  "W7OHX/sHASzJiaEmjtIlPx/7uFFowktEmXyybEmBvYp64UZ2mo2v+CCm+236wPTS\r\n"
+  "gGfpcp9nP2RI0VFdJLHuqWapa5CQJZISRAO/tj7UqflOWBohm04EvmJe53JGEq+4\r\n"
+  "Dk41kC+z3jVPGHG+jR3uYOw7JCmFT+bt4P5EDxGAKe9eoweLHBJ8vlJ7cUdHhBv1\r\n"
+  "BUCMVR86kPZFzHKVQtWNXt26H/khgz7RA/qUSJA17Nk2h0h60b1AbkljkduWWIMZ\r\n"
+  "5B2DUz4MEDUHjppHF9+A2q5ZN+25eOYbrkS5Dq50VPNrvd8dSQ==\r\n"
+  "-----END CERTIFICATE-----\r\n";
+
+static const rchar testpkpem[] =
+  "-----BEGIN PRIVATE KEY-----\r\n"
+  "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDCOiVSZBSv1DYV\r\n"
+  "ns7epq75nr5W+4lE6/HOO3VohAss7+EXRhrnoFkJkPlorKpAz/99Ob3tVNsJBgFo\r\n"
+  "2DTcPbRc8MhaavsR0fFgr5gj6PPsOtaqEziPBK++15dddYPttV0Kr5HK94M2uCgZ\r\n"
+  "movlQKJZLUFaQH2dL8pC2DGtPeFZI6UbXFGHqF94jLgfYIHdCT9Dc8eMxwfsIqEK\r\n"
+  "P5y1upHevYrcEsvd+Bkqd9B0I+xmmU3wTLiFI5z/rs1Ar/Kf9LQmB4eaNvwPnFto\r\n"
+  "OI6Wg4ckmDp2bVBTRS4SmIrZR1rRVHpMa70KLTmHlTcehX0JvIAZCGYVJ6Y2t4AQ\r\n"
+  "ti/z2wyDAgMBAAECggEABJZzAzsx8eVFUcVqhX/SajsBq/RNDb+0+nYVE97qlKkl\r\n"
+  "2/Lf99ClycAO5BYP/2/qTP7sKYrzkYb+yYcx2HHsrLVTRi94trcKyIndQhvihxXs\r\n"
+  "tB+4Gki2Df/xp1d7QkYiaHo1K2IlS0mWSOSJoWShcRHMlWEolmnmkSWiJsFrbTuL\r\n"
+  "sxB/6lVmD6Bbez/ob5JzK4QBAEREd0QbUCQiDssFvf0nlDmtKrxosLFuu86z0nIR\r\n"
+  "3OKyr9n6IW64r7x7Ccv/5pY3Cmkg0/knF4bi60ssm2byY2TW3wnOT0inVrp0UUQP\r\n"
+  "ex9Dse3izVyMLaeqLh6GCQhLFROE85qslLmOYb56YQKBgQD7HHWdsrNDtkHkXvyz\r\n"
+  "TWi8dPVMVk4/X/G3vPr2nBRHj9MzXX/ZgoFpklMsR/EtKh9LBBh9vY9YnXhIGUrc\r\n"
+  "vwt1PSUIsjUuHBfhxnHxcZEu2ROw18LJmSRp6duZADFcH8ApPFg1dVZ2APyHyS4J\r\n"
+  "tTL/DIeQ6ASq0EENjuO5VgM5PwKBgQDGAiz9c3/1OPZNiENyCYbrqOzduzkoisX7\r\n"
+  "yGYFiJpLdsmrRsztqJktwiDEYYrJoV+AHmKa79Iexp6vvq9gQFN3XvFw6U1XXF5D\r\n"
+  "RtLHHqWgoj9yFIpmVXfcdFICfNdPcVn7NAE0CQBRNgBJGSvRoSeTpOyjVmF9Mu18\r\n"
+  "h2wUK0L3vQKBgBms7kXCmNvKjfA42iPHPXdPiilVBckrGT8NPqfqi5RJm3G8FK97\r\n"
+  "zZmq0YBMltdkYDC+aXap5DdOWpccpu/tRNGm/9tkxVVCoBqAvPPQBeVBYucJGKye\r\n"
+  "UP/XXpHFWEawJGjS9733knCcZzXHF0L82QsFD/N8FcYVZyFow9YWelvnAoGAIj8o\r\n"
+  "FuIOJJSojPpfZ+7b5hB+f08tcKSn34dmldhtj1XJRZVmRkidzbtAvZZ9UahWgys+\r\n"
+  "NLv75JTHx2+8l3IovYGvUq8XUF/Kcepi9EuJrAHD5XBGC7MGmxuHP6Tl/HiHbpot\r\n"
+  "Bxnzcxha7kmrOYOc+71PrGR5UhUn3Bz0BX0CBSUCgYAKxDbgtJ1NZgf33yMQb1BG\r\n"
+  "vgLQWiysO9t1dXFN9YiPsZ1Rkyj9iOdROG47T1ifcrCw45mqBF71COM23zplWz64\r\n"
+  "wUg8Baom8FExrgLtVDeyQO7qkiOoP96r9Fm34Y4Sgv1/oiO9f5KYckMcSig9zCQA\r\n"
+  "VFwqM04nD9RsYGRKy6NhrA==\r\n"
+  "-----END PRIVATE KEY-----\r\n";
 
 typedef struct {
   RHttpResponse * res;
@@ -122,6 +173,37 @@ r_test_http_client_server (REvLoop * loop, const rchar * path,
         r_test_http_client_handler, RUINT_TO_POINTER (status), NULL));
 
   *out = r_test_http_listen_ephemeral (srv);
+  r_assert_cmpptr (*out, !=, NULL);
+  return srv;
+}
+
+/* As r_test_http_client_server, but the listener terminates TLS with the
+ * embedded test cert/key; the bound HTTPS address is returned in *out. */
+static RHttpServer *
+r_test_http_client_server_tls (REvLoop * loop, const rchar * path,
+    RHttpStatus status, RSocketAddress ** out)
+{
+  RHttpServer * srv;
+  RCryptoCert * cert;
+  RCryptoKey * pk;
+  RSocketAddress * addr;
+
+  if ((srv = r_http_server_new (loop)) == NULL)
+    return NULL;
+
+  r_assert (r_http_server_set_handler (srv, path, -1,
+        r_test_http_client_handler, RUINT_TO_POINTER (status), NULL));
+
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (testcertpem, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem, -1, NULL, 0)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)),
+      !=, NULL);
+  r_assert (r_http_server_add_tls_listen_addr (srv, addr, cert, pk));
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+  r_socket_address_unref (addr);
+
+  *out = r_http_server_get_local_address (srv);
   r_assert_cmpptr (*out, !=, NULL);
   return srv;
 }
@@ -1114,5 +1196,180 @@ RTEST (rhttpclient, keepalive_idle_timeout, RTEST_FAST | RTEST_SYSTEM)
   r_http_client_unref (client);
   r_ev_loop_unref (loop);
   r_socket_address_unref (addr);
+}
+RTEST_END;
+
+/* End-to-end HTTPS: the client terminates TLS (https URI scheme) against an
+ * RHttpServer TLS listener, both on one loop. */
+RTEST (rhttpclient, https_get, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RHttpServer * srv;
+  RHttpClient * client;
+  RHttpRequest * req;
+  RHttpResponse * res;
+  RSocketAddress * addr;
+  RHttpClientResult result;
+  rchar * body;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((srv = r_test_http_client_server_tls (loop, "/",
+          R_HTTP_STATUS_OK, &addr)), !=, NULL);
+  r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
+
+  /* https scheme selects TLS; the explicit addr selects the loopback port. */
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+          "https://127.0.0.1/", NULL, NULL)), !=, NULL);
+  r_assert (r_http_request_add_header (req, "Host", -1, "127.0.0.1", -1));
+
+  res = r_test_http_send (loop, client, req, addr, &result);
+  r_http_request_unref (req);
+
+  r_assert_cmpint (result, ==, R_HTTP_CLIENT_OK);
+  r_assert_cmpptr (res, !=, NULL);
+  r_assert_cmpint (r_http_response_get_status (res), ==, R_HTTP_STATUS_OK);
+  r_assert_cmpstr ((body = r_http_response_get_body (res, NULL)), ==,
+      R_TEST_HTTP_CLIENT_BODY);
+  r_free (body);
+  r_http_response_unref (res);
+
+  r_socket_address_unref (addr);
+  r_test_http_client_teardown (loop, client, srv);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+/* A plaintext (http) request to a TLS listener is not valid TLS: the server
+ * drops it and the request fails rather than completing. */
+RTEST (rhttpclient, http_to_tls_port_fails, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RHttpServer * srv;
+  RHttpClient * client;
+  RHttpRequest * req;
+  RHttpResponse * res;
+  RSocketAddress * addr;
+  RHttpClientResult result;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((srv = r_test_http_client_server_tls (loop, "/",
+          R_HTTP_STATUS_OK, &addr)), !=, NULL);
+  r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
+
+  /* http scheme -> plaintext bytes sent to the TLS listener. */
+  r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+          "http://127.0.0.1/", NULL, NULL)), !=, NULL);
+  r_assert (r_http_request_add_header (req, "Host", -1, "127.0.0.1", -1));
+
+  res = r_test_http_send (loop, client, req, addr, &result);
+  r_http_request_unref (req);
+
+  r_assert_cmpint (result, !=, R_HTTP_CLIENT_OK);
+  r_assert_cmpptr (res, ==, NULL);
+
+  r_socket_address_unref (addr);
+  r_test_http_client_teardown (loop, client, srv);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
+/* Records the peer port of each request the handler serves; two requests on a
+ * reused connection arrive on the same client socket, hence the same port. */
+typedef struct {
+  ruint16 ports[4];
+  ruint n;
+} RTestPeerPorts;
+
+static RHttpResponse *
+r_test_http_peerport_handler (rpointer data, RHttpRequest * req,
+    RSocketAddress * addr, RHttpServer * server)
+{
+  RTestPeerPorts * pp = data;
+  RHttpResponse * res;
+
+  (void) server;
+
+  if (pp->n < R_N_ELEMENTS (pp->ports))
+    pp->ports[pp->n] = r_socket_address_ipv4_get_port (addr);
+  pp->n++;
+
+  if ((res = r_http_response_new (req, R_HTTP_STATUS_OK, NULL, NULL, NULL)) != NULL) {
+    RBuffer * buf = r_buffer_new_dup (R_STR_WITH_SIZE_ARGS (R_TEST_HTTP_CLIENT_BODY));
+    if (buf != NULL) {
+      r_http_response_set_body_buffer_full (res, buf, "text/plain", -1, TRUE);
+      r_buffer_unref (buf);
+    }
+  }
+
+  return res;
+}
+
+/* Two HTTPS requests to one destination reuse a single pooled TLS connection:
+ * the second skips the handshake and lands on the same socket. Proven by the
+ * server seeing both requests arrive from the same peer port. */
+RTEST (rhttpclient, https_keepalive_reuse, RTEST_FAST | RTEST_SYSTEM)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RHttpServer * srv;
+  RHttpClient * client;
+  RHttpRequest * req;
+  RHttpResponse * res;
+  RSocketAddress * addr;
+  RCryptoCert * cert;
+  RCryptoKey * pk;
+  RHttpClientResult result;
+  RTestPeerPorts pp = { { 0, }, 0 };
+  ruint i;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((srv = r_http_server_new (loop)), !=, NULL);
+  r_assert (r_http_server_set_handler (srv, "/", -1,
+        r_test_http_peerport_handler, &pp, NULL));
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (testcertpem, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem, -1, NULL, 0)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)),
+      !=, NULL);
+  r_assert (r_http_server_add_tls_listen_addr (srv, addr, cert, pk));
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+  r_socket_address_unref (addr);
+  r_assert_cmpptr ((addr = r_http_server_get_local_address (srv)), !=, NULL);
+
+  r_assert_cmpptr ((client = r_http_client_new (loop)), !=, NULL);
+  r_assert (r_http_client_get_keepalive (client));   /* on by default */
+
+  /* Two requests to the same destination; the second should reuse the pooled
+   * TLS connection rather than open (and re-handshake) a new one. */
+  for (i = 0; i < 2; i++) {
+    r_assert_cmpptr ((req = r_http_request_new (R_HTTP_METHOD_GET,
+            "https://127.0.0.1/", NULL, NULL)), !=, NULL);
+    r_assert (r_http_request_add_header (req, "Host", -1, "127.0.0.1", -1));
+    res = r_test_http_send (loop, client, req, addr, &result);
+    r_http_request_unref (req);
+    r_assert_cmpint (result, ==, R_HTTP_CLIENT_OK);
+    r_assert_cmpptr (res, !=, NULL);
+    r_assert_cmpint (r_http_response_get_status (res), ==, R_HTTP_STATUS_OK);
+    r_http_response_unref (res);
+  }
+
+  r_assert_cmpuint (pp.n, ==, 2);
+  r_assert_cmpuint (pp.ports[0], !=, 0);
+  r_assert_cmpuint (pp.ports[0], ==, pp.ports[1]);   /* same socket -> reused */
+
+  r_socket_address_unref (addr);
+  r_test_http_client_teardown (loop, client, srv);
+  r_ev_loop_unref (loop);
 }
 RTEST_END;


### PR DESCRIPTION
Adds client-side HTTPS to `RHttpClient` for parity with the server's TLS termination (#255), wiring a per-connection `RTLSClient` as a transparent filter: ciphertext from the socket feeds `r_tls_client_incoming_data`, decrypted appdata drives the existing response parser, and the serialized request goes out via `r_tls_client_send_appdata`. With both sides TLS-capable, client↔server HTTPS is now exercised end-to-end.

## API
No new entry points — TLS is selected by the request **URI scheme**:
- `r_http_client_request` accepts `https` (default port 443) alongside `http` (80).
- `r_http_client_request_to_addr` reads the request URI scheme to choose plaintext vs TLS; the explicit `addr` still chooses *where* to connect.
- `RHttpClientSync` inherits HTTPS through the same paths.
- New result `R_HTTP_CLIENT_TLS_FAILED` reports handshake/alert failures.

## Behaviour
On a fresh connection the client connects, runs the handshake, then sends the request once it completes; the connection pool keys on the TLS flag as well as the address (no plaintext/TLS cross-reuse), reused TLS connections skip the handshake, and the stale-connection retry re-establishes TLS on the new connection.

## Security (deliberate, tracked)
rlib has **no certificate trust store and no hostname matching**, so the server certificate is currently **accepted unconditionally** — the channel is encrypted but not authenticated (open to an active MITM). This is marked with a prominent `SECURITY TODO` at the `verify_cert` site and a `@warning` in the public header, and is a functional-only HTTPS client for now. Real trust (CA bundle / system trust + RFC 6125 hostname verification) is tracked separately.

## Testing
- `https_get` — client TLS handshake + GET against an `RHttpServer` TLS listener, asserts 200 + body.
- `http_to_tls_port_fails` — a plaintext request to the TLS listener fails rather than completing.
- `https_keepalive_reuse` — two keepalive HTTPS requests arrive on the same peer port, proving the pooled TLS connection is reused (not re-handshaked).
- Existing `request_uri_unsupported` updated (`https` is now valid; uses `ftp` for the rejected case).
- Full matrix green: `_build_linux/rpoll/asan/asan_rpoll/ubsan`; mingw compile-clean both backends; full suite under Wine; doxygen clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)