### PR TITLE
crypto: RTrustStore system trust backend (Linux CA bundle)

### DIFF
--- a/config.h.meson
+++ b/config.h.meson
@@ -10,6 +10,7 @@
 #mesondefine HAVE_WINDOWS_H
 #mesondefine HAVE_UNISTD_H
 #mesondefine HAVE_ALLOCA_H
+#mesondefine HAVE_DIRENT_H
 #mesondefine HAVE_SCHED_H
 #mesondefine HAVE_FCNTL_H
 #mesondefine HAVE_ARPA_INET_H

--- a/include/rlib/charset/runicode.h
+++ b/include/rlib/charset/runicode.h
@@ -213,9 +213,12 @@ R_API runichar2 * r_utf8_to_utf16_dup (const rchar * src, rssize srcsize,
     RUnicodeResult * res, rsize * retsize, rchar ** endptr) R_ATTR_MALLOC;
 /**
  * @brief Allocate and decode UTF-16 @p src as UTF-8.
+ *
+ * @p srcsize is the number of UTF-16 code units, or @c -1 to treat @p src as
+ * NUL-terminated (mirrors @ref r_utf8_to_utf16_dup).
  * @return Freshly allocated UTF-8 buffer, or NULL on failure.
  */
-R_API rchar * r_utf16_to_utf8_dup (const runichar2 * src, rsize srcsize,
+R_API rchar * r_utf16_to_utf8_dup (const runichar2 * src, rssize srcsize,
     RUnicodeResult * res, rsize * retsize, runichar2 ** endptr) R_ATTR_MALLOC;
 
 /**

--- a/include/rlib/crypto/rtruststore.h
+++ b/include/rlib/crypto/rtruststore.h
@@ -105,6 +105,22 @@ R_API rssize r_trust_store_add_pem (RTrustStore * store, const rchar * pem, rssi
  */
 R_API rssize r_trust_store_add_pem_file (RTrustStore * store, const rchar * filename);
 
+/**
+ * @brief Create a trust store populated from the operating system's CA bundle.
+ *
+ * On Unix the @c SSL_CERT_FILE (a single PEM bundle) and @c SSL_CERT_DIR (a
+ * directory of PEM files) environment variables take precedence, in that order;
+ * with neither set, the well-known bundle files and CA directories are probed in
+ * turn and the first that yields at least one anchor wins. The result is a
+ * certs-backed store (as @ref r_trust_store_new_certs), so further anchors may
+ * be added to it.
+ *
+ * @return A populated store the caller must unref, or @c NULL if no system
+ *         trust source was found or the platform exposes no file-based CA
+ *         bundle (e.g. Windows, where the native certificate store applies).
+ */
+R_API RTrustStore * r_trust_store_new_system (void) R_ATTR_MALLOC;
+
 /** @brief Length of an SPKI pin: the SHA-256 of a SubjectPublicKeyInfo. */
 #define R_TRUST_SPKI_PIN_SIZE  32
 

--- a/include/rlib/file/rfs.h
+++ b/include/rlib/file/rfs.h
@@ -122,6 +122,26 @@ R_API rboolean r_fs_mkdir (const rchar * path, int mode);
 /** @brief Create @p path and any missing parent directories (@c mkdir @c -p). */
 R_API rboolean r_fs_mkdir_full (const rchar * path, int mode);
 
+/** @brief Opaque directory-enumeration handle. */
+typedef struct RFsDir RFsDir;
+/**
+ * @brief Open directory @p path for enumeration.
+ * @return A new @ref RFsDir to be closed with @ref r_fs_dir_close, or @c NULL if
+ *         @p path is not an accessible directory.
+ */
+R_API RFsDir * r_fs_dir_open (const rchar * path) R_ATTR_MALLOC;
+/**
+ * @brief Return the next entry name in @p dir, or @c NULL once exhausted.
+ *
+ * The @c "." and @c ".." entries are skipped; the order is unspecified. The
+ * returned string is owned by @p dir and stays valid only until the next
+ * @ref r_fs_dir_read_next or @ref r_fs_dir_close call -- copy it if it must
+ * outlive that.
+ */
+R_API const rchar * r_fs_dir_read_next (RFsDir * dir);
+/** @brief Close a directory opened with @ref r_fs_dir_open. */
+R_API void r_fs_dir_close (RFsDir * dir);
+
 /**
  * @brief Create a symbolic link at @p linkpath pointing to @p target.
  * @param target   Path the link refers to (need not exist; may be relative).

--- a/meson.build
+++ b/meson.build
@@ -260,6 +260,7 @@ check_headers = [
   'windows.h',
   'unistd.h',
   'alloca.h',
+  'dirent.h',
   'dlfcn.h',
   'link.h',
   'sched.h',

--- a/rlib/charset/runicode.c
+++ b/rlib/charset/runicode.c
@@ -295,23 +295,33 @@ runichar2
 }
 
 rchar *
-r_utf16_to_utf8_dup (const runichar2 * src, rsize srcsize,
+r_utf16_to_utf8_dup (const runichar2 * src, rssize srcsize,
     RUnicodeResult * res, rsize * retsize, runichar2 ** endptr)
 {
   rchar * ret;
   RUnicodeResult r;
-  rsize dstsize;
+  rsize dstsize, n;
 
-  if (R_UNLIKELY (src == NULL || srcsize == 0)) {
+  if (R_UNLIKELY (src == NULL)) {
+    if (res != NULL) *res = R_UNICODE_INVAL;
+    return NULL;
+  }
+  if (srcsize < 0) {
+    n = 0;
+    while (src[n] != 0) n++;
+  } else {
+    n = (rsize) srcsize;
+  }
+  if (R_UNLIKELY (n == 0)) {
     if (res != NULL) *res = R_UNICODE_INVAL;
     return NULL;
   }
 
-  dstsize = (srcsize + 1) * 4;
+  dstsize = (n + 1) * 4;
 
   /* Converting from UTF16 limits to 0x0 - 0x10ffff meaning max 4byte UTF-8 */
   if ((ret = r_mem_new_n (rchar, dstsize)) != NULL) {
-    if ((r = r_utf16_to_utf8 (ret, dstsize, src, srcsize, retsize, endptr)) != R_UNICODE_OK) {
+    if ((r = r_utf16_to_utf8 (ret, dstsize, src, n, retsize, endptr)) != R_UNICODE_OK) {
       r_free (ret);
       ret = NULL;
     }

--- a/rlib/crypto/rtruststore.c
+++ b/rlib/crypto/rtruststore.c
@@ -25,7 +25,9 @@
 #include <rlib/crypto/rpem.h>
 #include <rlib/data/rptrarray.h>
 #include <rlib/file/rfile.h>
+#include <rlib/file/rfs.h>
 #include <rlib/format/rasn1.h>
+#include <rlib/os/renv.h>
 #include <rlib/rmem.h>
 #include <rlib/rstr.h>
 
@@ -240,6 +242,83 @@ r_trust_store_add_pem_file (RTrustStore * base, const rchar * filename)
   added = r_trust_store_add_pem (base, (const rchar *) data, (rssize) size);
   r_free (data);
   return added;
+}
+
+/* --- system trust: load the OS CA bundle / directory --------------------- */
+
+#if defined (R_OS_UNIX)
+/* Concatenated CA bundles, probed in order (first with anchors wins). */
+static const rchar * const g__r_trust_system_bundles[] = {
+  "/etc/ssl/certs/ca-certificates.crt",   /* Debian, Ubuntu, Arch, ... */
+  "/etc/pki/tls/certs/ca-bundle.crt",     /* RHEL, Fedora, ... */
+  "/etc/ssl/cert.pem",                    /* Alpine, BSD, ... */
+  "/etc/ssl/ca-bundle.pem",               /* openSUSE */
+};
+/* CA directories (hashed symlinks or plain PEM files), probed in order. */
+static const rchar * const g__r_trust_system_dirs[] = {
+  "/etc/ssl/certs",
+  "/etc/pki/tls/certs",
+};
+
+/* Add every regular file under @dirpath that parses as PEM certificate(s).
+ * Returns the number of anchors added, or -1 if the directory can't be read. */
+static rssize
+r_trust_store_add_dir (RTrustStore * store, const rchar * dirpath)
+{
+  RFsDir * dir;
+  const rchar * name;
+  rssize total = 0;
+
+  if ((dir = r_fs_dir_open (dirpath)) == NULL)
+    return -1;
+  while ((name = r_fs_dir_read_next (dir)) != NULL) {
+    rchar * path = r_fs_path_build (dirpath, name, NULL);
+    if (path != NULL) {
+      /* A non-certificate file just adds nothing; ignore the failure. */
+      if (!r_fs_test_is_directory (path)) {
+        rssize added = r_trust_store_add_pem_file (store, path);
+        if (added > 0)
+          total += added;
+      }
+      r_free (path);
+    }
+  }
+  r_fs_dir_close (dir);
+  return total;
+}
+#endif
+
+RTrustStore *
+r_trust_store_new_system (void)
+{
+#if defined (R_OS_UNIX)
+  RTrustStore * store;
+  const rchar * env;
+  rssize added = 0;
+  rsize i;
+
+  if ((store = r_trust_store_new_certs ()) == NULL)
+    return NULL;
+
+  if ((env = r_getenv ("SSL_CERT_FILE")) != NULL) {
+    added = r_trust_store_add_pem_file (store, env);
+  } else if ((env = r_getenv ("SSL_CERT_DIR")) != NULL) {
+    added = r_trust_store_add_dir (store, env);
+  } else {
+    for (i = 0; i < R_N_ELEMENTS (g__r_trust_system_bundles) && added <= 0; i++)
+      added = r_trust_store_add_pem_file (store, g__r_trust_system_bundles[i]);
+    for (i = 0; i < R_N_ELEMENTS (g__r_trust_system_dirs) && added <= 0; i++)
+      added = r_trust_store_add_dir (store, g__r_trust_system_dirs[i]);
+  }
+
+  if (added <= 0) {
+    r_trust_store_unref (store);
+    return NULL;
+  }
+  return store;
+#else
+  return NULL;
+#endif
 }
 
 /* --- pinned backend: SubjectPublicKeyInfo SHA-256 pins ------------------- */

--- a/rlib/file/rfs.c
+++ b/rlib/file/rfs.c
@@ -33,6 +33,9 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#ifdef HAVE_DIRENT_H
+#include <dirent.h>
+#endif
 
 #if defined (HAVE_WINDOWS_H)
 #include <rlib/charset/runicode.h>
@@ -626,5 +629,118 @@ r_fs_path_is_absolute (const rchar * path)
 #else
   return R_IS_DIR_SEP (path[0]);
 #endif
+}
+
+struct RFsDir {
+#if defined (R_OS_WIN32)
+  HANDLE h;
+  WIN32_FIND_DATAW fd;
+  rboolean pending;       /* fd already holds an entry not yet returned */
+  rchar * name;           /* UTF-8 of the most recent entry (owned) */
+#elif defined (HAVE_DIRENT_H)
+  DIR * d;
+#else
+  int unused;
+#endif
+};
+
+RFsDir *
+r_fs_dir_open (const rchar * path)
+{
+#if defined (R_OS_WIN32)
+  RFsDir * dir;
+  runichar2 * upattern;
+  rchar * pattern;
+  HANDLE h;
+
+  if (R_UNLIKELY (path == NULL || path[0] == 0))
+    return NULL;
+
+  /* FindFirstFileW enumerates the directory's contents via a "<path>\*"
+   * wildcard; a non-directory path makes it fail, matching opendir. */
+  pattern = r_strprintf ("%s%s*", path,
+      R_IS_DIR_SEP (path[r_strlen (path) - 1]) ? "" : R_DIR_SEP_STR);
+  upattern = r_utf8_to_utf16_dup (pattern, -1, NULL, NULL, NULL);
+  r_free (pattern);
+  if (upattern == NULL)
+    return NULL;
+
+  dir = r_mem_new0 (RFsDir);
+  h = FindFirstFileW (upattern, &dir->fd);
+  r_free (upattern);
+  if (h == INVALID_HANDLE_VALUE) {
+    r_free (dir);
+    return NULL;
+  }
+  dir->h = h;
+  dir->pending = TRUE;
+  return dir;
+#elif defined (HAVE_DIRENT_H)
+  RFsDir * dir;
+  DIR * d;
+
+  if (R_UNLIKELY (path == NULL))
+    return NULL;
+  if ((d = opendir (path)) == NULL)
+    return NULL;
+
+  dir = r_mem_new0 (RFsDir);
+  dir->d = d;
+  return dir;
+#else
+  (void) path;
+  return NULL;
+#endif
+}
+
+const rchar *
+r_fs_dir_read_next (RFsDir * dir)
+{
+  if (R_UNLIKELY (dir == NULL))
+    return NULL;
+#if defined (R_OS_WIN32)
+  for (;;) {
+    if (dir->pending)
+      dir->pending = FALSE;
+    else if (!FindNextFileW (dir->h, &dir->fd))
+      return NULL;
+
+    /* Skip "." and "..". */
+    if (dir->fd.cFileName[0] == L'.' && (dir->fd.cFileName[1] == 0 ||
+          (dir->fd.cFileName[1] == L'.' && dir->fd.cFileName[2] == 0)))
+      continue;
+
+    r_free (dir->name);
+    dir->name = r_utf16_to_utf8_dup (dir->fd.cFileName, -1, NULL, NULL, NULL);
+    return dir->name;
+  }
+#elif defined (HAVE_DIRENT_H)
+  {
+    struct dirent * de;
+    while ((de = readdir (dir->d)) != NULL) {
+      if (de->d_name[0] == '.' && (de->d_name[1] == 0 ||
+            (de->d_name[1] == '.' && de->d_name[2] == 0)))
+        continue;
+      return de->d_name;
+    }
+    return NULL;
+  }
+#else
+  return NULL;
+#endif
+}
+
+void
+r_fs_dir_close (RFsDir * dir)
+{
+  if (R_UNLIKELY (dir == NULL))
+    return;
+#if defined (R_OS_WIN32)
+  FindClose (dir->h);
+  r_free (dir->name);
+#elif defined (HAVE_DIRENT_H)
+  closedir (dir->d);
+#endif
+  r_free (dir);
 }
 

--- a/test/rfs.c
+++ b/test/rfs.c
@@ -167,3 +167,56 @@ RTEST (rfs, is_symlink, RTEST_FAST | RTEST_SYSTEM)
 }
 RTEST_END;
 
