### PR TITLE
net/tls: complete the TLS 1.3 handshake (HRR, resumption, 0-RTT, downgrade protection)

### DIFF
--- a/include/rlib/net/proto/rtls.h
+++ b/include/rlib/net/proto/rtls.h
@@ -578,8 +578,8 @@ R_API RTLSError r_tls_parser_parse_new_session_ticket (const RTLSParser * parser
  * The 1.3 message adds @c ticket_age_add, a @c ticket_nonce and a trailing
  * @c Extension list around the ticket, so it differs from the 1.2 layout parsed
  * by @ref r_tls_parser_parse_new_session_ticket. Out pointers point into the
- * record buffer. The trailing extensions are validated for length but not
- * returned.
+ * record buffer. The trailing extensions are validated for length; only the
+ * @c early_data @c max_early_data_size is surfaced (@p max_early_data).
  * @param parser Parser positioned on the message.
  * @param lifetime Out: ticket_lifetime in seconds (may be @c NULL).
  * @param age_add Out: ticket_age_add (may be @c NULL).
@@ -587,11 +587,13 @@ R_API RTLSError r_tls_parser_parse_new_session_ticket (const RTLSParser * parser
  * @param noncelen Out: ticket_nonce length (may be @c NULL).
  * @param ticket Out: pointer to the ticket bytes (may be @c NULL).
  * @param ticketsize Out: ticket length in bytes (may be @c NULL).
+ * @param max_early_data Out: the @c early_data extension's @c max_early_data_size,
+ *  or 0 if the ticket carries no @c early_data extension (may be @c NULL).
  */
 R_API RTLSError r_tls_parser_parse_new_session_ticket13 (const RTLSParser * parser,
     ruint32 * lifetime, ruint32 * age_add,
     const ruint8 ** nonce, ruint8 * noncelen,
-    const ruint8 ** ticket, ruint16 * ticketsize);
+    const ruint8 ** ticket, ruint16 * ticketsize, ruint32 * max_early_data);
 /**
  * @brief Parse the current record as a CertificateVerify.
  * @param parser Parser positioned on the message.
@@ -1074,8 +1076,9 @@ R_API RTLSError r_tls_write_hs_new_session_ticket (rpointer buf, rsize size, rsi
  * @brief Write a TLS 1.3 NewSessionTicket handshake-message body (RFC 8446 4.6.1).
  *
  * Emits @c ticket_lifetime, @c ticket_age_add, the @c ticket_nonce, the
- * @c ticket, and an empty @c Extension list. The caller frames the handshake
- * header and protects the record.
+ * @c ticket, and an @c Extension list carrying an @c early_data extension
+ * (@c max_early_data_size) when @p max_early_data is non-zero, else empty. The
+ * caller frames the handshake header and protects the record.
  * @param buf Destination buffer.
  * @param size Capacity of @p buf in bytes.
  * @param out Out: bytes written.
@@ -1085,10 +1088,26 @@ R_API RTLSError r_tls_write_hs_new_session_ticket (rpointer buf, rsize size, rsi
  * @param noncelen ticket_nonce length, at most 255.
  * @param ticket Ticket bytes.
  * @param tsize Ticket length in bytes (1..65535).
+ * @param max_early_data The 0-RTT @c max_early_data_size to advertise, or 0 to
+ *  omit the @c early_data extension (no 0-RTT with this ticket).
  */
 R_API RTLSError r_tls_write_hs_new_session_ticket13 (rpointer buf, rsize size, rsize * out,
     ruint32 lifetime, ruint32 age_add, const ruint8 * nonce, ruint8 noncelen,
-    const ruint8 * ticket, ruint16 tsize);
+    const ruint8 * ticket, ruint16 tsize, ruint32 max_early_data);
+
+/**
+ * @brief Write an EndOfEarlyData handshake-message body (RFC 8446, 4.5).
+ *
+ * The message has an empty body; this writes nothing and reports a zero length.
+ * The caller frames the handshake header and protects the record (under the
+ * client early-traffic key). Provided for symmetry so callers need not special-
+ * case the empty body.
+ * @param buf Destination buffer (unused; may be @c NULL).
+ * @param size Capacity of @p buf in bytes.
+ * @param out Out: bytes written (always 0).
+ */
+R_API RTLSError r_tls_write_hs_end_of_early_data (rpointer buf, rsize size,
+    rsize * out);
 
 /**
  * @brief Write a CertificateRequest handshake-message body into @p buf.

--- a/include/rlib/net/proto/rtls.h
+++ b/include/rlib/net/proto/rtls.h
@@ -228,6 +228,12 @@ typedef enum {
   R_TLS_EXT_TYPE_RENEGOTIATION_INFO                     = 0xff01, /* [RFC5746] */
 } RTLSExtensionType;
 
