### PR TITLE
net/tls: TLS 1.3 hardening follow-ups (SCSV, constant-time MACs, negative-path tests)

### DIFF
--- a/include/rlib/net/proto/rtls.h
+++ b/include/rlib/net/proto/rtls.h
@@ -371,6 +371,7 @@ typedef enum {
   R_TLS_ERROR_RECORD_OVERFLOW                           = -0x11, /**< Record fragment length exceeds the limit. */
   R_TLS_ERROR_ILLEGAL_PARAMETER                         = -0x12, /**< Field value well-formed but out of range. */
   R_TLS_ERROR_NO_APPLICATION_PROTOCOL                   = -0x13, /**< No ALPN protocol in common with the peer. */
+  R_TLS_ERROR_INAPPROPRIATE_FALLBACK                    = -0x14, /**< Client signalled a fallback below the highest common version (RFC 7507). */
 } RTLSError;
 
 /** @brief TLS record compression method (only @c NULL is supported / non-deprecated). */

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -1540,7 +1540,7 @@ r_tls_client_flight13 (RTLSClient * client, const RTLSParser * parser)
           !r_tls13_finished_key (client->cs13_hash, client->sched13.shs, finkey) ||
           !r_tls13_verify_data (client->cs13_hash, finkey, th, expect))
         return R_TLS_ERROR_HANDSHAKE_FAILURE;
-      if (vdsize != hlen || r_memcmp (vd, expect, hlen) != 0)
+      if (vdsize != hlen || r_memcmp_ct (vd, expect, hlen) != 0)
         return R_TLS_ERROR_HS_VERIFICATION_FAILED;
 
       /* Fold the server Finished, then derive the application secrets over
@@ -2128,7 +2128,7 @@ r_tls_client_parse_finished (RTLSClient * client, const RTLSParser * parser)
             client->mastersecret, sizeof (client->mastersecret),
             R_STR_WITH_SIZE_ARGS ("server finished"),
             hash, hashsize, NULL)) == R_TLS_ERROR_OK) {
-        if (r_memcmp (verify_calc, verify_data, size) != 0) {
+        if (r_memcmp_ct (verify_calc, verify_data, size) != 0) {
           R_LOG_WARNING ("Server Finished NOT verified");
           ret = R_TLS_ERROR_HS_VERIFICATION_FAILED;
         }

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -2445,6 +2445,15 @@ r_tls_server_nego_hello (RTLSServer * server, RTLSVersion verlo, RTLSVersion ver
       server->version < server->min_version)
     return R_TLS_ERROR_VERSION;
 
+  /* RFC 7507: TLS_FALLBACK_SCSV marks a ClientHello as a deliberate downgrade
+   * of the client's own retry. Having landed below the highest version we
+   * support, that fallback was forced by a meddler -- refuse it. Pairs with the
+   * RFC 8446 4.1.3 ServerHello.random sentinel, which guards the reverse path. */
+  if (!r_tls_version_is_dtls (server->version) &&
+      server->version < server->max_version &&
+      r_tls_hello_msg_has_cipher_suite (&server->hello, R_TLS_CS_FALLBACK_SCSV))
+    return R_TLS_ERROR_INAPPROPRIATE_FALLBACK;
+
   if (R_UNLIKELY (server->hello.cslen == 0 || (server->hello.cslen & 1)))
     return R_TLS_ERROR_CORRUPT_RECORD;
   count = server->hello.cslen / sizeof (ruint16);
@@ -3016,6 +3025,8 @@ r_tls_server_alert_for_error (RTLSError err)
       return R_TLS_ALERT_TYPE_ILLEGAL_PARAMETER;
     case R_TLS_ERROR_NO_APPLICATION_PROTOCOL: /* no ALPN protocol in common */
       return R_TLS_ALERT_TYPE_NO_APPLICATION_PROTOCOL;