+RTEST (rfs, dir_enumerate, RTEST_FAST | RTEST_SYSTEM)
+{
+  static const rchar * const expect[] = { "alpha", "beta", "gamma" };
+  rboolean seen[R_N_ELEMENTS (expect)] = { FALSE };
+  rchar * tmpdir, * p;
+  RFsDir * dir;
+  const rchar * name;
+  ruint i, count = 0;
+
+  /* Opening a path that does not exist fails. */
+  r_assert_cmpptr ((tmpdir = r_fs_path_new_tmpfile ()), !=, NULL);
+  r_assert_cmpptr (r_fs_dir_open (tmpdir), ==, NULL);
+
+  r_assert (r_fs_mkdir (tmpdir, 0777));
+
+  /* An empty directory yields no entries (". " / ".." are filtered). */
+  r_assert_cmpptr ((dir = r_fs_dir_open (tmpdir)), !=, NULL);
+  r_assert_cmpptr (r_fs_dir_read_next (dir), ==, NULL);
+  r_fs_dir_close (dir);
+
+  for (i = 0; i < R_N_ELEMENTS (expect); i++) {
+    r_assert_cmpptr ((p = r_fs_path_build (tmpdir, expect[i], NULL)), !=, NULL);
+    r_assert (r_file_write_all (p, expect[i], r_strlen (expect[i])));
+    r_assert (r_fs_test_is_regular (p));
+    r_free (p);
+  }
+
+  /* Enumeration returns exactly the created set, in any order, no duplicates. */
+  r_assert_cmpptr ((dir = r_fs_dir_open (tmpdir)), !=, NULL);
+  while ((name = r_fs_dir_read_next (dir)) != NULL) {
+    r_assert_cmpstr (name, !=, ".");
+    r_assert_cmpstr (name, !=, "..");
+    for (i = 0; i < R_N_ELEMENTS (expect) && !r_str_equals (name, expect[i]); i++) ;
+    r_assert_cmpuint (i, <, R_N_ELEMENTS (expect));   /* nothing unexpected */
+    r_assert (!seen[i]);                              /* no duplicate */
+    seen[i] = TRUE;
+    count++;
+  }
+  r_fs_dir_close (dir);
+
+  r_assert_cmpuint (count, ==, R_N_ELEMENTS (expect));
+  for (i = 0; i < R_N_ELEMENTS (expect); i++)
+    r_assert (seen[i]);
+
+  /* Opening a regular file (not a directory) fails. */
+  r_assert_cmpptr ((p = r_fs_path_build (tmpdir, expect[0], NULL)), !=, NULL);
+  r_assert_cmpptr (r_fs_dir_open (p), ==, NULL);
+  r_free (p);
+
+  r_free (tmpdir);
+}
+RTEST_END;
+