+/** @brief PSK key-exchange mode for the psk_key_exchange_modes extension (RFC 8446 4.2.9). */
+typedef enum {
+  R_TLS_PSK_KE_MODE_PSK_KE                              = 0x00, /* PSK-only key establishment */
+  R_TLS_PSK_KE_MODE_PSK_DHE_KE                          = 0x01, /* PSK with (EC)DHE */
+} RTLSPskKeyExchangeMode;
+
 /** @brief Named group / elliptic curve for key exchange (IANA TLS Supported Groups). */
 /* http://www.iana.org/assignments/tls-parameters/#tls-parameters-8 */
 typedef enum {
@@ -433,6 +439,16 @@ typedef struct {
 /** @brief Static initialiser for an empty @ref RTLSKeyShareEntry. */
 #define R_TLS_KEY_SHARE_ENTRY_INIT          { NULL, 0, 0, NULL }
 
+/** @brief One PskIdentity from a ClientHello pre_shared_key extension (RFC 8446). */
+typedef struct {
+  const ruint8 *  start;   /**< @brief First octet of the entry (its identity-length field). */
+  const ruint8 *  identity;/**< @brief Pointer to the identity (ticket) octets. */
+  ruint16         len;     /**< @brief Identity length in bytes. */
+  ruint32         age;     /**< @brief obfuscated_ticket_age. */
+} RTLSPskIdentity;
+/** @brief Static initialiser for an empty @ref RTLSPskIdentity. */
+#define R_TLS_PSK_IDENTITY_INIT             { NULL, NULL, 0, 0 }
+
 /** @brief One certificate entry from a Certificate handshake message. */
 typedef struct {
   const ruint8 * start;    /**< @brief First octet of the entry (its length field). */
@@ -556,6 +572,26 @@ R_API RTLSError r_tls_parser_parse_certificate_request (const RTLSParser * parse
  */
 R_API RTLSError r_tls_parser_parse_new_session_ticket (const RTLSParser * parser,
     ruint32 * lifetime, const ruint8 ** ticket, ruint16 * ticketsize);
+/**
+ * @brief Parse the current record as a TLS 1.3 NewSessionTicket (RFC 8446 4.6.1).
+ *
+ * The 1.3 message adds @c ticket_age_add, a @c ticket_nonce and a trailing
+ * @c Extension list around the ticket, so it differs from the 1.2 layout parsed
+ * by @ref r_tls_parser_parse_new_session_ticket. Out pointers point into the
+ * record buffer. The trailing extensions are validated for length but not
+ * returned.
+ * @param parser Parser positioned on the message.
+ * @param lifetime Out: ticket_lifetime in seconds (may be @c NULL).
+ * @param age_add Out: ticket_age_add (may be @c NULL).
+ * @param nonce Out: pointer to the ticket_nonce bytes (may be @c NULL).
+ * @param noncelen Out: ticket_nonce length (may be @c NULL).
+ * @param ticket Out: pointer to the ticket bytes (may be @c NULL).
+ * @param ticketsize Out: ticket length in bytes (may be @c NULL).
+ */
+R_API RTLSError r_tls_parser_parse_new_session_ticket13 (const RTLSParser * parser,
+    ruint32 * lifetime, ruint32 * age_add,
+    const ruint8 ** nonce, ruint8 * noncelen,
+    const ruint8 ** ticket, ruint16 * ticketsize);
 /**
  * @brief Parse the current record as a CertificateVerify.
  * @param parser Parser positioned on the message.
@@ -799,6 +835,76 @@ static inline const ruint8 * r_tls_hello_ext_cookie (const RTLSHelloExt * ext, r
 }
 /** @} */
 
+/** @name pre_shared_key / psk_key_exchange_modes accessors (RFC 8446)
+ *  @{ */
+/**
+ * @brief Whether a psk_key_exchange_modes extension @p ext offers @p mode.
+ *
+ * The extension data is @c PskKeyExchangeMode ke_modes<1..255>: a uint8 length
+ * then the mode octets, clamped to @p ext's declared length (RFC 8446 4.2.9).
+ * @param ext  The psk_key_exchange_modes extension.
+ * @param mode The mode to look for (e.g. @ref R_TLS_PSK_KE_MODE_PSK_DHE_KE).
+ * @return @c TRUE if @p mode is listed.
+ */
+static inline rboolean r_tls_hello_ext_psk_ke_modes_contains (const RTLSHelloExt * ext,
+    ruint8 mode)
+{
+  ruint8 n, i;
+  if (ext->len < 1) return FALSE;
+  n = MIN (ext->data[0], (ruint8) (ext->len - 1));
+  for (i = 0; i < n; i++)
+    if (ext->data[1 + i] == mode) return TRUE;
+  return FALSE;
+}
+
+/**
+ * @brief Read the first PskIdentity of a ClientHello pre_shared_key @p ext.
+ *
+ * Walks the @c PskIdentity list (a uint16 length prefix then
+ * @c {opaque identity<1..2^16-1>; uint32 obfuscated_ticket_age} records)
+ * strictly within @p ext's declared length; @p ident points into the buffer.
+ * @return @c R_TLS_ERROR_OK, @c R_TLS_ERROR_EOB once exhausted or truncated, or
+ *  @c R_TLS_ERROR_INVAL on a @c NULL argument.
+ */
+R_API RTLSError r_tls_hello_ext_psk_identity_first (const RTLSHelloExt * ext,
+    RTLSPskIdentity * ident);
+/** @brief Advance @p ident to the next PskIdentity; restarts from the first when
+ * @p ident is empty. @see r_tls_hello_ext_psk_identity_first */
+R_API RTLSError r_tls_hello_ext_psk_identity_next (const RTLSHelloExt * ext,
+    RTLSPskIdentity * ident);
+/**
+ * @brief Read the @p n-th PskBinderEntry of a ClientHello pre_shared_key @p ext.
+ *
+ * The binders list follows the identities list; entry @p n must exist for the
+ * offer to be well-formed (one binder per identity, in order).
+ * @param ext     The pre_shared_key extension.
+ * @param n       Zero-based binder index.
+ * @param binder  Out: pointer to the binder octets.
+ * @param binderlen Out: binder length in bytes.
+ * @return @c R_TLS_ERROR_OK, or @c R_TLS_ERROR_EOB if absent / truncated.
+ */
+R_API RTLSError r_tls_hello_ext_psk_binder (const RTLSHelloExt * ext, ruint n,
+    const ruint8 ** binder, ruint8 * binderlen);
+/**
+ * @brief The truncation point for the pre_shared_key binder transcript.
+ *
+ * The binders are computed over the ClientHello up to and including the
+ * identities, i.e. ending just before the binders-list length field. This
+ * returns a pointer to that field, so the caller hashes from the handshake
+ * message start up to (but not including) it (RFC 8446 4.2.11.2).
+ * @param ext The pre_shared_key extension.
+ * @return Pointer to the binders-list length field, or @c NULL if malformed.
+ */
+static inline const ruint8 * r_tls_hello_ext_psk_binders_start (const RTLSHelloExt * ext)
+{
+  ruint16 idlen;
+  if (ext->len < sizeof (ruint16)) return NULL;
+  idlen = r_load_be16 (ext->data);
+  if ((rsize) sizeof (ruint16) + idlen + sizeof (ruint16) > ext->len) return NULL;
+  return ext->data + sizeof (ruint16) + idlen;
+}
+/** @} */
+
 
 /** @brief Decode the certificate entry @p cert into an @c RCryptoCert (caller owns the result). */
 R_API RCryptoCert * r_tls_certificate_get_cert (const RTLSCertificate * cert);
@@ -964,6 +1070,25 @@ R_API RTLSError r_tls_write_hs_new_session_ticket (rpointer buf, rsize size, rsi
     ruint32 lifetime, const ruint8 * ticket, ruint16 tsize);
 /** @brief DTLS alias for @ref r_tls_write_hs_new_session_ticket. */
 #define r_dtls_write_hs_new_session_ticket r_tls_write_hs_new_session_ticket
+/**
+ * @brief Write a TLS 1.3 NewSessionTicket handshake-message body (RFC 8446 4.6.1).
+ *
+ * Emits @c ticket_lifetime, @c ticket_age_add, the @c ticket_nonce, the
+ * @c ticket, and an empty @c Extension list. The caller frames the handshake
+ * header and protects the record.
+ * @param buf Destination buffer.
+ * @param size Capacity of @p buf in bytes.
+ * @param out Out: bytes written.
+ * @param lifetime ticket_lifetime hint in seconds.
+ * @param age_add ticket_age_add (random per ticket).
+ * @param nonce ticket_nonce bytes; may be @c NULL when @p noncelen is 0.
+ * @param noncelen ticket_nonce length, at most 255.
+ * @param ticket Ticket bytes.
+ * @param tsize Ticket length in bytes (1..65535).
+ */
+R_API RTLSError r_tls_write_hs_new_session_ticket13 (rpointer buf, rsize size, rsize * out,
+    ruint32 lifetime, ruint32 age_add, const ruint8 * nonce, ruint8 noncelen,
+    const ruint8 * ticket, ruint16 tsize);
 
 /**
  * @brief Write a CertificateRequest handshake-message body into @p buf.

--- a/include/rlib/net/proto/rtls.h
+++ b/include/rlib/net/proto/rtls.h
@@ -778,6 +778,27 @@ static inline RTLSSupportedGroup r_tls_hello_ext_key_share_group (const RTLSHell
 { return (RTLSSupportedGroup) (ext->len >= sizeof (ruint16) ? r_load_be16 (ext->data) : 0); }
 /** @} */
 
+/** @name cookie extension accessor (RFC 8446)
+ *  @{ */
+/**
+ * @brief Read the cookie carried by a cookie extension @p ext (RFC 8446 4.2.2).
+ *
+ * The extension data is @c opaque cookie<1..2^16-1>: a uint16 length then the
+ * cookie bytes, clamped to @p ext's declared length.
+ * @param ext The cookie extension.
+ * @param len Out: cookie length in bytes.
+ * @return Pointer to the cookie bytes, or @c NULL if malformed (with @p len 0).
+ */
+static inline const ruint8 * r_tls_hello_ext_cookie (const RTLSHelloExt * ext, ruint16 * len)
+{
+  ruint16 l;
+  if (ext->len < sizeof (ruint16)) { *len = 0; return NULL; }
+  l = r_load_be16 (ext->data);
+  *len = MIN (l, (ruint16) (ext->len - sizeof (ruint16)));
+  return ext->data + sizeof (ruint16);
+}
+/** @} */
+
 
 /** @brief Decode the certificate entry @p cert into an @c RCryptoCert (caller owns the result). */
 R_API RCryptoCert * r_tls_certificate_get_cert (const RTLSCertificate * cert);

--- a/include/rlib/net/proto/rtls13.h
+++ b/include/rlib/net/proto/rtls13.h
@@ -298,6 +298,42 @@ R_API rboolean r_tls13_cert_verify_tbs (rboolean server,
     const ruint8 * transcript_hash, rsize thlen,
     ruint8 * out, rsize outsize, rsize * outlen);
 
+/**
+ * @brief Write the special HelloRetryRequest random (RFC 8446, section 4.1.3).
+ *
+ * A HelloRetryRequest is a ServerHello whose @c random is the fixed value
+ * @c SHA-256("HelloRetryRequest"); this fills @p out with it.
+ *
+ * @param out Destination for the @ref R_TLS_HELLO_RANDOM_BYTES-byte value.
+ */
+R_API void r_tls13_hello_retry_random (ruint8 * out);
+
+/**
+ * @brief Whether a ServerHello @p random is the HelloRetryRequest sentinel.
+ * @param random A ServerHello random field; @ref R_TLS_HELLO_RANDOM_BYTES bytes.
+ * @return @c TRUE if @p random equals @c SHA-256("HelloRetryRequest").
+ */
+R_API rboolean r_tls13_random_is_hrr (const ruint8 * random);
+
+/**
+ * @brief Build the synthetic @c message_hash handshake message (RFC 8446, 4.4.1).
+ *
+ * When a HelloRetryRequest is used the transcript replaces the first
+ * ClientHello with @c Handshake(message_hash) carrying @c Hash(ClientHello1):
+ * the handshake header (@c message_hash type @c 0xfe and a 3-byte length) over a
+ * body of @c Hash(@p msg). The caller folds the result into the transcript.
+ *
+ * @param hash   Cipher-suite hash.
+ * @param msg    The first ClientHello (handshake header + body).
+ * @param msglen Length of @p msg.
+ * @param out    Destination for the @c message_hash handshake message.
+ * @param outsize Capacity of @p out (at least @c 4 + HashLen).
+ * @param outlen  Out: bytes written (@c 4 + HashLen).
+ * @return @c TRUE on success; @c FALSE on invalid arguments / too-small @p out.
+ */
+R_API rboolean r_tls13_message_hash (RMsgDigestType hash,
+    const ruint8 * msg, rsize msglen, ruint8 * out, rsize outsize, rsize * outlen);
+
 R_END_DECLS
 
 /** @} */

--- a/include/rlib/net/proto/rtls13.h
+++ b/include/rlib/net/proto/rtls13.h
@@ -407,6 +407,36 @@ R_API void r_tls13_hello_retry_random (ruint8 * out);
 R_API rboolean r_tls13_random_is_hrr (const ruint8 * random);
 
 /**
+ * @brief Stamp the downgrade-protection sentinel into a ServerHello @p random
+ * (RFC 8446, section 4.1.3).
+ *
+ * A server that supports TLS 1.3 but settles on a lower version overwrites the
+ * last eight bytes of its ServerHello.random with a fixed sentinel so that a
+ * 1.3-capable client can detect a forced downgrade: @c "DOWNGRD\x01"
+ * (@c 44 4F 57 4E 47 52 44 01) when negotiating TLS 1.2, or @c "DOWNGRD\x00"
+ * when negotiating TLS 1.1 or below. For any other @p negotiated version
+ * (including 1.3 itself) @p random is left unchanged.
+ *
+ * @param random     ServerHello random to stamp; @ref R_TLS_HELLO_RANDOM_BYTES
+ *                   bytes. The leading bytes are preserved.
+ * @param negotiated The version the server selected.
+ */
+R_API void r_tls13_downgrade_random (ruint8 * random, RTLSVersion negotiated);
+
+/**
+ * @brief Whether a ServerHello @p random carries a downgrade sentinel.
+ *
+ * A 1.3-capable client that offered TLS 1.3 but was answered with a lower
+ * version checks the ServerHello.random with this; a @c TRUE result is a
+ * detected downgrade and the client must abort with @c illegal_parameter
+ * (RFC 8446, section 4.1.3).
+ *
+ * @param random A ServerHello random field; @ref R_TLS_HELLO_RANDOM_BYTES bytes.
+ * @return @c TRUE if the last eight bytes equal either downgrade sentinel.
+ */
+R_API rboolean r_tls13_random_is_downgrade (const ruint8 * random);
+
+/**
  * @brief Build the synthetic @c message_hash handshake message (RFC 8446, 4.4.1).
  *
  * When a HelloRetryRequest is used the transcript replaces the first

--- a/include/rlib/net/proto/rtls13.h
+++ b/include/rlib/net/proto/rtls13.h
@@ -189,6 +189,7 @@ typedef struct {
   ruint8 shs[R_TLS13_SECRET_MAX];        /**< @brief server_handshake_traffic_secret. */
   ruint8 cap[R_TLS13_SECRET_MAX];        /**< @brief client_application_traffic_secret_0. */
   ruint8 sap[R_TLS13_SECRET_MAX];        /**< @brief server_application_traffic_secret_0. */
+  ruint8 res_master[R_TLS13_SECRET_MAX]; /**< @brief resumption_master_secret. */
 } RTLS13Schedule;
 
 /**
@@ -201,6 +202,40 @@ typedef struct {
  * @return @c TRUE on success; @c FALSE on an unsupported hash.
  */
 R_API rboolean r_tls13_schedule_init (RTLS13Schedule * sched, RMsgDigestType hash);
+
+/**
+ * @brief Initialise the key schedule with a resumption PSK.
+ *
+ * The Early Secret becomes @c HKDF-Extract(0, PSK) instead of the PSK-less
+ * @c HKDF-Extract(0, 0^HashLen); the caller drives the rest of the schedule
+ * (@ref r_tls13_schedule_handshake, @ref r_tls13_schedule_master) exactly as in
+ * the full handshake. The @p psk is the ticket-derived secret from
+ * @ref r_tls13_resumption_psk and its length is the suite's @c HashLen.
+ *
+ * @param sched  Schedule to initialise.
+ * @param hash   Cipher-suite hash (SHA-256 / SHA-384).
+ * @param psk    The pre-shared key; @c HashLen bytes.
+ * @param psklen Length of @p psk.
+ * @return @c TRUE on success; @c FALSE on an unsupported hash or @c NULL @p psk.
+ */
+R_API rboolean r_tls13_schedule_init_psk (RTLS13Schedule * sched,
+    RMsgDigestType hash, const ruint8 * psk, rsize psklen);
+
+/**
+ * @brief Derive the resumption binder key (RFC 8446, section 7.1).
+ *
+ * @c binder_key = Derive-Secret(Early, "res binder", ""). The caller expands it
+ * into a Finished key with @ref r_tls13_finished_key and computes the
+ * @c pre_shared_key binder over the partial ClientHello transcript with
+ * @ref r_tls13_verify_data, the same construction as a Finished message.
+ *
+ * @param sched Schedule whose Early Secret was set from the PSK
+ *              (@ref r_tls13_schedule_init_psk, or @ref r_tls13_schedule_init
+ *              for the PSK-less binder in an external-PSK offer).
+ * @param out   Destination for the @c HashLen-byte binder key.
+ * @return @c TRUE on success.
+ */
+R_API rboolean r_tls13_binder_key (const RTLS13Schedule * sched, ruint8 * out);
 
 /**
  * @brief Derive the Handshake Secret and the handshake-traffic secrets.
@@ -231,6 +266,43 @@ R_API rboolean r_tls13_schedule_handshake (RTLS13Schedule * sched,
  */
 R_API rboolean r_tls13_schedule_master (RTLS13Schedule * sched,
     const ruint8 * transcript_hash);
+
+/**
+ * @brief Derive the resumption master secret (RFC 8446, section 7.1).
+ *
+ * @c resumption_master_secret = Derive-Secret(Master, "res master",
+ * Transcript-Hash(ClientHello..client Finished)); stored in @c sched->res_master
+ * for @ref r_tls13_resumption_psk to expand into per-ticket PSKs. Bound to the
+ * transcript through the client Finished, so it is derived once the handshake
+ * has completed (unlike the application secrets, bound through the server
+ * Finished).
+ *
+ * @param sched           Schedule, already @ref r_tls13_schedule_master.
+ * @param transcript_hash @c Transcript-Hash(ClientHello..client Finished); @c HashLen bytes.
+ * @return @c TRUE on success.
+ */
+R_API rboolean r_tls13_schedule_resumption (RTLS13Schedule * sched,
+    const ruint8 * transcript_hash);
+
+/**
+ * @brief Expand a per-ticket resumption PSK (RFC 8446, section 4.6.1).
+ *
+ * @c PSK = HKDF-Expand-Label(resumption_master_secret, "resumption",
+ * ticket_nonce, HashLen): the pre-shared key a NewSessionTicket represents,
+ * bound to that ticket's @p nonce so distinct tickets from one connection yield
+ * distinct PSKs.
+ *
+ * @param hash       Cipher-suite hash.
+ * @param res_master The resumption master secret (@ref RTLS13Schedule.res_master);
+ *                   @c HashLen bytes.
+ * @param nonce      The ticket_nonce; may be @c NULL when @p noncelen is 0.
+ * @param noncelen   Length of @p nonce, at most 255.
+ * @param out        Destination for the @c HashLen-byte PSK.
+ * @return @c TRUE on success; @c FALSE on invalid arguments.
+ */
+R_API rboolean r_tls13_resumption_psk (RMsgDigestType hash,
+    const ruint8 * res_master, const ruint8 * nonce, rsize noncelen,
+    ruint8 * out);
 
 /**
  * @brief Derive the @c "key" / @c "iv" traffic keys from a traffic secret.

--- a/include/rlib/net/proto/rtls13.h
+++ b/include/rlib/net/proto/rtls13.h
@@ -190,6 +190,7 @@ typedef struct {
   ruint8 cap[R_TLS13_SECRET_MAX];        /**< @brief client_application_traffic_secret_0. */
   ruint8 sap[R_TLS13_SECRET_MAX];        /**< @brief server_application_traffic_secret_0. */
   ruint8 res_master[R_TLS13_SECRET_MAX]; /**< @brief resumption_master_secret. */
+  ruint8 cet[R_TLS13_SECRET_MAX];        /**< @brief client_early_traffic_secret. */
 } RTLS13Schedule;
 
 /**
@@ -236,6 +237,24 @@ R_API rboolean r_tls13_schedule_init_psk (RTLS13Schedule * sched,
  * @return @c TRUE on success.
  */
 R_API rboolean r_tls13_binder_key (const RTLS13Schedule * sched, ruint8 * out);
+
+/**
+ * @brief Derive the client early-traffic secret for 0-RTT (RFC 8446, 7.1).
+ *
+ * @c client_early_traffic_secret = Derive-Secret(Early, "c e traffic",
+ * Transcript-Hash(ClientHello)); stored in @c sched->cet. It protects the 0-RTT
+ * data the client sends immediately after a resumption ClientHello (and the
+ * @c EndOfEarlyData that closes the early-data flow), so it is bound to the
+ * ClientHello alone -- before the ServerHello, unlike the handshake secrets.
+ * The Early Secret must have been set from the ticket PSK
+ * (@ref r_tls13_schedule_init_psk).
+ *
+ * @param sched           Schedule whose Early Secret was set from the PSK.
+ * @param transcript_hash @c Transcript-Hash(ClientHello); @c HashLen bytes.
+ * @return @c TRUE on success; @c FALSE on invalid arguments.
+ */
+R_API rboolean r_tls13_schedule_early (RTLS13Schedule * sched,
+    const ruint8 * transcript_hash);
 
 /**
  * @brief Derive the Handshake Secret and the handshake-traffic secrets.

--- a/include/rlib/net/rtlsclient.h
+++ b/include/rlib/net/rtlsclient.h
@@ -65,6 +65,20 @@ R_BEGIN_DECLS
 /** @brief Opaque, refcounted TLS / DTLS client session. */
 typedef struct RTLSClient RTLSClient;
 
+/**
+ * @brief Opaque, refcounted TLS 1.3 resumption session (RFC 8446).
+ *
+ * Carries a NewSessionTicket the server issued and the pre-shared key derived
+ * from it, so a later @ref RTLSClient can resume without a full handshake.
+ * Obtain one with @ref r_tls_client_get_session after a 1.3 handshake, and
+ * feed it to a new client with @ref r_tls_client_set_session before starting.
+ */
+typedef struct RTLSClientSession RTLSClientSession;
+/** @brief Take a reference on a resumption session (alias for @ref r_ref_ref). */
+#define r_tls_client_session_ref    r_ref_ref
+/** @brief Drop a reference; scrubs the PSK at zero (alias for @ref r_ref_unref). */
+#define r_tls_client_session_unref  r_ref_unref
+
 /** @brief Create a TLS client with the given callbacks and user context. */
 R_API RTLSClient * r_tls_client_new (const RTLSCallbacks * cb,
     rpointer userdata, RDestroyNotify notify) R_ATTR_MALLOC;
@@ -95,6 +109,27 @@ R_API RTLSError r_tls_client_set_server_name (RTLSClient * client,
 /** @brief Override the client-random (testing / determinism). */
 R_API RTLSError r_tls_client_set_random (RTLSClient * client,
     const ruint8 clirandom[R_TLS_HELLO_RANDOM_BYTES]);
+/**
+ * @brief Offer @p session for TLS 1.3 resumption in the next handshake.
+ *
+ * The ClientHello will carry the session's ticket in a @c pre_shared_key
+ * extension (with @c psk_dhe_ke); if the server accepts, the handshake is
+ * abbreviated and no server certificate is exchanged. Must be called before
+ * @ref r_tls_client_start and only applies when starting with
+ * @c R_TLS_VERSION_TLS_1_3. The client takes its own reference; pass @c NULL to
+ * clear. A server that declines simply runs a full handshake.
+ */
+R_API RTLSError r_tls_client_set_session (RTLSClient * client,
+    RTLSClientSession * session);
+/**
+ * @brief The resumption session from the server's NewSessionTicket, or @c NULL.
+ *
+ * Available once a 1.3 handshake has completed and the server has issued a
+ * ticket. The caller owns the returned reference (release with
+ * @ref r_tls_client_session_unref) and may feed it to a future client via
+ * @ref r_tls_client_set_session.
+ */
+R_API RTLSClientSession * r_tls_client_get_session (const RTLSClient * client);
 /**
  * @brief Start the session on @p loop, drawing randomness from @p prng, and
  * emit the ClientHello offering @p version (@c R_TLS_VERSION_TLS_1_2 or

--- a/include/rlib/net/rtlsclient.h
+++ b/include/rlib/net/rtlsclient.h
@@ -131,6 +131,34 @@ R_API RTLSError r_tls_client_set_session (RTLSClient * client,
  */
 R_API RTLSClientSession * r_tls_client_get_session (const RTLSClient * client);
 /**
+ * @brief Queue @p buffer as TLS 1.3 0-RTT early data for the next handshake.
+ *
+ * When the offered @ref RTLSClient session (@ref r_tls_client_set_session)
+ * permits early data, the client sends @p buffer encrypted under the client
+ * early-traffic key immediately after the ClientHello, before the handshake
+ * completes (RFC 8446 2.3). If the server accepts, the peer receives it through
+ * its @c appdata callback during the handshake; if the server rejects 0-RTT (or
+ * the session does not permit it, or @p buffer exceeds the ticket's
+ * @c max_early_data_size), the client transparently resends @p buffer as
+ * ordinary application data once the handshake completes, so the payload is
+ * delivered either way. Must be called before @ref r_tls_client_start; the
+ * client takes a reference on @p buffer. Pass @c NULL to clear.
+ *
+ * @warning 0-RTT data is not forward secret and may be replayed; only use it for
+ * idempotent requests (see @ref r_tls_server_set_max_early_data_size).
+ */
+R_API RTLSError r_tls_client_set_early_data (RTLSClient * client,
+    RBuffer * buffer);
+/**
+ * @brief Whether the server accepted the 0-RTT early data offered this handshake.
+ *
+ * @c TRUE once the server has echoed the @c early_data extension, i.e. the data
+ * set with @ref r_tls_client_set_early_data was delivered as 0-RTT. When @c FALSE
+ * after the handshake the data was (or will be) resent as ordinary application
+ * data. Meaningful once the handshake has progressed past EncryptedExtensions.
+ */
+R_API rboolean r_tls_client_get_early_data_accepted (const RTLSClient * client);
+/**
  * @brief Start the session on @p loop, drawing randomness from @p prng, and
  * emit the ClientHello offering @p version (@c R_TLS_VERSION_TLS_1_2 or
  * @c R_TLS_VERSION_DTLS_1_2).

--- a/include/rlib/net/rtlsclient.h
+++ b/include/rlib/net/rtlsclient.h
@@ -106,6 +106,22 @@ R_API RTLSError r_tls_client_set_cert (RTLSClient * client,
  */
 R_API RTLSError r_tls_client_set_server_name (RTLSClient * client,
     const rchar * host);
+/**
+ * @brief Constrain the TLS versions the client offers.
+ *
+ * Both bounds lie in the window @c R_TLS_VERSION_TLS_1_2 ..
+ * @c R_TLS_VERSION_TLS_1_3; @p min must not exceed @p max. The ClientHello
+ * offers every version in the range (a @c [1.2, 1.3] range sends a hybrid
+ * ClientHello that a server may answer with either), and a ServerHello outside
+ * the range is refused. Without this call the range defaults to @c [1.2, @p
+ * version] from @ref r_tls_client_start, so starting at 1.3 offers both 1.3 and
+ * 1.2 (the common modern default) and starting at 1.2 offers 1.2 only; setting
+ * @c [1.3, 1.3] pins the client to 1.3 with no downgrade. When set, the version
+ * passed to @ref r_tls_client_start only selects TLS versus DTLS. Must be called
+ * before @ref r_tls_client_start; DTLS is fixed at 1.2 and unaffected.
+ */
+R_API RTLSError r_tls_client_set_version_range (RTLSClient * client,
+    RTLSVersion min, RTLSVersion max);
 /** @brief Override the client-random (testing / determinism). */
 R_API RTLSError r_tls_client_set_random (RTLSClient * client,
     const ruint8 clirandom[R_TLS_HELLO_RANDOM_BYTES]);

--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -211,6 +211,34 @@ R_API const rchar * r_tls_server_get_server_name (const RTLSServer * server);
 R_API RTLSError r_tls_server_set_session_ticket_keys (RTLSServer * server,
     RTLSSessionTicketKeys * keys);
 /**
+ * @brief Enable TLS 1.3 0-RTT early data, accepting up to @p size bytes.
+ *
+ * Opt in to 0-RTT (RFC 8446 2.3): the NewSessionTicket then advertises an
+ * @c early_data extension with @p size as @c max_early_data_size, and a later
+ * resumption that offers @c early_data is accepted -- the server decrypts the
+ * client's 0-RTT records under the client early-traffic key and delivers them
+ * through the @c appdata callback before the handshake completes. Requires a
+ * session-ticket key store (@ref r_tls_server_set_session_ticket_keys); with
+ * @p size 0 (the default) the server neither advertises nor accepts early data.
+ *
+ * @warning 0-RTT data carries no forward secrecy and, because the tickets are
+ * stateless, this implementation provides no replay protection beyond the
+ * ticket lifetime: an on-path attacker may replay the early-data records and the
+ * server will accept them again. Enable this only when the 0-RTT-triggered
+ * application actions are idempotent (RFC 8446 8, appendix E.5). The 1-RTT data
+ * that follows the handshake is unaffected.
+ */
+R_API RTLSError r_tls_server_set_max_early_data_size (RTLSServer * server,
+    ruint32 size);
+/**
+ * @brief Whether the current handshake accepted TLS 1.3 0-RTT early data.
+ *
+ * @c TRUE once a resumption offered early data and the server accepted it (see
+ * @ref r_tls_server_set_max_early_data_size); the early-data bytes are delivered
+ * via the @c appdata callback during the handshake.
+ */
+R_API rboolean r_tls_server_get_early_data_accepted (const RTLSServer * server);
+/**
  * @brief Require a specific (EC)DHE group of TLS 1.3 clients (RFC 8446).
  *
  * When set, a TLS 1.3 ClientHello that does not carry a @c key_share for

--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -172,6 +172,21 @@ typedef enum {
 R_API RTLSError r_tls_server_set_cert (RTLSServer * server,
     RCryptoCert * cert, RCryptoKey * privkey);
 /**
+ * @brief Constrain the TLS versions the server will negotiate.
+ *
+ * Both bounds lie in the configurable window @c R_TLS_VERSION_TLS_1_2 ..
+ * @c R_TLS_VERSION_TLS_1_3 (the default range); @p min must not exceed @p max.
+ * A ClientHello that can only reach below @p min is rejected with a
+ * @c protocol_version alert. Capping @p max at @c R_TLS_VERSION_TLS_1_2 makes
+ * the server a genuine 1.2-only peer: it ignores a client's 1.3 offer and,
+ * being no longer 1.3-capable, does not stamp the RFC 8446 4.1.3 downgrade
+ * sentinel, so a 1.3-capable client falls back to 1.2 without treating it as an
+ * attack. Must be set before the handshake starts; DTLS is fixed at 1.2 and
+ * unaffected.
+ */
+R_API RTLSError r_tls_server_set_version_range (RTLSServer * server,
+    RTLSVersion min, RTLSVersion max);
+/**
  * @brief Set the client-certificate (mutual-TLS) policy; defaults to
  * @ref R_TLS_CLIENT_CERT_MODE_NONE. Must be set before the handshake starts.
  */

--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -211,6 +211,18 @@ R_API const rchar * r_tls_server_get_server_name (const RTLSServer * server);
 R_API RTLSError r_tls_server_set_session_ticket_keys (RTLSServer * server,
     RTLSSessionTicketKeys * keys);
 /**
+ * @brief Require a specific (EC)DHE group of TLS 1.3 clients (RFC 8446).
+ *
+ * When set, a TLS 1.3 ClientHello that does not carry a @c key_share for
+ * @p group is answered with a HelloRetryRequest asking for it (provided the
+ * client lists @p group in @c supported_groups); the client then retries with a
+ * matching share. With @p group 0 (the default) the server accepts the client's
+ * first offered key_share and never sends a HelloRetryRequest. Must be set
+ * before the handshake starts.
+ */
+R_API RTLSError r_tls_server_set_key_share_group (RTLSServer * server,
+    RTLSSupportedGroup group);
+/**
  * @brief Configure the application protocols the server supports for ALPN
  * (RFC 7301), in descending order of preference.
  *

--- a/include/rlib/net/rtlssessiontickets.h
+++ b/include/rlib/net/rtlssessiontickets.h
@@ -65,6 +65,21 @@ R_API RTLSSessionTicketKeys * r_tls_session_ticket_keys_new (void) R_ATTR_MALLOC
 /** @brief Decrement the refcount; scrubs and frees the key material at zero. */
 #define r_tls_session_ticket_keys_unref  r_ref_unref
 
+/**
+ * @brief Rotate the store: promote a fresh random key to active and age the
+ * oldest out.
+ *
+ * New tickets seal under the fresh key; tickets sealed under the previous keys
+ * still open until those keys age out of the retained set, so a caller can
+ * rotate on a schedule without invalidating live tickets. Safe to call
+ * concurrently with ticket sealing / opening.
+ *
+ * @param keys The key store.
+ * @return @c TRUE on success; @c FALSE on a @c NULL store or an entropy failure
+ *   (the existing keys are left untouched).
+ */
+R_API rboolean r_tls_session_ticket_keys_rotate (RTLSSessionTicketKeys * keys);
+
 R_END_DECLS
 
 /** @} */

--- a/rlib/net/proto/rtls.c
+++ b/rlib/net/proto/rtls.c
@@ -1332,13 +1332,15 @@ RTLSError
 r_tls_parser_parse_new_session_ticket13 (const RTLSParser * parser,
     ruint32 * lifetime, ruint32 * age_add,
     const ruint8 ** nonce, ruint8 * noncelen,
-    const ruint8 ** ticket, ruint16 * ticketsize)
+    const ruint8 ** ticket, ruint16 * ticketsize, ruint32 * max_early_data)
 {
   RTLSHandshakeType type;
   const ruint8 * ptr, * end;
   ruint8 nlen;
   ruint16 tlen, extlen;
   RTLSError ret;
+
+  if (max_early_data != NULL) *max_early_data = 0;
 
   ret = r_tls_parser_parse_handshake_internal (parser, &type, &ptr, &end);
   if (R_UNLIKELY (ret != R_TLS_ERROR_OK)) return ret;
@@ -1367,10 +1369,25 @@ r_tls_parser_parse_new_session_ticket13 (const RTLSParser * parser,
   if (ticketsize != NULL) *ticketsize = tlen;
   ptr += tlen;
 
-  /* Trailing Extension list must fit; its contents are not returned. */
+  /* Trailing Extension list must fit; surface only early_data's size. */
   extlen = r_load_be16 (ptr);
-  if (R_UNLIKELY (ptr + sizeof (ruint16) + extlen > end))
+  ptr += sizeof (ruint16);
+  if (R_UNLIKELY (ptr + extlen > end))
     return R_TLS_ERROR_CORRUPT_RECORD;
+  end = ptr + extlen;
+  while (ptr + 2 * sizeof (ruint16) <= end) {
+    ruint16 etype = r_load_be16 (ptr);
+    ruint16 elen = r_load_be16 (ptr + sizeof (ruint16));
+    ptr += 2 * sizeof (ruint16);
+    if (R_UNLIKELY (ptr + elen > end))
+      return R_TLS_ERROR_CORRUPT_RECORD;
+    if (etype == R_TLS_EXT_TYPE_EARLY_DATA) {
+      if (R_UNLIKELY (elen != sizeof (ruint32)))
+        return R_TLS_ERROR_CORRUPT_RECORD;
+      if (max_early_data != NULL) *max_early_data = r_load_be32 (ptr);
+    }
+    ptr += elen;
+  }
 
   return R_TLS_ERROR_OK;
 }
@@ -2046,11 +2063,13 @@ r_tls_write_hs_new_session_ticket (rpointer data, rsize size, rsize * out,
 RTLSError
 r_tls_write_hs_new_session_ticket13 (rpointer data, rsize size, rsize * out,
     ruint32 lifetime, ruint32 age_add, const ruint8 * nonce, ruint8 noncelen,
-    const ruint8 * ticket, ruint16 tsize)
+    const ruint8 * ticket, ruint16 tsize, ruint32 max_early_data)
 {
   ruint8 * p = data;
+  /* An early_data extension is 2 (type) + 2 (len) + 4 (max_early_data_size). */
+  rsize extslen = (max_early_data != 0) ? 2 * sizeof (ruint16) + sizeof (ruint32) : 0;
   rsize need = 2 * sizeof (ruint32) + 1 + (rsize)noncelen +
-      sizeof (ruint16) + (rsize)tsize + sizeof (ruint16);
+      sizeof (ruint16) + (rsize)tsize + sizeof (ruint16) + extslen;
 
   if (R_UNLIKELY (data == NULL || ticket == NULL || tsize == 0))
     return R_TLS_ERROR_INVAL;
@@ -2062,11 +2081,25 @@ r_tls_write_hs_new_session_ticket13 (rpointer data, rsize size, rsize * out,
   if (noncelen > 0) { r_memcpy (p, nonce, noncelen); p += noncelen; }
   r_store_be16 (p, tsize);          p += sizeof (ruint16);
   r_memcpy (p, ticket, tsize);      p += tsize;
-  r_store_be16 (p, 0);              p += sizeof (ruint16);  /* no extensions */
+  r_store_be16 (p, (ruint16)extslen); p += sizeof (ruint16);
+  if (extslen > 0) {
+    r_store_be16 (p, (ruint16)R_TLS_EXT_TYPE_EARLY_DATA); p += sizeof (ruint16);
+    r_store_be16 (p, (ruint16)sizeof (ruint32));          p += sizeof (ruint16);
+    r_store_be32 (p, max_early_data);                     p += sizeof (ruint32);
+  }
 
   if (out != NULL)
     *out = RPOINTER_TO_SIZE (p) - RPOINTER_TO_SIZE (data);
 
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_write_hs_end_of_early_data (rpointer data, rsize size, rsize * out)
+{
+  (void) data; (void) size;
+  if (out != NULL)
+    *out = 0;
   return R_TLS_ERROR_OK;
 }
 

--- a/rlib/net/proto/rtls.c
+++ b/rlib/net/proto/rtls.c
@@ -1329,6 +1329,53 @@ r_tls_parser_parse_new_session_ticket (const RTLSParser * parser,
 }
 
 RTLSError
+r_tls_parser_parse_new_session_ticket13 (const RTLSParser * parser,
+    ruint32 * lifetime, ruint32 * age_add,
+    const ruint8 ** nonce, ruint8 * noncelen,
+    const ruint8 ** ticket, ruint16 * ticketsize)
+{
+  RTLSHandshakeType type;
+  const ruint8 * ptr, * end;
+  ruint8 nlen;
+  ruint16 tlen, extlen;
+  RTLSError ret;
+
+  ret = r_tls_parser_parse_handshake_internal (parser, &type, &ptr, &end);
+  if (R_UNLIKELY (ret != R_TLS_ERROR_OK)) return ret;
+  if (R_UNLIKELY (type != R_TLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET))
+    return R_TLS_ERROR_WRONG_TYPE;
+
+  /* ticket_lifetime, ticket_age_add, then ticket_nonce<0..255>. */
+  if (R_UNLIKELY (ptr + 2 * sizeof (ruint32) + 1 > end))
+    return R_TLS_ERROR_CORRUPT_RECORD;
+  if (lifetime != NULL) *lifetime = r_load_be32 (ptr);
+  if (age_add != NULL)  *age_add = r_load_be32 (ptr + sizeof (ruint32));
+  ptr += 2 * sizeof (ruint32);
+  nlen = *ptr++;
+  if (R_UNLIKELY (ptr + nlen + sizeof (ruint16) > end))
+    return R_TLS_ERROR_CORRUPT_RECORD;
+  if (nonce != NULL)    *nonce = nlen != 0 ? ptr : NULL;
+  if (noncelen != NULL) *noncelen = nlen;
+  ptr += nlen;
+
+  /* ticket<1..2^16-1>. */
+  tlen = r_load_be16 (ptr);
+  ptr += sizeof (ruint16);
+  if (R_UNLIKELY (tlen == 0 || ptr + tlen + sizeof (ruint16) > end))
+    return R_TLS_ERROR_CORRUPT_RECORD;
+  if (ticket != NULL)     *ticket = ptr;
+  if (ticketsize != NULL) *ticketsize = tlen;
+  ptr += tlen;
+
+  /* Trailing Extension list must fit; its contents are not returned. */
+  extlen = r_load_be16 (ptr);
+  if (R_UNLIKELY (ptr + sizeof (ruint16) + extlen > end))
+    return R_TLS_ERROR_CORRUPT_RECORD;
+
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
 r_tls_parser_parse_certificate_verify (const RTLSParser * parser,
     RTLSSignatureScheme * sigscheme, const ruint8 ** sig, ruint16 * sigsize)
 {
@@ -1680,6 +1727,81 @@ r_tls_hello_ext_key_share_server (const RTLSHelloExt * ext, RTLSKeyShareEntry * 
   return r_tls_key_share_entry_read (ext->data, ext->data + ext->len, entry);
 }
 
+static RTLSError
+r_tls_psk_identity_read (const ruint8 * p, const ruint8 * end,
+    RTLSPskIdentity * ident)
+{
+  ruint16 idlen;
+
+  /* PskIdentity: opaque identity<1..2^16-1>, uint32 obfuscated_ticket_age. */
+  if (R_UNLIKELY (p + sizeof (ruint16) > end)) return R_TLS_ERROR_EOB;
+  idlen = r_load_be16 (p);
+  if (R_UNLIKELY (p + sizeof (ruint16) + idlen + sizeof (ruint32) > end))
+    return R_TLS_ERROR_EOB;
+
+  ident->start = p;
+  ident->len = idlen;
+  ident->identity = p + sizeof (ruint16);
+  ident->age = r_load_be32 (p + sizeof (ruint16) + idlen);
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_hello_ext_psk_identity_first (const RTLSHelloExt * ext, RTLSPskIdentity * ident)
+{
+  const ruint8 * end;
+
+  if (R_UNLIKELY (ext == NULL || ident == NULL)) return R_TLS_ERROR_INVAL;
+  /* OfferedPsks: uint16 identities_len, then PskIdentity*. Bound the walk by
+   * the identities list, not the whole extension (the binders follow). */
+  if (R_UNLIKELY (ext->len < sizeof (ruint16))) return R_TLS_ERROR_EOB;
+  end = ext->data + sizeof (ruint16) + r_load_be16 (ext->data);
+  if (R_UNLIKELY (end > ext->data + ext->len)) return R_TLS_ERROR_EOB;
+  return r_tls_psk_identity_read (ext->data + sizeof (ruint16), end, ident);
+}
+
+RTLSError
+r_tls_hello_ext_psk_identity_next (const RTLSHelloExt * ext, RTLSPskIdentity * ident)
+{
+  const ruint8 * end;
+
+  if (R_UNLIKELY (ext == NULL || ident == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (ident->start == NULL || ident->identity == NULL))
+    return r_tls_hello_ext_psk_identity_first (ext, ident);
+  end = ext->data + sizeof (ruint16) + r_load_be16 (ext->data);
+  return r_tls_psk_identity_read (
+      ident->identity + ident->len + sizeof (ruint32), end, ident);
+}
+
+RTLSError
+r_tls_hello_ext_psk_binder (const RTLSHelloExt * ext, ruint n,
+    const ruint8 ** binder, ruint8 * binderlen)
+{
+  const ruint8 * p, * end;
+  ruint i;
+
+  if (R_UNLIKELY (ext == NULL || binder == NULL || binderlen == NULL))
+    return R_TLS_ERROR_INVAL;
+  if ((p = r_tls_hello_ext_psk_binders_start (ext)) == NULL)
+    return R_TLS_ERROR_EOB;
+  /* binders<33..2^16-1>: uint16 list length, then PskBinderEntry<32..255>. */
+  end = p + sizeof (ruint16) + r_load_be16 (p);
+  if (R_UNLIKELY (end > ext->data + ext->len)) return R_TLS_ERROR_EOB;
+  p += sizeof (ruint16);
+  for (i = 0; ; i++) {
+    ruint8 l;
+    if (R_UNLIKELY (p + 1 > end)) return R_TLS_ERROR_EOB;
+    l = *p;
+    if (R_UNLIKELY (p + 1 + l > end)) return R_TLS_ERROR_EOB;
+    if (i == n) {
+      *binder = p + 1;
+      *binderlen = l;
+      return R_TLS_ERROR_OK;
+    }
+    p += 1 + l;
+  }
+}
+
 RCryptoCert *
 r_tls_certificate_get_cert (const RTLSCertificate * cert)
 {
@@ -1917,6 +2039,33 @@ r_tls_write_hs_new_session_ticket (rpointer data, rsize size, rsize * out,
 
   if (out != NULL)
     *out = sizeof (ruint32) + sizeof (ruint16) + tsize;
+
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_write_hs_new_session_ticket13 (rpointer data, rsize size, rsize * out,
+    ruint32 lifetime, ruint32 age_add, const ruint8 * nonce, ruint8 noncelen,
+    const ruint8 * ticket, ruint16 tsize)
+{
+  ruint8 * p = data;
+  rsize need = 2 * sizeof (ruint32) + 1 + (rsize)noncelen +
+      sizeof (ruint16) + (rsize)tsize + sizeof (ruint16);
+
+  if (R_UNLIKELY (data == NULL || ticket == NULL || tsize == 0))
+    return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (size < need)) return R_TLS_ERROR_BUF_TOO_SMALL;
+
+  r_store_be32 (p, lifetime);       p += sizeof (ruint32);
+  r_store_be32 (p, age_add);        p += sizeof (ruint32);
+  *p++ = noncelen;
+  if (noncelen > 0) { r_memcpy (p, nonce, noncelen); p += noncelen; }
+  r_store_be16 (p, tsize);          p += sizeof (ruint16);
+  r_memcpy (p, ticket, tsize);      p += tsize;
+  r_store_be16 (p, 0);              p += sizeof (ruint16);  /* no extensions */
+
+  if (out != NULL)
+    *out = RPOINTER_TO_SIZE (p) - RPOINTER_TO_SIZE (data);
 
   return R_TLS_ERROR_OK;
 }

--- a/rlib/net/proto/rtls13.c
+++ b/rlib/net/proto/rtls13.c
@@ -244,6 +244,18 @@ r_tls13_binder_key (const RTLS13Schedule * sched, ruint8 * out)
 }
 
 rboolean
+r_tls13_schedule_early (RTLS13Schedule * sched, const ruint8 * transcript_hash)
+{
+  if (R_UNLIKELY (sched == NULL || transcript_hash == NULL))
+    return FALSE;
+
+  /* client_early_traffic_secret = Derive-Secret(Early, "c e traffic",
+   *   Transcript-Hash(ClientHello)). */
+  return r_tls13_derive_secret (sched->hash, sched->early,
+      R_STR_WITH_SIZE_ARGS ("c e traffic"), transcript_hash, sched->cet);
+}
+
+rboolean
 r_tls13_schedule_handshake (RTLS13Schedule * sched, const ruint8 * ecdhe,
     rsize ecdhelen, const ruint8 * transcript_hash)
 {

--- a/rlib/net/proto/rtls13.c
+++ b/rlib/net/proto/rtls13.c
@@ -444,6 +444,38 @@ r_tls13_random_is_hrr (const ruint8 * random)
       r_memcmp (random, r_tls13_hrr_random, sizeof (r_tls13_hrr_random)) == 0;
 }
 
+/* RFC 8446 4.1.3 downgrade-protection sentinels, stamped into the last 8 bytes
+ * of ServerHello.random by a 1.3-capable server that negotiates a lower
+ * version: "DOWNGRD\x01" for TLS 1.2, "DOWNGRD\x00" for TLS 1.1 or below. */
+static const ruint8 r_tls13_downgrade_tls12[8] = {
+  0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 0x44, 0x01
+};
+static const ruint8 r_tls13_downgrade_tls11[8] = {
+  0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 0x44, 0x00
+};
+
+void
+r_tls13_downgrade_random (ruint8 * random, RTLSVersion negotiated)
+{
+  if (R_UNLIKELY (random == NULL))
+    return;
+  if (negotiated == R_TLS_VERSION_TLS_1_2)
+    r_memcpy (random + R_TLS_HELLO_RANDOM_BYTES - 8, r_tls13_downgrade_tls12, 8);
+  else if (negotiated >= R_TLS_VERSION_TLS_1_0 && negotiated < R_TLS_VERSION_TLS_1_2)
+    r_memcpy (random + R_TLS_HELLO_RANDOM_BYTES - 8, r_tls13_downgrade_tls11, 8);
+}
+
+rboolean
+r_tls13_random_is_downgrade (const ruint8 * random)
+{
+  if (R_UNLIKELY (random == NULL))
+    return FALSE;
+  return r_memcmp (random + R_TLS_HELLO_RANDOM_BYTES - 8,
+          r_tls13_downgrade_tls12, 8) == 0 ||
+      r_memcmp (random + R_TLS_HELLO_RANDOM_BYTES - 8,
+          r_tls13_downgrade_tls11, 8) == 0;
+}
+
 rboolean
 r_tls13_message_hash (RMsgDigestType hash, const ruint8 * msg, rsize msglen,
     ruint8 * out, rsize outsize, rsize * outlen)

--- a/rlib/net/proto/rtls13.c
+++ b/rlib/net/proto/rtls13.c
@@ -351,3 +351,54 @@ r_tls13_cert_verify_tbs (rboolean server, const ruint8 * transcript_hash,
   *outlen = n;
   return TRUE;
 }
+
+/* SHA-256("HelloRetryRequest"), the ServerHello.random of a HelloRetryRequest. */
+static const ruint8 r_tls13_hrr_random[32] = {
+  0xcf, 0x21, 0xad, 0x74, 0xe5, 0x9a, 0x61, 0x11, 0xbe, 0x1d, 0x8c, 0x02,
+  0x1e, 0x65, 0xb8, 0x91, 0xc2, 0xa2, 0x11, 0x16, 0x7a, 0xbb, 0x8c, 0x5e,
+  0x07, 0x9e, 0x09, 0xe2, 0xc8, 0xa8, 0x33, 0x9c
+};
+
+void
+r_tls13_hello_retry_random (ruint8 * out)
+{
+  if (R_LIKELY (out != NULL))
+    r_memcpy (out, r_tls13_hrr_random, sizeof (r_tls13_hrr_random));
+}
+
+rboolean
+r_tls13_random_is_hrr (const ruint8 * random)
+{
+  return random != NULL &&
+      r_memcmp (random, r_tls13_hrr_random, sizeof (r_tls13_hrr_random)) == 0;
+}
+
+rboolean
+r_tls13_message_hash (RMsgDigestType hash, const ruint8 * msg, rsize msglen,
+    ruint8 * out, rsize outsize, rsize * outlen)
+{
+  RMsgDigest * md;
+  rsize hlen = r_msg_digest_type_size (hash);
+  rboolean ok;
+
+  if (R_UNLIKELY (msg == NULL || out == NULL || outlen == NULL ||
+        hlen == 0 || outsize < 4 + hlen))
+    return FALSE;
+
+  /* Handshake header: message_hash type, then a 3-byte length of HashLen. */
+  out[0] = (ruint8) R_TLS_HANDSHAKE_TYPE_MESSAGE_HASH;
+  out[1] = 0x00;
+  out[2] = 0x00;
+  out[3] = (ruint8) hlen;
+
+  if ((md = r_msg_digest_new (hash)) == NULL)
+    return FALSE;
+  ok = r_msg_digest_update (md, msg, msglen) &&
+       r_msg_digest_get_data (md, out + 4, hlen, NULL);
+  r_msg_digest_free (md);
+  if (!ok)
+    return FALSE;
+
+  *outlen = 4 + hlen;
+  return TRUE;
+}

--- a/rlib/net/proto/rtls13.c
+++ b/rlib/net/proto/rtls13.c
@@ -213,6 +213,37 @@ r_tls13_schedule_init (RTLS13Schedule * sched, RMsgDigestType hash)
 }
 
 rboolean
+r_tls13_schedule_init_psk (RTLS13Schedule * sched, RMsgDigestType hash,
+    const ruint8 * psk, rsize psklen)
+{
+  rsize hlen = r_msg_digest_type_size (hash);
+
+  if (R_UNLIKELY (sched == NULL || psk == NULL || psklen == 0 ||
+        hlen == 0 || hlen > R_TLS13_SECRET_MAX))
+    return FALSE;
+
+  sched->hash = hash;
+  sched->hlen = hlen;
+
+  /* Early Secret = HKDF-Extract(0, PSK). */
+  return r_hkdf_extract (hash, NULL, 0, psk, psklen, sched->early);
+}
+
+rboolean
+r_tls13_binder_key (const RTLS13Schedule * sched, ruint8 * out)
+{
+  ruint8 emptyhash[R_TLS13_SECRET_MAX];
+
+  if (R_UNLIKELY (sched == NULL || out == NULL))
+    return FALSE;
+
+  /* binder_key = Derive-Secret(Early, "res binder", ""). */
+  return r_tls13_empty_transcript (sched->hash, emptyhash, sched->hlen) &&
+      r_tls13_derive_secret (sched->hash, sched->early,
+          R_STR_WITH_SIZE_ARGS ("res binder"), emptyhash, out);
+}
+
+rboolean
 r_tls13_schedule_handshake (RTLS13Schedule * sched, const ruint8 * ecdhe,
     rsize ecdhelen, const ruint8 * transcript_hash)
 {
@@ -263,6 +294,34 @@ r_tls13_schedule_master (RTLS13Schedule * sched, const ruint8 * transcript_hash)
             R_STR_WITH_SIZE_ARGS ("c ap traffic"), transcript_hash, sched->cap) &&
          r_tls13_derive_secret (sched->hash, sched->master,
             R_STR_WITH_SIZE_ARGS ("s ap traffic"), transcript_hash, sched->sap);
+}
+
+rboolean
+r_tls13_schedule_resumption (RTLS13Schedule * sched,
+    const ruint8 * transcript_hash)
+{
+  if (R_UNLIKELY (sched == NULL || transcript_hash == NULL))
+    return FALSE;
+
+  /* resumption_master_secret = Derive-Secret(Master, "res master",
+   *   Transcript-Hash(ClientHello..client Finished)). */
+  return r_tls13_derive_secret (sched->hash, sched->master,
+      R_STR_WITH_SIZE_ARGS ("res master"), transcript_hash, sched->res_master);
+}
+
+rboolean
+r_tls13_resumption_psk (RMsgDigestType hash, const ruint8 * res_master,
+    const ruint8 * nonce, rsize noncelen, ruint8 * out)
+{
+  rsize hlen = r_msg_digest_type_size (hash);
+
+  if (R_UNLIKELY (res_master == NULL || out == NULL || hlen == 0))
+    return FALSE;
+
+  /* PSK = HKDF-Expand-Label(resumption_master_secret, "resumption",
+   *   ticket_nonce, HashLen). */
+  return r_tls13_expand_label (hash, res_master,
+      R_STR_WITH_SIZE_ARGS ("resumption"), nonce, noncelen, out, hlen);
 }
 
 rboolean

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -123,6 +123,9 @@ struct RTLSClient {
   RTLSClientSession * resume;           /* session to offer for resumption, or NULL */
   RTLSClientSession * new_session;      /* session from a received NewSessionTicket */
   rboolean resumed13;                   /* server accepted our pre_shared_key */
+  RBuffer * early_data;                 /* 0-RTT payload to offer, or NULL */
+  rboolean early13_sent;                /* early_data offered and records emitted */
+  rboolean early13_accepted;            /* server echoed early_data in EncryptedExtensions */
 
   RBuffer * inbuf;
   RQueue qsend;
@@ -139,6 +142,7 @@ struct RTLSClientSession {
   RTLSCipherSuite suite;
   RMsgDigestType hash;
   ruint32 age_add;
+  ruint32 max_early_data;       /* early_data max_early_data_size, 0 if no 0-RTT */
   RClockTime obtained;          /* when the ticket arrived, for obfuscated age */
 };
 
@@ -215,6 +219,8 @@ r_tls_client_free (RTLSClient * client)
     r_tls_client_session_unref (client->resume);
   if (client->new_session != NULL)
     r_tls_client_session_unref (client->new_session);
+  if (client->early_data != NULL)
+    r_buffer_unref (client->early_data);
 
   if (client->inbuf != NULL)
     r_buffer_unref (client->inbuf);
@@ -242,6 +248,24 @@ r_tls_client_get_session (const RTLSClient * client)
   if (R_UNLIKELY (client == NULL) || client->new_session == NULL)
     return NULL;
   return r_tls_client_session_ref (client->new_session);
+}
+
+RTLSError
+r_tls_client_set_early_data (RTLSClient * client, RBuffer * buffer)
+{
+  if (R_UNLIKELY (client == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (client->loop != NULL)) return R_TLS_ERROR_WRONG_STATE;
+
+  if (client->early_data != NULL)
+    r_buffer_unref (client->early_data);
+  client->early_data = (buffer != NULL) ? r_buffer_ref (buffer) : NULL;
+  return R_TLS_ERROR_OK;
+}
+
+rboolean
+r_tls_client_get_early_data_accepted (const RTLSClient * client)
+{
+  return client != NULL && client->early13_accepted;
 }
 
 static RTLSError
@@ -405,6 +429,10 @@ r_tls_client_send_out (RTLSClient * client)
 
 static RTLSError r_tls_client_protect_record13 (RTLSClient * client,
     RTLSContentType ct, const ruint8 * plain, rsize plainlen);
+static rboolean r_tls_client_install_keys13 (RTLSClient * client,
+    RTLS13RecordKeys * rk, const ruint8 * secret);
+static rboolean r_tls_client_setup_early_keys13 (RTLSClient * client);
+static RTLSError r_tls_client_send_early_data13 (RTLSClient * client);
 
 /* Build an alert record and queue it for sending; the caller flushes. */
 static RTLSError
@@ -630,6 +658,46 @@ r_tls_client_write_hs_ext_psk_key_exchange_modes (ruint8 * ptr)
   return 6;
 }
 
+/* Empty early_data extension: signals a 0-RTT offer in the ClientHello
+ * (RFC 8446 4.2.10). */
+static ruint16
+r_tls_client_write_hs_ext_early_data (ruint8 * ptr)
+{
+  r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_EARLY_DATA);
+  r_store_be16 (&ptr[2], 0);
+  return 4;
+}
+
+/* Whether an EncryptedExtensions handshake message (a full message: 4-byte
+ * header then a uint16-prefixed extension list) carries an early_data
+ * extension, i.e. the server accepted 0-RTT. */
+static rboolean
+r_tls_client_ee_has_early_data (const ruint8 * msg, rsize msglen)
+{
+  const ruint8 * p, * end;
+  ruint16 extslen;
+
+  if (msglen < R_TLS_HS_HDR_SIZE + sizeof (ruint16))
+    return FALSE;
+  p = msg + R_TLS_HS_HDR_SIZE;
+  extslen = r_load_be16 (p);
+  p += sizeof (ruint16);
+  end = p + extslen;
+  if (RPOINTER_TO_SIZE (end) > RPOINTER_TO_SIZE (msg + msglen))
+    return FALSE;
+  while (p + 2 * sizeof (ruint16) <= end) {
+    ruint16 etype = r_load_be16 (p);
+    ruint16 elen = r_load_be16 (p + sizeof (ruint16));
+    p += 2 * sizeof (ruint16);
+    if (p + elen > end)
+      return FALSE;
+    if (etype == R_TLS_EXT_TYPE_EARLY_DATA)
+      return TRUE;
+    p += elen;
+  }
+  return FALSE;
+}
+
 /* pre_shared_key offer with a single identity and a zeroed binder placeholder
  * (RFC 8446 4.2.11). Returns bytes written and, via @binder_off, the offset of
  * the binder value within @ptr so the caller can patch it after computing it
@@ -702,6 +770,12 @@ r_tls_client_send_hello (RTLSClient * client, rboolean retry)
   RTLSCipherSuite cs[24];
   rsize ncs = R_N_ELEMENTS (cs);
   rboolean dtls = r_tls_version_is_dtls (client->version);
+  /* Offer 0-RTT when a resumption session that permits early data is set and
+   * the application queued a payload that fits the ticket's max_early_data_size
+   * (never on a retry); an oversized payload is sent as 1-RTT instead. */
+  rboolean offer_early = !retry && client->resume != NULL &&
+      client->resume->max_early_data > 0 && client->early_data != NULL &&
+      r_buffer_get_size (client->early_data) <= client->resume->max_early_data;
   /* TLS 1.3 keeps the legacy_version fields at 0x0303; the real version is
    * carried in the supported_versions extension. */
   RTLSVersion wire = (client->version == R_TLS_VERSION_TLS_1_3) ?
@@ -788,6 +862,9 @@ r_tls_client_send_hello (RTLSClient * client, rboolean retry)
         extsize += r_tls_client_write_hs_ext_server_name (ptr + 2 + extsize, client->server_name);
       /* Advertise (EC)DHE resumption support so the server issues tickets. */
       extsize += r_tls_client_write_hs_ext_psk_key_exchange_modes (ptr + 2 + extsize);
+      /* early_data (0-RTT) sits before pre_shared_key, which stays last. */
+      if (offer_early)
+        extsize += r_tls_client_write_hs_ext_early_data (ptr + 2 + extsize);
       /* pre_shared_key MUST be the last extension. Offered only on the initial
        * ClientHello (the binder transcript assumes an empty prior transcript). */
       if (client->resume != NULL && !retry) {
@@ -846,12 +923,24 @@ r_tls_client_send_hello (RTLSClient * client, rboolean retry)
             ret = R_TLS_ERROR_OOM;
         }
       }
+
+      /* Install the client early-traffic key (bound to the ClientHello just
+       * buffered) so the 0-RTT records can go out right behind the hello. */
+      if (ret == R_TLS_ERROR_OK && offer_early) {
+        if (r_tls_client_setup_early_keys13 (client))
+          client->early13_sent = TRUE;
+        else
+          ret = R_TLS_ERROR_HANDSHAKE_FAILURE;
+      }
     }
     r_buffer_unmap (buf, &info);
     r_buffer_set_size (buf, size);
 
     if (ret == R_TLS_ERROR_OK)
       ret = r_tls_client_send_record (client, buf);
+    /* 0-RTT data follows the ClientHello, encrypted under the early key. */
+    if (ret == R_TLS_ERROR_OK && client->early13_sent)
+      ret = r_tls_client_send_early_data13 (client);
   } else {
     ret = R_TLS_ERROR_OOM;
   }
@@ -950,6 +1039,55 @@ r_tls_client_protect_record13 (RTLSClient * client, RTLSContentType ct,
   return ret;
 }
 
+/* Derive the client early-traffic secret (bound to the just-built ClientHello)
+ * from the resumption PSK and install it as the write key, so 0-RTT data and
+ * the later EndOfEarlyData go out under it. The suite is the ticket's -- 0-RTT
+ * commits to it before the ServerHello confirms it. */
+static rboolean
+r_tls_client_setup_early_keys13 (RTLSClient * client)
+{
+  RTLSClientSession * s = client->resume;
+  const RTLSCipherSuiteInfo * info = r_tls_cipher_suite_get_info (s->suite);
+  ruint8 th[R_TLS13_SECRET_MAX];
+  rsize hlen = r_msg_digest_type_size (s->hash);
+  RMsgDigest * md;
+  rboolean ok;
+
+  if (info == NULL || info->cipher == NULL)
+    return FALSE;
+  if ((md = r_msg_digest_new (s->hash)) == NULL)
+    return FALSE;
+  ok = r_msg_digest_update (md, client->clienthello, client->clienthellolen) &&
+       r_msg_digest_get_data (md, th, hlen, NULL);
+  r_msg_digest_free (md);
+  if (!ok)
+    return FALSE;
+
+  client->cs13_hash = s->hash;
+  client->cs13_cipher = info->cipher;
+  return r_tls13_schedule_init_psk (&client->sched13, s->hash, s->psk, s->psklen) &&
+      r_tls13_schedule_early (&client->sched13, th) &&
+      r_tls_client_install_keys13 (client, &client->rk_write, client->sched13.cet);
+}
+
+/* Encrypt and queue the queued 0-RTT payload under the early write key. */
+static RTLSError
+r_tls_client_send_early_data13 (RTLSClient * client)
+{
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  RTLSError ret = R_TLS_ERROR_OK;
+
+  if (client->early_data == NULL)
+    return R_TLS_ERROR_OK;
+  if (!r_buffer_map (client->early_data, &info, R_MEM_MAP_READ))
+    return R_TLS_ERROR_OOM;
+  if (info.size > 0)
+    ret = r_tls_client_protect_record13 (client,
+        R_TLS_CONTENT_TYPE_APPLICATION_DATA, info.data, info.size);
+  r_buffer_unmap (client->early_data, &info);
+  return ret;
+}
+
 /* Frame, transcript-fold and send a handshake message under the write key. */
 static RTLSError
 r_tls_client_send_hs13 (RTLSClient * client, RTLSHandshakeType type,
@@ -965,7 +1103,8 @@ r_tls_client_send_hs13 (RTLSClient * client, RTLSHandshakeType type,
   msg[1] = (ruint8) ((bodylen >> 16) & 0xff);
   msg[2] = (ruint8) ((bodylen >>  8) & 0xff);
   msg[3] = (ruint8) ((bodylen      ) & 0xff);
-  r_memcpy (msg + R_TLS_HS_HDR_SIZE, body, bodylen);
+  if (bodylen > 0)
+    r_memcpy (msg + R_TLS_HS_HDR_SIZE, body, bodylen);
 
   r_msg_digest_update (client->hshash, msg, msglen);
   ret = r_tls_client_protect_record13 (client, R_TLS_CONTENT_TYPE_HANDSHAKE,
@@ -1085,8 +1224,13 @@ r_tls_client_setup_keys13 (RTLSClient * client)
   }
   r_memclear_secure (ecdhe, sizeof (ecdhe));
 
-  /* Client reads the server (shs) and writes as the client (chs). */
-  if (!r_tls_client_install_keys13 (client, &client->rk_read, client->sched13.shs) ||
+  /* Client reads the server (shs) and writes as the client (chs). While 0-RTT
+   * is in flight the write key stays the early-traffic key -- it switches to
+   * chs only once we know the server's decision (EncryptedExtensions), so the
+   * EndOfEarlyData (on accept) is still protected under the early key. */
+  if (!r_tls_client_install_keys13 (client, &client->rk_read, client->sched13.shs))
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  if (!client->early13_sent &&
       !r_tls_client_install_keys13 (client, &client->rk_write, client->sched13.chs))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
   return R_TLS_ERROR_OK;
@@ -1249,6 +1393,20 @@ r_tls_client_flight13 (RTLSClient * client, const RTLSParser * parser)
       if (type != R_TLS_HANDSHAKE_TYPE_ENCRYPTED_EXTENSIONS)
         return R_TLS_ERROR_WRONG_TYPE;
       r_msg_digest_update (client->hshash, parser->fragment.data, parser->fragment.size);
+      /* EncryptedExtensions carries the server's 0-RTT decision. On acceptance
+       * the write key stays the early-traffic key until the EndOfEarlyData; on
+       * rejection switch to the handshake key now and let the queued early data
+       * be resent as 1-RTT once the handshake completes. */
+      if (client->early13_sent) {
+        client->early13_accepted = r_tls_client_ee_has_early_data (
+            parser->fragment.data, parser->fragment.size);
+        if (!client->early13_accepted) {
+          client->early13_sent = FALSE;
+          if (!r_tls_client_install_keys13 (client, &client->rk_write,
+                client->sched13.chs))
+            return R_TLS_ERROR_HANDSHAKE_FAILURE;
+        }
+      }
       /* A resumed handshake authenticates via the PSK, so no Certificate /
        * CertificateVerify follow: jump straight to the server Finished. */
       client->flight13_step = client->resumed13 ? 3 : 1;
@@ -1330,7 +1488,21 @@ r_tls_client_flight13 (RTLSClient * client, const RTLSParser * parser)
           !r_tls13_schedule_master (&client->sched13, th))
         return R_TLS_ERROR_HANDSHAKE_FAILURE;
 
-      /* Client Finished, still under the client handshake-traffic key. */
+      /* On accepted 0-RTT, close the early-data flow with an EndOfEarlyData
+       * (still under the early write key), fold it, then switch the write key to
+       * the client handshake-traffic secret. The client Finished then covers the
+       * transcript through EndOfEarlyData. */
+      if (client->early13_accepted) {
+        if ((err = r_tls_client_send_hs13 (client,
+                R_TLS_HANDSHAKE_TYPE_END_OF_EARLY_DATA, NULL, 0)) != R_TLS_ERROR_OK)
+          return err;
+        client->early13_sent = FALSE;
+        if (!r_tls_client_install_keys13 (client, &client->rk_write, client->sched13.chs) ||
+            !r_msg_digest_get_data (client->hshash, th, hlen, NULL))
+          return R_TLS_ERROR_HANDSHAKE_FAILURE;
+      }
+
+      /* Client Finished under the client handshake-traffic key. */
       if (!r_tls13_finished_key (client->cs13_hash, client->sched13.chs, finkey) ||
           !r_tls13_verify_data (client->cs13_hash, finkey, th, cvd))
         return R_TLS_ERROR_HANDSHAKE_FAILURE;
@@ -2014,6 +2186,15 @@ r_tls_client_state_certificate (RTLSClient * client, const RTLSParser * parser)
       err = r_tls_client_change_state (client, R_TLS_CLIENT_APPDATA);
       r_msg_digest_free (client->hshash);
       client->hshash = NULL;
+      /* Deliver the 0-RTT payload as ordinary application data when the server
+       * did not accept it (declined 0-RTT, or the session never permitted it),
+       * so it is sent either way. */
+      if (client->early_data != NULL) {
+        if (!client->early13_accepted)
+          r_tls_client_send_appdata (client, client->early_data);
+        r_buffer_unref (client->early_data);
+        client->early_data = NULL;
+      }
       if (client->cb.handshake_done != NULL)
         client->cb.handshake_done (client->userdata, client);
     } else if (err != R_TLS_ERROR_OK) {
@@ -2268,14 +2449,14 @@ r_tls_client_state_finished (RTLSClient * client, const RTLSParser * parser)
 static void
 r_tls_client_store_ticket13 (RTLSClient * client, const RTLSParser * parser)
 {
-  ruint32 lifetime, age_add;
+  ruint32 lifetime, age_add, max_early_data;
   const ruint8 * nonce, * ticket;
   ruint8 noncelen;
   ruint16 ticketsize;
   RTLSClientSession * s;
 
   if (r_tls_parser_parse_new_session_ticket13 (parser, &lifetime, &age_add,
-        &nonce, &noncelen, &ticket, &ticketsize, NULL) != R_TLS_ERROR_OK)
+        &nonce, &noncelen, &ticket, &ticketsize, &max_early_data) != R_TLS_ERROR_OK)
     return;
   if ((s = r_mem_new0 (RTLSClientSession)) == NULL)
     return;
@@ -2287,6 +2468,7 @@ r_tls_client_store_ticket13 (RTLSClient * client, const RTLSParser * parser)
   s->suite = client->cs13_suite;
   s->hash = client->cs13_hash;
   s->age_add = age_add;
+  s->max_early_data = max_early_data;
   s->obtained = r_tls_client_now (client);
   if (!r_tls13_resumption_psk (client->cs13_hash, client->sched13.res_master,
         nonce, noncelen, s->psk)) {

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -77,6 +77,9 @@ struct RTLSClient {
 
   RTLSVersion version;
   RTLSVersion recordver;
+  RTLSVersion min_version;      /* lowest TLS version the client will offer / accept */
+  RTLSVersion max_version;      /* highest offered; == version at start, then negotiated */
+  rboolean version_range_set;   /* an explicit range was configured before start */
   RTLSCompressionMethod comp;
   const RTLSCipherSuiteInfo * csinfo;
   rboolean support_ext_master_secret;
@@ -297,6 +300,8 @@ r_tls_client_new (const RTLSCallbacks * cb, rpointer userdata, RDestroyNotify no
     r_queue_init (&ret->qsend);
     ret->decrypt = r_tls_client_null_decrypt;
     ret->encrypt = r_tls_client_null_encrypt;
+    ret->min_version = R_TLS_VERSION_TLS_1_2;
+    ret->max_version = R_TLS_VERSION_TLS_1_3;
   }
 
   return ret;
@@ -344,6 +349,23 @@ r_tls_client_set_server_name (RTLSClient * client, const rchar * host)
   r_free (client->server_name);
   client->server_name = (host != NULL) ? r_strdup (host) : NULL;
 
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_client_set_version_range (RTLSClient * client,
+    RTLSVersion min, RTLSVersion max)
+{
+  if (R_UNLIKELY (client == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (client->state != R_TLS_CLIENT_INITIAL)) return R_TLS_ERROR_WRONG_STATE;
+  /* Only the TLS 1.2..1.3 window is configurable; DTLS is fixed at 1.2. */
+  if (R_UNLIKELY (min < R_TLS_VERSION_TLS_1_2 || max > R_TLS_VERSION_TLS_1_3 ||
+        min > max))
+    return R_TLS_ERROR_VERSION;
+
+  client->min_version = min;
+  client->max_version = max;
+  client->version_range_set = TRUE;
   return R_TLS_ERROR_OK;
 }
 
@@ -605,15 +627,20 @@ r_tls_client_write_hs_ext_signature_algorithms13 (ruint8 * ptr)
   return 12;
 }
 
-/* ClientHello supported_versions offering only TLS 1.3. */
+/* ClientHello supported_versions offering TLS 1.3 first, then 1.2 when it is
+ * within the configured range, so a 1.3-capable server picks 1.3 while a
+ * 1.2-only server can still match the hybrid offer. */
 static ruint16
-r_tls_client_write_hs_ext_supported_versions13 (ruint8 * ptr)
+r_tls_client_write_hs_ext_supported_versions13 (ruint8 * ptr, rboolean include_tls12)
 {
+  ruint8 n = include_tls12 ? 2 : 1;
   r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_SUPPORTED_VERSIONS);
-  r_store_be16 (&ptr[2], sizeof (ruint8) + sizeof (ruint16));
-  ptr[4] = sizeof (ruint16);                          /* ProtocolVersion list length */
+  r_store_be16 (&ptr[2], sizeof (ruint8) + n * sizeof (ruint16));
+  ptr[4] = n * sizeof (ruint16);                      /* ProtocolVersion list length */
   r_store_be16 (&ptr[5], (ruint16)R_TLS_VERSION_TLS_1_3);
-  return 7;
+  if (include_tls12)
+    r_store_be16 (&ptr[7], (ruint16)R_TLS_VERSION_TLS_1_2);
+  return 5 + n * sizeof (ruint16);
 }
 
 /* ClientHello key_share with a single KeyShareEntry for the offered group. */
@@ -808,6 +835,18 @@ r_tls_client_send_hello (RTLSClient * client, rboolean retry)
       cs[1] = R_TLS_CS_AES_256_GCM_SHA384;
       ncs = 2;
     }
+    /* When 1.2 is within range, also offer the 1.2 suites so a server may
+     * negotiate 1.2 from this same ClientHello (RFC 8446 hybrid); a 1.3 server
+     * ignores them. */
+    if (client->min_version <= R_TLS_VERSION_TLS_1_2) {
+      rsize n12 = R_N_ELEMENTS (cs) - ncs;
+      if (client->cb.preferred_cipher_suites == NULL ||
+          !client->cb.preferred_cipher_suites (client->userdata,
+            R_TLS_VERSION_TLS_1_2, cs + ncs, &n12))
+        r_tls_client_default_cipher_suites (client->userdata,
+            R_TLS_VERSION_TLS_1_2, cs + ncs, &n12);
+      ncs += n12;
+    }
     /* On a retry the group + ephemeral were re-selected for the
      * HelloRetryRequest's group; keep them. */
     if (!retry) {
@@ -852,9 +891,20 @@ r_tls_client_send_hello (RTLSClient * client, rboolean retry)
 
     extsize = 0;
     if (client->version == R_TLS_VERSION_TLS_1_3) {
+      rboolean include12 = client->min_version <= R_TLS_VERSION_TLS_1_2;
+      /* When 1.2 is within range, the 1.2-compatible extensions go first so the
+       * same ClientHello completes a 1.2 handshake if the server negotiates it
+       * (the 1.3 signature_algorithms is a superset, so it serves both). */
+      if (include12) {
+        extsize += r_tls_client_write_hs_ext_renegotiation (ptr + 2 + extsize);
+        extsize += r_tls_client_write_hs_ext_extended_ms (ptr + 2 + extsize);
+        extsize += r_tls_client_write_hs_ext_encrypt_then_mac (ptr + 2 + extsize);
+      }
       extsize += r_tls_client_write_hs_ext_supported_groups (ptr + 2 + extsize);
+      if (include12)
+        extsize += r_tls_client_write_hs_ext_ec_point_formats (ptr + 2 + extsize);
       extsize += r_tls_client_write_hs_ext_signature_algorithms13 (ptr + 2 + extsize);
-      extsize += r_tls_client_write_hs_ext_supported_versions13 (ptr + 2 + extsize);
+      extsize += r_tls_client_write_hs_ext_supported_versions13 (ptr + 2 + extsize, include12);
       extsize += r_tls_client_write_hs_ext_key_share13 (client, ptr + 2 + extsize);
       if (retry && client->cookielen > 0)
         extsize += r_tls_client_write_hs_ext_cookie (client, ptr + 2 + extsize);
@@ -966,8 +1016,20 @@ r_tls_client_start (RTLSClient * client, REvLoop * loop, RPrng * prng,
   if (prng != NULL) r_prng_ref (prng);
   client->loop = r_ev_loop_ref (loop);
   client->prng = prng;
-  client->version = version;
   client->comp = R_TLS_COMPRESSION_NULL;
+
+  /* Resolve the offered version range. DTLS is fixed at 1.2. For TLS the range
+   * is the one configured with r_tls_client_set_version_range, or [1.2, version]
+   * by default so start(1.3) offers both versions and start(1.2) offers 1.2. */
+  if (r_tls_version_is_dtls (version)) {
+    client->min_version = client->max_version = version;
+  } else if (!client->version_range_set) {
+    client->min_version = R_TLS_VERSION_TLS_1_2;
+    client->max_version = version;
+  }
+  /* version carries the highest offered version now and the negotiated one once
+   * the ServerHello lands (a 1.2 fallback pins it down). */
+  client->version = client->max_version;
 
   /* The PRF and transcript hash depend on the suite the server selects, which
    * is not known until its ServerHello. The ClientHello is buffered and the
@@ -1561,6 +1623,20 @@ r_tls_client_nego_server_hello (RTLSClient * client, const RTLSParser * parser)
      * in the random is a forced downgrade and must abort (RFC 8446 4.1.3). */
     if (r_tls13_random_is_downgrade (hello.random))
       return R_TLS_ERROR_ILLEGAL_PARAMETER;
+    /* No sentinel: the server negotiated a lower version. Accept it only if it
+     * is within our offered range (a hybrid ClientHello also offers 1.2), then
+     * fall back to a full 1.2 handshake -- pin the negotiated version (it frames
+     * records and the RSA premaster) and drop the 1.3 key_share ephemeral so the
+     * 1.2 ECDHE exchange keys itself from the server-selected curve. A 1.3-only
+     * client leaves version unchanged and the check below rejects the mismatch. */
+    if (hello.version == R_TLS_VERSION_TLS_1_2 &&
+        client->min_version <= R_TLS_VERSION_TLS_1_2) {
+      client->version = R_TLS_VERSION_TLS_1_2;
+      if (client->ecdhe_key != NULL) {
+        r_crypto_key_unref (client->ecdhe_key);
+        client->ecdhe_key = NULL;
+      }
+    }
   }
 
   if (hello.version != client->version)

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -1557,6 +1557,10 @@ r_tls_client_nego_server_hello (RTLSClient * client, const RTLSParser * parser)
     RTLSError r13 = r_tls_client_nego_server_hello13 (client, &hello);
     if (r13 != R_TLS_ERROR_NOT_NEEDED)
       return r13;
+    /* Offered 1.3 but the server selected a lower version: a downgrade sentinel
+     * in the random is a forced downgrade and must abort (RFC 8446 4.1.3). */
+    if (r_tls13_random_is_downgrade (hello.random))
+      return R_TLS_ERROR_ILLEGAL_PARAMETER;
   }
 
   if (hello.version != client->version)
@@ -2155,6 +2159,9 @@ r_tls_client_state_server_hello (RTLSClient * client, const RTLSParser * parser)
       break;
     case R_TLS_ERROR_VERSION:
       r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_PROTOCOL_VERSION);
+      break;
+    case R_TLS_ERROR_ILLEGAL_PARAMETER:
+      r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_ILLEGAL_PARAMETER);
       break;
     case R_TLS_ERROR_HANDSHAKE_FAILURE:
       r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_HANDSHAKE_FAILURE);

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -116,6 +116,10 @@ struct RTLSClient {
   RMsgDigestType cs13_hash;             /* SHA-256 / SHA-384 */
   RTLSSupportedGroup ks_group;          /* offered key_share group */
   ruint8 flight13_step;                 /* sub-step within the encrypted flight */
+  rboolean hrr_received;                /* a HelloRetryRequest was processed */
+  rboolean hrr_just_sent;              /* the retry ClientHello was just sent */
+  ruint8 cookie[256];                   /* cookie echoed in the retry ClientHello */
+  ruint16 cookielen;
 
   RBuffer * inbuf;
   RQueue qsend;
@@ -540,8 +544,19 @@ r_tls_client_write_hs_ext_key_share13 (RTLSClient * client, ruint8 * ptr)
   return (ruint16) (10 + plen);
 }
 
+/* ClientHello cookie echo: returns the HelloRetryRequest's cookie verbatim. */
+static ruint16
+r_tls_client_write_hs_ext_cookie (RTLSClient * client, ruint8 * ptr)
+{
+  r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_COOKIE);
+  r_store_be16 (&ptr[2], (ruint16) (sizeof (ruint16) + client->cookielen));
+  r_store_be16 (&ptr[4], client->cookielen);
+  r_memcpy (&ptr[6], client->cookie, client->cookielen);
+  return (ruint16) (6 + client->cookielen);
+}
+
 static RTLSError
-r_tls_client_send_hello (RTLSClient * client)
+r_tls_client_send_hello (RTLSClient * client, rboolean retry)
 {
   RBuffer * buf;
   RTLSError ret;
@@ -581,9 +596,13 @@ r_tls_client_send_hello (RTLSClient * client)
       cs[1] = R_TLS_CS_AES_256_GCM_SHA384;
       ncs = 2;
     }
-    client->ks_group = R_TLS_SUPPORTED_GROUP_X25519;
-    if (!r_tls_ecdhe_group_to_curve (client->ks_group, &client->ecdhe_curve))
-      return R_TLS_ERROR_HANDSHAKE_FAILURE;
+    /* On a retry the group + ephemeral were re-selected for the
+     * HelloRetryRequest's group; keep them. */
+    if (!retry) {
+      client->ks_group = R_TLS_SUPPORTED_GROUP_X25519;
+      if (!r_tls_ecdhe_group_to_curve (client->ks_group, &client->ecdhe_curve))
+        return R_TLS_ERROR_HANDSHAKE_FAILURE;
+    }
     if (client->ecdhe_key == NULL &&
         (client->ecdhe_key = r_tls_ecdhe_keygen (client->ecdhe_curve, client->prng)) == NULL)
       return R_TLS_ERROR_HANDSHAKE_FAILURE;
@@ -625,6 +644,8 @@ r_tls_client_send_hello (RTLSClient * client)
       extsize += r_tls_client_write_hs_ext_signature_algorithms13 (ptr + 2 + extsize);
       extsize += r_tls_client_write_hs_ext_supported_versions13 (ptr + 2 + extsize);
       extsize += r_tls_client_write_hs_ext_key_share13 (client, ptr + 2 + extsize);
+      if (retry && client->cookielen > 0)
+        extsize += r_tls_client_write_hs_ext_cookie (client, ptr + 2 + extsize);
       if (client->server_name != NULL)
         extsize += r_tls_client_write_hs_ext_server_name (ptr + 2 + extsize, client->server_name);
     } else {
@@ -650,12 +671,18 @@ r_tls_client_send_hello (RTLSClient * client)
       else
         ret = r_tls_update_handshake_len (info.data, info.size, (ruint16)(size - hssize));
 
-      /* Buffer the ClientHello handshake message; it is folded into the
-       * transcript once the ServerHello picks the suite (hence the hash). */
       if (ret == R_TLS_ERROR_OK) {
-        client->clienthellolen = size - hdrsize;
-        if ((client->clienthello = r_memdup (info.data + hdrsize, client->clienthellolen)) == NULL)
-          ret = R_TLS_ERROR_OOM;
+        if (retry) {
+          /* The retry ClientHello is folded straight into the live transcript
+           * (which already holds message_hash(CH1) || HelloRetryRequest). */
+          r_msg_digest_update (client->hshash, info.data + hdrsize, size - hdrsize);
+        } else {
+          /* Buffer the first ClientHello; it is folded once the ServerHello
+           * picks the suite (hence the hash). */
+          client->clienthellolen = size - hdrsize;
+          if ((client->clienthello = r_memdup (info.data + hdrsize, client->clienthellolen)) == NULL)
+            ret = R_TLS_ERROR_OOM;
+        }
       }
     }
     r_buffer_unmap (buf, &info);
