### PR TITLE
net/tls: per-vhost cipher suites via a pre-negotiation SNI hook

### DIFF
--- a/include/rlib/net/rhttpserver.h
+++ b/include/rlib/net/rhttpserver.h
@@ -177,6 +177,18 @@ R_API rboolean r_http_server_set_vhost_client_cert_mode (RHttpServer * server,
  */
 R_API rboolean r_http_server_set_vhost_client_trust_store (RHttpServer * server,
     const rchar * host, RTrustStore * store);
+/**
+ * @brief Set the cipher-suite preference (server order) for the vhost @p host,
+ * applied when a connection's SNI selects it.
+ *
+ * @p suites is copied (@p count entries). The negotiated suite is the server's
+ * first preference the client also offers and that the vhost's certificate key
+ * supports; an empty intersection fails the handshake. Pass @c NULL / @c 0 to
+ * clear it and fall back to the library defaults. @return @c FALSE if @p host is
+ * unknown (or on allocation failure).
+ */
+R_API rboolean r_http_server_set_vhost_cipher_suites (RHttpServer * server,
+    const rchar * host, const RTLSCipherSuite * suites, rsize count);
 
 /**
  * @brief The verified client certificate for the request currently being

--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -125,13 +125,12 @@ typedef void (*RTLSClosedCb) (rpointer ctx, rpointer session);
  * configure this connection for the named host. Return @ref R_TLS_ERROR_OK to
  * proceed, or an error to abort the handshake. May be @c NULL.
  *
- * Applies to full handshakes only: a resumed (abbreviated) session reuses the
- * original session's certificate and verified peer, so a per-name policy is not
- * re-applied on resumption. If a per-name client-cert requirement must hold
- * across resumption, do not enable session tickets
- * (@ref r_tls_server_set_session_ticket_keys). Also keep the selected key's type
- * consistent with the offered one: the signature scheme is negotiated from the
- * cert set before this callback runs.
+ * Runs before cipher negotiation, so the selected certificate (its key type) and
+ * any per-connection cipher preference drive suite selection. Applies to full
+ * handshakes only: a resumed (abbreviated) session reuses the original session's
+ * certificate and verified peer, so a per-name policy is not re-applied on
+ * resumption. If a per-name client-cert requirement must hold across resumption,
+ * do not enable session tickets (@ref r_tls_server_set_session_ticket_keys).
  */
 typedef RTLSError (*RTLSServerNameCb) (rpointer ctx, const rchar * name, rpointer session);
 

--- a/rlib/net/rhttpserver.c
+++ b/rlib/net/rhttpserver.c
@@ -615,6 +615,9 @@ struct RHttpVhost {
   RTLSClientCertMode client_cert_mode;
   rboolean has_client_trust;
   RTrustStore * client_trust;
+  /* Per-host cipher-suite preference (owned copy); NULL = library defaults. */
+  RTLSCipherSuite * ciphers;
+  rsize cipher_count;
 };
 
 static void
@@ -626,6 +629,7 @@ r_http_vhost_free (rpointer data)
   r_crypto_key_unref (v->privkey);
   if (v->client_trust != NULL)
     r_trust_store_unref (v->client_trust);
+  r_free (v->ciphers);
   r_free (v);
 }
 
@@ -759,8 +763,25 @@ r_http_client_ctx_tls_sni (rpointer data, const rchar * name, rpointer session)
   return R_TLS_ERROR_OK;
 }
 
+/* Offer the SNI-selected vhost's cipher preference, if it set one. The SNI
+ * callback runs before cipher negotiation, so ctx->vhost is already resolved
+ * here; with no per-vhost list (or no vhost) we fall back to the defaults. */
+static rboolean
+r_http_client_ctx_tls_prefer_ciphers (rpointer data, RTLSVersion ver,
+    RTLSCipherSuite * cs, rsize * count)
+{
+  RHttpClientCtx * ctx = data;
+  (void) ver;
+
+  if (ctx->vhost == NULL || ctx->vhost->ciphers == NULL)
+    return FALSE;
+  *count = MIN (*count, ctx->vhost->cipher_count);
+  r_memcpy (cs, ctx->vhost->ciphers, *count * sizeof (RTLSCipherSuite));
+  return TRUE;
+}
+
 static const RTLSCallbacks g__r_http_tls_callbacks = {
-  NULL,                              /* preferred_cipher_suites (defaults) */
+  r_http_client_ctx_tls_prefer_ciphers, /* preferred_cipher_suites (per-vhost) */
   NULL,                              /* handshake_done (appdata drives parsing) */
   r_http_client_ctx_tls_out,         /* out */
   r_http_client_ctx_tls_appdata,     /* appdata */
@@ -997,6 +1018,26 @@ r_http_server_set_vhost_client_trust_store (RHttpServer * server,
     r_trust_store_unref (v->client_trust);
   v->client_trust = store;
   v->has_client_trust = TRUE;
+  return TRUE;
+}
+
+rboolean
+r_http_server_set_vhost_cipher_suites (RHttpServer * server, const rchar * host,
+    const RTLSCipherSuite * suites, rsize count)
+{
+  RHttpVhost * v;
+  RTLSCipherSuite * copy = NULL;
+
+  if (R_UNLIKELY (server == NULL)) return FALSE;
+  if ((v = r_http_server_vhost_find (server, host)) == NULL)
+    return FALSE;
+  if (suites != NULL && count > 0 &&
+      (copy = r_memdup (suites, count * sizeof (RTLSCipherSuite))) == NULL)
+    return FALSE;
+
+  r_free (v->ciphers);
+  v->ciphers = copy;
+  v->cipher_count = (copy != NULL) ? count : 0;
   return TRUE;
 }
 

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -1350,6 +1350,39 @@ r_tls_server_nego_ecdhe_curve (RTLSServer * server, REcurveID * out)
   return FALSE;
 }
 