--- a/test/rtruststore.c
+++ b/test/rtruststore.c
@@ -268,3 +268,86 @@ RTEST (rtruststore, add_pem_bundle_counts, RTEST_FAST)
   r_trust_store_unref (store);
 }
 RTEST_END;
+
+/* The file-based system trust backend is Unix-only; on Windows the native
+ * certificate store applies and r_trust_store_new_system returns NULL. */
+#if defined (R_OS_UNIX)
+/* r_trust_store_new_system honours $SSL_CERT_FILE and yields a store anchored to
+ * the named bundle; a missing or certificate-less bundle yields NULL. */
+RTEST (rtruststore, system_env_file, RTEST_FAST | RTEST_SYSTEM)
+{
+  RTrustStore * store;
+  rchar * bundle;
+
+  r_assert_cmpptr ((bundle = r_fs_path_new_tmpfile ()), !=, NULL);
+  r_assert (r_file_write_all (bundle, rtest_root_pem, r_strlen (rtest_root_pem)));
+  r_unsetenv ("SSL_CERT_DIR");
+  r_assert (r_setenv ("SSL_CERT_FILE", bundle, TRUE));
+
+  r_assert_cmpptr ((store = r_trust_store_new_system ()), !=, NULL);
+  r_assert_cmpint (r_test_verify (store, RTEST_NOW,
+        R_X509_EXT_KEY_USAGE_SERVER_AUTH, rtest_leaf_root_pem, NULL, NULL),
+      ==, R_TRUST_OK);
+  r_trust_store_unref (store);
+
+  /* A file that exists but carries no certificate -> NULL. */
+  r_assert (r_file_write_all (bundle, "not a certificate\n", 18));
+  r_assert_cmpptr (r_trust_store_new_system (), ==, NULL);
+
+  /* A missing file -> NULL. */
+  r_assert (r_setenv ("SSL_CERT_FILE", "/nonexistent/rlib-test/ca.pem", TRUE));
+  r_assert_cmpptr (r_trust_store_new_system (), ==, NULL);
+
+  r_unsetenv ("SSL_CERT_FILE");
+  r_free (bundle);
+}
+RTEST_END;
+
+/* r_trust_store_new_system honours $SSL_CERT_DIR, loading every certificate file
+ * in the directory; an empty directory yields NULL. */
+RTEST (rtruststore, system_env_dir, RTEST_FAST | RTEST_SYSTEM)
+{
+  RTrustStore * store;
+  rchar * dir, * empty, * pem;
+
+  r_assert_cmpptr ((dir = r_fs_path_new_tmpfile ()), !=, NULL);
+  r_assert (r_fs_mkdir (dir, 0777));
+  r_assert_cmpptr ((pem = r_fs_path_build (dir, "root.pem", NULL)), !=, NULL);
+  r_assert (r_file_write_all (pem, rtest_root_pem, r_strlen (rtest_root_pem)));
+
+  r_unsetenv ("SSL_CERT_FILE");
+  r_assert (r_setenv ("SSL_CERT_DIR", dir, TRUE));
+
+  r_assert_cmpptr ((store = r_trust_store_new_system ()), !=, NULL);
+  r_assert_cmpint (r_test_verify (store, RTEST_NOW,
+        R_X509_EXT_KEY_USAGE_SERVER_AUTH, rtest_leaf_root_pem, NULL, NULL),
+      ==, R_TRUST_OK);
+  r_trust_store_unref (store);
+
+  /* An empty directory contributes no anchors -> NULL. */
+  r_assert_cmpptr ((empty = r_fs_path_new_tmpfile ()), !=, NULL);
+  r_assert (r_fs_mkdir (empty, 0777));
+  r_assert (r_setenv ("SSL_CERT_DIR", empty, TRUE));
+  r_assert_cmpptr (r_trust_store_new_system (), ==, NULL);
+
+  r_unsetenv ("SSL_CERT_DIR");
+  r_free (pem);
+  r_free (dir);
+  r_free (empty);
+}
+RTEST_END;
+
+/* The no-environment probe path: with neither variable set it either finds the
+ * host CA bundle or returns NULL, but must not crash or leak (exercises the
+ * well-known bundle/directory probe lists). */
+RTEST (rtruststore, system_probe, RTEST_FAST | RTEST_SYSTEM)
+{
+  RTrustStore * store;
+
+  r_unsetenv ("SSL_CERT_FILE");
+  r_unsetenv ("SSL_CERT_DIR");
+  if ((store = r_trust_store_new_system ()) != NULL)
+    r_trust_store_unref (store);
+}
+RTEST_END;
+#endif /* R_OS_UNIX */