@@ -697,7 +724,7 @@ r_tls_client_start (RTLSClient * client, REvLoop * loop, RPrng * prng,
 
   r_tls_client_change_state (client, R_TLS_CLIENT_SERVER_HELLO);
 
-  if (r_tls_client_send_hello (client) != R_TLS_ERROR_OK)
+  if (r_tls_client_send_hello (client, FALSE) != R_TLS_ERROR_OK)
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
   client->client.msgseq++;
   r_tls_client_send_out (client);
@@ -814,6 +841,10 @@ r_tls_client_nego_server_hello13 (RTLSClient * client, const RTLSHelloMsg * hell
   if (hello->cslen != sizeof (ruint16))
     return R_TLS_ERROR_CORRUPT_RECORD;
   cs = (RTLSCipherSuite) r_load_be16 (hello->cs);
+  /* After a HelloRetryRequest the ServerHello must keep the suite the HRR
+   * committed to (RFC 8446 4.1.4); a changed suite is illegal_parameter. */
+  if (client->hrr_received && cs != client->cs13_suite)
+    return R_TLS_ERROR_ILLEGAL_PARAMETER;
   /* The 1.3 suites carry a table entry (key_exchange NULL, the AEAD cipher and
    * the HKDF/transcript hash); record it as the negotiated suite so the public
    * accessors report it, and take the cipher and hash from it. */
@@ -838,15 +869,19 @@ r_tls_client_nego_server_hello13 (RTLSClient * client, const RTLSHelloMsg * hell
   r_memcpy (client->servrandom, hello->random, R_TLS_HELLO_RANDOM_BYTES);
 
   /* Start the transcript on the suite hash and fold the buffered ClientHello;
-   * the caller folds the ServerHello right after this returns. */
-  if (R_UNLIKELY (client->hshash != NULL || client->clienthello == NULL))
-    return R_TLS_ERROR_WRONG_STATE;
-  if ((client->hshash = r_msg_digest_new (client->cs13_hash)) == NULL)
-    return R_TLS_ERROR_HANDSHAKE_FAILURE;
-  r_msg_digest_update (client->hshash, client->clienthello, client->clienthellolen);
-  r_free (client->clienthello);
-  client->clienthello = NULL;
-  client->clienthellolen = 0;
+   * the caller folds the ServerHello right after this returns. After a
+   * HelloRetryRequest the transcript (message_hash(CH1) || HRR || CH2) is
+   * already established, so leave it. */
+  if (!client->hrr_received) {
+    if (R_UNLIKELY (client->hshash != NULL || client->clienthello == NULL))
+      return R_TLS_ERROR_WRONG_STATE;
+    if ((client->hshash = r_msg_digest_new (client->cs13_hash)) == NULL)
+      return R_TLS_ERROR_HANDSHAKE_FAILURE;
+    r_msg_digest_update (client->hshash, client->clienthello, client->clienthellolen);
+    r_free (client->clienthello);
+    client->clienthello = NULL;
+    client->clienthellolen = 0;
+  }
 
   client->flight13_step = 0;
   client->tls13 = TRUE;
@@ -877,6 +912,102 @@ r_tls_client_setup_keys13 (RTLSClient * client)
   if (!r_tls_client_install_keys13 (client, &client->rk_read, client->sched13.shs) ||
       !r_tls_client_install_keys13 (client, &client->rk_write, client->sched13.chs))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  return R_TLS_ERROR_OK;
+}
+
+/* Handle a HelloRetryRequest (a ServerHello carrying the HRR-sentinel random):
+ * rewrite the transcript to message_hash(CH1) || HRR, regenerate the key_share
+ * for the group the server selected, and send the second ClientHello. */
+static RTLSError
+r_tls_client_handle_hrr (RTLSClient * client, const RTLSHelloMsg * hello,
+    const RTLSParser * parser)
+{
+  RTLSHelloExt ext, sv = R_TLS_HELLO_EXT_INIT, ks = R_TLS_HELLO_EXT_INIT,
+      ck = R_TLS_HELLO_EXT_INIT;
+  rboolean have_sv = FALSE, have_ks = FALSE, have_ck = FALSE;
+  RTLSSupportedGroup selected;
+  RTLSCipherSuite cs;
+  REcurveID curve;
+  ruint8 mh[4 + R_TLS13_SECRET_MAX];
+  rsize mhlen = 0;
+  RTLSError r;
+
+  /* Only one HelloRetryRequest is permitted (RFC 8446 4.1.4). */
+  if (client->hrr_received)
+    return R_TLS_ERROR_WRONG_TYPE;
+
+  for (r = r_tls_hello_msg_extension_first (hello, &ext); r == R_TLS_ERROR_OK;
+      r = r_tls_hello_msg_extension_next (hello, &ext)) {
+    if (ext.type == R_TLS_EXT_TYPE_SUPPORTED_VERSIONS) { sv = ext; have_sv = TRUE; }
+    else if (ext.type == R_TLS_EXT_TYPE_KEY_SHARE) { ks = ext; have_ks = TRUE; }
+    else if (ext.type == R_TLS_EXT_TYPE_COOKIE) { ck = ext; have_ck = TRUE; }
+  }
+  if (!have_sv || r_tls_hello_ext_selected_version (&sv) != R_TLS_VERSION_TLS_1_3)
+    return R_TLS_ERROR_VERSION;
+  if (!have_ks)
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
+  /* The selected group must be one we support and must differ from the one we
+   * already sent a share for (otherwise the server should not have retried). */
+  selected = r_tls_hello_ext_key_share_group (&ks);
+  if (!r_tls_ecdhe_group_to_curve (selected, &curve) || selected == client->ks_group)
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
+  /* Cipher suite from the HelloRetryRequest. */
+  if (hello->cslen != sizeof (ruint16))
+    return R_TLS_ERROR_CORRUPT_RECORD;
+  cs = (RTLSCipherSuite) r_load_be16 (hello->cs);
+  if ((client->csinfo = r_tls_cipher_suite_get_info (cs)) == NULL ||
+      client->csinfo->cipher == NULL ||
+      (cs != R_TLS_CS_AES_128_GCM_SHA256 && cs != R_TLS_CS_AES_256_GCM_SHA384))
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  client->cs13_suite = cs;
+  client->cs13_cipher = client->csinfo->cipher;
+  client->cs13_hash = client->csinfo->prf;
+
+  /* Stash the cookie to echo in the retry. */
+  if (have_ck) {
+    ruint16 clen;
+    const ruint8 * c = r_tls_hello_ext_cookie (&ck, &clen);
+    if (c == NULL || clen > sizeof (client->cookie))
+      return R_TLS_ERROR_HANDSHAKE_FAILURE;
+    r_memcpy (client->cookie, c, clen);
+    client->cookielen = clen;
+  }
+
+  /* Regenerate the (EC)DHE share for the selected group. */
+  client->ks_group = selected;
+  client->ecdhe_curve = curve;
+  if (client->ecdhe_key != NULL) {
+    r_crypto_key_unref (client->ecdhe_key);
+    client->ecdhe_key = NULL;
+  }
+  if ((client->ecdhe_key = r_tls_ecdhe_keygen (curve, client->prng)) == NULL)
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
+  /* Transcript rewrite (RFC 8446 4.4.1): the first ClientHello is replaced by
+   * message_hash(CH1), then the HelloRetryRequest is folded. */
+  if (R_UNLIKELY (client->hshash != NULL || client->clienthello == NULL))
+    return R_TLS_ERROR_WRONG_STATE;
+  if ((client->hshash = r_msg_digest_new (client->cs13_hash)) == NULL)
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  if (!r_tls13_message_hash (client->cs13_hash, client->clienthello,
+        client->clienthellolen, mh, sizeof (mh), &mhlen))
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  r_msg_digest_update (client->hshash, mh, mhlen);
+  r_free (client->clienthello);
+  client->clienthello = NULL;
+  client->clienthellolen = 0;
+  r_msg_digest_update (client->hshash, parser->fragment.data, parser->fragment.size);
+
+  client->tls13 = TRUE;
+  client->hrr_received = TRUE;
+
+  /* Send the second ClientHello; it folds itself into the live transcript. */
+  if ((r = r_tls_client_send_hello (client, TRUE)) != R_TLS_ERROR_OK)
+    return r;
+  client->client.msgseq++;
+  client->hrr_just_sent = TRUE;
   return R_TLS_ERROR_OK;
 }
 
@@ -1056,6 +1187,12 @@ r_tls_client_nego_server_hello (RTLSClient * client, const RTLSParser * parser)
 
   if ((r = r_tls_parser_parse_hello (parser, &hello)) != R_TLS_ERROR_OK)
     return r;
+
+  /* A ServerHello carrying the HelloRetryRequest sentinel random is a retry
+   * request: rewrite the transcript and send a second ClientHello. */
+  if (client->version == R_TLS_VERSION_TLS_1_3 &&
+      r_tls13_random_is_hrr (hello.random))
+    return r_tls_client_handle_hrr (client, &hello, parser);
 
   /* A 1.3-capable client checks supported_versions before the legacy version,
    * which a 1.3 ServerHello pins to 0x0303. */
@@ -1635,12 +1772,20 @@ r_tls_client_state_server_hello (RTLSClient * client, const RTLSParser * parser)
   if ((err = r_tls_parser_parse_handshake_peek_type (parser, &type)) == R_TLS_ERROR_OK) {
     if (type != R_TLS_HANDSHAKE_TYPE_SERVER_HELLO)
       err = R_TLS_ERROR_WRONG_TYPE;
-    else if ((err = r_tls_client_nego_server_hello (client, parser)) == R_TLS_ERROR_OK)
+    else if ((err = r_tls_client_nego_server_hello (client, parser)) == R_TLS_ERROR_OK &&
+             !client->hrr_just_sent)
       err = r_tls_client_change_state (client, R_TLS_CLIENT_CERTIFICATE);
   }
 
   switch (err) {
     case R_TLS_ERROR_OK:
+      if (client->hrr_just_sent) {
+        /* A HelloRetryRequest was processed and the second ClientHello sent;
+         * the transcript was rewritten there. Stay in this state to await the
+         * real ServerHello. */
+        client->hrr_just_sent = FALSE;
+        break;
+      }
       r_msg_digest_update (client->hshash, parser->fragment.data, parser->fragment.size);
       /* With the ServerHello folded, the 1.3 handshake secrets can be derived
        * and the handshake-traffic keys installed. */

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -120,10 +120,50 @@ struct RTLSClient {
   rboolean hrr_just_sent;              /* the retry ClientHello was just sent */
   ruint8 cookie[256];                   /* cookie echoed in the retry ClientHello */
   ruint16 cookielen;
+  RTLSClientSession * resume;           /* session to offer for resumption, or NULL */
+  RTLSClientSession * new_session;      /* session from a received NewSessionTicket */
+  rboolean resumed13;                   /* server accepted our pre_shared_key */
 
   RBuffer * inbuf;
   RQueue qsend;
 };
+
+/* A stored TLS 1.3 resumption session: the server's ticket, the PSK derived
+ * from it, and the parameters needed to offer it again (RFC 8446 4.6.1). */
+struct RTLSClientSession {
+  RRef ref;
+  ruint8 * ticket;              /* opaque NewSessionTicket identity */
+  rsize ticketlen;
+  ruint8 psk[R_TLS13_SECRET_MAX];
+  rsize psklen;
+  RTLSCipherSuite suite;
+  RMsgDigestType hash;
+  ruint32 age_add;
+  RClockTime obtained;          /* when the ticket arrived, for obfuscated age */
+};
+
+static void
+r_tls_client_session_free (RTLSClientSession * s)
+{
+  r_free (s->ticket);
+  r_memclear_secure (s->psk, sizeof (s->psk));
+  r_free (s);
+}
+
+/* Wall-clock 'now' for ticket age bookkeeping; a synthetic loop clock drives it
+ * deterministically in tests (mirrors r_tls_server_now). */
+static RClockTime
+r_tls_client_now (const RTLSClient * client)
+{
+  RClock * clock;
+
+  if (client->loop != NULL &&
+      (clock = r_ev_loop_get_clock (client->loop)) != NULL &&
+      r_clock_is_synthetic (clock))
+    return r_clock_get_time (clock);
+
+  return r_time_get_ts_wallclock ();
+}
 
 R_LOG_CATEGORY_DEFINE_STATIC (tlsclicat, "tlsclient", "RLib TLS Client",
     R_CLR_FG_WHITE | R_CLR_BG_BLUE | R_CLR_FMT_BOLD);
@@ -171,6 +211,10 @@ r_tls_client_free (RTLSClient * client)
   r_free (client->server.fixediv);
   r_msg_digest_free (client->hshash);
   r_free (client->clienthello);
+  if (client->resume != NULL)
+    r_tls_client_session_unref (client->resume);
+  if (client->new_session != NULL)
+    r_tls_client_session_unref (client->new_session);
 
   if (client->inbuf != NULL)
     r_buffer_unref (client->inbuf);
@@ -178,6 +222,26 @@ r_tls_client_free (RTLSClient * client)
   r_memclear_secure (client->mastersecret, sizeof (client->mastersecret));
   r_memclear_secure (&client->sched13, sizeof (client->sched13));
   r_free (client);
+}
+
+RTLSError
+r_tls_client_set_session (RTLSClient * client, RTLSClientSession * session)
+{
+  if (R_UNLIKELY (client == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (client->loop != NULL)) return R_TLS_ERROR_WRONG_STATE;
+
+  if (client->resume != NULL)
+    r_tls_client_session_unref (client->resume);
+  client->resume = (session != NULL) ? r_tls_client_session_ref (session) : NULL;
+  return R_TLS_ERROR_OK;
+}
+
+RTLSClientSession *
+r_tls_client_get_session (const RTLSClient * client)
+{
+  if (R_UNLIKELY (client == NULL) || client->new_session == NULL)
+    return NULL;
+  return r_tls_client_session_ref (client->new_session);
 }
 
 static RTLSError
@@ -555,6 +619,80 @@ r_tls_client_write_hs_ext_cookie (RTLSClient * client, ruint8 * ptr)
   return (ruint16) (6 + client->cookielen);
 }
 
+/* psk_key_exchange_modes offering psk_dhe_ke (RFC 8446 4.2.9). */
+static ruint16
+r_tls_client_write_hs_ext_psk_key_exchange_modes (ruint8 * ptr)
+{
+  r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_PSK_KEY_EXCHANGE_MODES);
+  r_store_be16 (&ptr[2], 2);
+  ptr[4] = 1;                                     /* ke_modes<1..255> length */
+  ptr[5] = (ruint8) R_TLS_PSK_KE_MODE_PSK_DHE_KE;
+  return 6;
+}
+
+/* pre_shared_key offer with a single identity and a zeroed binder placeholder
+ * (RFC 8446 4.2.11). Returns bytes written and, via @binder_off, the offset of
+ * the binder value within @ptr so the caller can patch it after computing it
+ * over the truncated ClientHello. */
+static ruint16
+r_tls_client_write_hs_ext_pre_shared_key (RTLSClient * client, ruint8 * ptr,
+    ruint8 binderlen, rsize * binder_off)
+{
+  RTLSClientSession * s = client->resume;
+  ruint16 idlen = (ruint16) s->ticketlen;
+  ruint16 idslen = (ruint16) (sizeof (ruint16) + idlen + sizeof (ruint32));
+  ruint16 bslen = (ruint16) (1 + binderlen);
+  ruint32 age;
+  rsize n = 0;
+
+  /* obfuscated_ticket_age = elapsed_ms + ticket_age_add (RFC 8446 4.2.11.1). */
+  age = (ruint32) ((r_tls_client_now (client) - s->obtained) / R_MSECOND) + s->age_add;
+
+  r_store_be16 (&ptr[n], (ruint16)R_TLS_EXT_TYPE_PRE_SHARED_KEY); n += 2;
+  r_store_be16 (&ptr[n], (ruint16) (sizeof (ruint16) + idslen +
+        sizeof (ruint16) + bslen)); n += 2;
+  r_store_be16 (&ptr[n], idslen); n += 2;         /* identities<7..> length */
+  r_store_be16 (&ptr[n], idlen); n += 2;
+  r_memcpy (&ptr[n], s->ticket, idlen); n += idlen;
+  r_store_be32 (&ptr[n], age); n += 4;
+  r_store_be16 (&ptr[n], bslen); n += 2;          /* binders<33..> length */
+  ptr[n++] = binderlen;
+  *binder_off = n;
+  r_memset (&ptr[n], 0, binderlen); n += binderlen;
+  return (ruint16) n;
+}
+
+/* Compute the pre_shared_key binder over the truncated ClientHello
+ * [@chstart, @binders) with the resumption PSK's binder key (RFC 8446
+ * 4.2.11.2). Assumes an empty prior transcript (the non-retry offer). */
+static rboolean
+r_tls_client_psk_binder (RTLSClient * client, const ruint8 * chstart,
+    const ruint8 * binders, ruint8 * out)
+{
+  RTLSClientSession * s = client->resume;
+  RTLS13Schedule sched;
+  ruint8 bhash[R_TLS13_SECRET_MAX], bk[R_TLS13_SECRET_MAX], finkey[R_TLS13_SECRET_MAX];
+  rsize hlen = r_msg_digest_type_size (s->hash);
+  RMsgDigest * md;
+  rboolean ok;
+
+  if ((md = r_msg_digest_new (s->hash)) == NULL)
+    return FALSE;
+  ok = r_msg_digest_update (md, chstart,
+          RPOINTER_TO_SIZE (binders) - RPOINTER_TO_SIZE (chstart)) &&
+       r_msg_digest_get_data (md, bhash, hlen, NULL);
+  r_msg_digest_free (md);
+  if (!ok)
+    return FALSE;
+
+  ok = r_tls13_schedule_init_psk (&sched, s->hash, s->psk, s->psklen) &&
+       r_tls13_binder_key (&sched, bk) &&
+       r_tls13_finished_key (s->hash, bk, finkey) &&
+       r_tls13_verify_data (s->hash, finkey, bhash, out);
+  r_memclear_secure (&sched, sizeof (sched));
+  return ok;
+}
+
 static RTLSError
 r_tls_client_send_hello (RTLSClient * client, rboolean retry)
 {
@@ -616,10 +754,10 @@ r_tls_client_send_hello (RTLSClient * client, rboolean retry)
     return R_TLS_ERROR_OOM;
 
   if (r_buffer_map (buf, &info, R_MEM_MAP_WRITE)) {
-    ruint8 * ptr;
+    ruint8 * ptr, * psk_binder_ptr = NULL;
     rsize hssize, size = 0;
     ruint16 extsize;
-    ruint8 hdrsize;
+    ruint8 hdrsize, psk_binderlen = 0;
 
     if (dtls) {
       ret = r_dtls_write_handshake (info.data, info.size, &hssize,
@@ -648,6 +786,18 @@ r_tls_client_send_hello (RTLSClient * client, rboolean retry)
         extsize += r_tls_client_write_hs_ext_cookie (client, ptr + 2 + extsize);
       if (client->server_name != NULL)
         extsize += r_tls_client_write_hs_ext_server_name (ptr + 2 + extsize, client->server_name);
+      /* Advertise (EC)DHE resumption support so the server issues tickets. */
+      extsize += r_tls_client_write_hs_ext_psk_key_exchange_modes (ptr + 2 + extsize);
+      /* pre_shared_key MUST be the last extension. Offered only on the initial
+       * ClientHello (the binder transcript assumes an empty prior transcript). */
+      if (client->resume != NULL && !retry) {
+        ruint8 * pskptr = ptr + 2 + extsize;
+        rsize boff;
+        psk_binderlen = (ruint8) r_msg_digest_type_size (client->resume->hash);
+        extsize += r_tls_client_write_hs_ext_pre_shared_key (client, pskptr,
+            psk_binderlen, &boff);
+        psk_binder_ptr = pskptr + boff;
+      }
     } else {
       extsize += r_tls_client_write_hs_ext_renegotiation (ptr + 2 + extsize);
       extsize += r_tls_client_write_hs_ext_extended_ms (ptr + 2 + extsize);
@@ -670,6 +820,18 @@ r_tls_client_send_hello (RTLSClient * client, rboolean retry)
             (ruint16)(size - hssize), 0, (ruint32)(size - hssize));
       else
         ret = r_tls_update_handshake_len (info.data, info.size, (ruint16)(size - hssize));
+
+      /* Now that the header length covers the full ClientHello, compute the
+       * binder over the message truncated before the binders list and patch it
+       * in, so the folded transcript carries the real binder. */
+      if (ret == R_TLS_ERROR_OK && psk_binder_ptr != NULL) {
+        ruint8 binder[R_TLS13_SECRET_MAX];
+        if (!r_tls_client_psk_binder (client, info.data + hdrsize,
+              psk_binder_ptr - 3, binder))
+          ret = R_TLS_ERROR_HANDSHAKE_FAILURE;
+        else
+          r_memcpy (psk_binder_ptr, binder, psk_binderlen);
+      }
 
       if (ret == R_TLS_ERROR_OK) {
         if (retry) {
@@ -822,8 +984,9 @@ static RTLSError
 r_tls_client_nego_server_hello13 (RTLSClient * client, const RTLSHelloMsg * hello)
 {
   RTLSHelloExt ext, sv = R_TLS_HELLO_EXT_INIT, ks = R_TLS_HELLO_EXT_INIT;
+  RTLSHelloExt psk = R_TLS_HELLO_EXT_INIT;
   RTLSKeyShareEntry entry = R_TLS_KEY_SHARE_ENTRY_INIT;
-  rboolean have_sv = FALSE, have_ks = FALSE;
+  rboolean have_sv = FALSE, have_ks = FALSE, have_psk = FALSE;
   RTLSCipherSuite cs;
   REcurveID curve;
   RTLSError r;
@@ -832,10 +995,19 @@ r_tls_client_nego_server_hello13 (RTLSClient * client, const RTLSHelloMsg * hell
       r = r_tls_hello_msg_extension_next (hello, &ext)) {
     if (ext.type == R_TLS_EXT_TYPE_SUPPORTED_VERSIONS) { sv = ext; have_sv = TRUE; }
     else if (ext.type == R_TLS_EXT_TYPE_KEY_SHARE) { ks = ext; have_ks = TRUE; }
+    else if (ext.type == R_TLS_EXT_TYPE_PRE_SHARED_KEY) { psk = ext; have_psk = TRUE; }
   }
   if (!have_sv ||
       r_tls_hello_ext_selected_version (&sv) != R_TLS_VERSION_TLS_1_3)
     return R_TLS_ERROR_NOT_NEEDED;
+
+  /* The server accepts resumption by echoing pre_shared_key with the identity
+   * it selected; it must be one we offered (we offer a single identity, 0). */
+  if (have_psk && client->resume != NULL) {
+    if (psk.len != sizeof (ruint16) || r_load_be16 (psk.data) != 0)
+      return R_TLS_ERROR_HANDSHAKE_FAILURE;
+    client->resumed13 = TRUE;
+  }
 
   /* Committed to 1.3. */
   if (hello->cslen != sizeof (ruint16))
@@ -901,7 +1073,12 @@ r_tls_client_setup_keys13 (RTLSClient * client)
   if (!r_tls_ecdhe_compute (client->ecdhe_key, client->ecdhe_server_pub,
         ecdhe, sizeof (ecdhe), &ecdhelen))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
-  if (!r_tls13_schedule_init (&client->sched13, client->cs13_hash) ||
+  /* On an accepted resumption the Early Secret comes from the ticket PSK
+   * (psk_dhe_ke); otherwise it is the PSK-less zero value. */
+  if (!(client->resumed13 ?
+          r_tls13_schedule_init_psk (&client->sched13, client->cs13_hash,
+              client->resume->psk, client->resume->psklen) :
+          r_tls13_schedule_init (&client->sched13, client->cs13_hash)) ||
       !r_tls13_schedule_handshake (&client->sched13, ecdhe, ecdhelen, th)) {
     r_memclear_secure (ecdhe, sizeof (ecdhe));
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
@@ -1072,7 +1249,9 @@ r_tls_client_flight13 (RTLSClient * client, const RTLSParser * parser)
       if (type != R_TLS_HANDSHAKE_TYPE_ENCRYPTED_EXTENSIONS)
         return R_TLS_ERROR_WRONG_TYPE;
       r_msg_digest_update (client->hshash, parser->fragment.data, parser->fragment.size);
-      client->flight13_step = 1;
+      /* A resumed handshake authenticates via the PSK, so no Certificate /
+       * CertificateVerify follow: jump straight to the server Finished. */
+      client->flight13_step = client->resumed13 ? 3 : 1;
       return R_TLS_ERROR_OK;
 
     case 1: {
@@ -1161,6 +1340,12 @@ r_tls_client_flight13 (RTLSClient * client, const RTLSParser * parser)
       if ((err = r_tls_client_send_hs13 (client,
               R_TLS_HANDSHAKE_TYPE_FINISHED, body, bodylen)) != R_TLS_ERROR_OK)
         return err;
+
+      /* Derive the resumption master secret over the transcript through the
+       * client Finished (send_hs13 just folded it), for tickets received later. */
+      if (!r_msg_digest_get_data (client->hshash, th, hlen, NULL) ||
+          !r_tls13_schedule_resumption (&client->sched13, th))
+        return R_TLS_ERROR_HANDSHAKE_FAILURE;
 
       /* Switch to application keys: client writes cap, reads sap. */
       if (!r_tls_client_install_keys13 (client, &client->rk_write, client->sched13.cap) ||
@@ -2076,6 +2261,48 @@ r_tls_client_state_finished (RTLSClient * client, const RTLSParser * parser)
   return err;
 }
 
+/* Store a post-handshake NewSessionTicket (RFC 8446 4.6.1) as a resumption
+ * session: keep the ticket and derive its PSK from our resumption master
+ * secret and the ticket nonce. A malformed ticket or allocation failure is
+ * ignored (resumption is best-effort). */
+static void
+r_tls_client_store_ticket13 (RTLSClient * client, const RTLSParser * parser)
+{
+  ruint32 lifetime, age_add;
+  const ruint8 * nonce, * ticket;
+  ruint8 noncelen;
+  ruint16 ticketsize;
+  RTLSClientSession * s;
+
+  if (r_tls_parser_parse_new_session_ticket13 (parser, &lifetime, &age_add,
+        &nonce, &noncelen, &ticket, &ticketsize) != R_TLS_ERROR_OK)
+    return;
+  if ((s = r_mem_new0 (RTLSClientSession)) == NULL)
+    return;
+  if ((s->ticket = r_memdup (ticket, ticketsize)) == NULL) {
+    r_free (s);
+    return;
+  }
+  s->ticketlen = ticketsize;
+  s->suite = client->cs13_suite;
+  s->hash = client->cs13_hash;
+  s->age_add = age_add;
+  s->obtained = r_tls_client_now (client);
+  if (!r_tls13_resumption_psk (client->cs13_hash, client->sched13.res_master,
+        nonce, noncelen, s->psk)) {
+    r_memclear_secure (s->psk, sizeof (s->psk));
+    r_free (s->ticket);
+    r_free (s);
+    return;
+  }
+  s->psklen = r_msg_digest_type_size (client->cs13_hash);
+  r_ref_init (s, r_tls_client_session_free);
+
+  if (client->new_session != NULL)
+    r_tls_client_session_unref (client->new_session);
+  client->new_session = s;
+}
+
 static RTLSError
 r_tls_client_state_appdata (RTLSClient * client, const RTLSParser * parser)
 {
@@ -2086,6 +2313,14 @@ r_tls_client_state_appdata (RTLSClient * client, const RTLSParser * parser)
       client->cb.appdata (client->userdata, buf, client);
       r_buffer_unref (buf);
     }
+  } else if (parser->content == R_TLS_CONTENT_TYPE_HANDSHAKE) {
+    /* Post-handshake messages (1.3): store a NewSessionTicket for resumption,
+     * ignore the rest (e.g. KeyUpdate is out of scope). */
+    RTLSHandshakeType type;
+    if (client->tls13 &&
+        r_tls_parser_parse_handshake_peek_type (parser, &type) == R_TLS_ERROR_OK &&
+        type == R_TLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET)
+      r_tls_client_store_ticket13 (client, parser);
   } else {
     R_LOG_WARNING ("Received non-app-data record");
   }

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -2275,7 +2275,7 @@ r_tls_client_store_ticket13 (RTLSClient * client, const RTLSParser * parser)
   RTLSClientSession * s;
 
   if (r_tls_parser_parse_new_session_ticket13 (parser, &lifetime, &age_add,
-        &nonce, &noncelen, &ticket, &ticketsize) != R_TLS_ERROR_OK)
+        &nonce, &noncelen, &ticket, &ticketsize, NULL) != R_TLS_ERROR_OK)
     return;
   if ((s = r_mem_new0 (RTLSClientSession)) == NULL)
     return;

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -2238,7 +2238,7 @@ r_tls_server_write_new_session_ticket13 (RTLSServer * server)
 
   if ((ret = r_tls_write_hs_new_session_ticket13 (body, sizeof (body), &bodylen,
           R_TLS_SESSION_TICKET_LIFETIME, age_add, nonce, sizeof (nonce),
-          server->ticket, server->ticketsize)) != R_TLS_ERROR_OK)
+          server->ticket, server->ticketsize, 0)) != R_TLS_ERROR_OK)
     return ret;
 
   msg[0] = (ruint8) R_TLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET;

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -136,6 +136,12 @@ struct RTLSServer {
   rboolean hrr_sent;                    /* a HelloRetryRequest was sent */
   ruint8 cookie[32];                    /* cookie issued in the HRR */
   ruint8 cookielen;
+  rboolean resumed13;                   /* 1.3 PSK resumption accepted */
+  rboolean psk_dhe_ke13;                /* client offered psk_dhe_ke mode */
+  ruint16 selected_identity13;          /* pre_shared_key identity echoed in SH */
+  ruint8 psk13[R_TLS13_SECRET_MAX];     /* ticket-derived PSK for the schedule */
+  rsize psk13_len;
+  ruint32 nst13_count;                  /* NewSessionTicket nonce counter */
 
   RBuffer * inbuf;
   RQueue qsend;
@@ -1477,6 +1483,156 @@ r_tls_server_read_key_share (const RTLSServer * server,
   return NULL;
 }
 
+/* Session state sealed inside a TLS 1.3 resumption ticket (format version 3):
+ *   version(1) | cipher_suite(2) | issued_at(8) | nonce_len(1) | nonce |
+ *   resumption_master_secret(HashLen)
+ * The nonce and res_master together yield the PSK; issued_at bounds expiry and
+ * cipher_suite fixes the hash (so HashLen). Distinct from the 1.2 layout. */
+#define R_TLS_TICKET13_STATE_VERSION  3
+#define R_TLS_TICKET13_NONCE_SIZE     4
+#define R_TLS_TICKET13_STATE_MAX      (1 + 2 + 8 + 1 + \
+    R_TLS_TICKET13_NONCE_SIZE + R_TLS13_SECRET_MAX)
+
+/* Seal the resumption state (res_master + @nonce, keyed to the negotiated
+ * suite) into an opaque ticket under the shared key store. */
+static RTLSError
+r_tls_server_create_session_ticket13 (RTLSServer * server,
+    const ruint8 * nonce, ruint8 noncelen)
+{
+  ruint8 plain[R_TLS_TICKET13_STATE_MAX];
+  ruint8 * ticket;
+  rsize ticketsize, n = 0, hlen = r_msg_digest_type_size (server->cs13_hash);
+
+  plain[n++] = R_TLS_TICKET13_STATE_VERSION;
+  r_store_be16 (&plain[n], (ruint16) server->cs13_suite); n += 2;
+  r_store_be64 (&plain[n], (ruint64) r_tls_server_now (server)); n += 8;
+  plain[n++] = noncelen;
+  r_memcpy (&plain[n], nonce, noncelen); n += noncelen;
+  r_memcpy (&plain[n], server->sched13.res_master, hlen); n += hlen;
+
+  if (!r_tls_session_ticket_keys_seal (server->ticket_keys, plain, n,
+        &ticket, &ticketsize)) {
+    r_memclear_secure (plain, sizeof (plain));
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  }
+  r_memclear_secure (plain, sizeof (plain));
+  if (ticketsize > RUINT16_MAX) {
+    r_free (ticket);
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  }
+
+  r_free (server->ticket);
+  server->ticket = ticket;
+  server->ticketsize = (ruint16) ticketsize;
+  return R_TLS_ERROR_OK;
+}
+
+/* Compute the pre_shared_key binder over the truncated ClientHello (RFC 8446
+ * 4.2.11.2): a fresh transcript from the handshake-message start up to the
+ * binders-list length field, with the given PSK's binder key. */
+static rboolean
+r_tls_server_psk_binder (RTLSServer * server, const RTLSHelloExt * psk,
+    const ruint8 * chstart, ruint8 * out)
+{
+  RTLS13Schedule sched;
+  ruint8 bhash[R_TLS13_SECRET_MAX], bk[R_TLS13_SECRET_MAX], finkey[R_TLS13_SECRET_MAX];
+  rsize hlen = r_msg_digest_type_size (server->cs13_hash);
+  const ruint8 * binders = r_tls_hello_ext_psk_binders_start (psk);
+  RMsgDigest * md;
+  rboolean ok;
+
+  if (binders == NULL || chstart == NULL || binders < chstart)
+    return FALSE;
+
+  if ((md = r_msg_digest_new (server->cs13_hash)) == NULL)
+    return FALSE;
+  ok = r_msg_digest_update (md, chstart,
+          RPOINTER_TO_SIZE (binders) - RPOINTER_TO_SIZE (chstart)) &&
+       r_msg_digest_get_data (md, bhash, hlen, NULL);
+  r_msg_digest_free (md);
+  if (!ok)
+    return FALSE;
+
+  ok = r_tls13_schedule_init_psk (&sched, server->cs13_hash,
+          server->psk13, server->psk13_len) &&
+       r_tls13_binder_key (&sched, bk) &&
+       r_tls13_finished_key (server->cs13_hash, bk, finkey) &&
+       r_tls13_verify_data (server->cs13_hash, finkey, bhash, out);
+  r_memclear_secure (&sched, sizeof (sched));
+  return ok;
+}
+
+/* Accept a 1.3 PSK resumption offer. Requires psk_key_exchange_modes offering
+ * psk_dhe_ke and a pre_shared_key whose first identity opens under our key
+ * store; the ticket's suite must match and it must be unexpired, and the binder
+ * must verify. Sets server->resumed13 / psk13 / selected_identity13 on success.
+ * Returns NOT_NEEDED to decline (fall back to a full handshake), OK to resume,
+ * or a fatal error if a valid identity carries a bad binder. */
+static RTLSError
+r_tls_server_try_resume13 (RTLSServer * server)
+{
+  RTLSHelloExt modes = R_TLS_HELLO_EXT_INIT, psk = R_TLS_HELLO_EXT_INIT;
+  RTLSPskIdentity ident = R_TLS_PSK_IDENTITY_INIT;
+  ruint8 plain[R_TLS_TICKET13_STATE_MAX], expect[R_TLS13_SECRET_MAX];
+  const ruint8 * nonce, * binder;
+  ruint8 noncelen, binderlen;
+  rsize plainlen, hlen = r_msg_digest_type_size (server->cs13_hash);
+  RTLSCipherSuite suite;
+  RClockTime issued, now;
+
+  server->resumed13 = FALSE;
+
+  if (server->ticket_keys == NULL ||
+      !r_tls_server_find_ext (server, R_TLS_EXT_TYPE_PSK_KEY_EXCHANGE_MODES, &modes) ||
+      !r_tls_hello_ext_psk_ke_modes_contains (&modes, R_TLS_PSK_KE_MODE_PSK_DHE_KE) ||
+      !r_tls_server_find_ext (server, R_TLS_EXT_TYPE_PRE_SHARED_KEY, &psk))
+    return R_TLS_ERROR_NOT_NEEDED;
+
+  /* Try the first offered identity (this cut offers a single ticket). */
+  if (r_tls_hello_ext_psk_identity_first (&psk, &ident) != R_TLS_ERROR_OK ||
+      !r_tls_session_ticket_keys_open (server->ticket_keys, ident.identity,
+          ident.len, plain, sizeof (plain), &plainlen))
+    return R_TLS_ERROR_NOT_NEEDED;   /* unknown / stale key: full handshake */
+
+  /* version | suite | issued_at | nonce_len | nonce | res_master(hlen). */
+  if (plainlen < 1 + 2 + 8 + 1 || plain[0] != R_TLS_TICKET13_STATE_VERSION)
+    goto decline;
+  suite = (RTLSCipherSuite) r_load_be16 (&plain[1]);
+  issued = (RClockTime) r_load_be64 (&plain[3]);
+  noncelen = plain[11];
+  if ((rsize) 12 + noncelen + hlen != plainlen || suite != server->cs13_suite)
+    goto decline;
+  nonce = &plain[12];
+
+  now = r_tls_server_now (server);
+  if (now < issued ||
+      now - issued > (RClockTime) R_TLS_SESSION_TICKET_LIFETIME * R_SECOND)
+    goto decline;
+
+  /* PSK = HKDF-Expand-Label(res_master, "resumption", nonce). */
+  if (!r_tls13_resumption_psk (server->cs13_hash, &plain[12 + noncelen],
+        nonce, noncelen, server->psk13))
+    goto decline;
+  server->psk13_len = hlen;
+  r_memclear_secure (plain, sizeof (plain));
+
+  /* The binder proves the client holds the PSK: a valid ticket with a bad
+   * binder is an attack, so fail fatally rather than falling back. */
+  if (r_tls_hello_ext_psk_binder (&psk, 0, &binder, &binderlen) != R_TLS_ERROR_OK ||
+      !r_tls_server_psk_binder (server, &psk, server->hello.random - 6, expect))
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  if (binderlen != hlen || r_memcmp (binder, expect, hlen) != 0)
+    return R_TLS_ERROR_HS_VERIFICATION_FAILED;
+
+  server->resumed13 = TRUE;
+  server->selected_identity13 = 0;
+  return R_TLS_ERROR_OK;
+
+decline:
+  r_memclear_secure (plain, sizeof (plain));
+  return R_TLS_ERROR_NOT_NEEDED;
+}
+
 /* Detect and negotiate TLS 1.3 from the parsed ClientHello. Returns
  * R_TLS_ERROR_NOT_NEEDED when 1.3 is not selected, so the caller falls through
  * to the <=1.2 negotiation; otherwise it commits to 1.3 (or fails). */
@@ -1567,6 +1723,24 @@ r_tls_server_nego_hello13 (RTLSServer * server)
   if ((server->hshash = r_msg_digest_new (server->cs13_hash)) == NULL)
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
 
+  /* Whether the client supports (EC)DHE resumption, so we know to issue a
+   * ticket after the handshake. */
+  {
+    RTLSHelloExt m = R_TLS_HELLO_EXT_INIT;
+    server->psk_dhe_ke13 =
+        r_tls_server_find_ext (server, R_TLS_EXT_TYPE_PSK_KEY_EXCHANGE_MODES, &m) &&
+        r_tls_hello_ext_psk_ke_modes_contains (&m, R_TLS_PSK_KE_MODE_PSK_DHE_KE);
+  }
+
+  /* Session resumption via pre_shared_key (psk_dhe_ke): accept the ticket and
+   * validate the binder, or decline (NOT_NEEDED) for a full handshake. A fatal
+   * error (bad binder on a valid ticket) aborts. */
+  {
+    RTLSError rr = r_tls_server_try_resume13 (server);
+    if (rr != R_TLS_ERROR_OK && rr != R_TLS_ERROR_NOT_NEEDED)
+      return rr;
+  }
+
   server->comp = R_TLS_COMPRESSION_NULL;
   server->version = R_TLS_VERSION_TLS_1_3;
   server->tls13 = TRUE;
@@ -1607,6 +1781,16 @@ r_tls_server_write_ext13_key_share_hrr (RTLSServer * server, ruint8 * p)
   r_store_be16 (p, R_TLS_EXT_TYPE_KEY_SHARE);
   r_store_be16 (p + 2, sizeof (ruint16));
   r_store_be16 (p + 4, (ruint16) server->ks_group);
+  return 6;
+}
+
+/* ServerHello pre_shared_key: the selected_identity (RFC 8446 4.2.11). */
+static ruint16
+r_tls_server_write_ext13_pre_shared_key (RTLSServer * server, ruint8 * p)
+{
+  r_store_be16 (p, R_TLS_EXT_TYPE_PRE_SHARED_KEY);
+  r_store_be16 (p + 2, sizeof (ruint16));
+  r_store_be16 (p + 4, server->selected_identity13);
   return 6;
 }
 
@@ -1738,6 +1922,8 @@ r_tls_server_write_hello13 (RTLSServer * server)
 
     extsize += r_tls_server_write_ext13_supported_versions (ptr + 2 + extsize);
     extsize += r_tls_server_write_ext13_key_share (server, ptr + 2 + extsize);
+    if (server->resumed13)
+      extsize += r_tls_server_write_ext13_pre_shared_key (server, ptr + 2 + extsize);
     r_store_be16 (ptr, extsize);
     ptr += extsize + 2;
 
@@ -1902,7 +2088,12 @@ r_tls_server_write_flight13 (RTLSServer * server)
   if (!r_tls_ecdhe_compute (server->ecdhe_key, server->ks_peer_pub,
         ecdhe, sizeof (ecdhe), &ecdhelen))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
-  if (!r_tls13_schedule_init (&server->sched13, server->cs13_hash) ||
+  /* Resumption is psk_dhe_ke: the Early Secret comes from the ticket PSK
+   * instead of zero, then the Handshake Secret still mixes in the ECDHE. */
+  if (!(server->resumed13 ?
+          r_tls13_schedule_init_psk (&server->sched13, server->cs13_hash,
+              server->psk13, server->psk13_len) :
+          r_tls13_schedule_init (&server->sched13, server->cs13_hash)) ||
       !r_tls13_schedule_handshake (&server->sched13, ecdhe, ecdhelen, th)) {
     r_memclear_secure (ecdhe, sizeof (ecdhe));
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
@@ -1922,35 +2113,39 @@ r_tls_server_write_flight13 (RTLSServer * server)
           R_TLS_HANDSHAKE_TYPE_ENCRYPTED_EXTENSIONS, body, bodylen)) != R_TLS_ERROR_OK)
     return ret;
 
-  /* 5. Certificate (single leaf). */
-  if ((certbuf = r_crypto_cert_get_data_buffer (server->cert)) == NULL)
-    return R_TLS_ERROR_NO_CERTIFICATE;
-  if (!r_buffer_map (certbuf, &certinfo, R_MEM_MAP_READ)) {
+  /* 5. + 6. Certificate and CertificateVerify: authenticated by the PSK on a
+   * resumed handshake, so both are skipped (RFC 8446 2.2). */
+  if (!server->resumed13) {
+    /* Certificate (single leaf). */
+    if ((certbuf = r_crypto_cert_get_data_buffer (server->cert)) == NULL)
+      return R_TLS_ERROR_NO_CERTIFICATE;
+    if (!r_buffer_map (certbuf, &certinfo, R_MEM_MAP_READ)) {
+      r_buffer_unref (certbuf);
+      return R_TLS_ERROR_OOM;
+    }
+    ret = r_tls_write_hs_certificate13 (body, sizeof (body), &bodylen,
+        certinfo.data, certinfo.size);
+    r_buffer_unmap (certbuf, &certinfo);
     r_buffer_unref (certbuf);
-    return R_TLS_ERROR_OOM;
-  }
-  ret = r_tls_write_hs_certificate13 (body, sizeof (body), &bodylen,
-      certinfo.data, certinfo.size);
-  r_buffer_unmap (certbuf, &certinfo);
-  r_buffer_unref (certbuf);
-  if (ret != R_TLS_ERROR_OK)
-    return ret;
-  if ((ret = r_tls_server_send_hs13 (server,
-          R_TLS_HANDSHAKE_TYPE_CERTIFICATE, body, bodylen)) != R_TLS_ERROR_OK)
-    return ret;
+    if (ret != R_TLS_ERROR_OK)
+      return ret;
+    if ((ret = r_tls_server_send_hs13 (server,
+            R_TLS_HANDSHAKE_TYPE_CERTIFICATE, body, bodylen)) != R_TLS_ERROR_OK)
+      return ret;
 
-  /* 6. CertificateVerify over Transcript-Hash(ClientHello..Certificate). */
-  if (!r_msg_digest_get_data (server->hshash, th, hlen, NULL))
-    return R_TLS_ERROR_HANDSHAKE_FAILURE;
-  if ((ret = r_tls_server_sign_certificate_verify13 (server, th, hlen,
-          sig, &siglen)) != R_TLS_ERROR_OK)
-    return ret;
-  if ((ret = r_tls_write_hs_certificate_verify (body, sizeof (body), &bodylen,
-          server->cv_scheme, sig, (ruint16) siglen)) != R_TLS_ERROR_OK)
-    return ret;
-  if ((ret = r_tls_server_send_hs13 (server,
-          R_TLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY, body, bodylen)) != R_TLS_ERROR_OK)
-    return ret;
+    /* CertificateVerify over Transcript-Hash(ClientHello..Certificate). */
+    if (!r_msg_digest_get_data (server->hshash, th, hlen, NULL))
+      return R_TLS_ERROR_HANDSHAKE_FAILURE;
+    if ((ret = r_tls_server_sign_certificate_verify13 (server, th, hlen,
+            sig, &siglen)) != R_TLS_ERROR_OK)
+      return ret;
+    if ((ret = r_tls_write_hs_certificate_verify (body, sizeof (body), &bodylen,
+            server->cv_scheme, sig, (ruint16) siglen)) != R_TLS_ERROR_OK)
+      return ret;
+    if ((ret = r_tls_server_send_hs13 (server,
+            R_TLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY, body, bodylen)) != R_TLS_ERROR_OK)
+      return ret;
+  }
 
   /* 7. server Finished over Transcript-Hash(ClientHello..CertificateVerify). */
   if (!r_msg_digest_get_data (server->hshash, th, hlen, NULL))
@@ -2008,7 +2203,55 @@ r_tls_server_finished13 (RTLSServer * server, const RTLSParser * parser)
       !r_tls_server_install_keys13 (server, &server->rk_read, server->sched13.cap))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
 
+  /* Fold the client Finished and derive the resumption master secret over
+   * Transcript-Hash(ClientHello..client Finished) for any tickets we issue. */
+  r_msg_digest_update (server->hshash, parser->fragment.data, parser->fragment.size);
+  if (!r_msg_digest_get_data (server->hshash, th, hlen, NULL) ||
+      !r_tls13_schedule_resumption (&server->sched13, th))
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
   return R_TLS_ERROR_OK;
+}
+
+/* Issue a post-handshake NewSessionTicket (RFC 8446 4.6.1): mint an opaque
+ * ticket around a per-ticket nonce and send it protected under the application
+ * write key. Only when a key store is configured and the client offered
+ * psk_dhe_ke. Not folded into any transcript (the handshake is complete). */
+static RTLSError
+r_tls_server_write_new_session_ticket13 (RTLSServer * server)
+{
+  ruint8 body[512], msg[512], nonce[R_TLS_TICKET13_NONCE_SIZE];
+  ruint32 age_add;
+  rsize bodylen = 0, msglen;
+  RTLSError ret;
+
+  if (server->ticket_keys == NULL || !server->psk_dhe_ke13)
+    return R_TLS_ERROR_NOT_NEEDED;
+
+  /* A per-connection counter nonce keeps each ticket's PSK distinct. */
+  r_store_be32 (nonce, server->nst13_count++);
+  if (!r_prng_fill (server->prng, (ruint8 *) &age_add, sizeof (age_add)))
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  if ((ret = r_tls_server_create_session_ticket13 (server,
+          nonce, sizeof (nonce))) != R_TLS_ERROR_OK)
+    return ret;
+
+  if ((ret = r_tls_write_hs_new_session_ticket13 (body, sizeof (body), &bodylen,
+          R_TLS_SESSION_TICKET_LIFETIME, age_add, nonce, sizeof (nonce),
+          server->ticket, server->ticketsize)) != R_TLS_ERROR_OK)
+    return ret;
+
+  msg[0] = (ruint8) R_TLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET;
+  msg[1] = (ruint8) ((bodylen >> 16) & 0xff);
+  msg[2] = (ruint8) ((bodylen >>  8) & 0xff);
+  msg[3] = (ruint8) ((bodylen      ) & 0xff);
+  msglen = R_TLS_HS_HDR_SIZE + bodylen;
+  if (R_UNLIKELY (msglen > sizeof (msg)))
+    return R_TLS_ERROR_BUF_TOO_SMALL;
+  r_memcpy (msg + R_TLS_HS_HDR_SIZE, body, bodylen);
+
+  return r_tls_server_protect_record13 (server, R_TLS_CONTENT_TYPE_HANDSHAKE,
+      msg, msglen);
 }
 
 /* ----------------------------------------------------------------------- */
