### PR TITLE
net/tls: TLS 1.3 KeyUpdate (RFC 8446)

### DIFF
--- a/include/rlib/net/proto/rtls.h
+++ b/include/rlib/net/proto/rtls.h
@@ -184,6 +184,12 @@ typedef enum {
   R_TLS_HANDSHAKE_TYPE_MESSAGE_HASH                     = 0xfe, /* [RFC8446] */
 } RTLSHandshakeType;
 
+/** @brief KeyUpdate @c request_update value (RFC 8446, section 4.6.3). */
+typedef enum {
+  R_TLS_KEY_UPDATE_NOT_REQUESTED                        = 0x00, /**< The peer need not update its keys. */
+  R_TLS_KEY_UPDATE_REQUESTED                            = 0x01, /**< The peer must respond with its own KeyUpdate. */
+} RTLSKeyUpdateRequest;
+
 /** @brief TLS extension type (IANA TLS ExtensionType). */
 /* http://www.iana.org/assignments/tls-extensiontype-values/ */
 typedef enum {
@@ -595,6 +601,17 @@ R_API RTLSError r_tls_parser_parse_new_session_ticket13 (const RTLSParser * pars
     ruint32 * lifetime, ruint32 * age_add,
     const ruint8 ** nonce, ruint8 * noncelen,
     const ruint8 ** ticket, ruint16 * ticketsize, ruint32 * max_early_data);
+/**
+ * @brief Parse the current record as a KeyUpdate (RFC 8446, section 4.6.3).
+ * @param parser Parser positioned on the post-handshake message.
+ * @param request_update Out: the raw @c request_update byte; the caller treats
+ *  a value above @ref R_TLS_KEY_UPDATE_REQUESTED as an @c illegal_parameter.
+ * @return @c R_TLS_ERROR_OK; @c R_TLS_ERROR_WRONG_TYPE if the message is not a
+ *  KeyUpdate; @c R_TLS_ERROR_CORRUPT_RECORD if the body is not one byte;
+ *  @c R_TLS_ERROR_INVAL on a @c NULL argument.
+ */
+R_API RTLSError r_tls_parser_parse_key_update (const RTLSParser * parser,
+    ruint8 * request_update);
 /**
  * @brief Parse the current record as a CertificateVerify.
  * @param parser Parser positioned on the message.

--- a/include/rlib/net/proto/rtls13.h
+++ b/include/rlib/net/proto/rtls13.h
@@ -340,6 +340,24 @@ R_API rboolean r_tls13_traffic_keys (RMsgDigestType hash, const ruint8 * secret,
     const RCryptoCipherInfo * info, RTLS13RecordKeys * out);
 
 /**
+ * @brief Advance an application-traffic secret one generation (RFC 8446, 7.2).
+ *
+ * @c application_traffic_secret_N+1 =
+ * @c HKDF-Expand-Label(application_traffic_secret_N, "traffic upd", "",
+ * Hash.length): the rekeying a @c KeyUpdate performs. Re-derive the record keys
+ * from @p out with @ref r_tls13_traffic_keys. @p out may alias @p secret for an
+ * in-place advance.
+ *
+ * @param hash   Cipher-suite hash.
+ * @param secret The current application-traffic secret; @c HashLen bytes.
+ * @param out    Destination for the next-generation secret; @c HashLen bytes.
+ * @return @c TRUE on success; @c FALSE on invalid arguments or a derivation
+ *  failure.
+ */
+R_API rboolean r_tls13_traffic_update (RMsgDigestType hash,
+    const ruint8 * secret, ruint8 * out);
+
+/**
  * @brief Derive a Finished key from a handshake-traffic secret.
  *
  * @c finished_key = HKDF-Expand-Label(secret, "finished", "", HashLen).

--- a/include/rlib/net/rtlsclient.h
+++ b/include/rlib/net/rtlsclient.h
@@ -187,6 +187,22 @@ R_API rboolean r_tls_client_incoming_data (RTLSClient * client, RBuffer * buffer
 /** @brief Encrypt and send application data through the session. */
 R_API rboolean r_tls_client_send_appdata (RTLSClient * client, RBuffer * buffer);
 /**
+ * @brief Rekey an established TLS 1.3 session (RFC 8446, section 4.6.3).
+ *
+ * Sends a post-handshake @c KeyUpdate and advances our sending key to its next
+ * generation. When @p request_peer_update is @c TRUE the peer must reply with
+ * its own @c KeyUpdate, advancing our receiving key too; the reply is processed
+ * on the next @ref r_tls_client_incoming_data.
+ *
+ * @param client              An established TLS 1.3 client.
+ * @param request_peer_update Ask the peer to rekey its sending direction.
+ * @return @c TRUE if the @c KeyUpdate was emitted; @c FALSE if the session is
+ *  not an established TLS 1.3 session (@c <=1.2 or not yet in its
+ *  application-data state) or the record could not be produced.
+ */
+R_API rboolean r_tls_client_key_update (RTLSClient * client,
+    rboolean request_peer_update);
+/**
  * @brief Cleanly close an established session.
  *
  * Emits a warning @c close_notify alert to the peer and moves the session to

--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -292,6 +292,22 @@ R_API rboolean r_tls_server_incoming_data (RTLSServer * server, RBuffer * buffer
 /** @brief Encrypt and send application data through the session. */
 R_API rboolean r_tls_server_send_appdata (RTLSServer * server, RBuffer * buffer);
 /**
+ * @brief Rekey an established TLS 1.3 session (RFC 8446, section 4.6.3).
+ *
+ * Sends a post-handshake @c KeyUpdate and advances our sending key to its next
+ * generation. When @p request_peer_update is @c TRUE the peer must reply with
+ * its own @c KeyUpdate, advancing our receiving key too; the reply is processed
+ * on the next @ref r_tls_server_incoming_data.
+ *
+ * @param server              An established TLS 1.3 server.
+ * @param request_peer_update Ask the peer to rekey its sending direction.
+ * @return @c TRUE if the @c KeyUpdate was emitted; @c FALSE if the session is
+ *  not an established TLS 1.3 session (@c <=1.2 or not yet in its
+ *  application-data state) or the record could not be produced.
+ */
+R_API rboolean r_tls_server_key_update (RTLSServer * server,
+    rboolean request_peer_update);
+/**
  * @brief Cleanly close an established session.
  *
  * Emits a warning @c close_notify alert to the peer and moves the session to

--- a/rlib/net/proto/rtls.c
+++ b/rlib/net/proto/rtls.c
@@ -1393,6 +1393,29 @@ r_tls_parser_parse_new_session_ticket13 (const RTLSParser * parser,
 }
 
 RTLSError
+r_tls_parser_parse_key_update (const RTLSParser * parser,
+    ruint8 * request_update)
+{
+  RTLSHandshakeType type;
+  const ruint8 * ptr, * end;
+  RTLSError ret;
+
+  if (R_UNLIKELY (parser == NULL || request_update == NULL))
+    return R_TLS_ERROR_INVAL;
+
+  ret = r_tls_parser_parse_handshake_internal (parser, &type, &ptr, &end);
+  if (R_UNLIKELY (ret != R_TLS_ERROR_OK)) return ret;
+  if (R_UNLIKELY (type != R_TLS_HANDSHAKE_TYPE_KEY_UPDATE))
+    return R_TLS_ERROR_WRONG_TYPE;
+
+  /* KeyUpdate body is a single request_update byte. */
+  if (R_UNLIKELY (end - ptr != 1))
+    return R_TLS_ERROR_CORRUPT_RECORD;
+  *request_update = *ptr;
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
 r_tls_parser_parse_certificate_verify (const RTLSParser * parser,
     RTLSSignatureScheme * sigscheme, const ruint8 ** sig, ruint16 * sigsize)
 {

--- a/rlib/net/proto/rtls13.c
+++ b/rlib/net/proto/rtls13.c
@@ -368,6 +368,27 @@ r_tls13_traffic_keys (RMsgDigestType hash, const ruint8 * secret,
 }
 
 rboolean
+r_tls13_traffic_update (RMsgDigestType hash, const ruint8 * secret, ruint8 * out)
+{
+  ruint8 next[R_TLS13_SECRET_MAX];
+  rsize hlen = r_msg_digest_type_size (hash);
+
+  if (R_UNLIKELY (secret == NULL || out == NULL ||
+        hlen == 0 || hlen > R_TLS13_SECRET_MAX))
+    return FALSE;
+
+  /* application_traffic_secret_N+1 = HKDF-Expand-Label(
+   *   application_traffic_secret_N, "traffic upd", "", Hash.length). A temporary
+   * keeps this correct when @out aliases @secret for an in-place advance. */
+  if (!r_tls13_expand_label (hash, secret, R_STR_WITH_SIZE_ARGS ("traffic upd"),
+        NULL, 0, next, hlen))
+    return FALSE;
+  r_memcpy (out, next, hlen);
+  r_memclear (next, sizeof (next));
+  return TRUE;
+}
+
+rboolean
 r_tls13_finished_key (RMsgDigestType hash, const ruint8 * secret, ruint8 * out)
 {
   rsize hlen = r_msg_digest_type_size (hash);

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -2568,6 +2568,61 @@ r_tls_client_store_ticket13 (RTLSClient * client, const RTLSParser * parser)
   client->new_session = s;
 }
 
+/* Send a post-handshake KeyUpdate (RFC 8446 4.6.3) and rotate our sending key.
+ * Unlike handshake-phase messages it is framed but not folded into the
+ * transcript. It goes out under the current write key; every record after it
+ * uses the advanced key, so the rotation follows the queued record. */
+static RTLSError
+r_tls_client_send_key_update13 (RTLSClient * client, rboolean request_peer_update)
+{
+  ruint8 msg[R_TLS_HS_HDR_SIZE + 1];
+  RTLSError ret;
+
+  msg[0] = (ruint8) R_TLS_HANDSHAKE_TYPE_KEY_UPDATE;
+  msg[1] = 0x00;
+  msg[2] = 0x00;
+  msg[3] = 0x01;
+  msg[4] = (ruint8) (request_peer_update ? R_TLS_KEY_UPDATE_REQUESTED
+                                         : R_TLS_KEY_UPDATE_NOT_REQUESTED);
+
+  if ((ret = r_tls_client_protect_record13 (client, R_TLS_CONTENT_TYPE_HANDSHAKE,
+          msg, sizeof (msg))) != R_TLS_ERROR_OK)
+    return ret;
+
+  if (!r_tls13_traffic_update (client->cs13_hash, client->sched13.cap,
+          client->sched13.cap) ||
+      !r_tls_client_install_keys13 (client, &client->rk_write, client->sched13.cap))
+    return R_TLS_ERROR_ENCRYPTION_FAILED;
+  return R_TLS_ERROR_OK;
+}
+
+/* Handle a peer KeyUpdate (RFC 8446 4.6.3): advance our receiving key to the
+ * peer's next generation and, when asked, answer with our own KeyUpdate --
+ * never itself update_requested, so the exchange cannot loop. The queued reply
+ * is flushed by the incoming_data send_out once dispatch returns. */
+static RTLSError
+r_tls_client_recv_key_update13 (RTLSClient * client, const RTLSParser * parser)
+{
+  ruint8 request;
+
+  if (r_tls_parser_parse_key_update (parser, &request) != R_TLS_ERROR_OK ||
+      request > R_TLS_KEY_UPDATE_REQUESTED) {
+    r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_ILLEGAL_PARAMETER);
+    return R_TLS_ERROR_ILLEGAL_PARAMETER;
+  }
+
+  if (!r_tls13_traffic_update (client->cs13_hash, client->sched13.sap,
+          client->sched13.sap) ||
+      !r_tls_client_install_keys13 (client, &client->rk_read, client->sched13.sap)) {
+    r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_INTERNAL_ERROR);
+    return R_TLS_ERROR_ENCRYPTION_FAILED;
+  }
+
+  if (request == R_TLS_KEY_UPDATE_REQUESTED)
+    return r_tls_client_send_key_update13 (client, FALSE);
+  return R_TLS_ERROR_OK;
+}
+
 static RTLSError
 r_tls_client_state_appdata (RTLSClient * client, const RTLSParser * parser)
 {
@@ -2580,12 +2635,15 @@ r_tls_client_state_appdata (RTLSClient * client, const RTLSParser * parser)
     }
   } else if (parser->content == R_TLS_CONTENT_TYPE_HANDSHAKE) {
     /* Post-handshake messages (1.3): store a NewSessionTicket for resumption,
-     * ignore the rest (e.g. KeyUpdate is out of scope). */
+     * rekey on a KeyUpdate, ignore the rest. */
     RTLSHandshakeType type;
     if (client->tls13 &&
-        r_tls_parser_parse_handshake_peek_type (parser, &type) == R_TLS_ERROR_OK &&
-        type == R_TLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET)
-      r_tls_client_store_ticket13 (client, parser);
+        r_tls_parser_parse_handshake_peek_type (parser, &type) == R_TLS_ERROR_OK) {
+      if (type == R_TLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET)
+        r_tls_client_store_ticket13 (client, parser);
+      else if (type == R_TLS_HANDSHAKE_TYPE_KEY_UPDATE)
+        return r_tls_client_recv_key_update13 (client, parser);
+    }
   } else {
     R_LOG_WARNING ("Received non-app-data record");
   }