--- a/test/runicode.c
+++ b/test/runicode.c
@@ -50,6 +50,15 @@ RTEST (runicode, utf16_to_utf8, RTEST_FAST)
   r_assert_cmpint (res, ==, R_UNICODE_INVALID_CODE_POINT);
   r_assert_cmpuint (u8len, ==, 2);
   r_assert_cmpptr (utf16end, ==, utf16 + 2);
+
+  /* srcsize == -1 treats src as NUL-terminated (mirrors r_utf8_to_utf16_dup). */
+  utf16[0] = 0x61; utf16[1] = 0x62; utf16[2] = 0x63; utf16[3] = 0;
+  r_assert_cmpptr ((utf8 = r_utf16_to_utf8_dup (utf16, -1, &res, &u8len, &utf16end)), !=, NULL);
+  r_assert_cmpint (res, ==, R_UNICODE_OK);
+  r_assert_cmpstr (utf8, ==, "abc");
+  r_assert_cmpuint (u8len, ==, 3);
+  r_assert_cmpptr (utf16end, ==, utf16 + 3);
+  r_free (utf8);
 }
 RTEST_END;
 


### PR DESCRIPTION
Adds `r_trust_store_new_system`, which loads the operating system's CA bundle so HTTPS works against public servers without the caller supplying trust anchors (#353). Built on a new portable directory-enumeration primitive, since rlib had no way to list a directory.