@@ -2829,8 +3072,8 @@ r_tls_server_state_hello (RTLSServer * server, const RTLSParser * parser)
     if ((err = r_tls_server_nego_hello (server, parser->version, server->hello.version)) == R_TLS_ERROR_OK) {
       if (server->tls13) {
         /* The 1.3 flight is written below, after the ClientHello is folded into
-         * the transcript; state advances there. No session resumption (PSK is
-         * out of scope, issue #373). */
+         * the transcript; state advances there. A pre_shared_key offer is
+         * accepted (or declined to a full handshake) as part of writing it. */
       } else {
         RTLSError rr = r_tls_server_try_resume (server);
         if (rr == R_TLS_ERROR_OK)
@@ -3052,6 +3295,9 @@ r_tls_server_state_finished (RTLSServer * server, const RTLSParser * parser)
     if (err == R_TLS_ERROR_OK) {
       r_msg_digest_free (server->hshash);
       server->hshash = NULL;
+      /* Offer a resumption ticket now that the handshake (and the resumption
+       * master secret) is complete. A failure here does not fail the session. */
+      r_tls_server_write_new_session_ticket13 (server);
       if (server->cb.handshake_done != NULL)
         server->cb.handshake_done (server->userdata, server);
     } else {

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -783,6 +783,11 @@ r_tls_server_write_hello (RTLSServer * server)
 
     if (!server->servrandompinned) {
       r_tls_generate_hello_random (server->servrandom, server->prng);
+      /* This path only writes a <= 1.2 ServerHello; the server is otherwise
+       * 1.3-capable, so stamp the downgrade sentinel (RFC 8446 4.1.3). DTLS is
+       * excluded -- the stack has no DTLS 1.3 to be downgraded from. */
+      if (!r_tls_version_is_dtls (server->version))
+        r_tls13_downgrade_random (server->servrandom, server->version);
       server->servrandompinned = TRUE;
     }
 
@@ -3106,6 +3111,11 @@ r_tls_server_try_resume (RTLSServer * server)
   r_prng_fill (server->prng, server->session_id, server->session_id_len);
   if (!server->servrandompinned) {
     r_tls_generate_hello_random (server->servrandom, server->prng);
+    /* Resuming a <= 1.2 session still warrants the downgrade sentinel when the
+     * server is 1.3-capable (RFC 8446 4.1.3), matching r_tls_server_write_hello. */
+    if (!r_tls_version_is_dtls (server->version) &&
+        server->max_version >= R_TLS_VERSION_TLS_1_3)
+      r_tls13_downgrade_random (server->servrandom, server->version);
     server->servrandompinned = TRUE;
   }
 

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -130,8 +130,12 @@ struct RTLSServer {
   RTLSCipherSuite cs13_suite;           /* 0x1301 / 0x1302 */
   RMsgDigestType cs13_hash;             /* SHA-256 / SHA-384 */
   RTLSSupportedGroup ks_group;          /* selected key_share group */
+  RTLSSupportedGroup ks_pref_group;     /* group to require via HRR, or 0 */
   RCryptoKey * ks_peer_pub;             /* client key_share public key */
   RTLSSignatureScheme cv_scheme;        /* CertificateVerify signature scheme */
+  rboolean hrr_sent;                    /* a HelloRetryRequest was sent */
+  ruint8 cookie[32];                    /* cookie issued in the HRR */
+  ruint8 cookielen;
 
   RBuffer * inbuf;
   RQueue qsend;
@@ -344,6 +348,19 @@ r_tls_server_set_session_ticket_keys (RTLSServer * server,
     r_tls_session_ticket_keys_unref (server->ticket_keys);
   server->ticket_keys = r_tls_session_ticket_keys_ref (keys);
 
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_server_set_key_share_group (RTLSServer * server, RTLSSupportedGroup group)
+{
+  if (R_UNLIKELY (server == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (server->state > R_TLS_SERVER_HELLO)) return R_TLS_ERROR_WRONG_STATE;
+
+  /* A configured group is required of TLS 1.3 clients: if a ClientHello does
+   * not carry a key_share for it the server answers with a HelloRetryRequest.
+   * group 0 (the default) accepts the client's first offered key_share. */
+  server->ks_pref_group = group;
   return R_TLS_ERROR_OK;
 }
 
@@ -1423,6 +1440,43 @@ r_tls_server_find_ext (const RTLSServer * server, RTLSExtensionType type,
   return FALSE;
 }
 
+/* Whether the ClientHello's supported_groups lists @group. */
+static rboolean
+r_tls_server_client_offers_group (const RTLSServer * server,
+    RTLSSupportedGroup group)
+{
+  RTLSHelloExt sg = R_TLS_HELLO_EXT_INIT;
+  ruint16 n, i;
+
+  if (!r_tls_server_find_ext (server, R_TLS_EXT_TYPE_SUPPORTED_GROUPS, &sg))
+    return FALSE;
+  n = r_tls_hello_ext_supported_groups_count (&sg);
+  for (i = 0; i < n; i++)
+    if (r_tls_hello_ext_supported_group (&sg, i) == group)
+      return TRUE;
+  return FALSE;
+}
+
+/* Read the client's key_share for @group (on @curve) into a public key, or NULL
+ * when the client offered no share for that group. */
+static RCryptoKey *
+r_tls_server_read_key_share (const RTLSServer * server,
+    RTLSSupportedGroup group, REcurveID curve)
+{
+  RTLSHelloExt ks = R_TLS_HELLO_EXT_INIT;
+  RTLSKeyShareEntry entry = R_TLS_KEY_SHARE_ENTRY_INIT;
+  RTLSError r;
+
+  if (!r_tls_server_find_ext (server, R_TLS_EXT_TYPE_KEY_SHARE, &ks))
+    return NULL;
+  for (r = r_tls_hello_ext_key_share_first (&ks, &entry); r == R_TLS_ERROR_OK;
+      r = r_tls_hello_ext_key_share_next (&ks, &entry)) {
+    if (entry.group == group)
+      return r_tls_ecdhe_point_read (curve, entry.key, entry.len);
+  }
+  return NULL;
+}
+
 /* Detect and negotiate TLS 1.3 from the parsed ClientHello. Returns
  * R_TLS_ERROR_NOT_NEEDED when 1.3 is not selected, so the caller falls through
  * to the <=1.2 negotiation; otherwise it commits to 1.3 (or fails). */
@@ -1465,21 +1519,35 @@ r_tls_server_nego_hello13 (RTLSServer * server)
   server->cs13_cipher = server->csinfo->cipher;
   server->cs13_hash = server->csinfo->prf;
 
-  /* key_share: the first offered entry on a curve we support. A
-   * HelloRetryRequest when none overlaps is out of scope (issue #372). */
-  if (!r_tls_server_find_ext (server, R_TLS_EXT_TYPE_KEY_SHARE, &ks))
-    return R_TLS_ERROR_HANDSHAKE_FAILURE;
-  for (r = r_tls_hello_ext_key_share_first (&ks, &entry); r == R_TLS_ERROR_OK;
-      r = r_tls_hello_ext_key_share_next (&ks, &entry)) {
-    if (r_tls_ecdhe_group_to_curve (entry.group, &curve)) {
-      server->ks_group = entry.group;
-      server->ecdhe_curve = curve;
-      server->ks_peer_pub = r_tls_ecdhe_point_read (curve, entry.key, entry.len);
-      break;
+  /* key_share / group selection. A configured preferred group is required of
+   * the client: use the client's share for it, or leave ks_peer_pub NULL to
+   * signal a HelloRetryRequest if the client lists the group (supported_groups)
+   * without a share. With no preference, pick the first offered share on a
+   * curve we support. */
+  if (server->ks_pref_group != 0) {
+    if (!r_tls_ecdhe_group_to_curve (server->ks_pref_group, &curve))
+      return R_TLS_ERROR_HANDSHAKE_FAILURE;
+    server->ks_group = server->ks_pref_group;
+    server->ecdhe_curve = curve;
+    server->ks_peer_pub = r_tls_server_read_key_share (server, server->ks_group, curve);
+    if (server->ks_peer_pub == NULL &&
+        !r_tls_server_client_offers_group (server, server->ks_group))
+      return R_TLS_ERROR_HANDSHAKE_FAILURE;   /* client cannot do the group */
+  } else {
+    if (!r_tls_server_find_ext (server, R_TLS_EXT_TYPE_KEY_SHARE, &ks))
+      return R_TLS_ERROR_HANDSHAKE_FAILURE;
+    for (r = r_tls_hello_ext_key_share_first (&ks, &entry); r == R_TLS_ERROR_OK;
+        r = r_tls_hello_ext_key_share_next (&ks, &entry)) {
+      if (r_tls_ecdhe_group_to_curve (entry.group, &curve)) {
+        server->ks_group = entry.group;
+        server->ecdhe_curve = curve;
+        server->ks_peer_pub = r_tls_ecdhe_point_read (curve, entry.key, entry.len);
+        break;
+      }
     }
+    if (server->ks_peer_pub == NULL)
+      return R_TLS_ERROR_HANDSHAKE_FAILURE;
   }
-  if (server->ks_peer_pub == NULL)
-    return R_TLS_ERROR_HANDSHAKE_FAILURE;
 
   /* CertificateVerify scheme follows the certificate key (both hash SHA-256). */
   certalgo = r_crypto_key_get_algo (server->privkey);
@@ -1530,6 +1598,110 @@ r_tls_server_write_ext13_key_share (RTLSServer * server, ruint8 * p)
   r_store_be16 (p + 6, plen);
   r_memcpy (p + 8, point, plen);
   return (ruint16) (8 + plen);
+}
+
+/* HelloRetryRequest key_share: the selected group only, no key_exchange. */
+static ruint16
+r_tls_server_write_ext13_key_share_hrr (RTLSServer * server, ruint8 * p)
+{
+  r_store_be16 (p, R_TLS_EXT_TYPE_KEY_SHARE);
+  r_store_be16 (p + 2, sizeof (ruint16));
+  r_store_be16 (p + 4, (ruint16) server->ks_group);
+  return 6;
+}
+
+/* cookie extension carrying the server-issued cookie (RFC 8446 4.2.2). */
+static ruint16
+r_tls_server_write_ext13_cookie (RTLSServer * server, ruint8 * p)
+{
+  r_store_be16 (p, R_TLS_EXT_TYPE_COOKIE);
+  r_store_be16 (p + 2, (ruint16) (sizeof (ruint16) + server->cookielen));
+  r_store_be16 (p + 4, server->cookielen);
+  r_memcpy (p + 6, server->cookie, server->cookielen);
+  return (ruint16) (6 + server->cookielen);
+}
+
+/* Write a HelloRetryRequest: a ServerHello with the HRR-sentinel random asking
+ * the client to retry with a key_share for server->ks_group, plus a cookie. */
+static RTLSError
+r_tls_server_write_hrr (RTLSServer * server)
+{
+  RBuffer * buf;
+  RTLSError ret;
+  RMemMapInfo info;
+
+  if ((buf = r_tls_server_alloc_buffer (server)) == NULL)
+    return R_TLS_ERROR_OOM;
+
+  if (r_buffer_map (buf, &info, R_MEM_MAP_WRITE)) {
+    ruint8 * ptr;
+    rsize hssize, size = 0;
+    ruint16 extsize = 0;
+    ruint8 hrr_random[R_TLS_HELLO_RANDOM_BYTES];
+
+    r_tls13_hello_retry_random (hrr_random);
+    ret = r_tls_write_handshake (info.data, info.size, &hssize,
+        R_TLS_VERSION_TLS_1_2, R_TLS_HANDSHAKE_TYPE_SERVER_HELLO, 0);
+    ptr = info.data + hssize;
+    if (ret == R_TLS_ERROR_OK)
+      ret = r_tls_write_hs_server_hello (ptr, info.size - hssize, &size,
+          R_TLS_VERSION_TLS_1_2, hrr_random,
+          server->session_id, server->session_id_len,
+          server->cs13_suite, server->comp);
+    ptr += size;
+
+    extsize += r_tls_server_write_ext13_supported_versions (ptr + 2 + extsize);
+    extsize += r_tls_server_write_ext13_key_share_hrr (server, ptr + 2 + extsize);
+    extsize += r_tls_server_write_ext13_cookie (server, ptr + 2 + extsize);
+    r_store_be16 (ptr, extsize);
+    ptr += extsize + 2;
+
+    size = RPOINTER_TO_SIZE (ptr) - RPOINTER_TO_SIZE (info.data);
+    if (ret == R_TLS_ERROR_OK)
+      ret = r_tls_update_handshake_len (info.data, info.size,
+          (ruint16) (size - hssize));
+    if (ret == R_TLS_ERROR_OK)
+      r_msg_digest_update (server->hshash, info.data + R_TLS_RECORD_HDR_SIZE,
+          size - R_TLS_RECORD_HDR_SIZE);
+    r_buffer_unmap (buf, &info);
+    r_buffer_set_size (buf, size);
+
+    if (ret == R_TLS_ERROR_OK)
+      ret = r_tls_server_send_record (server, buf);
+  } else {
+    ret = R_TLS_ERROR_OOM;
+  }
+
+  r_buffer_unref (buf);
+  return ret;
+}
+
+/* Validate the second ClientHello after a HelloRetryRequest: it must echo our
+ * cookie and now carry a key_share for the group we asked for. */
+static RTLSError
+r_tls_server_nego_hello13_retry (RTLSServer * server)
+{
+  RTLSHelloExt ck = R_TLS_HELLO_EXT_INIT;
+  REcurveID curve;
+
+  if (server->cookielen > 0) {
+    const ruint8 * cookie;
+    ruint16 cookielen;
+    if (!r_tls_server_find_ext (server, R_TLS_EXT_TYPE_COOKIE, &ck))
+      return R_TLS_ERROR_HANDSHAKE_FAILURE;
+    cookie = r_tls_hello_ext_cookie (&ck, &cookielen);
+    if (cookie == NULL || cookielen != server->cookielen ||
+        r_memcmp (cookie, server->cookie, cookielen) != 0)
+      return R_TLS_ERROR_ILLEGAL_PARAMETER;
+  }
+
+  if (!r_tls_ecdhe_group_to_curve (server->ks_group, &curve))
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  server->ks_peer_pub = r_tls_server_read_key_share (server, server->ks_group, curve);
+  if (server->ks_peer_pub == NULL)
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;   /* still no usable share: no second HRR */
+
+  return R_TLS_ERROR_OK;
 }
 
 static RTLSError
@@ -2632,7 +2804,22 @@ r_tls_server_state_hello (RTLSServer * server, const RTLSParser * parser)
 {
   RTLSError err;
 
-  if ((err = r_tls_parser_parse_hello (parser, &server->hello)) == R_TLS_ERROR_OK) {
+  if ((err = r_tls_parser_parse_hello (parser, &server->hello)) == R_TLS_ERROR_OK &&
+      server->hrr_sent) {
+    /* Second ClientHello after our HelloRetryRequest. The transcript already
+     * holds message_hash(CH1) || HelloRetryRequest, so validate the retry, fold
+     * CH2 and run the 1.3 flight. */
+    if ((err = r_tls_server_nego_hello13_retry (server)) == R_TLS_ERROR_OK) {
+      r_msg_digest_update (server->hshash, parser->fragment.data, parser->fragment.size);
+      if ((err = r_tls_server_write_flight13 (server)) == R_TLS_ERROR_OK)
+        err = r_tls_server_change_state (server, R_TLS_SERVER_FINISHED);
+    }
+    if (err != R_TLS_ERROR_OK)
+      r_tls_server_send_alert (server, r_tls_server_alert_for_error (err));
+    return err;
+  }
+
+  if (err == R_TLS_ERROR_OK) {
     R_LOG_DEBUG ("%p - client hello parsed record ver %.4x, hello ver %.4x",
         server, parser->version, server->hello.version);
     server->hellobuf = r_buffer_ref (parser->buf);
@@ -2658,6 +2845,30 @@ r_tls_server_state_hello (RTLSServer * server, const RTLSParser * parser)
 
   switch (err) {
     case R_TLS_ERROR_OK:
+      if (server->tls13 && server->ks_peer_pub == NULL) {
+        /* The client did not offer a key_share for the required group: answer
+         * with a HelloRetryRequest. Per RFC 8446 4.4.1 the transcript replaces
+         * the first ClientHello with message_hash(CH1); issue a cookie the
+         * retry must echo. */
+        ruint8 mh[4 + R_TLS13_SECRET_MAX];
+        rsize mhlen = 0;
+        server->cookielen = (ruint8) sizeof (server->cookie);
+        if (!r_prng_fill (server->prng, server->cookie, server->cookielen) ||
+            !r_tls13_message_hash (server->cs13_hash, parser->fragment.data,
+                parser->fragment.size, mh, sizeof (mh), &mhlen)) {
+          err = R_TLS_ERROR_HANDSHAKE_FAILURE;
+        } else {
+          r_msg_digest_update (server->hshash, mh, mhlen);
+          if ((err = r_tls_server_write_hrr (server)) == R_TLS_ERROR_OK)
+            server->server.msgseq++;
+        }
+        if (err == R_TLS_ERROR_OK)
+          server->hrr_sent = TRUE;
+        else
+          r_tls_server_send_alert (server, r_tls_server_alert_for_error (err));
+        break;
+      }
+
       R_LOG_TRACE ("Updating HS hash with ClientHello %u bytes",
           (ruint)parser->fragment.size);
       r_msg_digest_update (server->hshash, parser->fragment.data, parser->fragment.size);

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -81,6 +81,8 @@ struct RTLSServer {
 
   RTLSVersion version;
   RTLSVersion recordver;        /* version of the last record seen, for pre-nego alerts */
+  RTLSVersion min_version;      /* lowest TLS version the server will negotiate */
+  RTLSVersion max_version;      /* highest; < 1.3 means the server is not 1.3-capable */
   RTLSCompressionMethod comp;
   const RTLSCipherSuiteInfo * csinfo;
   rboolean support_renego;
@@ -278,6 +280,8 @@ r_tls_server_new (const RTLSCallbacks * cb, rpointer userdata, RDestroyNotify no
     r_queue_init (&ret->qsend);
     ret->decrypt = r_tls_server_null_decrypt;
     ret->encrypt = r_tls_server_null_encrypt;
+    ret->min_version = R_TLS_VERSION_TLS_1_2;
+    ret->max_version = R_TLS_VERSION_TLS_1_3;
   }
 
   return ret;
@@ -311,6 +315,23 @@ r_tls_server_set_cert (RTLSServer * server,
   server->cert = r_crypto_cert_ref (cert);
   server->privkey = r_crypto_key_ref (privkey);
 
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_server_set_version_range (RTLSServer * server,
+    RTLSVersion min, RTLSVersion max)
+{
+  if (R_UNLIKELY (server == NULL)) return R_TLS_ERROR_INVAL;
+  /* The range gates version negotiation in the ServerHello; fix it first. */
+  if (R_UNLIKELY (server->state > R_TLS_SERVER_HELLO)) return R_TLS_ERROR_WRONG_STATE;
+  /* Only the TLS 1.2..1.3 window is configurable; DTLS is fixed at 1.2. */
+  if (R_UNLIKELY (min < R_TLS_VERSION_TLS_1_2 || max > R_TLS_VERSION_TLS_1_3 ||
+        min > max))
+    return R_TLS_ERROR_VERSION;
+
+  server->min_version = min;
+  server->max_version = max;
   return R_TLS_ERROR_OK;
 }
 
@@ -783,10 +804,12 @@ r_tls_server_write_hello (RTLSServer * server)
 
     if (!server->servrandompinned) {
       r_tls_generate_hello_random (server->servrandom, server->prng);
-      /* This path only writes a <= 1.2 ServerHello; the server is otherwise
-       * 1.3-capable, so stamp the downgrade sentinel (RFC 8446 4.1.3). DTLS is
+      /* This path only writes a <= 1.2 ServerHello. Stamp the downgrade
+       * sentinel (RFC 8446 4.1.3) only when the server is actually 1.3-capable;
+       * a range-capped 1.2 server is a genuine 1.2 peer and must not. DTLS is
        * excluded -- the stack has no DTLS 1.3 to be downgraded from. */
-      if (!r_tls_version_is_dtls (server->version))
+      if (!r_tls_version_is_dtls (server->version) &&
+          server->max_version >= R_TLS_VERSION_TLS_1_3)
         r_tls13_downgrade_random (server->servrandom, server->version);
       server->servrandompinned = TRUE;
     }
@@ -2385,7 +2408,8 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
   /* Detect a TLS 1.3 offer (supported_versions) before resolving SNI, so the
    * server_name callback sees the version that will actually be negotiated. The
    * full 1.3 negotiation runs after SNI (it needs the selected certificate). */
-  if (!r_tls_version_is_dtls (server->version)) {
+  if (!r_tls_version_is_dtls (server->version) &&
+      server->max_version >= R_TLS_VERSION_TLS_1_3) {
     RTLSHelloExt sv = R_TLS_HELLO_EXT_INIT;
     if (r_tls_server_find_ext (server, R_TLS_EXT_TYPE_SUPPORTED_VERSIONS, &sv) &&
         r_tls_hello_ext_supported_versions_contains (&sv, R_TLS_VERSION_TLS_1_3))
@@ -2406,12 +2430,20 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
   }
 
   /* A ClientHello selecting TLS 1.3 (supported_versions) takes the 1.3 path;
-   * NOT_NEEDED means it did not, so fall through to the <=1.2 negotiation. */
-  if (!r_tls_version_is_dtls (server->version)) {
+   * NOT_NEEDED means it did not, so fall through to the <=1.2 negotiation. The
+   * range cap suppresses 1.3 entirely, making the server a genuine 1.2 peer. */
+  if (!r_tls_version_is_dtls (server->version) &&
+      server->max_version >= R_TLS_VERSION_TLS_1_3) {
     RTLSError r13 = r_tls_server_nego_hello13 (server);
     if (r13 != R_TLS_ERROR_NOT_NEEDED)
       return r13;
   }
+
+  /* Falling through here means <=1.2 was negotiated; reject it if a higher
+   * minimum was required. */
+  if (!r_tls_version_is_dtls (server->version) &&
+      server->version < server->min_version)
+    return R_TLS_ERROR_VERSION;
 
   if (R_UNLIKELY (server->hello.cslen == 0 || (server->hello.cslen & 1)))
     return R_TLS_ERROR_CORRUPT_RECORD;

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -142,6 +142,12 @@ struct RTLSServer {
   ruint8 psk13[R_TLS13_SECRET_MAX];     /* ticket-derived PSK for the schedule */
   rsize psk13_len;
   ruint32 nst13_count;                  /* NewSessionTicket nonce counter */
+  ruint32 max_early_data13;             /* configured 0-RTT max_early_data_size; 0 disables */
+  rboolean early13_accepted;            /* 0-RTT accepted this handshake */
+  rboolean early13_draining;            /* reading early data under the early key, awaiting EndOfEarlyData */
+  rboolean early13_skip;                /* early data offered but rejected: discard the client's 0-RTT records */
+  rsize early13_skipped;                /* bytes of rejected early data discarded so far */
+  rsize early13_received;               /* bytes of accepted early data delivered so far */
 
   RBuffer * inbuf;
   RQueue qsend;
@@ -355,6 +361,22 @@ r_tls_server_set_session_ticket_keys (RTLSServer * server,
   server->ticket_keys = r_tls_session_ticket_keys_ref (keys);
 
   return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_server_set_max_early_data_size (RTLSServer * server, ruint32 size)
+{
+  if (R_UNLIKELY (server == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (server->state > R_TLS_SERVER_HELLO)) return R_TLS_ERROR_WRONG_STATE;
+
+  server->max_early_data13 = size;
+  return R_TLS_ERROR_OK;
+}
+
+rboolean
+r_tls_server_get_early_data_accepted (const RTLSServer * server)
+{
+  return server != NULL && server->early13_accepted;
 }
 
 RTLSError
@@ -1493,6 +1515,10 @@ r_tls_server_read_key_share (const RTLSServer * server,
 #define R_TLS_TICKET13_STATE_MAX      (1 + 2 + 8 + 1 + \
     R_TLS_TICKET13_NONCE_SIZE + R_TLS13_SECRET_MAX)
 
+/* Cap on rejected 0-RTT ciphertext discarded before we stop trial-decrypting
+ * and fail the record (bounds a peer that streams undecryptable data). */
+#define R_TLS13_EARLY_DATA_SKIP_MAX   16384
+
 /* Seal the resumption state (res_master + @nonce, keyed to the negotiated
  * suite) into an opaque ticket under the shared key store. */
 static RTLSError
@@ -1626,6 +1652,16 @@ r_tls_server_try_resume13 (RTLSServer * server)
 
   server->resumed13 = TRUE;
   server->selected_identity13 = 0;
+
+  /* 0-RTT is accepted only for the first identity (this cut offers one), only
+   * when configured (max_early_data13), and only when the ClientHello carries
+   * the early_data extension. */
+  {
+    RTLSHelloExt ed = R_TLS_HELLO_EXT_INIT;
+    if (server->max_early_data13 > 0 &&
+        r_tls_server_find_ext (server, R_TLS_EXT_TYPE_EARLY_DATA, &ed))
+      server->early13_accepted = TRUE;
+  }
   return R_TLS_ERROR_OK;
 
 decline:
@@ -1739,6 +1775,16 @@ r_tls_server_nego_hello13 (RTLSServer * server)
     RTLSError rr = r_tls_server_try_resume13 (server);
     if (rr != R_TLS_ERROR_OK && rr != R_TLS_ERROR_NOT_NEEDED)
       return rr;
+  }
+
+  /* A client that offered early_data we did not accept has already put its
+   * 0-RTT records on the wire; they must be discarded rather than fed to the
+   * handshake-key AEAD (RFC 8446 4.2.10). */
+  {
+    RTLSHelloExt ed = R_TLS_HELLO_EXT_INIT;
+    if (!server->early13_accepted &&
+        r_tls_server_find_ext (server, R_TLS_EXT_TYPE_EARLY_DATA, &ed))
+      server->early13_skip = TRUE;
   }
 
   server->comp = R_TLS_COMPRESSION_NULL;
@@ -2076,6 +2122,21 @@ r_tls_server_write_flight13 (RTLSServer * server)
   RMemMapInfo certinfo = R_MEM_MAP_INFO_INIT;
   RTLSError ret;
 
+  /* 0. Accepted 0-RTT: the client early-traffic secret is bound to the
+   * ClientHello alone, so derive it and install the early read key now, before
+   * the ServerHello is folded. The client's 0-RTT records then decrypt under it
+   * until the EndOfEarlyData switches the read key to the handshake secret. */
+  if (server->early13_accepted) {
+    if (!r_msg_digest_get_data (server->hshash, th, hlen, NULL))
+      return R_TLS_ERROR_HANDSHAKE_FAILURE;
+    if (!r_tls13_schedule_init_psk (&server->sched13, server->cs13_hash,
+            server->psk13, server->psk13_len) ||
+        !r_tls13_schedule_early (&server->sched13, th) ||
+        !r_tls_server_install_keys13 (server, &server->rk_read, server->sched13.cet))
+      return R_TLS_ERROR_HANDSHAKE_FAILURE;
+    server->early13_draining = TRUE;
+  }
+
   /* 1. ServerHello (plaintext); generate the server ephemeral first. */
   if ((server->ecdhe_key = r_tls_ecdhe_keygen (server->ecdhe_curve, server->prng)) == NULL)
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
@@ -2100,15 +2161,29 @@ r_tls_server_write_flight13 (RTLSServer * server)
   }
   r_memclear_secure (ecdhe, sizeof (ecdhe));
 
-  /* 3. Install handshake-traffic keys (server writes shs, reads chs). */
-  if (!r_tls_server_install_keys13 (server, &server->rk_write, server->sched13.shs) ||
+  /* 3. Install handshake-traffic keys (server writes shs, reads chs). While
+   * draining 0-RTT the read key stays the early-traffic key -- it switches to
+   * chs only once the EndOfEarlyData arrives. */
+  if (!r_tls_server_install_keys13 (server, &server->rk_write, server->sched13.shs))
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  if (!server->early13_draining &&
       !r_tls_server_install_keys13 (server, &server->rk_read, server->sched13.chs))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
 
-  /* 4. EncryptedExtensions (empty in this cut). */
-  if ((ret = r_tls_write_hs_encrypted_extensions (body, sizeof (body),
-          &bodylen, NULL, 0)) != R_TLS_ERROR_OK)
-    return ret;
+  /* 4. EncryptedExtensions: signal early-data acceptance back to the client
+   * (empty extension), otherwise an empty list. */
+  {
+    ruint8 ee[4];
+    ruint16 eelen = 0;
+    if (server->early13_accepted) {
+      r_store_be16 (ee, (ruint16)R_TLS_EXT_TYPE_EARLY_DATA);
+      r_store_be16 (ee + 2, 0);
+      eelen = sizeof (ee);
+    }
+    if ((ret = r_tls_write_hs_encrypted_extensions (body, sizeof (body),
+            &bodylen, eelen ? ee : NULL, eelen)) != R_TLS_ERROR_OK)
+      return ret;
+  }
   if ((ret = r_tls_server_send_hs13 (server,
           R_TLS_HANDSHAKE_TYPE_ENCRYPTED_EXTENSIONS, body, bodylen)) != R_TLS_ERROR_OK)
     return ret;
@@ -2238,7 +2313,8 @@ r_tls_server_write_new_session_ticket13 (RTLSServer * server)
 
   if ((ret = r_tls_write_hs_new_session_ticket13 (body, sizeof (body), &bodylen,
           R_TLS_SESSION_TICKET_LIFETIME, age_add, nonce, sizeof (nonce),
-          server->ticket, server->ticketsize, 0)) != R_TLS_ERROR_OK)
+          server->ticket, server->ticketsize,
+          server->max_early_data13)) != R_TLS_ERROR_OK)
     return ret;
 
   msg[0] = (ruint8) R_TLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET;
@@ -3290,6 +3366,46 @@ r_tls_server_state_finished (RTLSServer * server, const RTLSParser * parser)
   RTLSError err;
 
   if (server->tls13) {
+    /* While draining accepted 0-RTT (before the EndOfEarlyData), the client's
+     * records arrive under the early-traffic key: application_data is delivered
+     * as early data, and EndOfEarlyData ends the flow and switches the read key
+     * to the client handshake-traffic secret for the client Finished. */
+    if (server->early13_draining) {
+      if (parser->content == R_TLS_CONTENT_TYPE_APPLICATION_DATA) {
+        RBuffer * buf;
+        /* Reject a client that streams more 0-RTT than the max_early_data_size
+         * we advertised in the ticket (RFC 8446 4.2.10). */
+        if ((server->early13_received += parser->fragment.size) >
+            server->max_early_data13) {
+          r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_UNEXPECTED_MESSAGE);
+          return R_TLS_ERROR_WRONG_TYPE;
+        }
+        buf = r_buffer_view (parser->buf, parser->offset, parser->fragment.size);
+        if (buf != NULL) {
+          server->cb.appdata (server->userdata, buf, server);
+          r_buffer_unref (buf);
+        }
+        return R_TLS_ERROR_OK;
+      }
+      if (parser->content == R_TLS_CONTENT_TYPE_HANDSHAKE) {
+        RTLSHandshakeType type;
+        if ((err = r_tls_parser_parse_handshake_peek_type (parser, &type)) != R_TLS_ERROR_OK ||
+            type != R_TLS_HANDSHAKE_TYPE_END_OF_EARLY_DATA) {
+          r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_UNEXPECTED_MESSAGE);
+          return R_TLS_ERROR_WRONG_TYPE;
+        }
+        r_msg_digest_update (server->hshash, parser->fragment.data, parser->fragment.size);
+        server->early13_draining = FALSE;
+        if (!r_tls_server_install_keys13 (server, &server->rk_read, server->sched13.chs)) {
+          r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_INTERNAL_ERROR);
+          return R_TLS_ERROR_HANDSHAKE_FAILURE;
+        }
+        return R_TLS_ERROR_OK;
+      }
+      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_UNEXPECTED_MESSAGE);
+      return R_TLS_ERROR_WRONG_TYPE;
+    }
+
     if ((err = r_tls_server_finished13 (server, parser)) == R_TLS_ERROR_OK)
       err = r_tls_server_change_state (server, R_TLS_SERVER_APPDATA);
     if (err == R_TLS_ERROR_OK) {
@@ -3437,11 +3553,29 @@ r_tls_server_incoming_data (RTLSServer * server, RBuffer * buffer)
         if ((err = r_tls_parser_unprotect13 (&parser, server->rk_read.cipher,
                 server->rk_read.iv, server->rk_read.ivlen,
                 server->rk_read.seq)) != R_TLS_ERROR_OK) {
+          /* Rejected 0-RTT: the client's early-data records fail under the
+           * handshake key. Discard them (no alert) up to a bound, until the
+           * client Finished decrypts (RFC 8446 4.2.10). */
+          if (server->early13_skip &&
+              (server->early13_skipped += parser.fragment.size) <=
+                  R_TLS13_EARLY_DATA_SKIP_MAX)
+            continue;
           R_LOG_WARNING ("1.3 record unprotect returned: %d", err);
           r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_BAD_RECORD_MAC);
           continue;
         }
+        server->early13_skip = FALSE;   /* a record decrypted: early data is over */
         server->rk_read.seq++;
+      } else if (server->early13_skip &&
+          parser.content == R_TLS_CONTENT_TYPE_APPLICATION_DATA) {
+        /* Rejected 0-RTT with no read key yet installed (e.g. after a
+         * HelloRetryRequest): the early-data records are undecryptable, so
+         * discard them up to the same bound. */
+        if ((server->early13_skipped += parser.fragment.size) <=
+                R_TLS13_EARLY_DATA_SKIP_MAX)
+          continue;
+        r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_BAD_RECORD_MAC);
+        continue;
       }
     } else {
       /* TLS carries no explicit record sequence number; feed the running read

--- a/rlib/net/rtlssessiontickets.c
+++ b/rlib/net/rtlssessiontickets.c
@@ -22,6 +22,7 @@
 #include <rlib/crypto/raes.h>
 #include <rlib/crypto/rcipher.h>
 
+#include <rlib/concurrency/rthreads.h>
 #include <rlib/rmem.h>
 #include <rlib/rrand.h>
 
@@ -29,17 +30,42 @@
 #define R_TLS_STK_KEY_SIZE        16
 #define R_TLS_STK_NONCE_SIZE      12
 #define R_TLS_STK_TAG_SIZE        16
+/* The active key plus this many recent keys are retained, so a rotation does
+ * not invalidate tickets sealed under the keys it replaces. */
+#define R_TLS_STK_KEYS_MAX        3
+
+typedef struct {
+  ruint8 key_name[R_TLS_STK_KEY_NAME_SIZE];
+  ruint8 key[R_TLS_STK_KEY_SIZE];
+} RTLSSessionTicketKey;
 
 struct RTLSSessionTicketKeys {
   RRef ref;
-  ruint8 key_name[R_TLS_STK_KEY_NAME_SIZE];
-  ruint8 key[R_TLS_STK_KEY_SIZE];
+  /* Guards the key set: seal / open take the read lock, rotate the write lock.
+   * The store is shared across servers (and so potentially threads). */
+  RRWMutex lock;
+  rsize count;                              /* valid keys, 1..R_TLS_STK_KEYS_MAX */
+  RTLSSessionTicketKey keys[R_TLS_STK_KEYS_MAX];  /* keys[0] is the active key */
 };
+
+static rboolean
+r_tls_session_ticket_key_generate (RTLSSessionTicketKey * key)
+{
+  if (!r_rand_entropy_fill (key->key_name, sizeof (key->key_name)) ||
+      !r_rand_entropy_fill (key->key, sizeof (key->key))) {
+    r_memclear_secure (key->key, sizeof (key->key));
+    return FALSE;
+  }
+  return TRUE;
+}
 
 static void
 r_tls_session_ticket_keys_free (RTLSSessionTicketKeys * keys)
 {
-  r_memclear_secure (keys->key, sizeof (keys->key));
+  rsize i;
+  for (i = 0; i < R_TLS_STK_KEYS_MAX; i++)
+    r_memclear_secure (keys->keys[i].key, sizeof (keys->keys[i].key));
+  r_rwmutex_clear (&keys->lock);
   r_free (keys);
 }
 
@@ -48,17 +74,44 @@ r_tls_session_ticket_keys_new (void)
 {
   RTLSSessionTicketKeys * ret;
 
-  if ((ret = r_mem_new (RTLSSessionTicketKeys)) != NULL) {
-    if (!r_rand_entropy_fill (ret->key_name, sizeof (ret->key_name)) ||
-        !r_rand_entropy_fill (ret->key, sizeof (ret->key))) {
-      r_memclear_secure (ret->key, sizeof (ret->key));
+  if ((ret = r_mem_new0 (RTLSSessionTicketKeys)) != NULL) {
+    if (!r_tls_session_ticket_key_generate (&ret->keys[0])) {
       r_free (ret);
       return NULL;
     }
+    ret->count = 1;
+    r_rwmutex_init (&ret->lock);
     r_ref_init (ret, r_tls_session_ticket_keys_free);
   }
 
   return ret;
+}
+
+rboolean
+r_tls_session_ticket_keys_rotate (RTLSSessionTicketKeys * keys)
+{
+  RTLSSessionTicketKey fresh;
+  rsize i;
+
+  if (R_UNLIKELY (keys == NULL)) return FALSE;
+  if (!r_tls_session_ticket_key_generate (&fresh))
+    return FALSE;
+
+  r_rwmutex_wrlock (&keys->lock);
+  /* Age the oldest key out (scrubbed) and shift the rest down, then promote the
+   * fresh key to active. */
+  if (keys->count == R_TLS_STK_KEYS_MAX)
+    r_memclear_secure (keys->keys[R_TLS_STK_KEYS_MAX - 1].key,
+        sizeof (keys->keys[R_TLS_STK_KEYS_MAX - 1].key));
+  else
+    keys->count++;
+  for (i = keys->count - 1; i > 0; i--)
+    keys->keys[i] = keys->keys[i - 1];
+  keys->keys[0] = fresh;
+  r_rwmutex_wrunlock (&keys->lock);
+
+  r_memclear_secure (fresh.key, sizeof (fresh.key));
+  return TRUE;
 }
 
 rboolean
@@ -73,30 +126,32 @@ r_tls_session_ticket_keys_seal (RTLSSessionTicketKeys * keys,
 
   if (R_UNLIKELY (keys == NULL)) return FALSE;
 
-  if ((cipher = r_cipher_aes_128_gcm_new (keys->key)) == NULL)
+  if ((ticket = r_malloc (ticketlen)) == NULL)
     return FALSE;
-  if ((ticket = r_malloc (ticketlen)) == NULL) {
-    r_crypto_cipher_unref (cipher);
-    return FALSE;
-  }
 
-  r_memcpy (ticket, keys->key_name, R_TLS_STK_KEY_NAME_SIZE);
   nonce = ticket + R_TLS_STK_KEY_NAME_SIZE;
   ct = nonce + R_TLS_STK_NONCE_SIZE;
   tag = ct + plainlen;
 
   if (!r_rand_entropy_fill (nonce, R_TLS_STK_NONCE_SIZE)) {
-    r_crypto_cipher_unref (cipher);
     r_free (ticket);
     return FALSE;
   }
 
-  /* The key_name is authenticated (AAD) but not encrypted: it travels in the
-   * clear so the open side can pick the right key before decrypting. */
-  cr = r_crypto_cipher_encrypt_aead (cipher, ct, plainlen, plain,
-      keys->key_name, R_TLS_STK_KEY_NAME_SIZE, nonce, R_TLS_STK_NONCE_SIZE,
-      tag, R_TLS_STK_TAG_SIZE);
-  r_crypto_cipher_unref (cipher);
+  /* Seal under the active key (keys[0]). The key_name is authenticated (AAD)
+   * but not encrypted: it travels in the clear so the open side can pick the
+   * right key before decrypting. */
+  r_rwmutex_rdlock (&keys->lock);
+  r_memcpy (ticket, keys->keys[0].key_name, R_TLS_STK_KEY_NAME_SIZE);
+  if ((cipher = r_cipher_aes_128_gcm_new (keys->keys[0].key)) != NULL) {
+    cr = r_crypto_cipher_encrypt_aead (cipher, ct, plainlen, plain,
+        keys->keys[0].key_name, R_TLS_STK_KEY_NAME_SIZE,
+        nonce, R_TLS_STK_NONCE_SIZE, tag, R_TLS_STK_TAG_SIZE);
+    r_crypto_cipher_unref (cipher);
+  } else {
+    cr = R_CRYPTO_CIPHER_OOM;
+  }
+  r_rwmutex_rdunlock (&keys->lock);
 
   if (cr != R_CRYPTO_CIPHER_OK) {
     r_free (ticket);
@@ -115,8 +170,8 @@ r_tls_session_ticket_keys_open (RTLSSessionTicketKeys * keys,
 {
   RCryptoCipher * cipher;
   const ruint8 * nonce, * ct, * tag;
-  rsize plainlen;
-  RCryptoCipherResult cr;
+  rsize plainlen, i;
+  RCryptoCipherResult cr = R_CRYPTO_CIPHER_AUTH_FAILED;
 
   if (R_UNLIKELY (keys == NULL)) return FALSE;
   if (len < R_TLS_SESSION_TICKET_SEAL_OVERHEAD)
@@ -124,20 +179,26 @@ r_tls_session_ticket_keys_open (RTLSSessionTicketKeys * keys,
   plainlen = len - R_TLS_SESSION_TICKET_SEAL_OVERHEAD;
   if (plainlen > cap)
     return FALSE;
-  /* Reject tickets sealed under a different key before touching the cipher. */
-  if (r_memcmp (ticket, keys->key_name, R_TLS_STK_KEY_NAME_SIZE) != 0)
-    return FALSE;
 
   nonce = ticket + R_TLS_STK_KEY_NAME_SIZE;
   ct = nonce + R_TLS_STK_NONCE_SIZE;
   tag = ct + plainlen;
 
-  if ((cipher = r_cipher_aes_128_gcm_new (keys->key)) == NULL)
-    return FALSE;
-  cr = r_crypto_cipher_decrypt_aead (cipher, plain_out, plainlen, ct,
-      keys->key_name, R_TLS_STK_KEY_NAME_SIZE,
-      (ruint8 *) nonce, R_TLS_STK_NONCE_SIZE, (ruint8 *) tag, R_TLS_STK_TAG_SIZE);
-  r_crypto_cipher_unref (cipher);
+  /* Find the key whose key_name the ticket carries -- the active key or one of
+   * the recent keys still retained after a rotation -- then decrypt with it. */
+  r_rwmutex_rdlock (&keys->lock);
+  for (i = 0; i < keys->count; i++) {
+    if (r_memcmp (ticket, keys->keys[i].key_name, R_TLS_STK_KEY_NAME_SIZE) != 0)
+      continue;
+    if ((cipher = r_cipher_aes_128_gcm_new (keys->keys[i].key)) != NULL) {
+      cr = r_crypto_cipher_decrypt_aead (cipher, plain_out, plainlen, ct,
+          keys->keys[i].key_name, R_TLS_STK_KEY_NAME_SIZE,
+          (ruint8 *) nonce, R_TLS_STK_NONCE_SIZE, (ruint8 *) tag, R_TLS_STK_TAG_SIZE);
+      r_crypto_cipher_unref (cipher);
+    }
+    break;
+  }
+  r_rwmutex_rdunlock (&keys->lock);
 
   if (cr != R_CRYPTO_CIPHER_OK)
     return FALSE;

--- a/test/rtls.c
+++ b/test/rtls.c
@@ -370,7 +370,7 @@ RTEST (rtls, write_parse_new_session_ticket13_roundtrip, RTEST_FAST)
   ruint8 rec[128];
   rsize hssize = 0, bodylen = 0;
   RTLSParser parser = R_TLS_PARSER_INIT;
-  ruint32 lifetime = 0, age_add = 0;
+  ruint32 lifetime = 0, age_add = 0, max_early = 0xffff;
   const ruint8 * np = NULL, * tp = NULL;
   ruint8 nlen = 0;
   ruint16 tlen = 0;
@@ -379,7 +379,7 @@ RTEST (rtls, write_parse_new_session_ticket13_roundtrip, RTEST_FAST)
         &hssize, R_TLS_VERSION_TLS_1_3, R_TLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET, 0));
   r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_write_hs_new_session_ticket13 (
         rec + hssize, sizeof (rec) - hssize, &bodylen, 30, 0xfad6aac5,
-        nonce, sizeof (nonce), ticket, sizeof (ticket)));
+        nonce, sizeof (nonce), ticket, sizeof (ticket), 0));
   /* lifetime(4) + age_add(4) + nonce{1+2} + ticket{2+7} + ext<2>. */
   r_assert_cmpuint (bodylen, ==, 4 + 4 + (1 + 2) + (2 + sizeof (ticket)) + 2);
   r_assert_cmpint (R_TLS_ERROR_OK, ==,
@@ -388,18 +388,37 @@ RTEST (rtls, write_parse_new_session_ticket13_roundtrip, RTEST_FAST)
   r_assert_cmpint (R_TLS_ERROR_OK, ==,
       r_tls_parser_init (&parser, rec, hssize + bodylen));
   r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_parser_parse_new_session_ticket13 (
-        &parser, &lifetime, &age_add, &np, &nlen, &tp, &tlen));
+        &parser, &lifetime, &age_add, &np, &nlen, &tp, &tlen, &max_early));
   r_assert_cmpuint (lifetime, ==, 30);
   r_assert_cmphex (age_add, ==, 0xfad6aac5);
   r_assert_cmpuint (nlen, ==, sizeof (nonce));
   r_assert_cmpmem (np, ==, nonce, sizeof (nonce));
   r_assert_cmpuint (tlen, ==, sizeof (ticket));
   r_assert_cmpmem (tp, ==, ticket, sizeof (ticket));
+  r_assert_cmpuint (max_early, ==, 0);   /* no early_data extension */
+  r_tls_parser_clear (&parser);
+
+  /* With max_early_data set the ticket carries an early_data extension whose
+   * max_early_data_size the parser surfaces. */
+  r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_write_hs_new_session_ticket13 (
+        rec + hssize, sizeof (rec) - hssize, &bodylen, 30, 0xfad6aac5,
+        nonce, sizeof (nonce), ticket, sizeof (ticket), 0x4000));
+  /* ext<2> now holds one early_data extension: 2(type) + 2(len) + 4(size). */
+  r_assert_cmpuint (bodylen, ==, 4 + 4 + (1 + 2) + (2 + sizeof (ticket)) + 2 + 8);
+  r_assert_cmpint (R_TLS_ERROR_OK, ==,
+      r_tls_update_handshake_len (rec, sizeof (rec), (ruint16) bodylen));
+  r_assert_cmpint (R_TLS_ERROR_OK, ==,
+      r_tls_parser_init (&parser, rec, hssize + bodylen));
+  r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_parser_parse_new_session_ticket13 (
+        &parser, NULL, NULL, NULL, NULL, &tp, &tlen, &max_early));
+  r_assert_cmpuint (tlen, ==, sizeof (ticket));
+  r_assert_cmpmem (tp, ==, ticket, sizeof (ticket));
+  r_assert_cmphex (max_early, ==, 0x4000);
   r_tls_parser_clear (&parser);
 
   /* A zero-length ticket is rejected (ticket<1..2^16-1>). */
   r_assert_cmpint (R_TLS_ERROR_INVAL, ==, r_tls_write_hs_new_session_ticket13 (
-        rec, sizeof (rec), &bodylen, 30, 0, NULL, 0, ticket, 0));
+        rec, sizeof (rec), &bodylen, 30, 0, NULL, 0, ticket, 0, 0));
 }
 RTEST_END;
 

--- a/test/rtls.c
+++ b/test/rtls.c
@@ -361,6 +361,103 @@ RTEST (rtls, write_parse_certificate13_roundtrip, RTEST_FAST)
 }
 RTEST_END;
 
+RTEST (rtls, write_parse_new_session_ticket13_roundtrip, RTEST_FAST)
+{
+  /* Build a TLS 1.3 NewSessionTicket around a stand-in ticket and read the
+   * lifetime, age_add, nonce and ticket back with the 1.3 parser. */
+  static const ruint8 nonce[] = { 0x00, 0x00 };
+  static const ruint8 ticket[] = { 0x2c, 0x03, 0x5d, 0x82, 0x93, 0x59, 0xee };
+  ruint8 rec[128];
+  rsize hssize = 0, bodylen = 0;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  ruint32 lifetime = 0, age_add = 0;
+  const ruint8 * np = NULL, * tp = NULL;
+  ruint8 nlen = 0;
+  ruint16 tlen = 0;
+
+  r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_write_handshake (rec, sizeof (rec),
+        &hssize, R_TLS_VERSION_TLS_1_3, R_TLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET, 0));
+  r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_write_hs_new_session_ticket13 (
+        rec + hssize, sizeof (rec) - hssize, &bodylen, 30, 0xfad6aac5,
+        nonce, sizeof (nonce), ticket, sizeof (ticket)));
+  /* lifetime(4) + age_add(4) + nonce{1+2} + ticket{2+7} + ext<2>. */
+  r_assert_cmpuint (bodylen, ==, 4 + 4 + (1 + 2) + (2 + sizeof (ticket)) + 2);
+  r_assert_cmpint (R_TLS_ERROR_OK, ==,
+      r_tls_update_handshake_len (rec, sizeof (rec), (ruint16) bodylen));
+
+  r_assert_cmpint (R_TLS_ERROR_OK, ==,
+      r_tls_parser_init (&parser, rec, hssize + bodylen));
+  r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_parser_parse_new_session_ticket13 (
+        &parser, &lifetime, &age_add, &np, &nlen, &tp, &tlen));
+  r_assert_cmpuint (lifetime, ==, 30);
+  r_assert_cmphex (age_add, ==, 0xfad6aac5);
+  r_assert_cmpuint (nlen, ==, sizeof (nonce));
+  r_assert_cmpmem (np, ==, nonce, sizeof (nonce));
+  r_assert_cmpuint (tlen, ==, sizeof (ticket));
+  r_assert_cmpmem (tp, ==, ticket, sizeof (ticket));
+  r_tls_parser_clear (&parser);
+
+  /* A zero-length ticket is rejected (ticket<1..2^16-1>). */
+  r_assert_cmpint (R_TLS_ERROR_INVAL, ==, r_tls_write_hs_new_session_ticket13 (
+        rec, sizeof (rec), &bodylen, 30, 0, NULL, 0, ticket, 0));
+}
+RTEST_END;
+
+RTEST (rtls, parse_pre_shared_key_extension, RTEST_FAST)
+{
+  /* An OfferedPsks body: one identity (a 4-byte ticket + obfuscated age) and
+   * its 32-byte binder, plus a psk_key_exchange_modes body. Exercise the parse
+   * accessors against a hand-built extension. */
+  static const ruint8 psk[] = {
+    0x00, 0x0a,                             /* identities_length = 10 */
+    0x00, 0x04, 0xde, 0xad, 0xbe, 0xef,     /* identity<4> */
+    0x01, 0x02, 0x03, 0x04,                 /* obfuscated_ticket_age */
+    0x00, 0x21, 0x20,                       /* binders_length=33, entry len=32 */
+    0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
+    0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf,
+    0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7,
+    0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf };
+  static const ruint8 modes[] = { 0x02, 0x00, 0x01 };  /* psk_ke, psk_dhe_ke */
+  RTLSHelloExt ext = R_TLS_HELLO_EXT_INIT;
+  RTLSPskIdentity ident = R_TLS_PSK_IDENTITY_INIT;
+  const ruint8 * binder = NULL;
+  ruint8 binderlen = 0;
+
+  ext.type = R_TLS_EXT_TYPE_PRE_SHARED_KEY;
+  ext.data = psk;
+  ext.len = sizeof (psk);
+
+  r_assert_cmpint (R_TLS_ERROR_OK, ==,
+      r_tls_hello_ext_psk_identity_first (&ext, &ident));
+  r_assert_cmpuint (ident.len, ==, 4);
+  r_assert_cmpmem (ident.identity, ==, "\xde\xad\xbe\xef", 4);
+  r_assert_cmphex (ident.age, ==, 0x01020304);
+  /* Only one identity. */
+  r_assert_cmpint (R_TLS_ERROR_EOB, ==,
+      r_tls_hello_ext_psk_identity_next (&ext, &ident));
+
+  /* The binder transcript truncates at the binders-list length field. */
+  r_assert_cmpptr (r_tls_hello_ext_psk_binders_start (&ext), ==, psk + 12);
+
+  r_assert_cmpint (R_TLS_ERROR_OK, ==,
+      r_tls_hello_ext_psk_binder (&ext, 0, &binder, &binderlen));
+  r_assert_cmpuint (binderlen, ==, 32);
+  r_assert_cmpmem (binder, ==, psk + 15, 32);
+  /* No second binder. */
+  r_assert_cmpint (R_TLS_ERROR_EOB, ==,
+      r_tls_hello_ext_psk_binder (&ext, 1, &binder, &binderlen));
+
+  ext.type = R_TLS_EXT_TYPE_PSK_KEY_EXCHANGE_MODES;
+  ext.data = modes;
+  ext.len = sizeof (modes);
+  r_assert (r_tls_hello_ext_psk_ke_modes_contains (&ext,
+        R_TLS_PSK_KE_MODE_PSK_DHE_KE));
+  r_assert (r_tls_hello_ext_psk_ke_modes_contains (&ext,
+        R_TLS_PSK_KE_MODE_PSK_KE));
+  r_assert (!r_tls_hello_ext_psk_ke_modes_contains (&ext, 0x02));
+}
+RTEST_END;
+
 RTEST (rtls, parse_dtls_certificate_request, RTEST_FAST)
 {
   static const ruint8 pkt_dtls_certificate_request[] = {

--- a/test/rtls13.c
+++ b/test/rtls13.c
@@ -205,3 +205,51 @@ RTEST (rtls13, cert_verify_tbs, R_TEST_TYPE_FAST)
   r_assert (!r_tls13_cert_verify_tbs (TRUE, th, sizeof (th), out, 10, &outlen));
 }
 RTEST_END;
+
+RTEST (rtls13, hello_retry_random, R_TEST_TYPE_FAST)
+{
+  ruint8 r[32], other[32];
+  rsize i;
+
+  /* SHA-256("HelloRetryRequest") (RFC 8446 4.1.3). */
+  r_tls13_hello_retry_random (r);
+  r_assert_cmpmem (r, ==,
+      "\xcf\x21\xad\x74\xe5\x9a\x61\x11\xbe\x1d\x8c\x02\x1e\x65\xb8\x91"
+      "\xc2\xa2\x11\x16\x7a\xbb\x8c\x5e\x07\x9e\x09\xe2\xc8\xa8\x33\x9c", 32);
+  r_assert (r_tls13_random_is_hrr (r));
+
+  for (i = 0; i < sizeof (other); i++)
+    other[i] = (ruint8) i;
+  r_assert (!r_tls13_random_is_hrr (other));
+  r_assert (!r_tls13_random_is_hrr (NULL));
+}
+RTEST_END;
+
+RTEST (rtls13, message_hash, R_TEST_TYPE_FAST)
+{
+  static const ruint8 ch1[] = { 0x01, 0x00, 0x00, 0x04, 0xde, 0xad, 0xbe, 0xef };
+  ruint8 out[4 + 64], expect[32];
+  rsize outlen = 0;
+  RMsgDigest * md;
+
+  r_assert (r_tls13_message_hash (R_MSG_DIGEST_TYPE_SHA256, ch1, sizeof (ch1),
+        out, sizeof (out), &outlen));
+  /* message_hash handshake header: type 0xfe, 3-byte length = HashLen. */
+  r_assert_cmpuint (outlen, ==, 4 + 32);
+  r_assert_cmphex (out[0], ==, R_TLS_HANDSHAKE_TYPE_MESSAGE_HASH);
+  r_assert_cmphex (out[1], ==, 0x00);
+  r_assert_cmphex (out[2], ==, 0x00);
+  r_assert_cmphex (out[3], ==, 32);
+
+  /* The body is SHA-256(ch1). */
+  r_assert_cmpptr ((md = r_msg_digest_new_sha256 ()), !=, NULL);
+  r_assert (r_msg_digest_update (md, ch1, sizeof (ch1)));
+  r_assert (r_msg_digest_get_data (md, expect, sizeof (expect), NULL));
+  r_msg_digest_free (md);
+  r_assert_cmpmem (out + 4, ==, expect, 32);
+
+  /* Too-small output is rejected. */
+  r_assert (!r_tls13_message_hash (R_MSG_DIGEST_TYPE_SHA256, ch1, sizeof (ch1),
+        out, 4, &outlen));
+}
+RTEST_END;

--- a/test/rtls13.c
+++ b/test/rtls13.c
@@ -334,6 +334,40 @@ RTEST (rtls13, hello_retry_random, R_TEST_TYPE_FAST)
 }
 RTEST_END;
 