+/* Pull the SNI host_name out of the ClientHello into server->sni, before
+ * negotiation, so a server_name callback can select the cert (and per-host
+ * cipher preference) it drives. RFC 6066: ServerNameList<1..> of
+ * { NameType(1), HostName<1..> }; keep the first host_name entry. SNI is
+ * advisory, so a malformed list is ignored rather than fatal (bounds checked). */
+static void
+r_tls_server_parse_sni (RTLSServer * server)
+{
+  RTLSHelloExt hsext = R_TLS_HELLO_EXT_INIT;
+  RTLSError r;
+
+  for (r = r_tls_hello_msg_extension_first (&server->hello, &hsext);
+      r == R_TLS_ERROR_OK;
+      r = r_tls_hello_msg_extension_next (&server->hello, &hsext)) {
+    ruint16 listlen, namelen;
+
+    if (hsext.type != R_TLS_EXT_TYPE_SERVER_NAME)
+      continue;
+    if (hsext.len < 2)
+      break;
+    listlen = r_load_be16 (hsext.data);
+    if ((rsize) listlen + 2 <= hsext.len && listlen >= 3 &&
+        hsext.data[2] == 0 /* host_name */) {
+      namelen = r_load_be16 (hsext.data + 3);
+      if ((rsize) namelen + 3 <= (rsize) listlen) {
+        r_free (server->sni);
+        server->sni = r_strndup ((const rchar *) (hsext.data + 5), namelen);
+      }
+    }
+    break;
+  }
+}
+
 static RTLSError
 r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion verhi)
 {
@@ -1394,6 +1427,19 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
   }
 
   R_LOG_DEBUG ("%p - ver %.4x", server, server->version);
+
+  /* Resolve SNI and let the application select the certificate / policy for the
+   * requested host now -- before cipher negotiation below -- so the chosen cert
+   * key and any per-host cipher preference (the preferred_cipher_suites callback,
+   * which sees the SNI from here on) drive suite selection. state is still
+   * R_TLS_SERVER_HELLO, so the callback may call r_tls_server_set_cert /
+   * _set_client_cert_mode. A callback error aborts the handshake. */
+  r_tls_server_parse_sni (server);
+  if (server->server_name_cb != NULL) {
+    RTLSError snierr = server->server_name_cb (server->userdata, server->sni, server);
+    if (snierr != R_TLS_ERROR_OK)
+      return snierr;
+  }
 
   if (R_UNLIKELY (server->hello.cslen == 0 || (server->hello.cslen & 1)))
     return R_TLS_ERROR_CORRUPT_RECORD;
@@ -1576,22 +1622,7 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
           return R_TLS_ERROR_ILLEGAL_PARAMETER;
         server->max_fragment = hsext.data[0];
         break;
-      case R_TLS_EXT_TYPE_SERVER_NAME:
-        /* RFC 6066: ServerNameList<1..> of { NameType(1), HostName<1..> }. Keep
-         * the first host_name entry. SNI is advisory, so a malformed list is
-         * ignored rather than fatal (bounds are still checked). */
-        if (hsext.len >= 2) {
-          ruint16 listlen = r_load_be16 (hsext.data);
-          if ((rsize) listlen + 2 <= hsext.len && listlen >= 3 &&
-              hsext.data[2] == 0 /* host_name */) {
-            ruint16 namelen = r_load_be16 (hsext.data + 3);
-            if ((rsize) namelen + 3 <= (rsize) listlen) {
-              r_free (server->sni);
-              server->sni = r_strndup ((const rchar *) (hsext.data + 5), namelen);
-            }
-          }
-        }
-        break;
+      /* server_name (SNI) is parsed earlier, in r_tls_server_parse_sni. */
       default:
         break;
     }