## `r_utf16_to_utf8_dup` fix (commit 1)
Standalone fix surfaced by this work: the wrapper's size was unsigned, so a `-1` sentinel wrapped to `SIZE_MAX` and the allocation overflowed to a `NULL` return — unlike the sibling `r_utf8_to_utf16_dup`, whose signed size already treats `-1` as "NUL-terminated". Made it signed and symmetric. This also repairs `r_fs_get_cur_dir` on Windows, which already relied on the `-1` form. (The bug was caught running the suite under Wine — Linux never exercised the path.)

## RFsDir (commit 2)
A small opaque directory iterator in the `file` module:
- `r_fs_dir_open(path)` — open a directory for enumeration (`NULL` if not an accessible directory).
- `r_fs_dir_read_next(dir)` — next entry name, `.`/`..` filtered, order unspecified; the name is owned by the handle and valid until the next read/close.
- `r_fs_dir_close(dir)`.

POSIX uses `opendir`/`readdir`/`closedir` (gated on a new `HAVE_DIRENT_H` probe — covers Linux, macOS and the BSDs); Windows uses `FindFirstFileW`/`FindNextFileW` with the entry name decoded to UTF-8.

## System trust backend (commit 3)
`r_trust_store_new_system()` resolves anchors in order, first that yields ≥1 anchor wins:
1. `$SSL_CERT_FILE` (a PEM bundle)
2. `$SSL_CERT_DIR` (a directory of PEM files — uses `RFsDir`)
3. well-known bundles (`/etc/ssl/certs/ca-certificates.crt`, `/etc/pki/tls/certs/ca-bundle.crt`, `/etc/ssl/cert.pem`, `/etc/ssl/ca-bundle.pem`)
4. well-known directories (`/etc/ssl/certs`, `/etc/pki/tls/certs`)

The result is a certs-backed store (as `r_trust_store_new_certs`), so further anchors may be added. It returns `NULL` when no source is found or on platforms without a file-based CA bundle (e.g. Windows, whose native certificate store is a separate backend), so a caller can fall back.

## Testing
`r_utf16_to_utf8_dup`: NUL-terminated (`-1`) round-trip. `RFsDir`: enumerate a known file set (any order, no duplicates, `.`/`..` excluded), empty-directory and not-a-directory cases. System store: hermetic via `$SSL_CERT_FILE` / `$SSL_CERT_DIR` pointed at the test PKI (validates a chain to the named anchor; missing / certificate-less / empty source → `NULL`), plus a no-environment probe that must not crash or leak.

Full matrix green (linux/rpoll/asan/asan_rpoll/ubsan), mingw compile-clean both backends, full suite under Wine, doxygen clean.

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)