+    case R_TLS_ERROR_INAPPROPRIATE_FALLBACK:  /* RFC 7507 fallback SCSV */
+      return R_TLS_ALERT_TYPE_INAPPROPRIATE_FALLBACK;
     case R_TLS_ERROR_HS_VERIFICATION_FAILED:  /* could not verify Finished */
       return R_TLS_ALERT_TYPE_DECRYPT_ERROR;
     case R_TLS_ERROR_VERSION:

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -1675,7 +1675,7 @@ r_tls_server_try_resume13 (RTLSServer * server)
   if (r_tls_hello_ext_psk_binder (&psk, 0, &binder, &binderlen) != R_TLS_ERROR_OK ||
       !r_tls_server_psk_binder (server, &psk, server->hello.random - 6, expect))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
-  if (binderlen != hlen || r_memcmp (binder, expect, hlen) != 0)
+  if (binderlen != hlen || r_memcmp_ct (binder, expect, hlen) != 0)
     return R_TLS_ERROR_HS_VERIFICATION_FAILED;
 
   server->resumed13 = TRUE;
@@ -2298,7 +2298,7 @@ r_tls_server_finished13 (RTLSServer * server, const RTLSParser * parser)
       !r_tls13_finished_key (server->cs13_hash, server->sched13.chs, finkey) ||
       !r_tls13_verify_data (server->cs13_hash, finkey, th, expect))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
-  if (vdsize != hlen || r_memcmp (vd, expect, hlen) != 0)
+  if (vdsize != hlen || r_memcmp_ct (vd, expect, hlen) != 0)
     return R_TLS_ERROR_HS_VERIFICATION_FAILED;
 
   /* Switch to application-traffic keys (server writes sap, reads cap). */