@@ -2121,14 +2152,9 @@ r_tls_server_state_hello (RTLSServer * server, const RTLSParser * parser)
         server, parser->version, server->hello.version);
     server->hellobuf = r_buffer_ref (parser->buf);
 
+    /* nego_hello resolves SNI and fires the server_name callback (cert / policy
+     * / per-host cipher selection) before choosing the cipher suite. */
     if ((err = r_tls_server_nego_hello (server, parser->version, server->hello.version)) == R_TLS_ERROR_OK) {
-      /* SNI is now known; let the app pick the cert / client-cert policy for the
-       * requested name before the server flight. state is still SERVER_HELLO, so
-       * the callback may call r_tls_server_set_cert / _set_client_cert_mode. */
-      if (server->server_name_cb != NULL)
-        err = server->server_name_cb (server->userdata, server->sni, server);
-    }
-    if (err == R_TLS_ERROR_OK) {
       RTLSError rr = r_tls_server_try_resume (server);
       if (rr == R_TLS_ERROR_OK)
         err = r_tls_server_change_state (server, R_TLS_SERVER_CHANGE_CIPHER);

--- a/test/rhttpserver.c
+++ b/test/rhttpserver.c
@@ -955,6 +955,78 @@ RTEST (rhttpserver, vhost_host_case_insensitive, RTEST_FAST)
 }
 RTEST_END;
 
+/* A vhost can restrict its cipher suites: a client whose SNI selects it
+ * negotiates from that list (a static-RSA suite here) rather than the ECDHE
+ * default the listener would otherwise pick. */
+RTEST (rhttpserver, vhost_cipher_suites, RTEST_FAST | RTEST_SYSTEM)
+{
+  static const RTLSCipherSuite only[] = { R_TLS_CS_RSA_WITH_AES_128_GCM_SHA256 };
+  REvLoop * loop;
+  RClock * clock;
+  RHttpServer * srv;
+  RSocketAddress * addr;
+  RCryptoCert * cert;
+  RCryptoKey * pk;
+  RTestTLSClient c = { NULL, NULL, NULL, NULL, NULL, R_TLS_VERSION_UNKNOWN, NULL,
+      FALSE, FALSE };
+
+  r_assert_cmpptr ((clock = r_test_clock_new (FALSE)), !=, NULL);
+  r_assert_cmpptr ((loop = r_ev_loop_new_full (clock, NULL)), !=, NULL);
+  r_clock_unref (clock);
+
+  r_assert_cmpptr ((srv = r_http_server_new (loop)), !=, NULL);
+  r_assert (r_http_server_set_handler (srv, "/", -1,
+        r_test_http_simple_status_handler, RUINT_TO_POINTER (R_HTTP_STATUS_OK), NULL));
+
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (testcertpem, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem, -1, NULL, 0)), !=, NULL);
+  r_assert_cmpptr ((addr = r_socket_address_ipv4_new_uint8 (127, 0, 0, 1, 0)), !=, NULL);
+  r_assert (r_http_server_add_tls_listen_addr (srv, addr, cert, pk));
+  r_socket_address_unref (addr);
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (rtest_leaf_root_pem, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (rtest_leaf_root_key_pem, -1, NULL, 0)), !=, NULL);
+  r_assert (r_http_server_add_vhost (srv, "static.example.com", cert, pk));
+  r_assert (r_http_server_set_vhost_cipher_suites (srv, "static.example.com",
+        only, R_N_ELEMENTS (only)));
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+
+  r_assert_cmpptr ((addr = r_http_server_get_local_address (srv)), !=, NULL);
+
+  r_assert_cmpptr ((c.prng = r_prng_new_mt ()), !=, NULL);
+  r_assert_cmpptr ((c.resp = r_buffer_new ()), !=, NULL);
+  r_assert_cmpptr ((c.tls = r_tls_client_new (&g_test_tls_client_cbs, &c, NULL)), !=, NULL);
+  r_assert_cmpint (R_TLS_ERROR_OK, ==,
+      r_tls_client_set_server_name (c.tls, "static.example.com"));
+  c.loop = loop;
+  r_assert_cmpptr ((c.tcp = r_ev_tcp_new (R_SOCKET_FAMILY_IPV4, loop)), !=, NULL);
+  r_assert_cmpint (r_ev_tcp_connect (c.tcp, addr,
+        r_test_tls_client_connected, &c, NULL), >=, R_SOCKET_OK);
+
+  while (!c.got_response && !c.eos)
+    r_ev_loop_run (loop, R_EV_LOOP_RUN_ONCE);
+
+  r_assert (c.got_response);
+  r_assert_cmpptr (c.cipher, !=, NULL);
+  /* The default would be ECDHE-first; the vhost restricted it to static RSA. */
+  r_assert_cmpint (c.cipher->key_exchange, ==, R_KEY_EXCHANGE_RSA);
+
+  r_ev_tcp_close (c.tcp, NULL, NULL, NULL);
+  r_ev_tcp_unref (c.tcp);
+  r_tls_client_unref (c.tls);
+  r_buffer_unref (c.resp);
+  r_prng_unref (c.prng);
+  r_http_server_stop (srv, NULL, NULL, NULL);
+  r_ev_loop_run (loop, R_EV_LOOP_RUN_LOOP);
+  r_http_server_unref (srv);
+  r_socket_address_unref (addr);
+  r_ev_loop_unref (loop);
+}
+RTEST_END;
+
 typedef struct {
   RHttpRequest * other;     /* a request that is not the one being handled */
   rboolean null_for_req;    /* get_peer_cert (server, req) was NULL */

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -555,6 +555,36 @@ RTEST_F (rtlsclient, sni_name_length_capped, RTEST_FAST)
 }
 RTEST_END;
 