@@ -2758,6 +2816,22 @@ r_tls_client_send_appdata (RTLSClient * client, RBuffer * buffer)
   }
 
   if (ret != R_TLS_ERROR_OK)
+    return FALSE;
+
+  r_tls_client_send_out (client);
+  return TRUE;
+}
+
+rboolean
+r_tls_client_key_update (RTLSClient * client, rboolean request_peer_update)
+{
+  if (R_UNLIKELY (client == NULL)) return FALSE;
+  /* KeyUpdate is a TLS 1.3 post-handshake message; the record keys must be
+   * installed, i.e. the session established. */
+  if (R_UNLIKELY (!client->tls13 || client->state != R_TLS_CLIENT_APPDATA))
+    return FALSE;
+
+  if (r_tls_client_send_key_update13 (client, request_peer_update) != R_TLS_ERROR_OK)
     return FALSE;
 
   r_tls_client_send_out (client);

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -3510,6 +3510,61 @@ r_tls_server_state_finished (RTLSServer * server, const RTLSParser * parser)
   return err;
 }
 
+/* Send a post-handshake KeyUpdate (RFC 8446 4.6.3) and rotate our sending key.
+ * Unlike handshake-phase messages it is framed but not folded into the
+ * transcript. It goes out under the current write key; every record after it
+ * uses the advanced key, so the rotation follows the queued record. */
+static RTLSError
+r_tls_server_send_key_update13 (RTLSServer * server, rboolean request_peer_update)
+{
+  ruint8 msg[R_TLS_HS_HDR_SIZE + 1];
+  RTLSError ret;
+
+  msg[0] = (ruint8) R_TLS_HANDSHAKE_TYPE_KEY_UPDATE;
+  msg[1] = 0x00;
+  msg[2] = 0x00;
+  msg[3] = 0x01;
+  msg[4] = (ruint8) (request_peer_update ? R_TLS_KEY_UPDATE_REQUESTED
+                                         : R_TLS_KEY_UPDATE_NOT_REQUESTED);
+
+  if ((ret = r_tls_server_protect_record13 (server, R_TLS_CONTENT_TYPE_HANDSHAKE,
+          msg, sizeof (msg))) != R_TLS_ERROR_OK)
+    return ret;
+
+  if (!r_tls13_traffic_update (server->cs13_hash, server->sched13.sap,
+          server->sched13.sap) ||
+      !r_tls_server_install_keys13 (server, &server->rk_write, server->sched13.sap))
+    return R_TLS_ERROR_ENCRYPTION_FAILED;
+  return R_TLS_ERROR_OK;
+}
+
+/* Handle a peer KeyUpdate (RFC 8446 4.6.3): advance our receiving key to the
+ * peer's next generation and, when asked, answer with our own KeyUpdate --
+ * never itself update_requested, so the exchange cannot loop. The queued reply
+ * is flushed by the incoming_data send_out once dispatch returns. */
+static RTLSError
+r_tls_server_recv_key_update13 (RTLSServer * server, const RTLSParser * parser)
+{
+  ruint8 request;
+
+  if (r_tls_parser_parse_key_update (parser, &request) != R_TLS_ERROR_OK ||
+      request > R_TLS_KEY_UPDATE_REQUESTED) {
+    r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_ILLEGAL_PARAMETER);
+    return R_TLS_ERROR_ILLEGAL_PARAMETER;
+  }
+
+  if (!r_tls13_traffic_update (server->cs13_hash, server->sched13.cap,
+          server->sched13.cap) ||
+      !r_tls_server_install_keys13 (server, &server->rk_read, server->sched13.cap)) {
+    r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_INTERNAL_ERROR);
+    return R_TLS_ERROR_ENCRYPTION_FAILED;
+  }
+
+  if (request == R_TLS_KEY_UPDATE_REQUESTED)
+    return r_tls_server_send_key_update13 (server, FALSE);
+  return R_TLS_ERROR_OK;
+}
+
 static RTLSError
 r_tls_server_state_appdata (RTLSServer * server, const RTLSParser * parser)
 {
@@ -3525,11 +3580,14 @@ r_tls_server_state_appdata (RTLSServer * server, const RTLSParser * parser)
   } else if (parser->content == R_TLS_CONTENT_TYPE_HANDSHAKE) {
     RTLSHandshakeType hstype;
 
-    /* A post-handshake ClientHello is a renegotiation attempt. We do not
-     * renegotiate; decline with a warning and keep the session running
-     * (RFC 5246 7.2.1). The caller flushes via send_out after dispatch. */
-    if (r_tls_parser_parse_handshake_peek_type (parser, &hstype) == R_TLS_ERROR_OK &&
-        hstype == R_TLS_HANDSHAKE_TYPE_CLIENT_HELLO)
+    if (r_tls_parser_parse_handshake_peek_type (parser, &hstype) != R_TLS_ERROR_OK)
+      R_LOG_WARNING ("Received non-app-data record");
+    else if (server->tls13 && hstype == R_TLS_HANDSHAKE_TYPE_KEY_UPDATE)
+      return r_tls_server_recv_key_update13 (server, parser);
+    else if (hstype == R_TLS_HANDSHAKE_TYPE_CLIENT_HELLO)
+      /* A post-handshake ClientHello is a renegotiation attempt. We do not
+       * renegotiate; decline with a warning and keep the session running
+       * (RFC 5246 7.2.1). The caller flushes via send_out after dispatch. */
       r_tls_server_emit_alert (server, R_TLS_ALERT_LEVEL_WARNING,
           R_TLS_ALERT_TYPE_NO_RENEGOTIATION);
     else
@@ -3773,6 +3831,22 @@ r_tls_server_send_appdata (RTLSServer * server, RBuffer * buffer)
   }
 
   if (ret != R_TLS_ERROR_OK)