+RTEST (rtls13, downgrade_random, R_TEST_TYPE_FAST)
+{
+  ruint8 r[32];
+  rsize i;
+
+  for (i = 0; i < sizeof (r); i++)
+    r[i] = (ruint8) i;
+
+  /* TLS 1.2: "DOWNGRD\x01" in the last 8 bytes, leading bytes preserved. */
+  r_tls13_downgrade_random (r, R_TLS_VERSION_TLS_1_2);
+  r_assert_cmpmem (r + 24, ==, "\x44\x4f\x57\x4e\x47\x52\x44\x01", 8);
+  for (i = 0; i < 24; i++)
+    r_assert_cmpuint (r[i], ==, (ruint8) i);
+  r_assert (r_tls13_random_is_downgrade (r));
+
+  /* TLS 1.1 and below: "DOWNGRD\x00". */
+  r_tls13_downgrade_random (r, R_TLS_VERSION_TLS_1_1);
+  r_assert_cmpmem (r + 24, ==, "\x44\x4f\x57\x4e\x47\x52\x44\x00", 8);
+  r_assert (r_tls13_random_is_downgrade (r));
+  r_tls13_downgrade_random (r, R_TLS_VERSION_TLS_1_0);
+  r_assert_cmpmem (r + 24, ==, "\x44\x4f\x57\x4e\x47\x52\x44\x00", 8);
+
+  /* 1.3 (and unknown) leave the random untouched. */
+  for (i = 0; i < sizeof (r); i++)
+    r[i] = (ruint8) i;
+  r_tls13_downgrade_random (r, R_TLS_VERSION_TLS_1_3);
+  for (i = 0; i < sizeof (r); i++)
+    r_assert_cmpuint (r[i], ==, (ruint8) i);
+  r_assert (!r_tls13_random_is_downgrade (r));
+  r_assert (!r_tls13_random_is_downgrade (NULL));
+  r_tls13_downgrade_random (NULL, R_TLS_VERSION_TLS_1_2);
+}
+RTEST_END;
+
 RTEST (rtls13, message_hash, R_TEST_TYPE_FAST)
 {
   static const ruint8 ch1[] = { 0x01, 0x00, 0x00, 0x04, 0xde, 0xad, 0xbe, 0xef };

--- a/test/rtls13.c
+++ b/test/rtls13.c
@@ -253,6 +253,41 @@ RTEST (rtls13, key_schedule_resumption_rfc8448, R_TEST_TYPE_FAST)
 }
 RTEST_END;
 
