### PR TITLE
net/tls: client-side ALPN offering (RFC 7301)

### DIFF
--- a/include/rlib/net/rtlsclient.h
+++ b/include/rlib/net/rtlsclient.h
@@ -107,6 +107,21 @@ R_API RTLSError r_tls_client_set_cert (RTLSClient * client,
 R_API RTLSError r_tls_client_set_server_name (RTLSClient * client,
     const rchar * host);
 /**
+ * @brief Configure the application protocols the client offers for ALPN
+ * (RFC 7301), in descending order of preference.
+ *
+ * Each @p protocols entry is a NUL-terminated protocol name (e.g. @c "h2",
+ * @c "http/1.1"); names are copied and offered in a ClientHello @c ALPN
+ * extension. The server's selection is then available via
+ * @ref r_tls_client_get_alpn_selected. With no protocols configured (the
+ * default) the client does not offer ALPN. Must be called before
+ * @ref r_tls_client_start. Returns @c R_TLS_ERROR_INVAL if any name is empty or
+ * longer than 255 bytes. Call with @p count 0 to clear a previously configured
+ * list.
+ */
+R_API RTLSError r_tls_client_set_alpn_protocols (RTLSClient * client,
+    const rchar * const * protocols, rsize count);
+/**
  * @brief Constrain the TLS versions the client offers.
  *
  * Both bounds lie in the window @c R_TLS_VERSION_TLS_1_2 ..
@@ -226,6 +241,14 @@ R_API const RTLSCipherSuiteInfo * r_tls_client_get_cipher_suite (const RTLSClien
 R_API RCryptoCert * r_tls_client_get_peer_cert (const RTLSClient * client);
 /** @brief Negotiated DTLS-SRTP protection profile (for @ref r_srtp). */
 R_API RSRTPCipherSuite r_tls_client_get_dtls_srtp_profile (const RTLSClient * client);
+/**
+ * @brief Negotiated ALPN protocol, or @c NULL if none was negotiated.
+ *
+ * Returns the protocol the server selected from the offered list
+ * (NUL-terminated); @p len, when non-@c NULL, receives its length. See
+ * @ref r_tls_client_set_alpn_protocols.
+ */
+R_API const rchar * r_tls_client_get_alpn_selected (const RTLSClient * client, rsize * len);
 
 R_END_DECLS
 

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -105,6 +105,11 @@ struct RTLSClient {
 
   rchar * server_name;         /* SNI host to offer in the ClientHello, or NULL */
 
+  rchar ** alpn_protocols;     /* ALPN protocols to offer (owned), or NULL */
+  rsize alpn_count;
+  const rchar * alpn_selected; /* negotiated protocol, points into alpn_protocols */
+  rsize alpn_selected_len;
+
   rboolean ecdhe;                  /* an ECDHE suite was negotiated */
   REcurveID ecdhe_curve;           /* the server-selected named group */
   RCryptoKey * ecdhe_key;          /* client ephemeral ECDH private key */
@@ -198,6 +203,12 @@ r_tls_client_free (RTLSClient * client)
   if (client->privkey != NULL)
     r_crypto_key_unref (client->privkey);
   r_free (client->server_name);
+  if (client->alpn_protocols != NULL) {
+    rsize i;
+    for (i = 0; i < client->alpn_count; i++)
+      r_free (client->alpn_protocols[i]);
+    r_free (client->alpn_protocols);
+  }
   if (client->ecdhe_key != NULL)
     r_crypto_key_unref (client->ecdhe_key);
   if (client->ecdhe_server_pub != NULL)
@@ -348,6 +359,50 @@ r_tls_client_set_server_name (RTLSClient * client, const rchar * host)
 
   r_free (client->server_name);
   client->server_name = (host != NULL) ? r_strdup (host) : NULL;
+
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_client_set_alpn_protocols (RTLSClient * client,
+    const rchar * const * protocols, rsize count)
+{
+  rchar ** copy;
+  rsize i;
+
+  if (R_UNLIKELY (client == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (client->state != R_TLS_CLIENT_INITIAL)) return R_TLS_ERROR_WRONG_STATE;
+  if (R_UNLIKELY (protocols == NULL && count > 0)) return R_TLS_ERROR_INVAL;
+  /* ALPN protocol names are opaque<1..255> (RFC 7301). */
+  for (i = 0; i < count; i++) {
+    rsize len = (protocols[i] != NULL) ? r_strlen (protocols[i]) : 0;
+    if (len == 0 || len > 255)
+      return R_TLS_ERROR_INVAL;
+  }
+
+  /* Replace any previously configured list. */
+  if (client->alpn_protocols != NULL) {
+    for (i = 0; i < client->alpn_count; i++)
+      r_free (client->alpn_protocols[i]);
+    r_free (client->alpn_protocols);
+    client->alpn_protocols = NULL;
+    client->alpn_count = 0;
+  }
+  if (count == 0)
+    return R_TLS_ERROR_OK;
+
+  if ((copy = r_mem_new_n (rchar *, count)) == NULL)
+    return R_TLS_ERROR_OOM;
+  for (i = 0; i < count; i++) {
+    if ((copy[i] = r_strdup (protocols[i])) == NULL) {
+      while (i > 0)
+        r_free (copy[--i]);
+      r_free (copy);
+      return R_TLS_ERROR_OOM;
+    }
+  }
+  client->alpn_protocols = copy;
+  client->alpn_count = count;
 
   return R_TLS_ERROR_OK;
 }
@@ -587,6 +642,65 @@ r_tls_client_write_hs_ext_server_name (ruint8 * ptr, const rchar * name)
   return (ruint16)(9 + namelen);
 }
 
+/* application_layer_protocol_negotiation (ALPN, RFC 7301): a ProtocolNameList
+ * of the offered protocols. Offered only when configured via
+ * r_tls_client_set_alpn_protocols. */
+static ruint16
+r_tls_client_write_hs_ext_alpn (const RTLSClient * client, ruint8 * ptr)
+{
+  ruint16 listlen = 0;
+  rsize off, i;
+
+  /* ProtocolNameList: { uint8 name_len, name }* */
+  for (i = 0; i < client->alpn_count; i++)
+    listlen += (ruint16) (1 + r_strlen (client->alpn_protocols[i]));
+
+  r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_APPLICATION_LAYER_PROTOCOL_NEGOTIATION);
+  r_store_be16 (&ptr[2], (ruint16)(sizeof (ruint16) + listlen)); /* extension_data length */
+  r_store_be16 (&ptr[4], listlen);                              /* ProtocolNameList length */
+  off = 6;
+  for (i = 0; i < client->alpn_count; i++) {
+    ruint8 nlen = (ruint8) r_strlen (client->alpn_protocols[i]);
+    ptr[off++] = nlen;
+    r_memcpy (&ptr[off], client->alpn_protocols[i], nlen);
+    off += nlen;
+  }
+  return (ruint16) off;
+}
+
+/* Match the server's ALPN response (a ProtocolNameList carrying the single
+ * selected protocol) against our offered list, recording the selection. The
+ * pointer is kept inside our owned list so the getter stays valid; a protocol
+ * we did not offer is ignored (leaving no selection). */
+static void
+r_tls_client_alpn_apply_selection (RTLSClient * client,
+    const ruint8 * data, ruint16 len)
+{
+  const ruint8 * name;
+  ruint16 listlen;
+  ruint8 nlen;
+  rsize i;
+
+  if (len < sizeof (ruint16) + 1)
+    return;
+  listlen = r_load_be16 (data);
+  if (listlen < 1 || (rsize) listlen + sizeof (ruint16) > len)
+    return;
+  nlen = data[sizeof (ruint16)];
+  name = data + sizeof (ruint16) + 1;
+  if (nlen == 0 || (rsize) nlen + 1 > listlen)
+    return;
+
+  for (i = 0; i < client->alpn_count; i++) {
+    if (r_strlen (client->alpn_protocols[i]) == nlen &&
+        r_memcmp (client->alpn_protocols[i], name, nlen) == 0) {
+      client->alpn_selected = client->alpn_protocols[i];
+      client->alpn_selected_len = nlen;
+      return;
+    }
+  }
+}
+
 static ruint16
 r_tls_client_write_hs_ext_use_srtp (ruint8 * ptr)
 {
@@ -723,6 +837,36 @@ r_tls_client_ee_has_early_data (const ruint8 * msg, rsize msglen)
     p += elen;
   }
   return FALSE;
+}
+
+/* Walk an EncryptedExtensions message for the server's ALPN selection and, when
+ * present, apply it against our offered list. */
+static void
+r_tls_client_ee_apply_alpn (RTLSClient * client, const ruint8 * msg, rsize msglen)
+{
+  const ruint8 * p, * end;
+  ruint16 extslen;
+
+  if (client->alpn_count == 0 || msglen < R_TLS_HS_HDR_SIZE + sizeof (ruint16))
+    return;
+  p = msg + R_TLS_HS_HDR_SIZE;
+  extslen = r_load_be16 (p);
+  p += sizeof (ruint16);
+  end = p + extslen;
+  if (RPOINTER_TO_SIZE (end) > RPOINTER_TO_SIZE (msg + msglen))
+    return;
+  while (p + 2 * sizeof (ruint16) <= end) {
+    ruint16 etype = r_load_be16 (p);
+    ruint16 elen = r_load_be16 (p + sizeof (ruint16));
+    p += 2 * sizeof (ruint16);
+    if (p + elen > end)
+      return;
+    if (etype == R_TLS_EXT_TYPE_APPLICATION_LAYER_PROTOCOL_NEGOTIATION) {
+      r_tls_client_alpn_apply_selection (client, p, elen);
+      return;
+    }
+    p += elen;
+  }
 }
 
 /* pre_shared_key offer with a single identity and a zeroed binder placeholder
@@ -910,6 +1054,8 @@ r_tls_client_send_hello (RTLSClient * client, rboolean retry)
         extsize += r_tls_client_write_hs_ext_cookie (client, ptr + 2 + extsize);
       if (client->server_name != NULL)
         extsize += r_tls_client_write_hs_ext_server_name (ptr + 2 + extsize, client->server_name);
+      if (client->alpn_count > 0)
+        extsize += r_tls_client_write_hs_ext_alpn (client, ptr + 2 + extsize);
       /* Advertise (EC)DHE resumption support so the server issues tickets. */
       extsize += r_tls_client_write_hs_ext_psk_key_exchange_modes (ptr + 2 + extsize);
       /* early_data (0-RTT) sits before pre_shared_key, which stays last. */