+    return FALSE;
+
+  r_tls_server_send_out (server);
+  return TRUE;
+}
+
+rboolean
+r_tls_server_key_update (RTLSServer * server, rboolean request_peer_update)
+{
+  if (R_UNLIKELY (server == NULL)) return FALSE;
+  /* KeyUpdate is a TLS 1.3 post-handshake message; the record keys must be
+   * installed, i.e. the session established. */
+  if (R_UNLIKELY (!server->tls13 || server->state != R_TLS_SERVER_APPDATA))
+    return FALSE;
+
+  if (r_tls_server_send_key_update13 (server, request_peer_update) != R_TLS_ERROR_OK)
     return FALSE;
 
   r_tls_server_send_out (server);

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -557,6 +557,70 @@ RTEST_F (rtlsclient, tls13_loopback_aes256, RTEST_FAST)
 }
 RTEST_END;
 
+/* TLS 1.3 post-handshake KeyUpdate (RFC 8446 4.6.3). After the handshake each
+ * endpoint rekeys its sending direction; the peer must track the rotation for
+ * records to keep decrypting. A key_update requesting a peer update makes the
+ * peer answer with its own KeyUpdate, rotating both directions. An app-data
+ * round trip after each rotation proves the keys stayed in sync. */
+RTEST_F (rtlsclient, tls13_key_update, RTEST_FAST)
+{
+  static const ruint8 a[] = { 'a', 'f', 't', 'e', 'r', '1' };
+  static const ruint8 b[] = { 'a', 'f', 't', 'e', 'r', '2' };
+  RBuffer * app;
+
+  /* KeyUpdate is refused before the session is established. */
+  r_assert (!r_tls_client_key_update (fixture->client, FALSE));
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->cli_hs_done);
+  r_assert (fixture->srv_hs_done);
+
+  /* Client rekeys its sending direction; the peer need not respond. */
+  r_assert (r_tls_client_key_update (fixture->client, FALSE));
+  r_test_tls_loopback_pump (fixture);
+  r_assert (!fixture->cli_error);
+  r_assert (!fixture->srv_error);
+
+  /* client -> server still decrypts under the client's new send key. */
+  r_assert_cmpptr ((app = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)a, sizeof (a), sizeof (a), 0, NULL, NULL)), !=, NULL);
+  r_assert (r_tls_client_send_appdata (fixture->client, app));
+  r_buffer_unref (app);
+  r_test_tls_loopback_pump (fixture);
+  r_test_tls_assert_appdata (&fixture->srv_app, a, sizeof (a));
+
+  /* Server rekeys and asks the client to rekey too: the client's auto-response
+   * KeyUpdate rotates the remaining direction, so both are now fresh. */
+  r_assert (r_tls_server_key_update (fixture->server, TRUE));
+  r_test_tls_loopback_pump (fixture);
+  r_assert (!fixture->cli_error);
+  r_assert (!fixture->srv_error);
+
+  /* server -> client under the server's new send key. */
+  r_assert_cmpptr ((app = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)b, sizeof (b), sizeof (b), 0, NULL, NULL)), !=, NULL);
+  r_assert (r_tls_server_send_appdata (fixture->server, app));
+  r_buffer_unref (app);
+  r_test_tls_loopback_pump (fixture);
+  r_test_tls_assert_appdata (&fixture->cli_app, b, sizeof (b));
+
+  /* client -> server under the client's twice-rotated send key. */
+  r_assert_cmpptr ((app = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          (rpointer)a, sizeof (a), sizeof (a), 0, NULL, NULL)), !=, NULL);
+  r_assert (r_tls_client_send_appdata (fixture->client, app));
+  r_buffer_unref (app);
+  r_test_tls_loopback_pump (fixture);
+  r_test_tls_assert_appdata (&fixture->srv_app, a, sizeof (a));
+
+  r_assert (!fixture->cli_error);
+  r_assert (!fixture->srv_error);
+}
+RTEST_END;
+
 /* The server requires secp256r1 but the client offers an x25519 key_share, so
  * the server answers with a HelloRetryRequest and the client retries with a
  * secp256r1 share. The handshake can only complete if the retry worked. */