+RTEST (rtls13, key_schedule_early_rfc8448, R_TEST_TYPE_FAST)
+{
+  /* The 0-RTT values of RFC 8448 section 4: the client_early_traffic_secret is
+   * Derive-Secret(Early, "c e traffic", Transcript-Hash(ClientHello)), where
+   * the Early Secret comes from the section 3 ticket PSK and the transcript
+   * hash covers the resumed ClientHello (binders included). */
+  static const ruint8 psk[32] = {
+    0x4e, 0xcd, 0x0e, 0xb6, 0xec, 0x3b, 0x4d, 0x87, 0xf5, 0xd6, 0x02, 0x8f,
+    0x92, 0x2c, 0xa4, 0xc5, 0x85, 0x1a, 0x27, 0x7f, 0xd4, 0x13, 0x11, 0xc9,
+    0xe6, 0x2d, 0x2c, 0x94, 0x92, 0xe1, 0xc4, 0xf3 };
+  static const ruint8 th_ch[32] = {    /* Transcript-Hash(ClientHello) */
+    0x08, 0xad, 0x0f, 0xa0, 0x5d, 0x7c, 0x72, 0x33, 0xb1, 0x77, 0x5b, 0xa2,
+    0xff, 0x9f, 0x4c, 0x5b, 0x8b, 0x59, 0x27, 0x6b, 0x7f, 0x22, 0x7f, 0x13,
+    0xa9, 0x76, 0x24, 0x5f, 0x5d, 0x96, 0x09, 0x13 };
+  RTLS13Schedule sched;
+
+  /* Early Secret = HKDF-Extract(0, PSK). */
+  r_assert (r_tls13_schedule_init_psk (&sched, R_MSG_DIGEST_TYPE_SHA256,
+        psk, sizeof (psk)));
+  r_assert_cmpmem (sched.early, ==,
+      "\x9b\x21\x88\xe9\xb2\xfc\x6d\x64\xd7\x1d\xc3\x29\x90\x0e\x20\xbb"
+      "\x41\x91\x50\x00\xf6\x78\xaa\x83\x9c\xbb\x79\x7c\xb7\xd8\x33\x2c", 32);
+
+  /* client_early_traffic_secret = Derive-Secret(Early, "c e traffic", th). */
+  r_assert (r_tls13_schedule_early (&sched, th_ch));
+  r_assert_cmpmem (sched.cet, ==,
+      "\x3f\xbb\xe6\xa6\x0d\xeb\x66\xc3\x0a\x32\x79\x5a\xba\x0e\xff\x7e"
+      "\xaa\x10\x10\x55\x86\xe7\xbe\x5c\x09\x67\x8d\x63\xb6\xca\xab\x62", 32);
+
+  /* Argument checks. */
+  r_assert (!r_tls13_schedule_early (NULL, th_ch));
+  r_assert (!r_tls13_schedule_early (&sched, NULL));
+}
+RTEST_END;
+
 RTEST (rtls13, cert_verify_tbs, R_TEST_TYPE_FAST)
 {
   ruint8 th[32], out[R_TLS13_CERT_VERIFY_TBS_MAX];

--- a/test/rtls13.c
+++ b/test/rtls13.c
@@ -179,6 +179,80 @@ RTEST (rtls13, key_schedule_rfc8448, R_TEST_TYPE_FAST)
 }
 RTEST_END;
 