+/* The SNI hook runs before cipher negotiation, so installing an ECDSA cert for
+ * the requested host makes the server negotiate an ECDHE_ECDSA suite (the client
+ * offers both ECDSA and RSA) -- i.e. the SNI-selected cert's key type drives the
+ * cipher choice. The fixture default cert is RSA, so without the early hook the
+ * suite would have been chosen against the wrong key. */
+RTEST_F (rtlsclient, sni_cert_key_type_drives_cipher, RTEST_FAST)
+{
+  r_assert_cmpptr ((fixture->sni_cert =
+      r_pem_parse_cert_from_data (testcertpem_ecdsa, -1)), !=, NULL);
+  r_assert_cmpptr ((fixture->sni_key =
+      r_pem_parse_key_from_data (testpkpem_ecdsa, -1, NULL, 0)), !=, NULL);
+
+  r_assert_cmpint (r_tls_server_set_server_name_cb (fixture->server,
+      r_tlsclient_test_sni), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_set_server_name (fixture->client,
+      "ecdsa.example.com"), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop,
+      fixture->prng), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop,
+      fixture->prng, R_TLS_VERSION_TLS_1_2), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+
+  r_assert (fixture->cli_hs_done);
+  r_assert (fixture->srv_hs_done);
+  r_assert_cmpint (r_tls_client_get_cipher_suite (fixture->client)->key_exchange,
+      ==, R_KEY_EXCHANGE_ECDHE_ECDSA);
+}
+RTEST_END;
+
 RTEST_F (rtlsclient, tls_close_notify_client, RTEST_FAST)
 {
   r_test_tls_close_notify (fixture, R_TLS_VERSION_TLS_1_2, FALSE);


### PR DESCRIPTION
Follow-up to #360 (filed as #369). SNI virtual hosts could vary the certificate
and client-cert policy per host, but not the cipher suites: the `server_name`
callback fired *after* `nego_hello` had already negotiated version, ciphers and
ALPN, so those negotiation inputs couldn't be made per-host.

**net/tls — reorder.** SNI parsing and the `server_name` callback now run at the
top of `nego_hello`, before cipher selection (previously they ran afterwards, in
`state_hello`). The callback installs the per-host certificate before the suite
is chosen, so the cert's key type — and a per-connection cipher preference, since
`preferred_cipher_suites` now sees the SNI — drive suite selection. This also
removes the prior caveat that a callback swapping in a different-key-type cert
could desync the negotiated signature scheme. The `RTLSServerNameCb` signature
and contract are unchanged; only its timing moved.

**net/http — per-vhost cipher.** `r_http_server_set_vhost_cipher_suites` sets a
cipher preference for an SNI vhost; a per-connection `preferred_cipher_suites`
callback offers the selected vhost's list, falling back to the library defaults
for a vhost with no list or a connection matching none.

Tests: a `server_name` callback installing an ECDSA cert makes the server
negotiate `ECDHE_ECDSA` (the client offers both) — proving cert selection now
precedes and drives cipher choice; and an HTTPS vhost restricted to a static-RSA
suite negotiates it rather than the ECDHE default.

ALPN and per-host protocol/min-version remain out of scope (the latter blocked on
TLS 1.3, #329); both are now mechanically unblocked by this reorder.

Closes #369