@@ -934,6 +1080,8 @@ r_tls_client_send_hello (RTLSClient * client, rboolean retry)
       extsize += r_tls_client_write_hs_ext_signature_algorithms (ptr + 2 + extsize);
       if (client->server_name != NULL)
         extsize += r_tls_client_write_hs_ext_server_name (ptr + 2 + extsize, client->server_name);
+      if (client->alpn_count > 0)
+        extsize += r_tls_client_write_hs_ext_alpn (client, ptr + 2 + extsize);
       if (dtls)
         extsize += r_tls_client_write_hs_ext_use_srtp (ptr + 2 + extsize);
     }
@@ -1469,6 +1617,7 @@ r_tls_client_flight13 (RTLSClient * client, const RTLSParser * parser)
             return R_TLS_ERROR_HANDSHAKE_FAILURE;
         }
       }
+      r_tls_client_ee_apply_alpn (client, parser->fragment.data, parser->fragment.size);
       /* A resumed handshake authenticates via the PSK, so no Certificate /
        * CertificateVerify follow: jump straight to the server Finished. */
       client->flight13_step = client->resumed13 ? 3 : 1;
@@ -1681,6 +1830,9 @@ r_tls_client_nego_server_hello (RTLSClient * client, const RTLSParser * parser)
       case R_TLS_EXT_TYPE_USE_SRTP:
         if (r_tls_hello_ext_use_srtp_profile_count (&ext) > 0)
           client->dtls_srtp_profile = r_tls_hello_ext_use_srtp_profile (&ext, 0);