+RTEST (rtls13, key_schedule_resumption_rfc8448, R_TEST_TYPE_FAST)
+{
+  /* The resumption values of RFC 8448: the "res master" secret derived at the
+   * end of the section 3 handshake, the per-ticket PSK it expands into, and the
+   * section 4 resumed ClientHello's early secret, binder key and PSK binder
+   * (the binder uses the Finished construction over a truncated-ClientHello
+   * transcript). */
+  static const ruint8 master[32] = {   /* section 3 Master Secret */
+    0x18, 0xdf, 0x06, 0x84, 0x3d, 0x13, 0xa0, 0x8b, 0xf2, 0xa4, 0x49, 0x84,
+    0x4c, 0x5f, 0x8a, 0x47, 0x80, 0x01, 0xbc, 0x4d, 0x4c, 0x62, 0x79, 0x84,
+    0xd5, 0xa4, 0x1d, 0xa8, 0xd0, 0x40, 0x29, 0x19 };
+  static const ruint8 th_cf[32] = {    /* Transcript-Hash(CH..client Finished) */
+    0x20, 0x91, 0x45, 0xa9, 0x6e, 0xe8, 0xe2, 0xa1, 0x22, 0xff, 0x81, 0x00,
+    0x47, 0xcc, 0x95, 0x26, 0x84, 0x65, 0x8d, 0x60, 0x49, 0xe8, 0x64, 0x29,
+    0x42, 0x6d, 0xb8, 0x7c, 0x54, 0xad, 0x14, 0x3d };
+  static const ruint8 nonce[2] = { 0x00, 0x00 };
+  static const ruint8 binder_hash[32] = { /* Transcript-Hash(truncated CH) */
+    0x63, 0x22, 0x4b, 0x2e, 0x45, 0x73, 0xf2, 0xd3, 0x45, 0x4c, 0xa8, 0x4b,
+    0x9d, 0x00, 0x9a, 0x04, 0xf6, 0xbe, 0x9e, 0x05, 0x71, 0x1a, 0x83, 0x96,
+    0x47, 0x3a, 0xef, 0xa0, 0x1e, 0x92, 0x4a, 0x14 };
+  RTLS13Schedule sched;
+  ruint8 psk[32], binder_key[32], finkey[32], binder[32];
+
+  /* resumption_master_secret = Derive-Secret(Master, "res master", th). */
+  r_memset (&sched, 0, sizeof (sched));
+  sched.hash = R_MSG_DIGEST_TYPE_SHA256;
+  sched.hlen = 32;
+  r_memcpy (sched.master, master, sizeof (master));
+  r_assert (r_tls13_schedule_resumption (&sched, th_cf));
+  r_assert_cmpmem (sched.res_master, ==,
+      "\x7d\xf2\x35\xf2\x03\x1d\x2a\x05\x12\x87\xd0\x2b\x02\x41\xb0\xbf"
+      "\xda\xf8\x6c\xc8\x56\x23\x1f\x2d\x5a\xba\x46\xc4\x34\xec\x19\x6c", 32);
+
+  /* PSK = HKDF-Expand-Label(res_master, "resumption", ticket_nonce, 32). */
+  r_assert (r_tls13_resumption_psk (R_MSG_DIGEST_TYPE_SHA256, sched.res_master,
+        nonce, sizeof (nonce), psk));
+  r_assert_cmpmem (psk, ==,
+      "\x4e\xcd\x0e\xb6\xec\x3b\x4d\x87\xf5\xd6\x02\x8f\x92\x2c\xa4\xc5"
+      "\x85\x1a\x27\x7f\xd4\x13\x11\xc9\xe6\x2d\x2c\x94\x92\xe1\xc4\xf3", 32);
+
+  /* Early Secret = HKDF-Extract(0, PSK). */
+  r_assert (r_tls13_schedule_init_psk (&sched, R_MSG_DIGEST_TYPE_SHA256,
+        psk, sizeof (psk)));
+  r_assert_cmpmem (sched.early, ==,
+      "\x9b\x21\x88\xe9\xb2\xfc\x6d\x64\xd7\x1d\xc3\x29\x90\x0e\x20\xbb"
+      "\x41\x91\x50\x00\xf6\x78\xaa\x83\x9c\xbb\x79\x7c\xb7\xd8\x33\x2c", 32);
+
+  /* binder_key = Derive-Secret(Early, "res binder", ""). */
+  r_assert (r_tls13_binder_key (&sched, binder_key));
+  r_assert_cmpmem (binder_key, ==,
+      "\x69\xfe\x13\x1a\x3b\xba\xd5\xd6\x3c\x64\xee\xbc\xc3\x0e\x39\x5b"
+      "\x9d\x81\x07\x72\x6a\x13\xd0\x74\xe3\x89\xdb\xc8\xa4\xe4\x72\x56", 32);
+
+  /* The binder is a Finished over the truncated-ClientHello transcript. */
+  r_assert (r_tls13_finished_key (R_MSG_DIGEST_TYPE_SHA256, binder_key, finkey));
+  r_assert_cmpmem (finkey, ==,
+      "\x55\x88\x67\x3e\x72\xcb\x59\xc8\x7d\x22\x0c\xaf\xfe\x94\xf2\xde"
+      "\xa9\xa3\xb1\x60\x9f\x7d\x50\xe9\x0a\x48\x22\x7d\xb9\xed\x7e\xaa", 32);
+  r_assert (r_tls13_verify_data (R_MSG_DIGEST_TYPE_SHA256, finkey, binder_hash,
+        binder));
+  r_assert_cmpmem (binder, ==,
+      "\x3a\xdd\x4f\xb2\xd8\xfd\xf8\x22\xa0\xca\x3c\xf7\x67\x8e\xf5\xe8"
+      "\x8d\xae\x99\x01\x41\xc5\x92\x4d\x57\xbb\x6f\xa3\x1b\x9e\x5f\x9d", 32);
+
+  /* Argument checks. */
+  r_assert (!r_tls13_schedule_resumption (NULL, th_cf));
+  r_assert (!r_tls13_schedule_resumption (&sched, NULL));
+  r_assert (!r_tls13_resumption_psk (R_MSG_DIGEST_TYPE_SHA256, NULL,
+        nonce, sizeof (nonce), psk));
+  r_assert (!r_tls13_schedule_init_psk (&sched, R_MSG_DIGEST_TYPE_SHA256, NULL, 0));
+  r_assert (!r_tls13_binder_key (NULL, binder_key));
+}
+RTEST_END;
+
 RTEST (rtls13, cert_verify_tbs, R_TEST_TYPE_FAST)
 {
   ruint8 th[32], out[R_TLS13_CERT_VERIFY_TBS_MAX];

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -219,26 +219,27 @@ r_tlsclient_test_sni (rpointer ctx, const rchar * name, rpointer session)
   return R_TLS_ERROR_OK;
 }
 