@@ -2903,7 +2903,7 @@ r_tls_server_parse_finished (RTLSServer * server, const RTLSParser * parser)
             server->mastersecret, sizeof (server->mastersecret),
             R_STR_WITH_SIZE_ARGS ("client finished"),
             hash, hashsize, NULL)) == R_TLS_ERROR_OK) {
-        if (r_memcmp (verify_calc, verify_data, size) != 0) {
+        if (r_memcmp_ct (verify_calc, verify_data, size) != 0) {
           R_LOG_WARNING ("Handshake NOT verified");
           R_LOG_MEM_DUMP (R_LOG_LEVEL_DEBUG, verify_data, size);
           R_LOG_DEBUG ("expected:");

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -84,6 +84,7 @@ RTEST_FIXTURE_STRUCT (rtlsclient)
 
   rboolean srv_hs_done, cli_hs_done;
   rboolean srv_error, cli_error;
+  RTLSAlertType srv_alert, cli_alert;   /* alert each side raised at its error */
   rboolean srv_closed, cli_closed;
   ruint verify_calls;
   rboolean verify_result;
@@ -135,16 +136,18 @@ static void
 r_tlsclient_test_srv_error (rpointer ctx, RTLSAlertType alert, rpointer session)
 {
   RTEST_FIXTURE_STRUCT (rtlsclient) * fixture = ctx;
-  (void) alert; (void) session;
+  (void) session;
   fixture->srv_error = TRUE;
+  fixture->srv_alert = alert;
 }
 
 static void
 r_tlsclient_test_cli_error (rpointer ctx, RTLSAlertType alert, rpointer session)
 {
   RTEST_FIXTURE_STRUCT (rtlsclient) * fixture = ctx;
-  (void) alert; (void) session;
+  (void) session;
   fixture->cli_error = TRUE;
+  fixture->cli_alert = alert;
 }
 
 static void
@@ -249,6 +252,7 @@ RTEST_FIXTURE_SETUP (rtlsclient)
 
   fixture->srv_hs_done = fixture->cli_hs_done = FALSE;
   fixture->srv_error = fixture->cli_error = FALSE;
+  fixture->srv_alert = fixture->cli_alert = R_TLS_ALERT_TYPE_CLOSE_NOTIFY;
   fixture->srv_closed = fixture->cli_closed = FALSE;
   fixture->verify_calls = 0;
   fixture->verify_result = TRUE;
@@ -561,6 +565,195 @@ RTEST_F (rtlsclient, tls13_loopback_hrr, RTEST_FAST)
   r_assert_cmpint (r_tls_server_set_key_share_group (fixture->server,
         R_TLS_SUPPORTED_GROUP_SECP256R1), ==, R_TLS_ERROR_OK);
   r_test_tls13_loopback (fixture);
+}
+RTEST_END;
+
+/* Drive CH1 -> HelloRetryRequest with a server that requires secp256r1 while
+ * the client first offers x25519. Returns the (still-owned) HRR record and
+ * leaves the client having consumed nothing yet. */
+static RBuffer *
+r_test_tls13_hrr_drive (RTEST_FIXTURE_STRUCT (rtlsclient) * fixture)
+{
+  RBuffer * ch1, * hrr;
+
+  r_assert_cmpint (r_tls_server_set_key_share_group (fixture->server,
+        R_TLS_SUPPORTED_GROUP_SECP256R1), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpptr ((ch1 = r_queue_pop (&fixture->cli_out)), !=, NULL);
+  r_tls_server_incoming_data (fixture->server, ch1);
+  r_buffer_unref (ch1);
+  r_assert_cmpptr ((hrr = r_queue_pop (&fixture->srv_out)), !=, NULL);
+  return hrr;
+}
+
+/* A second HelloRetryRequest is illegal (RFC 8446 4.1.4): once the client has
+ * answered one HRR, replaying it aborts with unexpected_message. */
+RTEST_F (rtlsclient, tls13_hrr_second_rejected, RTEST_FAST)
+{
+  RBuffer * hrr = r_test_tls13_hrr_drive (fixture);
+
+  /* First HRR: the client retries (CH2), no error. */
+  r_tls_client_incoming_data (fixture->client, hrr);
+  r_assert (!fixture->cli_error);
+
+  /* Replaying the HRR is a second one -- reject it. */
+  r_tls_client_incoming_data (fixture->client, hrr);
+  r_buffer_unref (hrr);
+
+  r_assert (fixture->cli_error);
+  r_assert_cmpuint (fixture->cli_alert, ==, R_TLS_ALERT_TYPE_UNEXPECTED_MESSAGE);
+  r_assert (!fixture->cli_hs_done);
+}
+RTEST_END;
+
+/* After a HelloRetryRequest the ServerHello must keep the suite the HRR
+ * committed to; a changed suite is illegal_parameter (RFC 8446 4.1.4). */
+RTEST_F (rtlsclient, tls13_hrr_serverhello_suite_mismatch, RTEST_FAST)
+{
+  RBuffer * hrr = r_test_tls13_hrr_drive (fixture);
+  RBuffer * ch2, * sh;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  rsize csoff;
+  ruint16 cur;
+
+  r_tls_client_incoming_data (fixture->client, hrr);
+  r_buffer_unref (hrr);
+
+  /* CH2 -> server sends its second flight; the ServerHello is the first record. */
+  r_assert_cmpptr ((ch2 = r_queue_pop (&fixture->cli_out)), !=, NULL);
+  r_tls_server_incoming_data (fixture->server, ch2);
+  r_buffer_unref (ch2);
+  r_assert_cmpptr ((sh = r_queue_pop (&fixture->srv_out)), !=, NULL);
+
+  /* Rewrite the ServerHello cipher_suite to a different (valid) 1.3 suite. The
+   * field sits after record hdr(5) + hs hdr(4) + version(2) + random(32) +
+   * legacy_session_id (1-byte length + echo). */
+  r_assert (r_buffer_map (sh, &info, R_MEM_MAP_WRITE));
+  r_assert_cmpuint (info.data[0], ==, R_TLS_CONTENT_TYPE_HANDSHAKE);
+  r_assert_cmpuint (info.data[5], ==, R_TLS_HANDSHAKE_TYPE_SERVER_HELLO);
+  csoff = 44 + info.data[43];
+  cur = r_load_be16 (info.data + csoff);
+  r_store_be16 (info.data + csoff, cur == R_TLS_CS_AES_128_GCM_SHA256 ?
+      (ruint16) R_TLS_CS_AES_256_GCM_SHA384 : (ruint16) R_TLS_CS_AES_128_GCM_SHA256);
+  r_assert (r_buffer_unmap (sh, &info));
+
+  r_tls_client_incoming_data (fixture->client, sh);
+  r_buffer_unref (sh);
+
+  r_assert (fixture->cli_error);
+  r_assert_cmpuint (fixture->cli_alert, ==, R_TLS_ALERT_TYPE_ILLEGAL_PARAMETER);
+  r_assert (!fixture->cli_hs_done);
+}
+RTEST_END;
+
+/* The retry ClientHello must echo the HelloRetryRequest cookie verbatim; a
+ * corrupted echo is rejected by the server with illegal_parameter. */
+RTEST_F (rtlsclient, tls13_hrr_cookie_mismatch, RTEST_FAST)
+{
+  RBuffer * hrr = r_test_tls13_hrr_drive (fixture);
+  RBuffer * ch2;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSHelloMsg hello;
+  RTLSHelloExt ext;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  const ruint8 * cookie = NULL;
+  ruint16 cookielen = 0;
+  ruint8 ckcopy[64];
+  rsize i, off = 0;
+  rboolean found = FALSE;
+  RTLSError e;
+
+  /* Read the cookie the HRR carries. */
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, hrr), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_parser_parse_hello (&parser, &hello), ==, R_TLS_ERROR_OK);
+  for (e = r_tls_hello_msg_extension_first (&hello, &ext); e == R_TLS_ERROR_OK;
+      e = r_tls_hello_msg_extension_next (&hello, &ext)) {
+    if (ext.type == R_TLS_EXT_TYPE_COOKIE) {
+      cookie = r_tls_hello_ext_cookie (&ext, &cookielen);
+      r_assert_cmpuint (cookielen, >, 0);
+      r_assert_cmpuint (cookielen, <=, sizeof (ckcopy));
+      r_memcpy (ckcopy, cookie, cookielen);
+      found = TRUE;
+    }
+  }
+  r_assert (found);
+  r_tls_parser_clear (&parser);
+
+  /* Client retries (CH2), echoing the cookie. */
+  r_tls_client_incoming_data (fixture->client, hrr);
+  r_buffer_unref (hrr);
+  r_assert_cmpptr ((ch2 = r_queue_pop (&fixture->cli_out)), !=, NULL);
+
+  /* Locate the echoed cookie in CH2 and flip one of its bytes. */
+  r_assert (r_buffer_map (ch2, &info, R_MEM_MAP_WRITE));
+  found = FALSE;
+  for (i = 0; i + cookielen <= info.size; i++) {
+    if (r_memcmp (info.data + i, ckcopy, cookielen) == 0) { off = i; found = TRUE; break; }
+  }
+  r_assert (found);
+  info.data[off] ^= 0xff;
+  r_assert (r_buffer_unmap (ch2, &info));
+
+  r_tls_server_incoming_data (fixture->server, ch2);
+  r_buffer_unref (ch2);
+
+  r_assert (fixture->srv_error);
+  r_assert_cmpuint (fixture->srv_alert, ==, R_TLS_ALERT_TYPE_ILLEGAL_PARAMETER);
+  r_assert (!fixture->srv_hs_done);
+}
+RTEST_END;
+
+/* The retry ClientHello must carry a key_share for the group the
+ * HelloRetryRequest asked for; a retry that still omits it (here its share is
+ * repointed to another group) leaves the server with no usable share and it
+ * aborts with handshake_failure rather than issuing a second HRR. */
+RTEST_F (rtlsclient, tls13_hrr_retry_missing_share, RTEST_FAST)
+{
+  RBuffer * hrr = r_test_tls13_hrr_drive (fixture);
+  RBuffer * ch2;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSHelloMsg hello;
+  RTLSHelloExt ext;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  rsize ksoff = 0;
+  rboolean found = FALSE;
+  RTLSError e;
+
+  r_tls_client_incoming_data (fixture->client, hrr);
+  r_buffer_unref (hrr);
+  r_assert_cmpptr ((ch2 = r_queue_pop (&fixture->cli_out)), !=, NULL);
+
+  /* Find the first KeyShareEntry's group id -- ext.data opens with the
+   * client_shares vector length(2), then group(2) -- and repoint it. */
+  r_assert (r_buffer_map (ch2, &info, R_MEM_MAP_READ));
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, ch2), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_parser_parse_hello (&parser, &hello), ==, R_TLS_ERROR_OK);
+  for (e = r_tls_hello_msg_extension_first (&hello, &ext); e == R_TLS_ERROR_OK;
+      e = r_tls_hello_msg_extension_next (&hello, &ext)) {
+    if (ext.type == R_TLS_EXT_TYPE_KEY_SHARE) {
+      ksoff = (rsize) (ext.data - info.data) + 2;
+      found = TRUE;
+    }
+  }
+  r_tls_parser_clear (&parser);
+  r_assert (found);
+  r_assert (r_buffer_unmap (ch2, &info));
+
+  r_assert (r_buffer_map (ch2, &info, R_MEM_MAP_WRITE));
+  r_assert_cmpuint (r_load_be16 (info.data + ksoff), ==, R_TLS_SUPPORTED_GROUP_SECP256R1);
+  r_store_be16 (info.data + ksoff, (ruint16) R_TLS_SUPPORTED_GROUP_X25519);
+  r_assert (r_buffer_unmap (ch2, &info));
+
+  r_tls_server_incoming_data (fixture->server, ch2);
+  r_buffer_unref (ch2);
+
+  r_assert (fixture->srv_error);
+  r_assert_cmpuint (fixture->srv_alert, ==, R_TLS_ALERT_TYPE_HANDSHAKE_FAILURE);
+  r_assert (!fixture->srv_hs_done);
 }
 RTEST_END;
 

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -2521,6 +2521,62 @@ RTEST_F (rtlsserver, tls_session_resume, RTEST_FAST)
 }
 RTEST_END;
 