+        break;
+      case R_TLS_EXT_TYPE_APPLICATION_LAYER_PROTOCOL_NEGOTIATION:
+        r_tls_client_alpn_apply_selection (client, ext.data, ext.len);
         break;
       default:
         break;
@@ -2900,4 +3052,12 @@ RSRTPCipherSuite
 r_tls_client_get_dtls_srtp_profile (const RTLSClient * client)
 {
   return client->dtls_srtp_profile;
+}
+
+const rchar *
+r_tls_client_get_alpn_selected (const RTLSClient * client, rsize * len)
+{
+  if (len != NULL)
+    *len = (client != NULL) ? client->alpn_selected_len : 0;
+  return (client != NULL) ? client->alpn_selected : NULL;
 }

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -1815,6 +1815,28 @@ r_tls_server_nego_hello13 (RTLSServer * server)
       server->early13_skip = TRUE;
   }
 
+  /* ALPN: pick the first configured protocol the client also offered (server
+   * preference), echoed later in EncryptedExtensions. The <=1.2 negotiation
+   * runs the same selection in nego_hello, but the 1.3 cut returns before it.
+   * An offer with no overlap aborts the handshake (RFC 7301 3.2). */
+  {
+    RTLSHelloExt a = R_TLS_HELLO_EXT_INIT;
+    if (r_tls_server_find_ext (server,
+          R_TLS_EXT_TYPE_APPLICATION_LAYER_PROTOCOL_NEGOTIATION, &a)) {
+      rsize k;
+      for (k = 0; k < server->alpn_count && server->alpn_selected == NULL; k++) {
+        rsize plen = r_strlen (server->alpn_protocols[k]);
+        if (r_tls_hello_ext_alpn_contains (&a,
+              (const ruint8 *) server->alpn_protocols[k], (ruint8) plen)) {
+          server->alpn_selected = server->alpn_protocols[k];
+          server->alpn_selected_len = plen;
+        }
+      }
+      if (server->alpn_count > 0 && server->alpn_selected == NULL)
+        return R_TLS_ERROR_NO_APPLICATION_PROTOCOL;
+    }
+  }
+
   server->comp = R_TLS_COMPRESSION_NULL;
   server->version = R_TLS_VERSION_TLS_1_3;
   server->tls13 = TRUE;