+static const RTLSCallbacks srvcbs = {
+  r_tlsclient_test_prefer_ecdhe,
+  r_tlsclient_test_srv_hs_done,
+  r_tlsclient_test_srv_out,
+  r_tlsclient_test_srv_app,
+  r_tlsclient_test_srv_error,
+  NULL,
+  r_tlsclient_test_srv_closed,
+};
+static const RTLSCallbacks clicbs = {
+  r_tlsclient_test_prefer_ecdhe,
+  r_tlsclient_test_cli_hs_done,
+  r_tlsclient_test_cli_out,
+  r_tlsclient_test_cli_app,
+  r_tlsclient_test_cli_error,
+  r_tlsclient_test_verify_cert,
+  r_tlsclient_test_cli_closed,
+};
+
 RTEST_FIXTURE_SETUP (rtlsclient)
 {
-  static RTLSCallbacks srvcbs = {
-    r_tlsclient_test_prefer_ecdhe,
-    r_tlsclient_test_srv_hs_done,
-    r_tlsclient_test_srv_out,
-    r_tlsclient_test_srv_app,
-    r_tlsclient_test_srv_error,
-    NULL,
-    r_tlsclient_test_srv_closed,
-  };
-  static RTLSCallbacks clicbs = {
-    r_tlsclient_test_prefer_ecdhe,
-    r_tlsclient_test_cli_hs_done,
-    r_tlsclient_test_cli_out,
-    r_tlsclient_test_cli_app,
-    r_tlsclient_test_cli_error,
-    r_tlsclient_test_verify_cert,
-    r_tlsclient_test_cli_closed,
-  };
   RCryptoCert * cert;
   RCryptoKey * pk;
 
@@ -560,6 +561,355 @@ RTEST_F (rtlsclient, tls13_loopback_hrr, RTEST_FAST)
   r_assert_cmpint (r_tls_server_set_key_share_group (fixture->server,
         R_TLS_SUPPORTED_GROUP_SECP256R1), ==, R_TLS_ERROR_OK);
   r_test_tls13_loopback (fixture);
+}
+RTEST_END;
+
+/* Build a fresh server pre-loaded with the test cert and @keys (shared so a
+ * later connection can open a ticket the first sealed). */
+static RTLSServer *
+r_test_tls13_new_server (RTEST_FIXTURE_STRUCT (rtlsclient) * fixture,
+    RTLSSessionTicketKeys * keys)
+{
+  RTLSServer * s = r_tls_server_new (&srvcbs, fixture, NULL);
+  RCryptoCert * cert = r_pem_parse_cert_from_data (testcertpem, -1);
+  RCryptoKey * pk = r_pem_parse_key_from_data (testpkpem, -1, NULL, 0);
+  r_assert_cmpint (r_tls_server_set_cert (s, cert, pk), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (s, keys), ==, R_TLS_ERROR_OK);
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+  return s;
+}
+
+/* Full 1.3 handshake yields a NewSessionTicket; a second connection resumes
+ * from it with an abbreviated handshake (no certificate exchanged) that still
+ * carries application data both ways. The two servers share a ticket-key store,
+ * as separate server instances would in production. */
+RTEST_F (rtlsclient, tls13_resumption, RTEST_FAST)
+{
+  static const ruint8 c2s[] = { 'r', 'e', 's', 'u', 'm', 'e' };
+  static const ruint8 s2c[] = { 'o', 'k' };
+  RTLSSessionTicketKeys * keys;
+  RTLSClientSession * session;
+  RBuffer * app;
+
+  r_assert_cmpptr ((keys = r_tls_session_ticket_keys_new ()), !=, NULL);
+
+  /* First (full) handshake. The server issues a NewSessionTicket. */
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (fixture->server, keys),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->cli_hs_done && fixture->srv_hs_done);
+  r_assert (!fixture->cli_error && !fixture->srv_error);
+  r_assert_cmpuint (fixture->verify_calls, ==, 1);   /* full handshake verified a cert */
+
+  r_assert_cmpptr ((session = r_tls_client_get_session (fixture->client)), !=, NULL);
+
+  /* Fresh endpoints (sharing the key store) for the resumed handshake. */
+  r_tls_client_unref (fixture->client);
+  r_tls_server_unref (fixture->server);
+  fixture->server = r_test_tls13_new_server (fixture, keys);
+  r_assert_cmpptr ((fixture->client = r_tls_client_new (&clicbs, fixture, NULL)), !=, NULL);
+  r_assert_cmpint (r_tls_client_set_session (fixture->client, session), ==, R_TLS_ERROR_OK);
+
+  fixture->cli_hs_done = fixture->srv_hs_done = FALSE;
+  r_queue_clear (&fixture->srv_out, r_buffer_unref);
+  r_queue_clear (&fixture->cli_out, r_buffer_unref);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+
+  r_assert (fixture->cli_hs_done && fixture->srv_hs_done);
+  r_assert (!fixture->cli_error && !fixture->srv_error);
+  r_assert_cmpuint (r_tls_client_get_version (fixture->client), ==, R_TLS_VERSION_TLS_1_3);
+  /* Resumption authenticates via the PSK: no Certificate, so verify_cert was
+   * not called again and no peer certificate was received. */
+  r_assert_cmpuint (fixture->verify_calls, ==, 1);
+  r_assert_cmpptr (r_tls_client_get_peer_cert (fixture->client), ==, NULL);
+
+  /* The resumed session carries application data both ways. */
+  r_assert_cmpptr ((app = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)c2s, sizeof (c2s), sizeof (c2s), 0, NULL, NULL)), !=, NULL);
+  r_assert (r_tls_client_send_appdata (fixture->client, app));
+  r_buffer_unref (app);
+  r_test_tls_loopback_pump (fixture);
+  r_test_tls_assert_appdata (&fixture->srv_app, c2s, sizeof (c2s));
+
+  r_assert_cmpptr ((app = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)s2c, sizeof (s2c), sizeof (s2c), 0, NULL, NULL)), !=, NULL);
+  r_assert (r_tls_server_send_appdata (fixture->server, app));
+  r_buffer_unref (app);
+  r_test_tls_loopback_pump (fixture);
+  r_test_tls_assert_appdata (&fixture->cli_app, s2c, sizeof (s2c));
+
+  r_tls_client_session_unref (session);
+  r_tls_session_ticket_keys_unref (keys);
+}
+RTEST_END;
+
+/* A resumption ClientHello whose pre_shared_key binder does not match the one
+ * the server recomputes over the ticket PSK is rejected: the server opens the
+ * ticket, fails the binder check and aborts with a fatal decrypt_error alert
+ * instead of completing the abbreviated handshake. */
+RTEST_F (rtlsclient, tls13_resumption_bad_binder, RTEST_FAST)
+{
+  RTLSSessionTicketKeys * keys;
+  RTLSClientSession * session;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  RTLSAlertLevel alevel;
+  RTLSAlertType atype;
+  RBuffer * ch, * alert;
+
+  r_assert_cmpptr ((keys = r_tls_session_ticket_keys_new ()), !=, NULL);
+
+  /* First (full) handshake to obtain a ticket. */
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (fixture->server, keys),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->cli_hs_done && fixture->srv_hs_done);
+  r_assert_cmpptr ((session = r_tls_client_get_session (fixture->client)), !=, NULL);
+
+  /* Fresh endpoints sharing the key store; the ticket opens but we corrupt the
+   * binder on the wire. */
+  r_tls_client_unref (fixture->client);
+  r_tls_server_unref (fixture->server);
+  fixture->server = r_test_tls13_new_server (fixture, keys);
+  r_assert_cmpptr ((fixture->client = r_tls_client_new (&clicbs, fixture, NULL)), !=, NULL);
+  r_assert_cmpint (r_tls_client_set_session (fixture->client, session), ==, R_TLS_ERROR_OK);
+  fixture->cli_hs_done = fixture->srv_hs_done = FALSE;
+  fixture->cli_error = fixture->srv_error = FALSE;
+  r_queue_clear (&fixture->srv_out, r_buffer_unref);
+  r_queue_clear (&fixture->cli_out, r_buffer_unref);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+
+  /* The ClientHello ends with the binder (pre_shared_key is last); flipping its
+   * final byte leaves the transcript the server hashes intact but breaks the
+   * binder value. */
+  r_assert_cmpptr ((ch = r_queue_pop (&fixture->cli_out)), !=, NULL);
+  r_assert (r_buffer_map (ch, &info, R_MEM_MAP_WRITE));
+  info.data[info.size - 1] ^= 0xff;
+  r_assert (r_buffer_unmap (ch, &info));
+
+  r_tls_server_incoming_data (fixture->server, ch);
+  r_buffer_unref (ch);
+
+  r_assert (fixture->srv_error);
+  r_assert (!fixture->srv_hs_done);
+
+  r_assert_cmpptr ((alert = r_queue_pop (&fixture->srv_out)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, alert), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_ALERT);
+  r_assert_cmpint (r_tls_parser_parse_alert (&parser, &alevel, &atype), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (alevel, ==, R_TLS_ALERT_LEVEL_FATAL);
+  r_assert_cmpuint (atype, ==, R_TLS_ALERT_TYPE_DECRYPT_ERROR);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (alert);
+
+  r_tls_client_session_unref (session);
+  r_tls_session_ticket_keys_unref (keys);
+}
+RTEST_END;
+
+/* A ticket the resuming server cannot open (its key store never sealed it) is
+ * silently declined: the pre_shared_key offer is ignored and the handshake
+ * falls back to a full one, verifying the certificate again. */
+RTEST_F (rtlsclient, tls13_resumption_ticket_declined, RTEST_FAST)
+{
+  RTLSSessionTicketKeys * keys, * otherkeys;
+  RTLSClientSession * session;
+
+  r_assert_cmpptr ((keys = r_tls_session_ticket_keys_new ()), !=, NULL);
+
+  /* First (full) handshake seals a ticket under @keys. */
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (fixture->server, keys),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->cli_hs_done && fixture->srv_hs_done);
+  r_assert_cmpuint (fixture->verify_calls, ==, 1);
+  r_assert_cmpptr ((session = r_tls_client_get_session (fixture->client)), !=, NULL);
+
+  /* The resuming server holds an unrelated key store, so the ticket will not
+   * open. */
+  r_assert_cmpptr ((otherkeys = r_tls_session_ticket_keys_new ()), !=, NULL);
+  r_tls_client_unref (fixture->client);
+  r_tls_server_unref (fixture->server);
+  fixture->server = r_test_tls13_new_server (fixture, otherkeys);
+  r_assert_cmpptr ((fixture->client = r_tls_client_new (&clicbs, fixture, NULL)), !=, NULL);
+  r_assert_cmpint (r_tls_client_set_session (fixture->client, session), ==, R_TLS_ERROR_OK);
+  fixture->cli_hs_done = fixture->srv_hs_done = FALSE;
+  r_queue_clear (&fixture->srv_out, r_buffer_unref);
+  r_queue_clear (&fixture->cli_out, r_buffer_unref);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+
+  /* Full handshake ran instead: no error, a certificate was verified again and
+   * a peer certificate is present. */
+  r_assert (fixture->cli_hs_done && fixture->srv_hs_done);
+  r_assert (!fixture->cli_error && !fixture->srv_error);
+  r_assert_cmpuint (r_tls_client_get_version (fixture->client), ==, R_TLS_VERSION_TLS_1_3);
+  r_assert_cmpuint (fixture->verify_calls, ==, 2);
+  r_assert_cmpptr (r_tls_client_get_peer_cert (fixture->client), !=, NULL);
+
+  r_tls_client_session_unref (session);
+  r_tls_session_ticket_keys_unref (keys);
+  r_tls_session_ticket_keys_unref (otherkeys);
+}
+RTEST_END;
+
+/* A first handshake against an early-data-enabled server yields a ticket that
+ * permits 0-RTT; the resumed connection sends early data after the ClientHello,
+ * the server accepts it (echoes early_data) and delivers it via appdata before
+ * the handshake completes. */
+RTEST_F (rtlsclient, tls13_early_data_accepted, RTEST_FAST)
+{
+  static const ruint8 early[] = { 'G', 'E', 'T', ' ', '/' };
+  static const ruint8 s2c[] = { 'o', 'k' };
+  RTLSSessionTicketKeys * keys;
+  RTLSClientSession * session;
+  RBuffer * app;
+
+  r_assert_cmpptr ((keys = r_tls_session_ticket_keys_new ()), !=, NULL);
+
+  /* First handshake: the server offers 0-RTT, so its ticket advertises it. */
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (fixture->server, keys),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_set_max_early_data_size (fixture->server, 0x4000),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->cli_hs_done && fixture->srv_hs_done);
+  r_assert_cmpptr ((session = r_tls_client_get_session (fixture->client)), !=, NULL);
+
+  /* Fresh endpoints (sharing the key store); the client offers 0-RTT data. */
+  r_tls_client_unref (fixture->client);
+  r_tls_server_unref (fixture->server);
+  fixture->server = r_test_tls13_new_server (fixture, keys);
+  r_assert_cmpint (r_tls_server_set_max_early_data_size (fixture->server, 0x4000),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpptr ((fixture->client = r_tls_client_new (&clicbs, fixture, NULL)), !=, NULL);
+  r_assert_cmpint (r_tls_client_set_session (fixture->client, session), ==, R_TLS_ERROR_OK);
+  r_assert_cmpptr ((app = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)early, sizeof (early), sizeof (early), 0, NULL, NULL)), !=, NULL);
+  r_assert_cmpint (r_tls_client_set_early_data (fixture->client, app), ==, R_TLS_ERROR_OK);
+  r_buffer_unref (app);
+
+  fixture->cli_hs_done = fixture->srv_hs_done = FALSE;
+  fixture->verify_calls = 0;
+  r_queue_clear (&fixture->srv_out, r_buffer_unref);
+  r_queue_clear (&fixture->cli_out, r_buffer_unref);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+
+  r_assert (fixture->cli_hs_done && fixture->srv_hs_done);
+  r_assert (!fixture->cli_error && !fixture->srv_error);
+  /* Both endpoints agree 0-RTT was accepted; the certificate was not re-sent. */
+  r_assert (r_tls_client_get_early_data_accepted (fixture->client));
+  r_assert (r_tls_server_get_early_data_accepted (fixture->server));
+  r_assert_cmpuint (fixture->verify_calls, ==, 0);
+  r_assert_cmpptr (r_tls_client_get_peer_cert (fixture->client), ==, NULL);
+  /* The early data reached the server as application data during the handshake. */
+  r_test_tls_assert_appdata (&fixture->srv_app, early, sizeof (early));
+
+  /* 1-RTT data still flows afterwards. */
+  r_assert_cmpptr ((app = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)s2c, sizeof (s2c), sizeof (s2c), 0, NULL, NULL)), !=, NULL);
+  r_assert (r_tls_server_send_appdata (fixture->server, app));
+  r_buffer_unref (app);
+  r_test_tls_loopback_pump (fixture);
+  r_test_tls_assert_appdata (&fixture->cli_app, s2c, sizeof (s2c));
+
+  r_tls_client_session_unref (session);
+  r_tls_session_ticket_keys_unref (keys);
+}
+RTEST_END;
+
+/* When the resuming server declines 0-RTT (early data disabled), the client's
+ * early-data records are discarded and the payload is transparently resent as
+ * ordinary application data once the handshake completes. */
+RTEST_F (rtlsclient, tls13_early_data_rejected, RTEST_FAST)
+{
+  static const ruint8 early[] = { 'P', 'I', 'N', 'G' };
+  RTLSSessionTicketKeys * keys;
+  RTLSClientSession * session;
+  RBuffer * app;
+
+  r_assert_cmpptr ((keys = r_tls_session_ticket_keys_new ()), !=, NULL);
+
+  /* First handshake against an early-data-enabled server: the ticket permits
+   * 0-RTT, so the client will actually put early data on the wire. */
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (fixture->server, keys),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_set_max_early_data_size (fixture->server, 0x4000),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->cli_hs_done && fixture->srv_hs_done);
+  r_assert_cmpptr ((session = r_tls_client_get_session (fixture->client)), !=, NULL);
+
+  /* The resuming server does NOT enable 0-RTT, so it declines the offer. */
+  r_tls_client_unref (fixture->client);
+  r_tls_server_unref (fixture->server);
+  fixture->server = r_test_tls13_new_server (fixture, keys);
+  r_assert_cmpptr ((fixture->client = r_tls_client_new (&clicbs, fixture, NULL)), !=, NULL);
+  r_assert_cmpint (r_tls_client_set_session (fixture->client, session), ==, R_TLS_ERROR_OK);
+  r_assert_cmpptr ((app = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)early, sizeof (early), sizeof (early), 0, NULL, NULL)), !=, NULL);
+  r_assert_cmpint (r_tls_client_set_early_data (fixture->client, app), ==, R_TLS_ERROR_OK);
+  r_buffer_unref (app);
+
+  fixture->cli_hs_done = fixture->srv_hs_done = FALSE;
+  r_queue_clear (&fixture->srv_out, r_buffer_unref);
+  r_queue_clear (&fixture->cli_out, r_buffer_unref);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+
+  r_assert (fixture->cli_hs_done && fixture->srv_hs_done);
+  r_assert (!fixture->cli_error && !fixture->srv_error);
+  /* Neither side saw 0-RTT accepted, yet the payload was delivered once, resent
+   * as 1-RTT application data. */
+  r_assert (!r_tls_client_get_early_data_accepted (fixture->client));
+  r_assert (!r_tls_server_get_early_data_accepted (fixture->server));
+  r_test_tls_assert_appdata (&fixture->srv_app, early, sizeof (early));
+
+  r_tls_client_session_unref (session);
+  r_tls_session_ticket_keys_unref (keys);
 }
 RTEST_END;
 

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -1171,6 +1171,66 @@ RTEST_F (rtlsclient, tls_verify_cert_reject, RTEST_FAST)
 }
 RTEST_END;
 
+/* RFC 8446 4.1.3 downgrade protection: a 1.3-capable server that settles on
+ * TLS 1.2 stamps the downgrade sentinel into its ServerHello.random, and a
+ * client that offered 1.3 but is answered with that ServerHello aborts with a
+ * fatal illegal_parameter alert rather than completing the downgrade. */
+RTEST_F (rtlsclient, tls_downgrade_protection, RTEST_FAST)
+{
+  RBuffer * ch, * sh, * alert;
+  RTLSClient * victim;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSHelloMsg hello;
+  RTLSAlertLevel alevel;
+  RTLSAlertType atype;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_2), ==, R_TLS_ERROR_OK);
+
+  /* Drive the 1.2 ClientHello into the server so it emits its flight. */
+  r_assert_cmpptr ((ch = r_queue_pop (&fixture->cli_out)), !=, NULL);
+  r_tls_server_incoming_data (fixture->server, ch);
+  r_buffer_unref (ch);
+
+  /* The first server record is the ServerHello; its random carries the
+   * "DOWNGRD\x01" sentinel because the 1.3-capable server settled on 1.2. */
+  r_assert_cmpptr ((sh = r_queue_pop (&fixture->srv_out)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, sh), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_parser_parse_hello (&parser, &hello), ==, R_TLS_ERROR_OK);
+  r_assert (r_tls13_random_is_downgrade (hello.random));
+  r_assert_cmpmem (hello.random + R_TLS_HELLO_RANDOM_BYTES - 8, ==,
+      "\x44\x4f\x57\x4e\x47\x52\x44\x01", 8);
+  r_tls_parser_clear (&parser);
+
+  /* A fresh client that offered 1.3 detects the downgrade in that ServerHello
+   * and aborts instead of accepting 1.2. */
+  r_assert_cmpptr ((victim = r_tls_client_new (&clicbs, fixture, NULL)), !=, NULL);
+  r_assert_cmpint (r_tls_client_start (victim, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_queue_clear (&fixture->cli_out, r_buffer_unref);   /* drop victim's ClientHello */
+  fixture->cli_error = fixture->cli_hs_done = FALSE;
+
+  r_tls_client_incoming_data (victim, sh);
+  r_assert (fixture->cli_error);
+  r_assert (!fixture->cli_hs_done);
+
+  /* It signalled the peer with a fatal illegal_parameter alert. */
+  r_assert_cmpptr ((alert = r_queue_pop (&fixture->cli_out)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, alert), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_ALERT);
+  r_assert_cmpint (r_tls_parser_parse_alert (&parser, &alevel, &atype), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (alevel, ==, R_TLS_ALERT_LEVEL_FATAL);
+  r_assert_cmpuint (atype, ==, R_TLS_ALERT_TYPE_ILLEGAL_PARAMETER);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (alert);
+
+  r_tls_client_unref (victim);
+  r_buffer_unref (sh);
+}
+RTEST_END;
+
 /* Mutual TLS: the server requires a client certificate, the client presents
  * one, and the handshake completes with each side holding the other's leaf. */
 static void

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -1231,6 +1231,73 @@ RTEST_F (rtlsclient, tls_downgrade_protection, RTEST_FAST)
 }
 RTEST_END;
 
+/* The client offers both 1.3 and 1.2 in one ClientHello. Against the default
+ * (1.3-capable) server it negotiates 1.3. */
+RTEST_F (rtlsclient, tls_hybrid_negotiates_tls13, RTEST_FAST)
+{
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+
+  r_test_tls_loopback_pump (fixture);
+
+  r_assert (fixture->cli_hs_done);
+  r_assert (fixture->srv_hs_done);
+  r_assert (!fixture->cli_error);
+  r_assert (!fixture->srv_error);
+  r_assert_cmpuint (r_tls_client_get_version (fixture->client), ==, R_TLS_VERSION_TLS_1_3);
+  r_assert_cmpuint (r_tls_server_get_version (fixture->server), ==, R_TLS_VERSION_TLS_1_3);
+}
+RTEST_END;
+
+/* Same hybrid client, but the server is capped at 1.2 -- a genuine 1.2 peer
+ * that neither speaks 1.3 nor stamps the downgrade sentinel. The client falls
+ * back to a full 1.2 handshake (no false downgrade abort) and data flows. */
+RTEST_F (rtlsclient, tls_hybrid_falls_back_to_tls12, RTEST_FAST)
+{
+  static const ruint8 c2s[] = { 'f', 'a', 'l', 'l', 'b', 'a', 'c', 'k' };
+  static const ruint8 s2c[] = { 'o', 'k', ' ', '1', '.', '2' };
+  RBuffer * app;
+
+  r_assert_cmpint (r_tls_server_set_version_range (fixture->server,
+        R_TLS_VERSION_TLS_1_2, R_TLS_VERSION_TLS_1_2), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+
+  r_test_tls_loopback_pump (fixture);
+
+  r_assert (fixture->cli_hs_done);
+  r_assert (fixture->srv_hs_done);
+  r_assert (!fixture->cli_error);
+  r_assert (!fixture->srv_error);
+  r_assert_cmpuint (r_tls_client_get_version (fixture->client), ==, R_TLS_VERSION_TLS_1_2);
+  r_assert_cmpuint (r_tls_server_get_version (fixture->server), ==, R_TLS_VERSION_TLS_1_2);
+  r_assert_cmpptr (r_tls_client_get_peer_cert (fixture->client), !=, NULL);
+  /* 1.2 with the default ECDHE-first preference: forward secrecy preserved. */
+  r_assert_cmpptr (r_tls_client_get_cipher_suite (fixture->client), !=, NULL);
+  r_assert_cmpint (r_tls_client_get_cipher_suite (fixture->client)->key_exchange,
+      ==, R_KEY_EXCHANGE_ECDHE_RSA);
+
+  r_assert_cmpptr ((app = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)c2s, sizeof (c2s), sizeof (c2s), 0, NULL, NULL)), !=, NULL);
+  r_assert (r_tls_client_send_appdata (fixture->client, app));
+  r_buffer_unref (app);
+  r_test_tls_loopback_pump (fixture);
+  r_test_tls_assert_appdata (&fixture->srv_app, c2s, sizeof (c2s));
+
+  r_assert_cmpptr ((app = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)s2c, sizeof (s2c), sizeof (s2c), 0, NULL, NULL)), !=, NULL);
+  r_assert (r_tls_server_send_appdata (fixture->server, app));
+  r_buffer_unref (app);
+  r_test_tls_loopback_pump (fixture);
+  r_test_tls_assert_appdata (&fixture->cli_app, s2c, sizeof (s2c));
+}
+RTEST_END;
+
 /* A server that requires 1.3 rejects a 1.2-only client with a fatal
  * protocol_version alert. */
 RTEST_F (rtlsclient, tls_server_requires_tls13, RTEST_FAST)
@@ -1263,6 +1330,78 @@ RTEST_F (rtlsclient, tls_server_requires_tls13, RTEST_FAST)
   r_assert_cmpuint (atype, ==, R_TLS_ALERT_TYPE_PROTOCOL_VERSION);
   r_tls_parser_clear (&parser);
   r_buffer_unref (alert);
+}
+RTEST_END;
+
+/* r_tls_client_set_version_range accepts the 1.2..1.3 window and rejects
+ * inverted, out-of-window and DTLS bounds. */
+RTEST_F (rtlsclient, tls_client_version_range_validation, RTEST_FAST)
+{
+  r_assert_cmpint (r_tls_client_set_version_range (fixture->client,
+        R_TLS_VERSION_TLS_1_2, R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_set_version_range (fixture->client,
+        R_TLS_VERSION_TLS_1_3, R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_set_version_range (fixture->client,
+        R_TLS_VERSION_TLS_1_3, R_TLS_VERSION_TLS_1_2), ==, R_TLS_ERROR_VERSION);
+  r_assert_cmpint (r_tls_client_set_version_range (fixture->client,
+        R_TLS_VERSION_TLS_1_0, R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_VERSION);
+  r_assert_cmpint (r_tls_client_set_version_range (fixture->client,
+        R_TLS_VERSION_DTLS_1_2, R_TLS_VERSION_DTLS_1_2), ==, R_TLS_ERROR_VERSION);
+}
+RTEST_END;
+
+/* A client pinned to 1.3 (no fallback) rejects a 1.2 ServerHello as out of its
+ * offered range, aborting with protocol_version rather than downgrading. A
+ * pinned client offers no 1.2 suites, so a genuine 1.2 server could not answer
+ * it at all; the rejection guards the case where a server (or an attacker)
+ * replies 1.2 regardless. The 1.2 ServerHello is sourced from the capped server
+ * answering a hybrid client. */
+RTEST_F (rtlsclient, tls_client_requires_tls13, RTEST_FAST)
+{
+  RBuffer * ch, * sh, * alert;
+  RTLSClient * victim;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSAlertLevel alevel;
+  RTLSAlertType atype;
+
+  r_assert_cmpint (r_tls_server_set_version_range (fixture->server,
+        R_TLS_VERSION_TLS_1_2, R_TLS_VERSION_TLS_1_2), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  /* A hybrid client so the capped server produces a real (sentinel-free) 1.2
+   * ServerHello. */
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_assert_cmpptr ((ch = r_queue_pop (&fixture->cli_out)), !=, NULL);
+  r_tls_server_incoming_data (fixture->server, ch);
+  r_buffer_unref (ch);
+  r_assert_cmpptr ((sh = r_queue_pop (&fixture->srv_out)), !=, NULL);
+
+  /* Pinned-1.3 client fed that 1.2 ServerHello aborts. */
+  r_assert_cmpptr ((victim = r_tls_client_new (&clicbs, fixture, NULL)), !=, NULL);
+  r_assert_cmpint (r_tls_client_set_version_range (victim,
+        R_TLS_VERSION_TLS_1_3, R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (victim, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_queue_clear (&fixture->cli_out, r_buffer_unref);   /* drop victim's ClientHello */
+  fixture->cli_error = fixture->cli_hs_done = FALSE;
+
+  r_tls_client_incoming_data (victim, sh);
+  r_assert (fixture->cli_error);
+  r_assert (!fixture->cli_hs_done);
+
+  r_assert_cmpptr ((alert = r_queue_pop (&fixture->cli_out)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, alert), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_ALERT);
+  r_assert_cmpint (r_tls_parser_parse_alert (&parser, &alevel, &atype), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (alevel, ==, R_TLS_ALERT_LEVEL_FATAL);
+  r_assert_cmpuint (atype, ==, R_TLS_ALERT_TYPE_PROTOCOL_VERSION);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (alert);
+
+  r_tls_client_unref (victim);
+  r_buffer_unref (sh);
 }
 RTEST_END;
 

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -552,6 +552,17 @@ RTEST_F (rtlsclient, tls13_loopback_aes256, RTEST_FAST)
 }
 RTEST_END;
 
+/* The server requires secp256r1 but the client offers an x25519 key_share, so
+ * the server answers with a HelloRetryRequest and the client retries with a
+ * secp256r1 share. The handshake can only complete if the retry worked. */
+RTEST_F (rtlsclient, tls13_loopback_hrr, RTEST_FAST)
+{
+  r_assert_cmpint (r_tls_server_set_key_share_group (fixture->server,
+        R_TLS_SUPPORTED_GROUP_SECP256R1), ==, R_TLS_ERROR_OK);
+  r_test_tls13_loopback (fixture);
+}
+RTEST_END;
+
 /* In 1.3, alerts after the handshake are AEAD-protected (RFC 8446 5): the
  * server's close_notify goes out as an application_data record, the client
  * decrypts it, reports the orderly close and auto-responds with its own

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -1231,6 +1231,41 @@ RTEST_F (rtlsclient, tls_downgrade_protection, RTEST_FAST)
 }
 RTEST_END;
 
+/* A server that requires 1.3 rejects a 1.2-only client with a fatal
+ * protocol_version alert. */
+RTEST_F (rtlsclient, tls_server_requires_tls13, RTEST_FAST)
+{
+  RBuffer * ch, * alert;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSAlertLevel alevel;
+  RTLSAlertType atype;
+
+  r_assert_cmpint (r_tls_server_set_version_range (fixture->server,
+        R_TLS_VERSION_TLS_1_3, R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_2), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpptr ((ch = r_queue_pop (&fixture->cli_out)), !=, NULL);
+  r_tls_server_incoming_data (fixture->server, ch);
+  r_buffer_unref (ch);
+
+  r_assert (fixture->srv_error);
+  r_assert (!fixture->srv_hs_done);
+
+  r_assert_cmpptr ((alert = r_queue_pop (&fixture->srv_out)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, alert), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_ALERT);
+  r_assert_cmpint (r_tls_parser_parse_alert (&parser, &alevel, &atype), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (alevel, ==, R_TLS_ALERT_LEVEL_FATAL);
+  r_assert_cmpuint (atype, ==, R_TLS_ALERT_TYPE_PROTOCOL_VERSION);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (alert);
+}
+RTEST_END;
+
 /* Mutual TLS: the server requires a client certificate, the client presents
  * one, and the handshake completes with each side holding the other's leaf. */
 static void

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -913,6 +913,68 @@ RTEST_F (rtlsclient, tls13_early_data_rejected, RTEST_FAST)
 }
 RTEST_END;
 
+/* The resuming server accepts 0-RTT but has a smaller max_early_data_size than
+ * the ticket originally advertised; a client payload that overshoots that limit
+ * is rejected on the server rather than delivered (RFC 8446 4.2.10). */
+RTEST_F (rtlsclient, tls13_early_data_exceeds_max, RTEST_FAST)
+{
+  static const ruint8 early[] = { 'T', 'O', 'O', 'M', 'U', 'C', 'H', '!' };
+  RTLSSessionTicketKeys * keys;
+  RTLSClientSession * session;
+  RBuffer * app;
+
+  r_assert_cmpptr ((keys = r_tls_session_ticket_keys_new ()), !=, NULL);
+
+  /* First handshake advertises a generous limit, so the ticket permits enough
+   * early data for the payload below. */
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (fixture->server, keys),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_set_max_early_data_size (fixture->server, 0x4000),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->cli_hs_done && fixture->srv_hs_done);
+  r_assert_cmpptr ((session = r_tls_client_get_session (fixture->client)), !=, NULL);
+
+  /* The resuming server now enforces a limit of 4 bytes, below the 8-byte
+   * payload the client offers as 0-RTT. */
+  r_tls_client_unref (fixture->client);
+  r_tls_server_unref (fixture->server);
+  fixture->server = r_test_tls13_new_server (fixture, keys);
+  r_assert_cmpint (r_tls_server_set_max_early_data_size (fixture->server, 4),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpptr ((fixture->client = r_tls_client_new (&clicbs, fixture, NULL)), !=, NULL);
+  r_assert_cmpint (r_tls_client_set_session (fixture->client, session), ==, R_TLS_ERROR_OK);
+  r_assert_cmpptr ((app = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)early, sizeof (early), sizeof (early), 0, NULL, NULL)), !=, NULL);
+  r_assert_cmpint (r_tls_client_set_early_data (fixture->client, app), ==, R_TLS_ERROR_OK);
+  r_buffer_unref (app);
+
+  fixture->cli_hs_done = fixture->srv_hs_done = FALSE;
+  fixture->cli_error = fixture->srv_error = FALSE;
+  r_queue_clear (&fixture->srv_out, r_buffer_unref);
+  r_queue_clear (&fixture->cli_out, r_buffer_unref);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+
+  /* The server aborted the handshake on the over-long early data; the oversized
+   * record was never delivered to the application. */
+  r_assert (fixture->srv_error);
+  r_assert (!fixture->srv_hs_done);
+  r_assert_cmpuint (r_queue_size (&fixture->srv_app), ==, 0);
+
+  r_tls_client_session_unref (session);
+  r_tls_session_ticket_keys_unref (keys);
+}
+RTEST_END;
+
 /* In 1.3, alerts after the handshake are AEAD-protected (RFC 8446 5): the
  * server's close_notify goes out as an application_data record, the client
  * decrypts it, reports the orderly close and auto-responds with its own

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -2428,6 +2428,81 @@ RTEST_F (rtlsserver, tls_session_resume, RTEST_FAST)
 }
 RTEST_END;
 
+/* A ticket still opens after the key store rotates, as long as its sealing key
+ * is still in the retained current+recent set (#348). */
+RTEST_F (rtlsserver, tls_session_resume_after_rotation, RTEST_FAST)
+{
+  RTLSServer * srv2;
+  ruint8 ms[48], * ticket = NULL;
+  rsize ticketlen = 0;
+
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (fixture->server,
+        fixture->ticket_keys), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_test_tls_client_issue (fixture->server, fixture->prng, &fixture->qout,
+      ms, &ticket, &ticketlen);
+  r_assert (fixture->hs_done);
+
+  /* Two rotations leave the ticket's key as the oldest retained key (the store
+   * keeps the active key plus two recent ones). */
+  r_assert (r_tls_session_ticket_keys_rotate (fixture->ticket_keys));
+  r_assert (r_tls_session_ticket_keys_rotate (fixture->ticket_keys));
+
+  fixture->hs_done = FALSE;
+  r_queue_clear (&fixture->qout, r_buffer_unref);
+  r_assert_cmpptr ((srv2 = r_test_tls_server_new_cfg (fixture)), !=, NULL);
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (srv2, fixture->ticket_keys),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (srv2, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  r_test_tls_client_resume (srv2, fixture->prng, &fixture->qout, ms, ticket, ticketlen);
+  r_assert (fixture->hs_done);
+
+  r_free (ticket);
+  r_tls_server_unref (srv2);
+}
+RTEST_END;
+
+/* Once the sealing key rotates out of the retained set, the ticket can no
+ * longer be opened and the server falls back to a full handshake (#348). */
+RTEST_F (rtlsserver, tls_session_resume_rotated_out, RTEST_FAST)
+{
+  RTLSServer * srv2;
+  ruint8 ms[48], * ticket = NULL;
+  rsize ticketlen = 0;
+  ruint i;
+
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (fixture->server,
+        fixture->ticket_keys), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_test_tls_client_issue (fixture->server, fixture->prng, &fixture->qout,
+      ms, &ticket, &ticketlen);
+  r_assert (fixture->hs_done);
+
+  /* Three rotations push the ticket's key past the retained set. */
+  for (i = 0; i < 3; i++)
+    r_assert (r_tls_session_ticket_keys_rotate (fixture->ticket_keys));
+
+  fixture->hs_done = FALSE;
+  r_queue_clear (&fixture->qout, r_buffer_unref);
+  r_assert_cmpptr ((srv2 = r_test_tls_server_new_cfg (fixture)), !=, NULL);
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (srv2, fixture->ticket_keys),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (srv2, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  r_test_tls_client_resume_assert_full (srv2, fixture->prng, &fixture->qout,
+      R_TLS_CS_RSA_WITH_AES_128_CBC_SHA, ticket, ticketlen);
+  r_assert (!fixture->hs_done);
+
+  r_free (ticket);
+  r_tls_server_unref (srv2);
+}
+RTEST_END;
+
 /* A ClientHello carrying an unopenable ticket falls back to a full handshake. */
 RTEST_F (rtlsserver, tls_session_resume_bad_ticket, RTEST_FAST)
 {


### PR DESCRIPTION
Completes the TLS 1.3 stack begun in the 1-RTT work, plus the version-negotiation hardening that a dual 1.2/1.3 stack needs.

- **HelloRetryRequest** — the server can require a specific (EC)DHE group and the client retries with a matching share, over the RFC 8446 4.4.1 `message_hash` transcript rewrite; the follow-up ServerHello is checked for consistency with the HRR.
- **Session resumption** — 1.3 `NewSessionTicket` and `pre_shared_key` (psk_dhe_ke): the server derives the resumption master secret, seals a ticket and validates the binder; a later ClientHello resumes with an abbreviated flight. A bad binder aborts; an unopenable ticket falls back to a full handshake.
- **0-RTT early data** — the client sends early data under the client early-traffic secret; the server accepts (opt-in via `max_early_data_size`, enforced on received bytes) or rejects with transparent 1-RTT fallback. Tickets are stateless, so replay protection is bounded by the ticket lifetime — documented, opt-in, idempotent-only.
- **Downgrade protection & version ranges** — RFC 8446 4.1.3 sentinels wired into version negotiation, plus `r_tls_server_set_version_range` / `r_tls_client_set_version_range`. The client sends a hybrid 1.2/1.3 ClientHello by default and aborts a forced downgrade with `illegal_parameter`.
- Session-ticket **key rotation** (active key plus a recent set) so rotation no longer invalidates live tickets.

Verified across the linux, asan, ubsan and mingw tiers under `-Werror`.

Closes #372
Closes #373
Closes #374
Closes #376