+/* A 1.3-capable server resuming a <= 1.2 session via ticket still stamps the
+ * RFC 8446 4.1.3 downgrade sentinel into the ServerHello.random, so a
+ * 1.3-capable client can detect a forced downgrade even on the abbreviated
+ * path. A NewSessionTicket -- not a Certificate -- follows the ServerHello,
+ * confirming the sentinel was written on the resumption path. */
+RTEST_F (rtlsserver, tls_session_resume_downgrade_sentinel, RTEST_FAST)
+{
+  RTLSServer * srv2;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSHelloMsg hello;
+  RBuffer * buf;
+  RTLSHandshakeType hs;
+  ruint32 l;
+  ruint16 msgseq;
+  ruint8 ms[48], crand[R_TLS_HELLO_RANDOM_BYTES], * ticket = NULL, ch[512];
+  rsize ticketlen = 0, chlen;
+
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (fixture->server,
+        fixture->ticket_keys), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_test_tls_client_issue (fixture->server, fixture->prng, &fixture->qout,
+      ms, &ticket, &ticketlen);
+  r_assert_cmpuint (ticketlen, >, 0);
+
+  r_queue_clear (&fixture->qout, r_buffer_unref);
+  r_assert_cmpptr ((srv2 = r_test_tls_server_new_cfg (fixture)), !=, NULL);
+  r_assert_cmpint (r_tls_server_set_session_ticket_keys (srv2, fixture->ticket_keys),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (srv2, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  chlen = r_test_tls_build_client_hello (fixture->prng, ch, sizeof (ch),
+      R_TLS_CS_RSA_WITH_AES_128_CBC_SHA, ticket, ticketlen, crand);
+  r_test_tls_server_feed (srv2, ch, chlen);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_HANDSHAKE);
+  r_assert_cmpint (r_tls_parser_parse_hello (&parser, &hello), ==, R_TLS_ERROR_OK);
+  r_assert_cmphex (r_tls_server_get_version (srv2), ==, R_TLS_VERSION_TLS_1_2);
+  r_assert (r_tls13_random_is_downgrade (hello.random));
+
+  r_assert_cmpint (r_tls_parser_init_next (&parser, NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_HANDSHAKE);
+  r_assert_cmpint (r_tls_parser_parse_handshake_full (&parser, &hs, &l, &msgseq,
+        NULL, NULL), ==, R_TLS_ERROR_OK);
+  r_assert_cmphex (hs, ==, R_TLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET);
+
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+  r_free (ticket);
+  r_tls_server_unref (srv2);
+}
+RTEST_END;
+
 /* A ticket still opens after the key store rotates, as long as its sealing key
  * is still in the retained current+recent set (#348). */
 RTEST_F (rtlsserver, tls_session_resume_after_rotation, RTEST_FAST)

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -1144,6 +1144,99 @@ RTEST_F (rtlsserver, dtls_renegotiation_info_scsv, RTEST_FAST)
 }
 RTEST_END;
 
+/* A TLS 1.2 ClientHello (RSA-AES128-CBC-SHA, null compression, empty
+ * renegotiation_info) that additionally lists TLS_FALLBACK_SCSV, marking the
+ * offer as a deliberate downgrade (RFC 7507). */
+static rsize
+r_test_tls_build_client_hello_fallback (RPrng * prng, ruint8 * ch, rsize chcap)
+{
+  ruint8 body[256];
+  ruint8 * p = body;
+  ruint8 * extlenp;
+  rsize bodylen, hssz;
+
+  *p++ = 0x03; *p++ = 0x03;                  /* client_version TLS 1.2 */
+  r_prng_fill (prng, p, R_TLS_HELLO_RANDOM_BYTES); p += R_TLS_HELLO_RANDOM_BYTES;
+  *p++ = 0;                                  /* session id length */
+  r_store_be16 (p, 4); p += 2;               /* cipher-suites length (2 entries) */
+  r_store_be16 (p, (ruint16) R_TLS_CS_RSA_WITH_AES_128_CBC_SHA); p += 2;
+  r_store_be16 (p, (ruint16) R_TLS_CS_FALLBACK_SCSV); p += 2;
+  *p++ = 1; *p++ = 0;                        /* compression: null */
+  extlenp = p; p += 2;
+  r_store_be16 (p, (ruint16) R_TLS_EXT_TYPE_RENEGOTIATION_INFO); p += 2;
+  r_store_be16 (p, 1); p += 2; *p++ = 0;
+  r_store_be16 (extlenp, (ruint16) (p - (extlenp + 2)));
+  bodylen = (rsize) (p - body);
+
+  r_assert_cmpint (r_tls_write_handshake (ch, chcap, &hssz, R_TLS_VERSION_TLS_1_2,
+        R_TLS_HANDSHAKE_TYPE_CLIENT_HELLO, (ruint16) bodylen), ==, R_TLS_ERROR_OK);
+  r_memcpy (ch + hssz, body, bodylen);
+  return hssz + bodylen;
+}
+
+/* RFC 7507: a ClientHello that lists TLS_FALLBACK_SCSV while offering only
+ * TLS 1.2 to a server that also speaks 1.3 has been downgraded below the
+ * highest common version; the server aborts with a fatal inappropriate_fallback
+ * alert. */
+RTEST_F (rtlsserver, tls_fallback_scsv_rejected, RTEST_FAST)
+{
+  ruint8 ch[256];
+  rsize chlen;
+  RBuffer * buf;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSAlertLevel alevel;
+  RTLSAlertType atype;
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  chlen = r_test_tls_build_client_hello_fallback (fixture->prng, ch, sizeof (ch));
+  r_test_tls_server_feed (fixture->server, ch, chlen);
+
+  r_assert (fixture->got_error);
+  r_assert_cmpuint (fixture->last_alert, ==, R_TLS_ALERT_TYPE_INAPPROPRIATE_FALLBACK);
+  r_assert (!fixture->hs_done);
+
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_ALERT);
+  r_assert_cmpint (r_tls_parser_parse_alert (&parser, &alevel, &atype), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (alevel, ==, R_TLS_ALERT_LEVEL_FATAL);
+  r_assert_cmpuint (atype, ==, R_TLS_ALERT_TYPE_INAPPROPRIATE_FALLBACK);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
+/* When the server's own maximum is TLS 1.2 the fallback SCSV is not a downgrade
+ * signal -- the client offered the server's best version -- so the handshake
+ * proceeds to a ServerHello rather than aborting (RFC 7507). */
+RTEST_F (rtlsserver, tls_fallback_scsv_at_max_version_ok, RTEST_FAST)
+{
+  ruint8 ch[256];
+  rsize chlen;
+  RBuffer * buf;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSHelloMsg msg;
+
+  r_assert_cmpint (r_tls_server_set_version_range (fixture->server,
+        R_TLS_VERSION_TLS_1_2, R_TLS_VERSION_TLS_1_2), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+
+  chlen = r_test_tls_build_client_hello_fallback (fixture->prng, ch, sizeof (ch));
+  r_test_tls_server_feed (fixture->server, ch, chlen);
+
+  r_assert (!fixture->got_error);
+  r_assert_cmpptr ((buf = r_test_tls_server_queue_agg (&fixture->qout)), !=, NULL);
+  r_assert_cmpint (r_tls_parser_init_buffer (&parser, buf), ==, R_TLS_ERROR_OK);
+  r_assert_cmpuint (parser.content, ==, R_TLS_CONTENT_TYPE_HANDSHAKE);
+  r_assert_cmpint (r_tls_parser_parse_hello (&parser, &msg), ==, R_TLS_ERROR_OK);
+  r_tls_parser_clear (&parser);
+  r_buffer_unref (buf);
+}
+RTEST_END;
+
 /* A ClientHello whose trailing extension declares a body that isn't present
  * must be parsed without reading past the extensions block: the extension
  * iterator stops at the truncated entry and the handshake proceeds from the


### PR DESCRIPTION
Follow-ups carved out of the TLS 1.3 work, one commit per issue.

## RFC 7507 fallback SCSV (#379)
A 1.3-capable server now aborts with `inappropriate_fallback` when a
ClientHello lists `TLS_FALLBACK_SCSV` yet negotiates a version below the
server's maximum — the client deliberately downgraded its own retry and landing
below the highest common version means the fallback was forced. This
complements the RFC 8446 4.1.3 ServerHello.random sentinel, which guards the
reverse direction. A fallback SCSV against a server whose own maximum *is* the
negotiated version is not a downgrade and is left alone.

## Constant-time handshake MAC comparison (#380)
The pre_shared_key binder and the Finished `verify_data` on both endpoints were
compared with the non-constant-time `r_memcmp`; they now use `r_memcmp_ct`, so
the compare does not leak a match position through its timing. Behaviour is
unchanged — a mismatch still aborts. Public values (the cleartext HRR cookie,
the downgrade/HRR-random sentinels, SNI/ALPN names) keep `r_memcmp`.

## Negative-path tests for 1.3 handshake rejections (#381)
Direct coverage for abort branches previously exercised only indirectly: a
replayed (second) HelloRetryRequest rejected by the client; a retry that no
longer carries a share for the group the HRR asked for, rejected by the server;
a corrupted cookie echo; a ServerHello whose cipher suite differs from the HRR;
and the RFC 8446 4.1.3 downgrade sentinel stamped when a 1.3-capable server
resumes a <= 1.2 session via ticket.

## Testing
Builds clean under `-Werror` on the linux, asan, ubsan and mingw tiers. The
`rtlsserver` and `rtlsclient` suites pass on linux/asan/ubsan, and the full
linux suite is green.

Closes #379
Closes #380
Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)