### PR DESCRIPTION
Adds the post-handshake `KeyUpdate` message (RFC 8446 4.6.3) to the TLS 1.3
client and server -- the last conformance gap in the TCP 1.3 stack. A receiver
must handle an incoming `KeyUpdate`, and a sender must rekey before the AEAD
record sequence number space is exhausted, so a long-lived connection cannot
stay correct without it.

## Behaviour
- **Send**: derive `application_traffic_secret_N+1` with the new
  `r_tls13_traffic_update` (`"traffic upd"`) and reinstall the write keys *after*
  queueing the message, so the `KeyUpdate` itself still travels under the old
  key and every following record uses the advanced key.
- **Receive**: advance the read keys; if the peer set `update_requested`, answer
  with our own `update_not_requested` `KeyUpdate` (never requesting, so the
  exchange cannot loop). A malformed `request_update` is a fatal
  `illegal_parameter`.
- Post-handshake messages stay out of the handshake transcript.
- Public API: `r_tls_client_key_update()` / `r_tls_server_key_update()`, guarded
  to established 1.3 sessions.

## Tests
`rtlsclient/tls13_key_update` drives a loopback rekey in each direction --
with and without a peer-update request (exercising the auto-response) -- and
asserts app-data round-trips under the rotated keys, proving keys and record
sequence numbers stay in sync.

Built clean under `-Werror` across the linux/asan/ubsan/mingw tiers; the TLS
suites and full linux suite pass.

Closes #383