@@ -2198,16 +2220,18 @@ r_tls_server_write_flight13 (RTLSServer * server)
       !r_tls_server_install_keys13 (server, &server->rk_read, server->sched13.chs))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
 
-  /* 4. EncryptedExtensions: signal early-data acceptance back to the client
-   * (empty extension), otherwise an empty list. */
+  /* 4. EncryptedExtensions: echo the server's decisions -- early-data
+   * acceptance (empty extension) and the negotiated ALPN protocol -- otherwise
+   * an empty list. */
   {
-    ruint8 ee[4];
+    ruint8 ee[4 + 7 + 255];   /* early_data(4) + ALPN(7 + name<=255>) */
     ruint16 eelen = 0;
     if (server->early13_accepted) {
       r_store_be16 (ee, (ruint16)R_TLS_EXT_TYPE_EARLY_DATA);
       r_store_be16 (ee + 2, 0);
-      eelen = sizeof (ee);
+      eelen = 4;
     }
+    eelen += r_tls_server_write_hs_ext_alpn (server, ee + eelen);
     if ((ret = r_tls_write_hs_encrypted_extensions (body, sizeof (body),
             &bodylen, eelen ? ee : NULL, eelen)) != R_TLS_ERROR_OK)
       return ret;

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -621,6 +621,89 @@ RTEST_F (rtlsclient, tls13_key_update, RTEST_FAST)
 }
 RTEST_END;
 
