### PR TITLE
net/tls: SNI-based virtual hosts (per-hostname cert and client-cert policy)

### DIFF
--- a/include/rlib/crypto/rx509.h
+++ b/include/rlib/crypto/rx509.h
@@ -256,6 +256,23 @@ R_API rboolean r_crypto_x509_cert_has_policy (const RCryptoCert * cert, const rc
 R_API rboolean r_crypto_x509_cert_verify_host (const RCryptoCert * cert,
     const rchar * host);
 
+/**
+ * @brief Match a host name @p host against a single @c dNSName @p pattern
+ * (RFC 6125).
+ *
+ * Case-insensitive exact match, plus a single leftmost-label @c * wildcard in
+ * @p pattern that matches exactly one label and never spans a dot (so
+ * @c *.example.com matches @c a.example.com but neither @c example.com nor
+ * @c a.b.example.com). This is the same matching
+ * @ref r_crypto_x509_cert_verify_host applies to @c dNSName SANs, exposed for
+ * callers that match a name against a configured pattern (e.g. SNI virtual-host
+ * selection). Identity only -- it does not establish trust.
+ *
+ * @return @c TRUE if @p host matches @p pattern.
+ */
+R_API rboolean r_crypto_x509_host_match_dns (const rchar * host,
+    const rchar * pattern);
+
 /** @brief Number of @c SubjectAltName general names (0 if absent). */
 R_API rsize r_crypto_x509_cert_subject_alt_name_count (const RCryptoCert * cert);
 /**

--- a/include/rlib/net/rhttpserver.h
+++ b/include/rlib/net/rhttpserver.h
@@ -140,6 +140,44 @@ R_API RTLSClientCertMode r_http_server_get_client_cert_mode (RHttpServer * serve
  */
 R_API void r_http_server_set_client_trust_store (RHttpServer * server,
     RTrustStore * store);
+
+/**
+ * @brief Add an SNI virtual host: serve @p cert / @p privkey to clients that
+ * request @p host in the TLS @c server_name extension.
+ *
+ * @p host is matched against the SNI name with the same exact / leftmost-label
+ * @c * wildcard semantics as @ref r_crypto_x509_host_match_dns (so
+ * @c *.example.com serves any single sub-label). Exact hosts win over wildcards;
+ * a connection whose SNI matches no vhost (or that sends none) falls back to the
+ * listener certificate and the whole-server client-cert policy. A vhost
+ * **inherits** the whole-server client-cert mode and trust store until overridden
+ * with @ref r_http_server_set_vhost_client_cert_mode /
+ * @ref r_http_server_set_vhost_client_trust_store, so adding a vhost never
+ * silently weakens a server-wide requirement. @p cert and @p privkey are
+ * referenced. Host matching is case-insensitive.
+ *
+ * @return @c FALSE on bad arguments, if @p host is already registered, or on
+ *         allocation failure.
+ */
+R_API rboolean r_http_server_add_vhost (RHttpServer * server,
+    const rchar * host, RCryptoCert * cert, RCryptoKey * privkey);
+/**
+ * @brief Set the client-certificate (mutual-TLS) policy for the vhost @p host
+ * (added via @ref r_http_server_add_vhost); the per-host counterpart of
+ * @ref r_http_server_set_client_cert_mode. Overrides the inherited whole-server
+ * mode for this host. @return @c FALSE if @p host is unknown.
+ */
+R_API rboolean r_http_server_set_vhost_client_cert_mode (RHttpServer * server,
+    const rchar * host, RTLSClientCertMode mode);
+/**
+ * @brief Set the trust store validating client certificates for the vhost
+ * @p host (referenced; @c NULL clears it); the per-host counterpart of
+ * @ref r_http_server_set_client_trust_store. Overrides the inherited whole-server
+ * trust store for this host. @return @c FALSE if @p host is unknown.
+ */
+R_API rboolean r_http_server_set_vhost_client_trust_store (RHttpServer * server,
+    const rchar * host, RTrustStore * store);
+
 /**
  * @brief The verified client certificate for the request currently being
  * handled, or @c NULL.

--- a/include/rlib/net/rtlsclient.h
+++ b/include/rlib/net/rtlsclient.h
@@ -83,6 +83,15 @@ R_API RTLSClient * r_tls_client_new (const RTLSCallbacks * cb,
  */
 R_API RTLSError r_tls_client_set_cert (RTLSClient * client,
     RCryptoCert * cert, RCryptoKey * privkey);
+/**
+ * @brief Offer @p host in the ClientHello @c server_name (SNI) extension.
+ *
+ * Lets the server select a certificate (and policy) for the requested name --
+ * see @ref r_tls_server_get_server_name. Pass @c NULL to clear. Must be called
+ * before @ref r_tls_client_start. @p host is copied.
+ */
+R_API RTLSError r_tls_client_set_server_name (RTLSClient * client,
+    const rchar * host);
 /** @brief Override the client-random (testing / determinism). */
 R_API RTLSError r_tls_client_set_random (RTLSClient * client,
     const ruint8 clirandom[R_TLS_HELLO_RANDOM_BYTES]);

--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -114,6 +114,26 @@ typedef rboolean (*RTLSCertVerifyCb) (rpointer ctx, RCryptoCert * const * chain,
  * to.
  */
 typedef void (*RTLSClosedCb) (rpointer ctx, rpointer session);
+/**
+ * @brief Callback selecting the certificate / policy for the requested SNI host
+ * (server only).
+ *
+ * Fired during the handshake once the ClientHello has been parsed, with the
+ * @c server_name (SNI) host the client requested (@c NULL if it sent none).
+ * @p session is the @ref RTLSServer; the callback may call
+ * @ref r_tls_server_set_cert and @ref r_tls_server_set_client_cert_mode on it to
+ * configure this connection for the named host. Return @ref R_TLS_ERROR_OK to
+ * proceed, or an error to abort the handshake. May be @c NULL.
+ *
+ * Applies to full handshakes only: a resumed (abbreviated) session reuses the
+ * original session's certificate and verified peer, so a per-name policy is not
+ * re-applied on resumption. If a per-name client-cert requirement must hold
+ * across resumption, do not enable session tickets
+ * (@ref r_tls_server_set_session_ticket_keys). Also keep the selected key's type
+ * consistent with the offered one: the signature scheme is negotiated from the
+ * cert set before this callback runs.
+ */
+typedef RTLSError (*RTLSServerNameCb) (rpointer ctx, const rchar * name, rpointer session);
 
 /** @brief Callback bundle wiring a session to its transport and policy. */
 typedef struct {
@@ -159,11 +179,29 @@ R_API RTLSError r_tls_server_set_cert (RTLSServer * server,
 R_API RTLSError r_tls_server_set_client_cert_mode (RTLSServer * server,
     RTLSClientCertMode mode);
 /**
+ * @brief Set a callback that selects the certificate / policy by SNI host name.
+ *
+ * Invoked during the handshake once the ClientHello is parsed (see
+ * @ref RTLSServerNameCb), letting the server pick the certificate and
+ * client-certificate policy for the requested name. Must be set before the
+ * handshake starts; @c NULL clears it.
+ */
+R_API RTLSError r_tls_server_set_server_name_cb (RTLSServer * server,
+    RTLSServerNameCb cb);
+/**
  * @brief The peer (client) leaf certificate presented during a mutual-TLS
  * handshake, or @c NULL if none was presented. The reference is borrowed
  * (owned by the session); ref it to outlive the session.
  */
 R_API RCryptoCert * r_tls_server_get_peer_cert (const RTLSServer * server);
+/**
+ * @brief The host requested in the ClientHello @c server_name (SNI) extension,
+ * or @c NULL if the client sent none.
+ *
+ * Borrowed (owned by the session). Valid once the ClientHello has been
+ * processed -- e.g. inside an @ref RTLSServerNameCb, or after the handshake.
+ */
+R_API const rchar * r_tls_server_get_server_name (const RTLSServer * server);
 /**
  * @brief Attach the shared key store used to seal and open session tickets.
  *

--- a/rlib/crypto/rx509.c
+++ b/rlib/crypto/rx509.c
@@ -1640,6 +1640,15 @@ r_x509_host_match_dns (const rchar * host, const rchar * pattern)
   return FALSE;
 }
 
+rboolean
+r_crypto_x509_host_match_dns (const rchar * host, const rchar * pattern)
+{
+  if (R_UNLIKELY (host == NULL || pattern == NULL ||
+        *host == '\0' || *pattern == '\0'))
+    return FALSE;
+  return r_x509_host_match_dns (host, pattern);
+}
+
 /* Render @host as raw IP octets if it is an IPv4/IPv6 literal; returns the
  * length (4 or 16) or 0 when @host is not an IP literal. */
 static rsize

--- a/rlib/net/rhttpserver.c
+++ b/rlib/net/rhttpserver.c
@@ -35,6 +35,7 @@
 #include <rlib/rtime.h>
 
 typedef struct RHttpServerHandlerCtx RHttpServerHandlerCtx;
+typedef struct RHttpVhost RHttpVhost;
 
 struct RHttpServer {
   RRef ref;
@@ -53,6 +54,11 @@ struct RHttpServer {
   /* Mutual TLS: request and verify a client certificate against client_trust. */
   RTrustStore * client_trust;
   RTLSClientCertMode client_cert_mode;
+  /* SNI virtual hosts (RHttpVhost*), matched against the ClientHello server_name
+   * to pick a per-host cert + client-cert policy; NULL until the first is added.
+   * A connection with no SNI or no match uses the listener cert + the
+   * whole-server client_trust/client_cert_mode above. */
+  RPtrArray * vhosts;
   /* The handler context being dispatched, so r_http_server_get_peer_cert
    * can reach the connection's verified client certificate. */
   RHttpServerHandlerCtx * cur;
@@ -64,6 +70,7 @@ typedef struct {
   REvTCP * evtcp;
 
   RTLSServer * tls;     /* per-connection TLS engine; NULL for plaintext */
+  RHttpVhost * vhost;   /* SNI-selected vhost for this connection, or NULL */
 
   RHttpRequest * req;
   rssize bodysize;
@@ -356,6 +363,8 @@ r_http_server_free (RHttpServer * server)
     r_prng_unref (server->prng);
   if (server->client_trust != NULL)
     r_trust_store_unref (server->client_trust);
+  if (server->vhosts != NULL)
+    r_ptr_array_unref (server->vhosts);
   r_free (server);
 }
 
@@ -380,6 +389,7 @@ r_http_server_new (REvLoop * loop)
     ret->prng = NULL;
     ret->client_trust = NULL;
     ret->client_cert_mode = R_TLS_CLIENT_CERT_MODE_NONE;
+    ret->vhosts = NULL;
     ret->cur = NULL;
 
     R_LOG_INFO ("New HTTP server %p", ret);
@@ -592,6 +602,73 @@ r_http_tls_listener_free (rpointer data)
   r_free (l);
 }
 
+/* One SNI virtual host: a cert/key plus an optional per-host client-cert policy.
+ * @host is the match pattern (exact name or a leftmost-label "*" wildcard). */
+struct RHttpVhost {
+  rchar * host;
+  RCryptoCert * cert;
+  RCryptoKey * privkey;
+  /* Per-host mTLS policy. Each field is used only when its has_* flag is set;
+   * otherwise the connection inherits the whole-server policy, so adding a vhost
+   * never silently weakens a server-wide requirement. */
+  rboolean has_client_cert_mode;
+  RTLSClientCertMode client_cert_mode;
+  rboolean has_client_trust;
+  RTrustStore * client_trust;
+};
+
+static void
+r_http_vhost_free (rpointer data)
+{
+  RHttpVhost * v = data;
+  r_free (v->host);
+  r_crypto_cert_unref (v->cert);
+  r_crypto_key_unref (v->privkey);
+  if (v->client_trust != NULL)
+    r_trust_store_unref (v->client_trust);
+  r_free (v);
+}
+
+/* Look up the vhost for an SNI @name: exact matches win over wildcard patterns. */
+static RHttpVhost *
+r_http_server_vhost_lookup (RHttpServer * server, const rchar * name)
+{
+  rsize i, n;
+
+  if (server->vhosts == NULL || name == NULL)
+    return NULL;
+  n = r_ptr_array_size (server->vhosts);
+  for (i = 0; i < n; i++) {
+    RHttpVhost * v = r_ptr_array_get (server->vhosts, i);
+    if (r_strcasecmp (v->host, name) == 0)
+      return v;
+  }
+  for (i = 0; i < n; i++) {
+    RHttpVhost * v = r_ptr_array_get (server->vhosts, i);
+    if (v->host[0] == '*' && r_crypto_x509_host_match_dns (name, v->host))
+      return v;
+  }
+  return NULL;
+}
+
+/* Find a vhost by configured host (for dup-detection and the config setters).
+ * Case-insensitive to match r_http_server_vhost_lookup, since host names are. */
+static RHttpVhost *
+r_http_server_vhost_find (RHttpServer * server, const rchar * host)
+{
+  rsize i, n;
+
+  if (server->vhosts == NULL || host == NULL)
+    return NULL;
+  n = r_ptr_array_size (server->vhosts);
+  for (i = 0; i < n; i++) {
+    RHttpVhost * v = r_ptr_array_get (server->vhosts, i);
+    if (r_strcasecmp (v->host, host) == 0)
+      return v;
+  }
+  return NULL;
+}
+
 static rboolean
 r_http_client_ctx_tls_out (rpointer data, RBuffer * buf, rpointer session)
 {
@@ -643,12 +720,43 @@ r_http_client_ctx_tls_verify_peer (rpointer data,
     RCryptoCert * const * chain, ruint count)
 {
   RHttpClientCtx * ctx = data;
-  RTrustStore * trust = ctx->server->client_trust;
+  /* Verify against the SNI-selected vhost's trust store when it set one,
+   * otherwise the whole-server store (inherit / no vhost matched). */
+  RTrustStore * trust = (ctx->vhost != NULL && ctx->vhost->has_client_trust) ?
+      ctx->vhost->client_trust : ctx->server->client_trust;
 
   if (trust == NULL)
     return FALSE;
   return r_trust_store_verify (trust, chain, count, r_time_get_unix_time (),
       R_X509_EXT_KEY_USAGE_CLIENT_AUTH) == R_TRUST_OK;
+}
+
+/* SNI selection: when the requested host matches a configured vhost, install its
+ * cert + client-cert policy for this connection (verify_peer then uses the
+ * vhost's trust). No SNI or no match keeps the listener cert + whole-server
+ * policy already set in r_http_server_tcp_connection_ready_tls. */
+static RTLSError
+r_http_client_ctx_tls_sni (rpointer data, const rchar * name, rpointer session)
+{
+  RHttpClientCtx * ctx = data;
+  RHttpVhost * v;
+  RTLSClientCertMode mode;
+  RTLSError err;
+
+  if ((v = r_http_server_vhost_lookup (ctx->server, name)) == NULL)
+    return R_TLS_ERROR_OK;
+
+  /* The vhost's own mode if set, otherwise the whole-server one (inherit). */
+  mode = v->has_client_cert_mode ? v->client_cert_mode : ctx->server->client_cert_mode;
+
+  if ((err = r_tls_server_set_cert ((RTLSServer *) session, v->cert,
+          v->privkey)) != R_TLS_ERROR_OK)
+    return err;
+  if ((err = r_tls_server_set_client_cert_mode ((RTLSServer *) session,
+          mode)) != R_TLS_ERROR_OK)
+    return err;
+  ctx->vhost = v;
+  return R_TLS_ERROR_OK;
 }
 
 static const RTLSCallbacks g__r_http_tls_callbacks = {
@@ -692,6 +800,8 @@ r_http_server_tcp_connection_ready_tls (rpointer data,
       (ctx->tls = r_tls_server_new (&g__r_http_tls_callbacks, ctx, NULL)) != NULL &&
       r_tls_server_set_cert (ctx->tls, l->cert, l->privkey) == R_TLS_ERROR_OK &&
       r_tls_server_set_client_cert_mode (ctx->tls, server->client_cert_mode) == R_TLS_ERROR_OK &&
+      (server->vhosts == NULL ||
+          r_tls_server_set_server_name_cb (ctx->tls, r_http_client_ctx_tls_sni) == R_TLS_ERROR_OK) &&
       r_tls_server_start (ctx->tls, server->loop, server->prng) == R_TLS_ERROR_OK &&
       r_ev_tcp_recv_start (newtcp, NULL, r_http_client_ctx_tls_recv, ctx, NULL)) {
     R_LOG_TRACE ("%p: New TLS connection "R_EV_IO_FORMAT" on "R_EV_IO_FORMAT,
@@ -823,6 +933,71 @@ r_http_server_set_client_trust_store (RHttpServer * server, RTrustStore * store)
   if (server->client_trust != NULL)
     r_trust_store_unref (server->client_trust);
   server->client_trust = store;
+}
+
+rboolean
+r_http_server_add_vhost (RHttpServer * server, const rchar * host,
+    RCryptoCert * cert, RCryptoKey * privkey)
+{
+  RHttpVhost * v;
+
+  if (R_UNLIKELY (server == NULL || host == NULL || *host == '\0')) return FALSE;
+  if (R_UNLIKELY (cert == NULL || privkey == NULL)) {
+    R_LOG_ERROR ("%p: add_vhost needs a cert and key", server);
+    return FALSE;
+  }
+  if (R_UNLIKELY (r_http_server_vhost_find (server, host) != NULL)) {
+    R_LOG_ERROR ("%p: vhost '%s' already added", server, host);
+    return FALSE;
+  }
+
+  if (server->vhosts == NULL && (server->vhosts = r_ptr_array_new ()) == NULL)
+    return FALSE;
+  if ((v = r_mem_new0 (RHttpVhost)) == NULL)
+    return FALSE;
+  if ((v->host = r_strdup (host)) == NULL) {
+    r_free (v);
+    return FALSE;
+  }
+  v->cert = r_crypto_cert_ref (cert);
+  v->privkey = r_crypto_key_ref (privkey);
+  /* has_* flags default FALSE (r_mem_new0): the vhost inherits the whole-server
+   * client-cert policy until a per-vhost setter overrides it. */
+
+  r_ptr_array_add (server->vhosts, v, r_http_vhost_free);
+  return TRUE;
+}
+
+rboolean
+r_http_server_set_vhost_client_cert_mode (RHttpServer * server,
+    const rchar * host, RTLSClientCertMode mode)
+{
+  RHttpVhost * v;
+
+  if (R_UNLIKELY (server == NULL)) return FALSE;
+  if ((v = r_http_server_vhost_find (server, host)) == NULL)
+    return FALSE;
+  v->client_cert_mode = mode;
+  v->has_client_cert_mode = TRUE;
+  return TRUE;
+}
+
+rboolean
+r_http_server_set_vhost_client_trust_store (RHttpServer * server,
+    const rchar * host, RTrustStore * store)
+{
+  RHttpVhost * v;
+
+  if (R_UNLIKELY (server == NULL)) return FALSE;
+  if ((v = r_http_server_vhost_find (server, host)) == NULL)
+    return FALSE;
+  if (store != NULL)
+    r_trust_store_ref (store);
+  if (v->client_trust != NULL)
+    r_trust_store_unref (v->client_trust);
+  v->client_trust = store;
+  v->has_client_trust = TRUE;
+  return TRUE;
 }
 
 RSocketAddress *

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -98,6 +98,8 @@ struct RTLSClient {
   RCryptoKey * privkey;        /* own private key for mTLS, or NULL */
   rboolean cert_requested;     /* server sent a CertificateRequest */
 
+  rchar * server_name;         /* SNI host to offer in the ClientHello, or NULL */
+
   rboolean ecdhe;                  /* an ECDHE suite was negotiated */
   REcurveID ecdhe_curve;           /* the server-selected named group */
   RCryptoKey * ecdhe_key;          /* client ephemeral ECDH private key */
@@ -132,6 +134,7 @@ r_tls_client_free (RTLSClient * client)
     r_crypto_cert_unref (client->cert);
   if (client->privkey != NULL)
     r_crypto_key_unref (client->privkey);
+  r_free (client->server_name);
   if (client->ecdhe_key != NULL)
     r_crypto_key_unref (client->ecdhe_key);
   if (client->ecdhe_server_pub != NULL)
@@ -215,6 +218,22 @@ r_tls_client_set_cert (RTLSClient * client, RCryptoCert * cert, RCryptoKey * pri
     r_crypto_key_unref (client->privkey);
   client->cert = r_crypto_cert_ref (cert);
   client->privkey = r_crypto_key_ref (privkey);
+
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_client_set_server_name (RTLSClient * client, const rchar * host)
+{
+  if (R_UNLIKELY (client == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (client->state != R_TLS_CLIENT_INITIAL)) return R_TLS_ERROR_WRONG_STATE;
+  /* The name is copied verbatim into one ClientHello record; a DNS host name is
+   * at most 255 bytes (RFC 1035). Reject anything longer rather than risk the
+   * record buffer / overflow the 16-bit extension length fields. */
+  if (R_UNLIKELY (host != NULL && r_strlen (host) > 255)) return R_TLS_ERROR_INVAL;
+
+  r_free (client->server_name);
+  client->server_name = (host != NULL) ? r_strdup (host) : NULL;
 
   return R_TLS_ERROR_OK;
 }
@@ -406,6 +425,21 @@ r_tls_client_write_hs_ext_signature_algorithms (ruint8 * ptr)
   return 10;
 }
 
+/* server_name (SNI, RFC 6066): a ServerNameList with one host_name entry.
+ * Offered only when a name was set via r_tls_client_set_server_name. */
+static ruint16
+r_tls_client_write_hs_ext_server_name (ruint8 * ptr, const rchar * name)
+{
+  rsize namelen = r_strlen (name);
+  r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_SERVER_NAME);
+  r_store_be16 (&ptr[2], (ruint16)(5 + namelen));    /* extension_data length */
+  r_store_be16 (&ptr[4], (ruint16)(3 + namelen));    /* ServerNameList length */
+  ptr[6] = 0;                                         /* NameType: host_name */
+  r_store_be16 (&ptr[7], (ruint16)namelen);          /* HostName length */
+  r_memcpy (&ptr[9], name, namelen);
+  return (ruint16)(9 + namelen);
+}
+
 static ruint16
 r_tls_client_write_hs_ext_use_srtp (ruint8 * ptr)
 {
@@ -487,6 +521,8 @@ r_tls_client_send_hello (RTLSClient * client)
     extsize += r_tls_client_write_hs_ext_supported_groups (ptr + 2 + extsize);
     extsize += r_tls_client_write_hs_ext_ec_point_formats (ptr + 2 + extsize);
     extsize += r_tls_client_write_hs_ext_signature_algorithms (ptr + 2 + extsize);
+    if (client->server_name != NULL)
+      extsize += r_tls_client_write_hs_ext_server_name (ptr + 2 + extsize, client->server_name);
     if (dtls)
       extsize += r_tls_client_write_hs_ext_use_srtp (ptr + 2 + extsize);
     r_store_be16 (ptr, extsize);

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -92,6 +92,8 @@ struct RTLSServer {
   rsize alpn_count;
   const rchar * alpn_selected;          /* negotiated protocol, points into alpn_protocols */
   rsize alpn_selected_len;
+  rchar * sni;                          /* SNI host_name from the ClientHello (owned), or NULL */
+  RTLSServerNameCb server_name_cb;      /* picks cert/policy for the SNI host; may be NULL */
   ruint8 max_fragment;                  /* negotiated max_fragment_length (RFC 6066): 0 none, else 1..4 */
   ruint8 * ticket;
   ruint16 ticketsize;
@@ -184,6 +186,7 @@ r_tls_server_free (RTLSServer * server)
       r_free (server->alpn_protocols[i]);
     r_free (server->alpn_protocols);
   }
+  r_free (server->sni);
   if (server->client.hmac != NULL)
     r_hmac_free (server->client.hmac);
   if (server->client.cipher != NULL)
@@ -286,11 +289,28 @@ r_tls_server_set_client_cert_mode (RTLSServer * server, RTLSClientCertMode mode)
   return R_TLS_ERROR_OK;
 }
 
+RTLSError
+r_tls_server_set_server_name_cb (RTLSServer * server, RTLSServerNameCb cb)
+{
+  if (R_UNLIKELY (server == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (server->state > R_TLS_SERVER_HELLO)) return R_TLS_ERROR_WRONG_STATE;
+
+  server->server_name_cb = cb;
+  return R_TLS_ERROR_OK;
+}
+
 RCryptoCert *
 r_tls_server_get_peer_cert (const RTLSServer * server)
 {
   if (R_UNLIKELY (server == NULL)) return NULL;
   return server->peer_cert;
+}
+
+const rchar *
+r_tls_server_get_server_name (const RTLSServer * server)
+{
+  if (R_UNLIKELY (server == NULL)) return NULL;
+  return server->sni;
 }
 
 RTLSError
@@ -1556,6 +1576,22 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
           return R_TLS_ERROR_ILLEGAL_PARAMETER;
         server->max_fragment = hsext.data[0];
         break;
+      case R_TLS_EXT_TYPE_SERVER_NAME:
+        /* RFC 6066: ServerNameList<1..> of { NameType(1), HostName<1..> }. Keep
+         * the first host_name entry. SNI is advisory, so a malformed list is
+         * ignored rather than fatal (bounds are still checked). */
+        if (hsext.len >= 2) {
+          ruint16 listlen = r_load_be16 (hsext.data);
+          if ((rsize) listlen + 2 <= hsext.len && listlen >= 3 &&
+              hsext.data[2] == 0 /* host_name */) {
+            ruint16 namelen = r_load_be16 (hsext.data + 3);
+            if ((rsize) namelen + 3 <= (rsize) listlen) {
+              r_free (server->sni);
+              server->sni = r_strndup ((const rchar *) (hsext.data + 5), namelen);
+            }
+          }
+        }
+        break;
       default:
         break;
     }
@@ -2086,6 +2122,13 @@ r_tls_server_state_hello (RTLSServer * server, const RTLSParser * parser)
     server->hellobuf = r_buffer_ref (parser->buf);
 
     if ((err = r_tls_server_nego_hello (server, parser->version, server->hello.version)) == R_TLS_ERROR_OK) {
+      /* SNI is now known; let the app pick the cert / client-cert policy for the
+       * requested name before the server flight. state is still SERVER_HELLO, so
+       * the callback may call r_tls_server_set_cert / _set_client_cert_mode. */
+      if (server->server_name_cb != NULL)
+        err = server->server_name_cb (server->userdata, server->sni, server);
+    }
+    if (err == R_TLS_ERROR_OK) {
       RTLSError rr = r_tls_server_try_resume (server);
       if (rr == R_TLS_ERROR_OK)
         err = r_tls_server_change_state (server, R_TLS_SERVER_CHANGE_CIPHER);

--- a/test/rcryptocert.c
+++ b/test/rcryptocert.c
@@ -849,6 +849,27 @@ RTEST (rcryptocert, x509_verify_host_wildcard, RTEST_FAST)
 }
 RTEST_END;
 
+/* r_crypto_x509_host_match_dns: the dNSName matcher exposed for SNI vhost
+ * selection -- same RFC 6125 semantics, a host against a single pattern. */
+RTEST (rcryptocert, x509_host_match_dns, RTEST_FAST)
+{
+  r_assert (r_crypto_x509_host_match_dns ("example.com", "example.com"));
+  r_assert (r_crypto_x509_host_match_dns ("Example.COM", "example.com")); /* case */
+  r_assert (!r_crypto_x509_host_match_dns ("example.org", "example.com"));
+
+  r_assert (r_crypto_x509_host_match_dns ("a.example.com", "*.example.com"));
+  r_assert (r_crypto_x509_host_match_dns ("A.EXAMPLE.COM", "*.example.com"));
+  r_assert (!r_crypto_x509_host_match_dns ("example.com", "*.example.com"));     /* no label */
+  r_assert (!r_crypto_x509_host_match_dns ("a.b.example.com", "*.example.com")); /* spans dot */
+  r_assert (!r_crypto_x509_host_match_dns ("a.example.org", "*.example.com"));
+
+  r_assert (!r_crypto_x509_host_match_dns (NULL, "example.com"));
+  r_assert (!r_crypto_x509_host_match_dns ("example.com", NULL));
+  r_assert (!r_crypto_x509_host_match_dns ("", "example.com"));
+  r_assert (!r_crypto_x509_host_match_dns ("example.com", ""));
+}
+RTEST_END;
+
 /* r_crypto_x509_cert_path_len: the BasicConstraints pathLenConstraint, or -1
  * when absent. */
 RTEST (rcryptocert, x509_path_len, RTEST_FAST)

--- a/test/rhttpserver.c
+++ b/test/rhttpserver.c
@@ -738,6 +738,223 @@ RTEST (rhttpserver, mtls_require_no_trust_store, RTEST_FAST | RTEST_SYSTEM)
 }
 RTEST_END;
 
+/* Drive one HTTPS attempt against a server with SNI virtual hosts. The default
+ * listener serves CN=rlib (client-cert NONE); vhost "localhost" and the wildcard
+ * "*.example.com" both serve the CN=localhost PKI leaf, but the wildcard
+ * additionally REQUIREs a client cert anchored at the test root. Reports whether
+ * the GET was answered, the server cert the client saw, and the client subject
+ * the handler observed. */
+static void
+r_test_vhost_run (RTLSClientCertMode server_mode, const rchar * sni,
+    const rchar * cli_cert_pem, const rchar * cli_key_pem,
+    rboolean * got_response, rchar ** server_subject, rchar ** client_subject)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RHttpServer * srv;
+  RTrustStore * trust;
+  RCryptoCert * cert, * peer;
+  RCryptoKey * pk;
+  RSocketAddress * addr;
+  RTestMtls m = { NULL, FALSE };
+  RTestTLSClient c = { NULL, NULL, NULL, NULL, NULL, R_TLS_VERSION_UNKNOWN, NULL,
+      FALSE, FALSE };
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((srv = r_http_server_new (loop)), !=, NULL);
+  r_assert (r_http_server_set_handler (srv, "/", -1, r_test_mtls_handler, &m, NULL));
+
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (testcertpem, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem, -1, NULL, 0)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
+  r_assert (r_http_server_add_tls_listen_addr (srv, addr, cert, pk));
+  r_socket_address_unref (addr);
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (rtest_leaf_root_pem, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (rtest_leaf_root_key_pem, -1, NULL, 0)), !=, NULL);
+  r_assert (r_http_server_add_vhost (srv, "localhost", cert, pk));
+  r_assert (r_http_server_add_vhost (srv, "*.example.com", cert, pk));
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+
+  r_assert_cmpptr ((trust = r_trust_store_new_certs ()), !=, NULL);
+  r_assert_cmpint (r_trust_store_add_pem (trust, rtest_root_pem, -1), ==, 1);
+  /* whole-server policy: the "localhost" vhost (no per-vhost mTLS) inherits it */
+  r_http_server_set_client_cert_mode (srv, server_mode);
+  if (server_mode != R_TLS_CLIENT_CERT_MODE_NONE)
+    r_http_server_set_client_trust_store (srv, trust);
+  /* the wildcard vhost overrides with its own REQUIRE + trust */
+  r_assert (r_http_server_set_vhost_client_cert_mode (srv, "*.example.com",
+        R_TLS_CLIENT_CERT_MODE_REQUIRE));
+  r_assert (r_http_server_set_vhost_client_trust_store (srv, "*.example.com", trust));
+  r_trust_store_unref (trust);
+
+  r_assert_cmpptr ((addr = r_http_server_get_local_address (srv)), !=, NULL);
+
+  r_assert_cmpptr ((c.prng = r_prng_new_mt ()), !=, NULL);
+  r_assert_cmpptr ((c.resp = r_buffer_new ()), !=, NULL);
+  r_assert_cmpptr ((c.tls = r_tls_client_new (&g_test_tls_client_cbs, &c, NULL)), !=, NULL);
+  if (sni != NULL)
+    r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_client_set_server_name (c.tls, sni));
+  if (cli_cert_pem != NULL) {
+    RCryptoCert * cc = r_pem_parse_cert_from_data (cli_cert_pem, -1);
+    RCryptoKey * ck = r_pem_parse_key_from_data (cli_key_pem, -1, NULL, 0);
+    r_assert_cmpptr (cc, !=, NULL);
+    r_assert_cmpptr (ck, !=, NULL);
+    r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_client_set_cert (c.tls, cc, ck));
+    r_crypto_key_unref (ck);
+    r_crypto_cert_unref (cc);
+  }
+  c.loop = loop;
+  r_assert_cmpptr ((c.tcp = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpint (r_ev_tcp_connect (c.tcp, addr,
+        r_test_tls_client_connected, &c, NULL), >=, R_SOCKET_OK);
+
+  while (!c.got_response && !c.eos)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE);
+
+  *got_response = c.got_response;
+  *client_subject = m.peer_subject;   /* ownership transferred to caller */
+  *server_subject = ((peer = r_tls_client_get_peer_cert (c.tls)) != NULL) ?
+      r_strdup (r_crypto_x509_cert_subject (peer)) : NULL;
+
+  r_ev_tcp_close (c.tcp, NULL, NULL, NULL);
+  r_ev_tcp_unref (c.tcp);
+  r_tls_client_unref (c.tls);
+  r_buffer_unref (c.resp);
+  r_prng_unref (c.prng);
+
+  r_http_server_stop (srv, NULL, NULL, NULL);
+  r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
+  r_http_server_unref (srv);
+  r_socket_address_unref (addr);
+  r_ev_loop_unref (loop);
+}
+
+/* SNI matching an exact vhost selects that vhost's certificate. */
+RTEST (rhttpserver, vhost_sni_exact, RTEST_FAST | RTEST_SYSTEM)
+{
+  rboolean got = FALSE; rchar * srv = NULL, * cli = NULL;
+  r_test_vhost_run (R_TLS_CLIENT_CERT_MODE_NONE, "localhost", NULL, NULL, &got, &srv, &cli);
+  r_assert (got);
+  r_assert_cmpstr (srv, ==, "CN=localhost");
+  r_assert_cmpptr (cli, ==, NULL);   /* this vhost requests no client cert */
+  r_free (srv); r_free (cli);
+}
+RTEST_END;
+
+/* SNI matching no vhost falls back to the listener certificate. */
+RTEST (rhttpserver, vhost_sni_fallback, RTEST_FAST | RTEST_SYSTEM)
+{
+  rboolean got = FALSE; rchar * srv = NULL, * cli = NULL;
+  r_test_vhost_run (R_TLS_CLIENT_CERT_MODE_NONE, "unknown.host", NULL, NULL, &got, &srv, &cli);
+  r_assert (got);
+  r_assert_cmpstr (srv, ==, "CN=rlib");
+  r_free (srv); r_free (cli);
+}
+RTEST_END;
+
+/* No SNI uses the listener certificate and the whole-server (NONE) policy. */
+RTEST (rhttpserver, vhost_no_sni_default, RTEST_FAST | RTEST_SYSTEM)
+{
+  rboolean got = FALSE; rchar * srv = NULL, * cli = NULL;
+  r_test_vhost_run (R_TLS_CLIENT_CERT_MODE_NONE, NULL, NULL, NULL, &got, &srv, &cli);
+  r_assert (got);
+  r_assert_cmpstr (srv, ==, "CN=rlib");
+  r_free (srv); r_free (cli);
+}
+RTEST_END;
+
+/* A wildcard vhost is matched and enforces its own REQUIRE policy: a trusted
+ * client certificate is accepted and reaches the handler. */
+RTEST (rhttpserver, vhost_wildcard_mtls_trusted, RTEST_FAST | RTEST_SYSTEM)
+{
+  rboolean got = FALSE; rchar * srv = NULL, * cli = NULL;
+  r_test_vhost_run (R_TLS_CLIENT_CERT_MODE_NONE, "api.example.com", rtest_leaf_clientauth_pem,
+      rtest_leaf_clientauth_key_pem, &got, &srv, &cli);
+  r_assert (got);
+  r_assert_cmpstr (srv, ==, "CN=localhost");
+  r_assert_cmpstr (cli, ==, "CN=rlib Test Client");
+  r_free (srv); r_free (cli);
+}
+RTEST_END;
+
+/* The wildcard vhost REQUIREs a client cert, so a connection without one fails
+ * even though the default listener policy is NONE. */
+RTEST (rhttpserver, vhost_wildcard_mtls_missing_cert, RTEST_FAST | RTEST_SYSTEM)
+{
+  rboolean got = FALSE; rchar * srv = NULL, * cli = NULL;
+  r_test_vhost_run (R_TLS_CLIENT_CERT_MODE_NONE, "api.example.com", NULL, NULL, &got, &srv, &cli);
+  r_assert (!got);
+  r_assert_cmpptr (cli, ==, NULL);
+  r_free (srv); r_free (cli);
+}
+RTEST_END;
+
+/* A vhost with no per-vhost mTLS inherits the whole-server REQUIRE + trust:
+ * a trusted client cert is required and reaches the handler. (The old
+ * NONE-default would have requested no cert -> the handler would see none.) */
+RTEST (rhttpserver, vhost_inherits_whole_server_mtls, RTEST_FAST | RTEST_SYSTEM)
+{
+  rboolean got = FALSE; rchar * srv = NULL, * cli = NULL;
+  r_test_vhost_run (R_TLS_CLIENT_CERT_MODE_REQUIRE, "localhost",
+      rtest_leaf_clientauth_pem, rtest_leaf_clientauth_key_pem, &got, &srv, &cli);
+  r_assert (got);
+  r_assert_cmpstr (srv, ==, "CN=localhost");
+  r_assert_cmpstr (cli, ==, "CN=rlib Test Client");
+  r_free (srv); r_free (cli);
+}
+RTEST_END;
+
+/* The inherited REQUIRE is enforced: a connection to that vhost without a client
+ * certificate is rejected. */
+RTEST (rhttpserver, vhost_inherits_require_rejects_no_cert, RTEST_FAST | RTEST_SYSTEM)
+{
+  rboolean got = FALSE; rchar * srv = NULL, * cli = NULL;
+  r_test_vhost_run (R_TLS_CLIENT_CERT_MODE_REQUIRE, "localhost", NULL, NULL,
+      &got, &srv, &cli);
+  r_assert (!got);
+  r_assert_cmpptr (cli, ==, NULL);
+  r_free (srv); r_free (cli);
+}
+RTEST_END;
+
+/* Vhost host names are case-insensitive: a case-variant is a duplicate, and the
+ * config setters find a vhost regardless of case. */
+RTEST (rhttpserver, vhost_host_case_insensitive, RTEST_FAST)
+{
+  REvLoop * loop;
+  RClock * clock;
+  RHttpServer * srv;
+  RCryptoCert * cert;
+  RCryptoKey * pk;
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+  r_assert_cmpptr ((srv = r_http_server_new (loop)), !=, NULL);
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (rtest_leaf_root_pem, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (rtest_leaf_root_key_pem, -1, NULL, 0)), !=, NULL);
+
+  r_assert (r_http_server_add_vhost (srv, "Example.com", cert, pk));
+  r_assert (!r_http_server_add_vhost (srv, "example.COM", cert, pk)); /* dup */
+  r_assert (r_http_server_set_vhost_client_cert_mode (srv, "EXAMPLE.com",
+        R_TLS_CLIENT_CERT_MODE_REQUIRE));                             /* found */
+  r_assert (!r_http_server_set_vhost_client_cert_mode (srv, "other.com",
+        R_TLS_CLIENT_CERT_MODE_REQUIRE));                            /* absent */
+
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+  r_http_server_unref (srv);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
 typedef struct {
   RHttpRequest * other;     /* a request that is not the one being handled */
   rboolean null_for_req;    /* get_peer_cert (server, req) was NULL */

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -1,6 +1,8 @@
 #include <rlib/rnet.h>
 #include <rlib/rcrypto.h>
 
+#include "rtlstestcerts.h"
+
 /* Self-signed test certificate + matching RSA private key (CN=rlib). */
 static const rchar testcertpem[] =
   "-----BEGIN CERTIFICATE-----\r\n"
@@ -86,6 +88,11 @@ RTEST_FIXTURE_STRUCT (rtlsclient)
   ruint verify_calls;
   rboolean verify_result;
   RTLSCipherSuite force_suite;   /* pin both endpoints to one suite; NONE = defaults */
+
+  rboolean sni_cb_called;        /* server's SNI selection cb fired */
+  rchar sni_seen[128];           /* SNI host the server's cb received ("" if NULL) */
+  RCryptoCert * sni_cert;        /* cert the cb installs for the SNI host, or NULL */
+  RCryptoKey * sni_key;
 
   RClock * clock;
   REvLoop * evloop;
@@ -197,6 +204,21 @@ r_tlsclient_test_verify_cert (rpointer ctx, RCryptoCert * const * chain, ruint c
   return fixture->verify_result;
 }
 
+/* Server-side SNI selection: record the requested name and, if the fixture has
+ * one staged, install a per-name certificate for this connection. */
+static RTLSError
+r_tlsclient_test_sni (rpointer ctx, const rchar * name, rpointer session)
+{
+  RTEST_FIXTURE_STRUCT (rtlsclient) * fixture = ctx;
+  fixture->sni_cb_called = TRUE;
+  if (name != NULL)
+    r_strncpy (fixture->sni_seen, name, sizeof (fixture->sni_seen));
+  if (fixture->sni_cert != NULL)
+    return r_tls_server_set_cert ((RTLSServer *) session,
+        fixture->sni_cert, fixture->sni_key);
+  return R_TLS_ERROR_OK;
+}
+
 RTEST_FIXTURE_SETUP (rtlsclient)
 {
   static RTLSCallbacks srvcbs = {
@@ -230,6 +252,10 @@ RTEST_FIXTURE_SETUP (rtlsclient)
   fixture->verify_calls = 0;
   fixture->verify_result = TRUE;
   fixture->force_suite = R_TLS_CS_NONE;
+  fixture->sni_cb_called = FALSE;
+  fixture->sni_seen[0] = '\0';
+  fixture->sni_cert = NULL;
+  fixture->sni_key = NULL;
 
   r_queue_init (&fixture->srv_out);
   r_queue_init (&fixture->cli_out);
@@ -249,6 +275,10 @@ RTEST_FIXTURE_SETUP (rtlsclient)
 
 RTEST_FIXTURE_TEARDOWN (rtlsclient)
 {
+  if (fixture->sni_cert != NULL)
+    r_crypto_cert_unref (fixture->sni_cert);
+  if (fixture->sni_key != NULL)
+    r_crypto_key_unref (fixture->sni_key);
   r_tls_client_unref (fixture->client);
   r_tls_server_unref (fixture->server);
 
@@ -444,6 +474,84 @@ RTEST_END;
 RTEST_F (rtlsclient, dtls_loopback, RTEST_FAST)
 {
   r_test_tls_loopback (fixture, R_TLS_VERSION_DTLS_1_2);
+}
+RTEST_END;
+
+/* The client offers SNI; the server's selection callback sees the name and
+ * installs a per-name certificate, which the client then receives. */
+RTEST_F (rtlsclient, sni_selects_cert, RTEST_FAST)
+{
+  RCryptoCert * peer;
+
+  r_assert_cmpptr ((fixture->sni_cert =
+      r_pem_parse_cert_from_data (rtest_leaf_root_pem, -1)), !=, NULL);
+  r_assert_cmpptr ((fixture->sni_key =
+      r_pem_parse_key_from_data (rtest_leaf_root_key_pem, -1, NULL, 0)), !=, NULL);
+
+  r_assert_cmpint (r_tls_server_set_server_name_cb (fixture->server,
+      r_tlsclient_test_sni), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_set_server_name (fixture->client,
+      "host.example.com"), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop,
+      fixture->prng), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop,
+      fixture->prng, R_TLS_VERSION_TLS_1_2), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+
+  r_assert (fixture->cli_hs_done);
+  r_assert (fixture->srv_hs_done);
+  r_assert (fixture->sni_cb_called);
+  r_assert_cmpstr (fixture->sni_seen, ==, "host.example.com");
+  /* the server exposes the requested name, and presented the selected cert */
+  r_assert_cmpstr (r_tls_server_get_server_name (fixture->server), ==,
+      "host.example.com");
+  r_assert_cmpptr ((peer = r_tls_client_get_peer_cert (fixture->client)), !=, NULL);
+  r_assert_cmpstr (r_crypto_x509_cert_subject (peer), ==, "CN=localhost");
+}
+RTEST_END;
+
+/* No SNI: the callback still fires (with a NULL name) and the default cert
+ * stands; the server-name getter reports NULL. */
+RTEST_F (rtlsclient, sni_absent_keeps_default, RTEST_FAST)
+{
+  RCryptoCert * peer;
+
+  r_assert_cmpint (r_tls_server_set_server_name_cb (fixture->server,
+      r_tlsclient_test_sni), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop,
+      fixture->prng), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop,
+      fixture->prng, R_TLS_VERSION_TLS_1_2), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+
+  r_assert (fixture->cli_hs_done);
+  r_assert (fixture->srv_hs_done);
+  r_assert (fixture->sni_cb_called);
+  r_assert_cmpstr (fixture->sni_seen, ==, "");
+  r_assert_cmpptr (r_tls_server_get_server_name (fixture->server), ==, NULL);
+  r_assert_cmpptr ((peer = r_tls_client_get_peer_cert (fixture->client)), !=, NULL);
+  r_assert_cmpstr (r_crypto_x509_cert_subject (peer), ==, "CN=rlib");
+}
+RTEST_END;
+
+/* An over-long SNI host is rejected (it would not fit a host name / the record);
+ * a 255-byte name is accepted. */
+RTEST_F (rtlsclient, sni_name_length_capped, RTEST_FAST)
+{
+  rchar name[300];
+  rsize i;
+
+  for (i = 0; i < sizeof (name) - 1; i++)
+    name[i] = 'a';
+
+  name[256] = '\0';   /* 256 bytes -> rejected */
+  r_assert_cmpint (r_tls_client_set_server_name (fixture->client, name), ==,
+      R_TLS_ERROR_INVAL);
+  name[255] = '\0';   /* 255 bytes -> accepted */
+  r_assert_cmpint (r_tls_client_set_server_name (fixture->client, name), ==,
+      R_TLS_ERROR_OK);
 }
 RTEST_END;
 


### PR DESCRIPTION
Today the TLS server ignores the ClientHello `server_name` (SNI) extension, so an
HTTPS listener serves one certificate and one server-wide client-cert policy.
This adds SNI virtual hosting across two layers, built on the #351 trust store
and #357 mutual TLS.

**TLS layer (`RTLSServer`)** — parse the `server_name` extension, expose it via
`r_tls_server_get_server_name`, and add `r_tls_server_set_server_name_cb`: a
callback fired once the ClientHello is parsed (while the state still permits it)
so the application can pick the certificate and client-cert policy for the
requested name before the server flight. The `RTLSClient` gains
`r_tls_client_set_server_name` to offer SNI.

**HTTP layer (`RHttpServer`)** — `r_http_server_add_vhost` maps an SNI host to its
own certificate, with `r_http_server_set_vhost_client_cert_mode` /
`_set_vhost_client_trust_store` for an independent mutual-TLS policy per host
(e.g. `admin.example.com` REQUIRE, `www.example.com` NONE). Lookup prefers an
exact host over a leftmost-label wildcard (reusing the exposed
`r_crypto_x509_host_match_dns`); a connection that matches no vhost — or sends no
SNI — keeps the listener certificate and the whole-server policy.

Tests drive a real client↔server handshake (cert selection: exact / wildcard /
fallback / no-SNI) and HTTPS over loopback (per-vhost REQUIRE accepted and
rejected, vs the default NONE), reusing the existing test PKI.

Closes #360