+/* ALPN (RFC 7301): the client offers a protocol list, the server selects by its
+ * own preference from the overlap, and both endpoints report the same choice.
+ * Parameterised by @version to cover the 1.2 ServerHello and the 1.3
+ * EncryptedExtensions carrier. */
+static void
+r_test_tls_alpn_negotiated (RTEST_FIXTURE_STRUCT (rtlsclient) * fixture,
+    RTLSVersion version)
+{
+  static const rchar * srv[] = { "h2", "http/1.1" };
+  static const rchar * cli[] = { "http/1.1", "h2" };
+  const rchar * sel;
+  rsize sellen = 0;
+
+  r_assert_cmpint (r_tls_server_set_alpn_protocols (fixture->server,
+        srv, R_N_ELEMENTS (srv)), ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_set_alpn_protocols (fixture->client,
+        cli, R_N_ELEMENTS (cli)), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        version), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+
+  r_assert (fixture->cli_hs_done);
+  r_assert (fixture->srv_hs_done);
+  r_assert (!fixture->cli_error);
+  r_assert (!fixture->srv_error);
+
+  /* Server preference wins: "h2" is the server's first choice and the client
+   * offers it too, so both sides agree on "h2". */
+  sel = r_tls_client_get_alpn_selected (fixture->client, &sellen);
+  r_assert_cmpptr (sel, !=, NULL);
+  r_assert_cmpuint (sellen, ==, 2);
+  r_assert_cmpint (r_memcmp (sel, "h2", 2), ==, 0);
+
+  sel = r_tls_server_get_alpn_selected (fixture->server, &sellen);
+  r_assert_cmpptr (sel, !=, NULL);
+  r_assert_cmpuint (sellen, ==, 2);
+  r_assert_cmpint (r_memcmp (sel, "h2", 2), ==, 0);
+}
+
+RTEST_F (rtlsclient, tls_alpn, RTEST_FAST)
+{
+  r_test_tls_alpn_negotiated (fixture, R_TLS_VERSION_TLS_1_2);
+}
+RTEST_END;
+
+RTEST_F (rtlsclient, tls13_alpn, RTEST_FAST)
+{
+  r_test_tls_alpn_negotiated (fixture, R_TLS_VERSION_TLS_1_3);
+}
+RTEST_END;
+
+/* The client offers ALPN but the server has none configured: no protocol is
+ * negotiated and the handshake still completes. Input validation of the
+ * protocol list is exercised alongside. */
+RTEST_F (rtlsclient, tls13_alpn_server_unconfigured, RTEST_FAST)
+{
+  static const rchar * cli[] = { "h2" };
+  static const rchar * bad[] = { "" };
+  rsize sellen = 1;
+
+  r_assert_cmpint (r_tls_client_set_alpn_protocols (fixture->client, bad, 1),
+      ==, R_TLS_ERROR_INVAL);
+  r_assert_cmpint (r_tls_client_set_alpn_protocols (fixture->client,
+        cli, R_N_ELEMENTS (cli)), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+
+  r_assert (fixture->cli_hs_done);
+  r_assert (fixture->srv_hs_done);
+  r_assert (!fixture->cli_error);
+  r_assert (!fixture->srv_error);
+  r_assert_cmpptr (r_tls_client_get_alpn_selected (fixture->client, &sellen), ==, NULL);
+  r_assert_cmpuint (sellen, ==, 0);
+}
+RTEST_END;
+
 /* The server requires secp256r1 but the client offers an x25519 key_share, so
  * the server answers with a HelloRetryRequest and the client retries with a
  * secp256r1 share. The handshake can only complete if the retry worked. */


### PR DESCRIPTION
Completes ALPN (RFC 7301) end to end. The server could already select and echo
a protocol, but nothing offered one from the client side; this adds the client
offer and selection read-back.

## Client
- `r_tls_client_set_alpn_protocols` configures the offered protocol list; the
  ClientHello carries an `application_layer_protocol_negotiation` extension over
  both 1.2 and 1.3.
- The server's choice is parsed from the ServerHello (1.2) and
  EncryptedExtensions (1.3), matched against the offered list so
  `r_tls_client_get_alpn_selected` returns an owned, stable pointer. A protocol
  the client did not offer is ignored.

## Server
The 1.3 negotiation returns before the `<=1.2` ALPN selection loop, so it gains
its own selection in `nego_hello13` (same server-preference rule, same
`no_application_protocol` abort on no overlap) and echoes the chosen protocol in
EncryptedExtensions. The `<=1.2` ServerHello path was already complete.

## Tests
`tls_alpn` / `tls13_alpn` assert server-preference negotiation and matching
selection on both endpoints across the 1.2 and 1.3 carriers;
`tls13_alpn_server_unconfigured` covers a client-only offer (no negotiation, the
handshake still completes) and protocol-list input validation.

Built clean under `-Werror` across the linux/asan/ubsan/mingw tiers; the TLS
suites and full linux suite pass.

Closes #385