### PR TITLE
net/tls: TLS 1.3 crypto agility (named groups, signature schemes, ffdhe)

### DIFF
--- a/rlib/net/proto/rtls-private.h
+++ b/rlib/net/proto/rtls-private.h
@@ -25,6 +25,7 @@
 #include <rlib/net/proto/rtls.h>
 #include <rlib/net/proto/rtls12.h>
 #include <rlib/crypto/recurve.h>
+#include <rlib/crypto/rdh.h>
 #include <rlib/crypto/rkey.h>
 #include <rlib/crypto/rmsgdigest.h>
 #include <rlib/rrand.h>
@@ -120,6 +121,41 @@ R_API_HIDDEN RCryptoKey * r_tls_ecdhe_point_read (REcurveID curve,
  * pre-master secret is this raw, fixed-width coordinate. FALSE on failure or a
  * rejected (e.g. all-zero) secret. */
 R_API_HIDDEN rboolean r_tls_ecdhe_compute (const RCryptoKey * priv,
+    const RCryptoKey * peer, ruint8 * out, rsize cap, rsize * len);
+
+/* TLS 1.3 key_share generalised over EC and finite-field (ffdhe) groups. The
+ * ffdhe values dwarf the EC ones -- the ffdhe8192 public value / shared secret
+ * are both 1024 bytes -- so key_share buffers on the 1.3 path use these. */
+#define R_TLS_KE_VALUE_MAX    1024
+#define R_TLS_KE_SECRET_MAX   1024
+
+/* Map a TLS supported_group to an RFC 7919 FFDHE named group; FALSE if @group
+ * is not one of the ffdhe* groups. */
+R_API_HIDDEN rboolean r_tls_group_to_dh (RTLSSupportedGroup group,
+    RDhNamedGroup * dh);
+
+/* TRUE if @group is a key-exchange group we support (an EC curve via
+ * r_tls_ecdhe_group_to_curve, or an ffdhe finite-field group). */
+R_API_HIDDEN rboolean r_tls_ke_group_supported (RTLSSupportedGroup group);
+
+/* Generate an ephemeral key-exchange private key for @group (EC or FFDHE).
+ * NULL on an unsupported group or failure. */
+R_API_HIDDEN RCryptoKey * r_tls_ke_keygen (RTLSSupportedGroup group, RPrng * prng);
+
+/* Serialize @key's public value into @out (capacity @cap) as @group's TLS
+ * KeyShareEntry.key_exchange, writing the length (up to R_TLS_KE_VALUE_MAX) to
+ * @len. FALSE on a bad key / small buffer. */
+R_API_HIDDEN rboolean r_tls_ke_pub_write (const RCryptoKey * key,
+    RTLSSupportedGroup group, ruint8 * out, rsize cap, rsize * len);
+
+/* Parse a peer's key_share value (@data/@len) for @group into a public key.
+ * NULL on a malformed value. */
+R_API_HIDDEN RCryptoKey * r_tls_ke_pub_read (RTLSSupportedGroup group,
+    const ruint8 * data, rsize len);
+
+/* Compute the key-exchange shared secret between @priv and @peer into @out
+ * (capacity @cap), writing its length to @len. Dispatches on the key type. */
+R_API_HIDDEN rboolean r_tls_ke_compute (const RCryptoKey * priv,
     const RCryptoKey * peer, ruint8 * out, rsize cap, rsize * len);
 
 R_END_DECLS

--- a/rlib/net/proto/rtls-private.h
+++ b/rlib/net/proto/rtls-private.h
@@ -80,8 +80,16 @@ R_API_HIDDEN rboolean r_tls_prf_and_hash_for (RMsgDigestType hash,
  * is Montgomery (raw little-endian u-coordinate, the rxdh primitives). These
  * helpers hide that split so both endpoints share one code path. */
 
+/* Largest (EC)DHE shared secret and uncompressed ECPoint across the supported
+ * groups: P-521 has 66-byte coordinates, so a 66-byte shared secret and a
+ * 133-byte uncompressed point (0x04 || X || Y). Buffers on the key-exchange
+ * paths are sized to these so any supported group fits (RFC 8446 7.4.2 / SEC 1). */
+#define R_TLS_ECDHE_SECRET_MAX    66
+#define R_TLS_ECDHE_POINT_MAX     133
+
 /* Map a TLS supported_group to an REcurveID we can do ECDHE on, gating to the
- * curves this cut supports (secp256r1, x25519). Returns FALSE otherwise. */
+ * curves this cut supports (secp256r1, secp384r1, secp521r1, x25519, x448).
+ * Returns FALSE otherwise. */
 R_API_HIDDEN rboolean r_tls_ecdhe_group_to_curve (RTLSSupportedGroup group,
     REcurveID * curve);
 

--- a/rlib/net/proto/rtls.c
+++ b/rlib/net/proto/rtls.c
@@ -26,6 +26,8 @@
 #include <rlib/crypto/rx509.h>
 #include <rlib/crypto/recc.h>
 #include <rlib/crypto/rxdh.h>
+#include <rlib/crypto/rdh.h>
+#include <rlib/data/rmpint.h>
 
 static inline ruint32
 _r_parse_u24 (const ruint8 * ptr)
@@ -159,6 +161,127 @@ r_tls_ecdhe_compute (const RCryptoKey * priv, const RCryptoKey * peer,
   if (res != R_CRYPTO_OK) return FALSE;
   *len = sz;
   return TRUE;
+}
+
+rboolean
+r_tls_group_to_dh (RTLSSupportedGroup group, RDhNamedGroup * dh)
+{
+  switch (group) {
+    case R_TLS_SUPPORTED_GROUP_FFDHE2048: *dh = R_DH_GROUP_FFDHE_2048; return TRUE;
+    case R_TLS_SUPPORTED_GROUP_FFDHE3072: *dh = R_DH_GROUP_FFDHE_3072; return TRUE;
+    case R_TLS_SUPPORTED_GROUP_FFDHE4096: *dh = R_DH_GROUP_FFDHE_4096; return TRUE;
+    case R_TLS_SUPPORTED_GROUP_FFDHE6144: *dh = R_DH_GROUP_FFDHE_6144; return TRUE;
+    case R_TLS_SUPPORTED_GROUP_FFDHE8192: *dh = R_DH_GROUP_FFDHE_8192; return TRUE;
+    default: return FALSE;
+  }
+}
+
+/* Serialize a FFDHE public value as the KeyShareEntry.key_exchange: the DH
+ * public value Y, big-endian, left-zero-padded to the size of p (RFC 8446
+ * 4.2.8.1). */
+static rboolean
+r_tls_dh_value_write (const RCryptoKey * key, ruint8 * out, rsize cap, rsize * len)
+{
+  rmpint p, y;
+  rsize plen;
+  rboolean ok = FALSE;
+
+  r_mpint_init (&p);
+  r_mpint_init (&y);
+  if (r_dh_pub_key_get_p (key, &p) && r_dh_pub_key_get_y (key, &y)) {
+    plen = r_mpint_bytes_used (&p);
+    if (plen <= cap && r_mpint_to_binary_with_size (&y, out, plen)) {
+      *len = plen;
+      ok = TRUE;
+    }
+  }
+  r_mpint_clear (&p);
+  r_mpint_clear (&y);
+  return ok;
+}
+
+/* Parse a peer FFDHE key_share value into a public key on @dh's (p, g). The
+ * range check on Y (small-subgroup defence) happens later in r_dh_compute_shared. */
+static RCryptoKey *
+r_tls_dh_value_read (RDhNamedGroup dh, const ruint8 * data, rsize len)
+{
+  rmpint p, g, y;
+  RCryptoKey * key = NULL;
+
+  r_mpint_init (&p);
+  r_mpint_init (&g);
+  r_mpint_init_binary (&y, data, len);
+  if (r_dh_named_group_get_params (dh, &p, &g))
+    key = r_dh_pub_key_new (&p, &g, &y);
+  r_mpint_clear (&p);
+  r_mpint_clear (&g);
+  r_mpint_clear (&y);
+  return key;
+}
+
+rboolean
+r_tls_ke_group_supported (RTLSSupportedGroup group)
+{
+  REcurveID curve;
+  RDhNamedGroup dh;
+  return r_tls_ecdhe_group_to_curve (group, &curve) ||
+      r_tls_group_to_dh (group, &dh);
+}
+
+RCryptoKey *
+r_tls_ke_keygen (RTLSSupportedGroup group, RPrng * prng)
+{
+  REcurveID curve;
+  RDhNamedGroup dh;
+  if (r_tls_group_to_dh (group, &dh))
+    return r_dh_priv_key_new_gen_named (dh, prng);
+  if (r_tls_ecdhe_group_to_curve (group, &curve))
+    return r_tls_ecdhe_keygen (curve, prng);
+  return NULL;
+}
+
+rboolean
+r_tls_ke_pub_write (const RCryptoKey * key, RTLSSupportedGroup group,
+    ruint8 * out, rsize cap, rsize * len)
+{
+  REcurveID curve;
+  RDhNamedGroup dh;
+  if (r_tls_group_to_dh (group, &dh))
+    return r_tls_dh_value_write (key, out, cap, len);
+  if (r_tls_ecdhe_group_to_curve (group, &curve)) {
+    ruint8 l8 = 0;
+    if (!r_tls_ecdhe_point_write (key, curve, out, cap, &l8))
+      return FALSE;
+    *len = l8;
+    return TRUE;
+  }
+  return FALSE;
+}
+
+RCryptoKey *
+r_tls_ke_pub_read (RTLSSupportedGroup group, const ruint8 * data, rsize len)
+{
+  REcurveID curve;
+  RDhNamedGroup dh;
+  if (r_tls_group_to_dh (group, &dh))
+    return r_tls_dh_value_read (dh, data, len);
+  if (r_tls_ecdhe_group_to_curve (group, &curve))
+    return r_tls_ecdhe_point_read (curve, data, len);
+  return NULL;
+}
+
+rboolean
+r_tls_ke_compute (const RCryptoKey * priv, const RCryptoKey * peer,
+    ruint8 * out, rsize cap, rsize * len)
+{
+  if (r_crypto_key_get_algo (priv) == R_CRYPTO_ALGO_DH) {
+    rsize sz = cap;
+    if (r_dh_compute_shared (priv, peer, out, &sz) != R_CRYPTO_OK)
+      return FALSE;
+    *len = sz;
+    return TRUE;
+  }
+  return r_tls_ecdhe_compute (priv, peer, out, cap, len);
 }
 
 void

--- a/rlib/net/proto/rtls.c
+++ b/rlib/net/proto/rtls.c
@@ -66,7 +66,10 @@ r_tls_ecdhe_group_to_curve (RTLSSupportedGroup group, REcurveID * curve)
 {
   switch (group) {
     case R_TLS_SUPPORTED_GROUP_SECP256R1: *curve = R_ECURVE_ID_SECP256R1; return TRUE;
+    case R_TLS_SUPPORTED_GROUP_SECP384R1: *curve = R_ECURVE_ID_SECP384R1; return TRUE;
+    case R_TLS_SUPPORTED_GROUP_SECP521R1: *curve = R_ECURVE_ID_SECP521R1; return TRUE;
     case R_TLS_SUPPORTED_GROUP_X25519:    *curve = R_ECURVE_ID_X25519;    return TRUE;
+    case R_TLS_SUPPORTED_GROUP_X448:      *curve = R_ECURVE_ID_X448;      return TRUE;
     default: return FALSE;
   }
 }

--- a/rlib/net/proto/rtls.c
+++ b/rlib/net/proto/rtls.c
@@ -46,7 +46,18 @@ r_tls_sign_scheme_to_md (RTLSSignatureScheme scheme, RMsgDigestType * md)
   switch (scheme) {
     case R_TLS_SIGN_SCHEME_RSA_PKCS1_SHA256:
     case R_TLS_SIGN_SCHEME_ECDSA_SECP256R1_SHA256:
+    case R_TLS_SIGN_SCHEME_RSA_PSS_SHA256:
       *md = R_MSG_DIGEST_TYPE_SHA256;
+      return TRUE;
+    case R_TLS_SIGN_SCHEME_RSA_PKCS1_SHA384:
+    case R_TLS_SIGN_SCHEME_ECDSA_SECP384R1_SHA384:
+    case R_TLS_SIGN_SCHEME_RSA_PSS_SHA384:
+      *md = R_MSG_DIGEST_TYPE_SHA384;
+      return TRUE;
+    case R_TLS_SIGN_SCHEME_RSA_PKCS1_SHA512:
+    case R_TLS_SIGN_SCHEME_ECDSA_SECP521R1_SHA512:
+    case R_TLS_SIGN_SCHEME_RSA_PSS_SHA512:
+      *md = R_MSG_DIGEST_TYPE_SHA512;
       return TRUE;
     default:
       return FALSE;
@@ -56,9 +67,15 @@ r_tls_sign_scheme_to_md (RTLSSignatureScheme scheme, RMsgDigestType * md)
 RTLSSignatureScheme
 r_tls_sign_scheme_for_key (const RCryptoKey * key)
 {
-  return (r_crypto_key_get_algo (key) == R_CRYPTO_ALGO_ECDSA) ?
-      R_TLS_SIGN_SCHEME_ECDSA_SECP256R1_SHA256 :
-      R_TLS_SIGN_SCHEME_RSA_PKCS1_SHA256;
+  if (r_crypto_key_get_algo (key) == R_CRYPTO_ALGO_ECDSA) {
+    /* The ECDSA schemes bind the curve to a digest (RFC 8446 4.2.3). */
+    switch (r_ecc_key_get_curve (key)) {
+      case R_ECURVE_ID_SECP384R1: return R_TLS_SIGN_SCHEME_ECDSA_SECP384R1_SHA384;
+      case R_ECURVE_ID_SECP521R1: return R_TLS_SIGN_SCHEME_ECDSA_SECP521R1_SHA512;
+      default:                    return R_TLS_SIGN_SCHEME_ECDSA_SECP256R1_SHA256;
+    }
+  }
+  return R_TLS_SIGN_SCHEME_RSA_PKCS1_SHA256;
 }
 
 rboolean

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -734,19 +734,30 @@ r_tls_client_default_cipher_suites (rpointer ctx, RTLSVersion ver,
   return TRUE;
 }
 
-/* signature_algorithms for 1.3: offer ecdsa_secp256r1_sha256 and
- * rsa_pss_rsae_sha256 (the schemes valid for a 1.3 CertificateVerify), plus
+/* signature_algorithms for 1.3: offer the ECDSA (secp256r1/384r1/521r1) and
+ * RSA-PSS (SHA-256/384/512) schemes valid for a 1.3 CertificateVerify, plus
  * rsa_pkcs1_sha256 for certificate signatures. */
 static ruint16
 r_tls_client_write_hs_ext_signature_algorithms13 (ruint8 * ptr)
 {
+  static const RTLSSignatureScheme schemes[] = {
+    R_TLS_SIGN_SCHEME_ECDSA_SECP256R1_SHA256,
+    R_TLS_SIGN_SCHEME_ECDSA_SECP384R1_SHA384,
+    R_TLS_SIGN_SCHEME_ECDSA_SECP521R1_SHA512,
+    R_TLS_SIGN_SCHEME_RSA_PSS_SHA256,
+    R_TLS_SIGN_SCHEME_RSA_PSS_SHA384,
+    R_TLS_SIGN_SCHEME_RSA_PSS_SHA512,
+    R_TLS_SIGN_SCHEME_RSA_PKCS1_SHA256,
+  };
+  ruint16 listlen = (ruint16) (R_N_ELEMENTS (schemes) * sizeof (ruint16));
+  rsize i;
+
   r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_SIGNATURE_ALGORITHMS);
-  r_store_be16 (&ptr[2], 2 + 3 * sizeof (ruint16));
-  r_store_be16 (&ptr[4], 3 * sizeof (ruint16));
-  r_store_be16 (&ptr[6], (ruint16)R_TLS_SIGN_SCHEME_ECDSA_SECP256R1_SHA256);
-  r_store_be16 (&ptr[8], (ruint16)R_TLS_SIGN_SCHEME_RSA_PSS_SHA256);
-  r_store_be16 (&ptr[10], (ruint16)R_TLS_SIGN_SCHEME_RSA_PKCS1_SHA256);
-  return 12;
+  r_store_be16 (&ptr[2], (ruint16)(sizeof (ruint16) + listlen));
+  r_store_be16 (&ptr[4], listlen);
+  for (i = 0; i < R_N_ELEMENTS (schemes); i++)
+    r_store_be16 (&ptr[6 + i * sizeof (ruint16)], (ruint16) schemes[i]);
+  return (ruint16) (6 + listlen);
 }
 
 /* ClientHello supported_versions offering TLS 1.3 first, then 1.2 when it is
@@ -1555,15 +1566,33 @@ static RTLSError
 r_tls_client_verify_certificate_verify13 (RTLSClient * client,
     RTLSSignatureScheme scheme, const ruint8 * sig, ruint16 sigsize)
 {
-  ruint8 th[R_TLS13_SECRET_MAX], tbs[R_TLS13_CERT_VERIFY_TBS_MAX], digest[R_TLS13_SECRET_MAX];
+  ruint8 th[R_TLS13_SECRET_MAX], tbs[R_TLS13_CERT_VERIFY_TBS_MAX], digest[64];  /* up to SHA-512 */
   rsize hlen = r_msg_digest_type_size (client->cs13_hash), tbslen = 0, dlen;
+  RMsgDigestType mdtype;
   RMsgDigest * md;
   RCryptoKey * pub;
+  rboolean pss;
   rboolean ok;
   RTLSError err;
 
-  if (scheme != R_TLS_SIGN_SCHEME_ECDSA_SECP256R1_SHA256 &&
-      scheme != R_TLS_SIGN_SCHEME_RSA_PSS_SHA256)
+  /* The schemes valid for a 1.3 CertificateVerify that we can verify: ECDSA
+   * (secp256r1/384r1/521r1) and RSA-PSS (SHA-256/384/512). PKCS#1 v1.5 is
+   * forbidden in 1.3; other schemes are rejected. */
+  switch (scheme) {
+    case R_TLS_SIGN_SCHEME_ECDSA_SECP256R1_SHA256:
+    case R_TLS_SIGN_SCHEME_ECDSA_SECP384R1_SHA384:
+    case R_TLS_SIGN_SCHEME_ECDSA_SECP521R1_SHA512:
+      pss = FALSE;
+      break;
+    case R_TLS_SIGN_SCHEME_RSA_PSS_SHA256:
+    case R_TLS_SIGN_SCHEME_RSA_PSS_SHA384:
+    case R_TLS_SIGN_SCHEME_RSA_PSS_SHA512:
+      pss = TRUE;
+      break;
+    default:
+      return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  }
+  if (!r_tls_sign_scheme_to_md (scheme, &mdtype))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
 
   /* The signature covers the content over Transcript-Hash(..Certificate). */
@@ -1571,7 +1600,7 @@ r_tls_client_verify_certificate_verify13 (RTLSClient * client,
       !r_tls13_cert_verify_tbs (TRUE, th, hlen, tbs, sizeof (tbs), &tbslen))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
 
-  if ((md = r_msg_digest_new (R_MSG_DIGEST_TYPE_SHA256)) == NULL)
+  if ((md = r_msg_digest_new (mdtype)) == NULL)
     return R_TLS_ERROR_OOM;
   dlen = r_msg_digest_size (md);
   ok = r_msg_digest_update (md, tbs, tbslen) &&
@@ -1582,9 +1611,9 @@ r_tls_client_verify_certificate_verify13 (RTLSClient * client,
 
   if ((pub = r_crypto_cert_get_public_key (client->peer_cert)) == NULL)
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
-  if (scheme == R_TLS_SIGN_SCHEME_RSA_PSS_SHA256)
+  if (pss)
     r_rsa_pub_key_set_padding (pub, R_RSA_PADDING_PKCS1_V21);
-  err = (r_crypto_key_verify (pub, R_MSG_DIGEST_TYPE_SHA256, digest, dlen,
+  err = (r_crypto_key_verify (pub, mdtype, digest, dlen,
             sig, sigsize) == R_CRYPTO_OK) ?
       R_TLS_ERROR_OK : R_TLS_ERROR_HS_VERIFICATION_FAILED;
   r_crypto_key_unref (pub);

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -602,6 +602,11 @@ r_tls_client_write_hs_ext_supported_groups (ruint8 * ptr)
     R_TLS_SUPPORTED_GROUP_SECP256R1, R_TLS_SUPPORTED_GROUP_X25519,
     R_TLS_SUPPORTED_GROUP_SECP384R1, R_TLS_SUPPORTED_GROUP_SECP521R1,
     R_TLS_SUPPORTED_GROUP_X448,
+    /* The finite-field groups rank below the EC groups (a 1.3-only preference:
+     * only a peer selecting ffdhe drives the finite-field key_share path). */
+    R_TLS_SUPPORTED_GROUP_FFDHE2048, R_TLS_SUPPORTED_GROUP_FFDHE3072,
+    R_TLS_SUPPORTED_GROUP_FFDHE4096, R_TLS_SUPPORTED_GROUP_FFDHE6144,
+    R_TLS_SUPPORTED_GROUP_FFDHE8192,
   };
   ruint16 listlen = (ruint16) (R_N_ELEMENTS (groups) * sizeof (ruint16));
   rsize i;
@@ -776,23 +781,26 @@ r_tls_client_write_hs_ext_supported_versions13 (ruint8 * ptr, rboolean include_t
   return 5 + n * sizeof (ruint16);
 }
 
-/* ClientHello key_share with a single KeyShareEntry for the offered group. */
+/* ClientHello key_share with a single KeyShareEntry for the offered group.
+ * The value is an EC point or, for an ffdhe group, the (larger) DH public
+ * value. */
 static ruint16
 r_tls_client_write_hs_ext_key_share13 (RTLSClient * client, ruint8 * ptr)
 {
-  ruint8 point[256], plen = 0;
+  ruint8 value[R_TLS_KE_VALUE_MAX];
+  rsize plen = 0;
   ruint16 entrylen;
 
-  if (!r_tls_ecdhe_point_write (client->ecdhe_key, client->ecdhe_curve,
-        point, sizeof (point), &plen))
+  if (!r_tls_ke_pub_write (client->ecdhe_key, client->ks_group,
+        value, sizeof (value), &plen))
     return 0;
   entrylen = (ruint16) (2 * sizeof (ruint16) + plen);     /* group + klen + key */
   r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_KEY_SHARE);
   r_store_be16 (&ptr[2], (ruint16) (sizeof (ruint16) + entrylen));
   r_store_be16 (&ptr[4], entrylen);                       /* client_shares length */
   r_store_be16 (&ptr[6], (ruint16)client->ks_group);
-  r_store_be16 (&ptr[8], plen);
-  r_memcpy (&ptr[10], point, plen);
+  r_store_be16 (&ptr[8], (ruint16) plen);
+  r_memcpy (&ptr[10], value, plen);
   return (ruint16) (10 + plen);
 }
 
@@ -1356,7 +1364,6 @@ r_tls_client_nego_server_hello13 (RTLSClient * client, const RTLSHelloMsg * hell
   RTLSKeyShareEntry entry = R_TLS_KEY_SHARE_ENTRY_INIT;
   rboolean have_sv = FALSE, have_ks = FALSE, have_psk = FALSE;
   RTLSCipherSuite cs;
-  REcurveID curve;
   RTLSError r;
 
   for (r = r_tls_hello_msg_extension_first (hello, &ext); r == R_TLS_ERROR_OK;
@@ -1399,11 +1406,10 @@ r_tls_client_nego_server_hello13 (RTLSClient * client, const RTLSHelloMsg * hell
   /* The server key_share must be on the group we offered. */
   if (!have_ks || r_tls_hello_ext_key_share_server (&ks, &entry) != R_TLS_ERROR_OK)
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
-  if (!r_tls_ecdhe_group_to_curve (entry.group, &curve) ||
-      curve != client->ecdhe_curve)
+  if (entry.group != client->ks_group)
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
   if ((client->ecdhe_server_pub =
-          r_tls_ecdhe_point_read (curve, entry.key, entry.len)) == NULL)
+          r_tls_ke_pub_read (entry.group, entry.key, entry.len)) == NULL)
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
 
   r_memcpy (client->servrandom, hello->random, R_TLS_HELLO_RANDOM_BYTES);
@@ -1433,12 +1439,12 @@ r_tls_client_nego_server_hello13 (RTLSClient * client, const RTLSHelloMsg * hell
 static RTLSError
 r_tls_client_setup_keys13 (RTLSClient * client)
 {
-  ruint8 ecdhe[R_TLS_ECDHE_SECRET_MAX], th[R_TLS13_SECRET_MAX];
+  ruint8 ecdhe[R_TLS_KE_SECRET_MAX], th[R_TLS13_SECRET_MAX];
   rsize ecdhelen = 0, hlen = r_msg_digest_type_size (client->cs13_hash);
 
   if (!r_msg_digest_get_data (client->hshash, th, hlen, NULL))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
-  if (!r_tls_ecdhe_compute (client->ecdhe_key, client->ecdhe_server_pub,
+  if (!r_tls_ke_compute (client->ecdhe_key, client->ecdhe_server_pub,
         ecdhe, sizeof (ecdhe), &ecdhelen))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
   /* On an accepted resumption the Early Secret comes from the ticket PSK
@@ -1477,7 +1483,6 @@ r_tls_client_handle_hrr (RTLSClient * client, const RTLSHelloMsg * hello,
   rboolean have_sv = FALSE, have_ks = FALSE, have_ck = FALSE;
   RTLSSupportedGroup selected;
   RTLSCipherSuite cs;
-  REcurveID curve;
   ruint8 mh[4 + R_TLS13_SECRET_MAX];
   rsize mhlen = 0;
   RTLSError r;
@@ -1500,7 +1505,7 @@ r_tls_client_handle_hrr (RTLSClient * client, const RTLSHelloMsg * hello,
   /* The selected group must be one we support and must differ from the one we
    * already sent a share for (otherwise the server should not have retried). */
   selected = r_tls_hello_ext_key_share_group (&ks);
-  if (!r_tls_ecdhe_group_to_curve (selected, &curve) || selected == client->ks_group)
+  if (!r_tls_ke_group_supported (selected) || selected == client->ks_group)
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
 
   /* Cipher suite from the HelloRetryRequest. */
@@ -1525,14 +1530,15 @@ r_tls_client_handle_hrr (RTLSClient * client, const RTLSHelloMsg * hello,
     client->cookielen = clen;
   }
 
-  /* Regenerate the (EC)DHE share for the selected group. */
+  /* Regenerate the (EC)DHE / ffdhe share for the selected group. */
   client->ks_group = selected;
-  client->ecdhe_curve = curve;
+  if (!r_tls_ecdhe_group_to_curve (selected, &client->ecdhe_curve))
+    client->ecdhe_curve = R_ECURVE_ID_NONE;   /* ffdhe: no curve */
   if (client->ecdhe_key != NULL) {
     r_crypto_key_unref (client->ecdhe_key);
     client->ecdhe_key = NULL;
   }
-  if ((client->ecdhe_key = r_tls_ecdhe_keygen (curve, client->prng)) == NULL)
+  if ((client->ecdhe_key = r_tls_ke_keygen (selected, client->prng)) == NULL)
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
 
   /* Transcript rewrite (RFC 8446 4.4.1): the first ClientHello is replaced by

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -598,12 +598,20 @@ r_tls_client_write_hs_ext_encrypt_then_mac (ruint8 * ptr)
 static ruint16
 r_tls_client_write_hs_ext_supported_groups (ruint8 * ptr)
 {
+  static const RTLSSupportedGroup groups[] = {
+    R_TLS_SUPPORTED_GROUP_SECP256R1, R_TLS_SUPPORTED_GROUP_X25519,
+    R_TLS_SUPPORTED_GROUP_SECP384R1, R_TLS_SUPPORTED_GROUP_SECP521R1,
+    R_TLS_SUPPORTED_GROUP_X448,
+  };
+  ruint16 listlen = (ruint16) (R_N_ELEMENTS (groups) * sizeof (ruint16));
+  rsize i;
+
   r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_SUPPORTED_GROUPS);
-  r_store_be16 (&ptr[2], 2 + 2 * sizeof (ruint16));   /* list length + 2 groups */
-  r_store_be16 (&ptr[4], 2 * sizeof (ruint16));       /* named-group list length */
-  r_store_be16 (&ptr[6], (ruint16)R_TLS_SUPPORTED_GROUP_SECP256R1);
-  r_store_be16 (&ptr[8], (ruint16)R_TLS_SUPPORTED_GROUP_X25519);
-  return 10;
+  r_store_be16 (&ptr[2], (ruint16)(sizeof (ruint16) + listlen));  /* list length + groups */
+  r_store_be16 (&ptr[4], listlen);                                /* named-group list length */
+  for (i = 0; i < R_N_ELEMENTS (groups); i++)
+    r_store_be16 (&ptr[6 + i * sizeof (ruint16)], (ruint16) groups[i]);
+  return (ruint16) (6 + listlen);
 }
 
 static ruint16
@@ -1414,7 +1422,7 @@ r_tls_client_nego_server_hello13 (RTLSClient * client, const RTLSHelloMsg * hell
 static RTLSError
 r_tls_client_setup_keys13 (RTLSClient * client)
 {
-  ruint8 ecdhe[64], th[R_TLS13_SECRET_MAX];
+  ruint8 ecdhe[R_TLS_ECDHE_SECRET_MAX], th[R_TLS13_SECRET_MAX];
   rsize ecdhelen = 0, hlen = r_msg_digest_type_size (client->cs13_hash);
 
   if (!r_msg_digest_get_data (client->hshash, th, hlen, NULL))
@@ -2046,12 +2054,13 @@ r_tls_client_send_certificate_verify (RTLSClient * client)
 /* ECDHE ClientKeyExchange: send our ephemeral public point and compute the
  * premaster from the ECDH shared secret. */
 static RTLSError
-r_tls_client_send_key_exchange_ecdhe (RTLSClient * client, ruint8 pms[48], rsize * pmslen)
+r_tls_client_send_key_exchange_ecdhe (RTLSClient * client,
+    ruint8 pms[R_TLS_ECDHE_SECRET_MAX], rsize * pmslen)
 {
   RBuffer * buf;
   RTLSError ret;
   RMemMapInfo info;
-  ruint8 point[65];
+  ruint8 point[R_TLS_ECDHE_POINT_MAX];
   ruint8 pointlen;
 
   if (client->ecdhe_key == NULL || client->ecdhe_server_pub == NULL)
@@ -2059,7 +2068,8 @@ r_tls_client_send_key_exchange_ecdhe (RTLSClient * client, ruint8 pms[48], rsize
   if (!r_tls_ecdhe_point_write (client->ecdhe_key, client->ecdhe_curve,
         point, sizeof (point), &pointlen))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
-  if (!r_tls_ecdhe_compute (client->ecdhe_key, client->ecdhe_server_pub, pms, 48, pmslen))
+  if (!r_tls_ecdhe_compute (client->ecdhe_key, client->ecdhe_server_pub,
+        pms, R_TLS_ECDHE_SECRET_MAX, pmslen))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
 
   if ((buf = r_tls_client_alloc_buffer (client)) == NULL)
@@ -2103,7 +2113,8 @@ r_tls_client_send_key_exchange_ecdhe (RTLSClient * client, ruint8 pms[48], rsize
 }
 
 static RTLSError
-r_tls_client_send_key_exchange (RTLSClient * client, ruint8 pms[48], rsize * pmslen)
+r_tls_client_send_key_exchange (RTLSClient * client,
+    ruint8 pms[R_TLS_ECDHE_SECRET_MAX], rsize * pmslen)
 {
   RBuffer * buf;
   RTLSError ret;
@@ -2299,7 +2310,7 @@ static RTLSError
 r_tls_client_send_flight (RTLSClient * client)
 {
   RTLSError ret = R_TLS_ERROR_OK;
-  ruint8 pms[48];
+  ruint8 pms[R_TLS_ECDHE_SECRET_MAX];
   rsize pmslen = sizeof (pms);
 
   /* mTLS: a Certificate (the configured one, or empty) precedes the

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -1513,11 +1513,10 @@ r_tls_server_client_offers_group (const RTLSServer * server,
   return FALSE;
 }
 
-/* Read the client's key_share for @group (on @curve) into a public key, or NULL
- * when the client offered no share for that group. */
+/* Read the client's key_share for @group into a public key, or NULL when the
+ * client offered no share for that group. */
 static RCryptoKey *
-r_tls_server_read_key_share (const RTLSServer * server,
-    RTLSSupportedGroup group, REcurveID curve)
+r_tls_server_read_key_share (const RTLSServer * server, RTLSSupportedGroup group)
 {
   RTLSHelloExt ks = R_TLS_HELLO_EXT_INIT;
   RTLSKeyShareEntry entry = R_TLS_KEY_SHARE_ENTRY_INIT;
@@ -1528,7 +1527,7 @@ r_tls_server_read_key_share (const RTLSServer * server,
   for (r = r_tls_hello_ext_key_share_first (&ks, &entry); r == R_TLS_ERROR_OK;
       r = r_tls_hello_ext_key_share_next (&ks, &entry)) {
     if (entry.group == group)
-      return r_tls_ecdhe_point_read (curve, entry.key, entry.len);
+      return r_tls_ke_pub_read (group, entry.key, entry.len);
   }
   return NULL;
 }
@@ -1708,7 +1707,6 @@ r_tls_server_nego_hello13 (RTLSServer * server)
   RTLSCipherSuite cs13 = R_TLS_CS_NONE;
   RCryptoAlgorithm certalgo;
   RTLSError r;
-  REcurveID curve;
   ruint16 i, ncs;
 
   if (!r_tls_server_find_ext (server, R_TLS_EXT_TYPE_SUPPORTED_VERSIONS, &sv) ||
@@ -1745,11 +1743,12 @@ r_tls_server_nego_hello13 (RTLSServer * server)
    * without a share. With no preference, pick the first offered share on a
    * curve we support. */
   if (server->ks_pref_group != 0) {
-    if (!r_tls_ecdhe_group_to_curve (server->ks_pref_group, &curve))
+    if (!r_tls_ke_group_supported (server->ks_pref_group))
       return R_TLS_ERROR_HANDSHAKE_FAILURE;
     server->ks_group = server->ks_pref_group;
-    server->ecdhe_curve = curve;
-    server->ks_peer_pub = r_tls_server_read_key_share (server, server->ks_group, curve);
+    if (!r_tls_ecdhe_group_to_curve (server->ks_group, &server->ecdhe_curve))
+      server->ecdhe_curve = R_ECURVE_ID_NONE;   /* ffdhe: no curve */
+    server->ks_peer_pub = r_tls_server_read_key_share (server, server->ks_group);
     if (server->ks_peer_pub == NULL &&
         !r_tls_server_client_offers_group (server, server->ks_group))
       return R_TLS_ERROR_HANDSHAKE_FAILURE;   /* client cannot do the group */
@@ -1758,10 +1757,11 @@ r_tls_server_nego_hello13 (RTLSServer * server)
       return R_TLS_ERROR_HANDSHAKE_FAILURE;
     for (r = r_tls_hello_ext_key_share_first (&ks, &entry); r == R_TLS_ERROR_OK;
         r = r_tls_hello_ext_key_share_next (&ks, &entry)) {
-      if (r_tls_ecdhe_group_to_curve (entry.group, &curve)) {
+      if (r_tls_ke_group_supported (entry.group)) {
         server->ks_group = entry.group;
-        server->ecdhe_curve = curve;
-        server->ks_peer_pub = r_tls_ecdhe_point_read (curve, entry.key, entry.len);
+        if (!r_tls_ecdhe_group_to_curve (entry.group, &server->ecdhe_curve))
+          server->ecdhe_curve = R_ECURVE_ID_NONE;   /* ffdhe: no curve */
+        server->ks_peer_pub = r_tls_ke_pub_read (entry.group, entry.key, entry.len);
         break;
       }
     }
@@ -1854,20 +1854,22 @@ r_tls_server_write_ext13_supported_versions (ruint8 * p)
   return 6;
 }
 
-/* ServerHello key_share: the single server KeyShareEntry. */
+/* ServerHello key_share: the single server KeyShareEntry (an EC point or, for
+ * an ffdhe group, the DH public value). */
 static ruint16
 r_tls_server_write_ext13_key_share (RTLSServer * server, ruint8 * p)
 {
-  ruint8 point[256], plen = 0;
+  ruint8 value[R_TLS_KE_VALUE_MAX];
+  rsize plen = 0;
 
-  if (!r_tls_ecdhe_point_write (server->ecdhe_key, server->ecdhe_curve,
-        point, sizeof (point), &plen))
+  if (!r_tls_ke_pub_write (server->ecdhe_key, server->ks_group,
+        value, sizeof (value), &plen))
     return 0;
   r_store_be16 (p, R_TLS_EXT_TYPE_KEY_SHARE);
   r_store_be16 (p + 2, (ruint16) (2 * sizeof (ruint16) + plen));
   r_store_be16 (p + 4, (ruint16) server->ks_group);
-  r_store_be16 (p + 6, plen);
-  r_memcpy (p + 8, point, plen);
+  r_store_be16 (p + 6, (ruint16) plen);
+  r_memcpy (p + 8, value, plen);
   return (ruint16) (8 + plen);
 }
 
@@ -1963,7 +1965,6 @@ static RTLSError
 r_tls_server_nego_hello13_retry (RTLSServer * server)
 {
   RTLSHelloExt ck = R_TLS_HELLO_EXT_INIT;
-  REcurveID curve;
 
   if (server->cookielen > 0) {
     const ruint8 * cookie;
@@ -1976,9 +1977,7 @@ r_tls_server_nego_hello13_retry (RTLSServer * server)
       return R_TLS_ERROR_ILLEGAL_PARAMETER;
   }
 
-  if (!r_tls_ecdhe_group_to_curve (server->ks_group, &curve))
-    return R_TLS_ERROR_HANDSHAKE_FAILURE;
-  server->ks_peer_pub = r_tls_server_read_key_share (server, server->ks_group, curve);
+  server->ks_peer_pub = r_tls_server_read_key_share (server, server->ks_group);
   if (server->ks_peer_pub == NULL)
     return R_TLS_ERROR_HANDSHAKE_FAILURE;   /* still no usable share: no second HRR */
 
@@ -2167,7 +2166,7 @@ r_tls_server_sign_certificate_verify13 (RTLSServer * server,
 static RTLSError
 r_tls_server_write_flight13 (RTLSServer * server)
 {
-  ruint8 ecdhe[R_TLS_ECDHE_SECRET_MAX], th[R_TLS13_SECRET_MAX];
+  ruint8 ecdhe[R_TLS_KE_SECRET_MAX], th[R_TLS13_SECRET_MAX];
   ruint8 sig[512], finkey[R_TLS13_SECRET_MAX], vd[R_TLS13_SECRET_MAX];
   ruint8 body[4096];
   rsize ecdhelen = 0, siglen = sizeof (sig), bodylen = 0;
@@ -2192,7 +2191,7 @@ r_tls_server_write_flight13 (RTLSServer * server)
   }
 
   /* 1. ServerHello (plaintext); generate the server ephemeral first. */
-  if ((server->ecdhe_key = r_tls_ecdhe_keygen (server->ecdhe_curve, server->prng)) == NULL)
+  if ((server->ecdhe_key = r_tls_ke_keygen (server->ks_group, server->prng)) == NULL)
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
   if ((ret = r_tls_server_write_hello13 (server)) != R_TLS_ERROR_OK)
     return ret;
@@ -2200,7 +2199,7 @@ r_tls_server_write_flight13 (RTLSServer * server)
   /* 2. Handshake secrets, bound to Transcript-Hash(ClientHello..ServerHello). */
   if (!r_msg_digest_get_data (server->hshash, th, hlen, NULL))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
-  if (!r_tls_ecdhe_compute (server->ecdhe_key, server->ks_peer_pub,
+  if (!r_tls_ke_compute (server->ecdhe_key, server->ks_peer_pub,
         ecdhe, sizeof (ecdhe), &ecdhelen))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
   /* Resumption is psk_dhe_ke: the Early Secret comes from the ticket PSK

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -1769,10 +1769,11 @@ r_tls_server_nego_hello13 (RTLSServer * server)
       return R_TLS_ERROR_HANDSHAKE_FAILURE;
   }
 
-  /* CertificateVerify scheme follows the certificate key (both hash SHA-256). */
+  /* CertificateVerify scheme follows the certificate key: ECDSA binds the curve
+   * to its digest (secp256r1/384r1/521r1), RSA uses rsa_pss_rsae_sha256. */
   certalgo = r_crypto_key_get_algo (server->privkey);
   if (certalgo == R_CRYPTO_ALGO_ECDSA)
-    server->cv_scheme = R_TLS_SIGN_SCHEME_ECDSA_SECP256R1_SHA256;
+    server->cv_scheme = r_tls_sign_scheme_for_key (server->privkey);
   else if (certalgo == R_CRYPTO_ALGO_RSA)
     server->cv_scheme = R_TLS_SIGN_SCHEME_RSA_PSS_SHA256;
   else
@@ -2129,17 +2130,20 @@ static RTLSError
 r_tls_server_sign_certificate_verify13 (RTLSServer * server,
     const ruint8 * th, rsize hlen, ruint8 * sig, rsize * siglen)
 {
-  ruint8 tbs[R_TLS13_CERT_VERIFY_TBS_MAX], digest[R_TLS13_SECRET_MAX];
+  ruint8 tbs[R_TLS13_CERT_VERIFY_TBS_MAX], digest[64];  /* up to SHA-512 */
   rsize tbslen = 0, dlen;
+  RMsgDigestType mdtype;
   RMsgDigest * md;
   rboolean ok;
 
   if (!r_tls13_cert_verify_tbs (TRUE, th, hlen, tbs, sizeof (tbs), &tbslen))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
 
-  /* Both ecdsa_secp256r1_sha256 and rsa_pss_rsae_sha256 hash with SHA-256,
-   * independent of the cipher-suite hash. */
-  if ((md = r_msg_digest_new (R_MSG_DIGEST_TYPE_SHA256)) == NULL)
+  /* The digest is the negotiated scheme's (e.g. SHA-384 for
+   * ecdsa_secp384r1_sha384), independent of the cipher-suite hash. */
+  if (!r_tls_sign_scheme_to_md (server->cv_scheme, &mdtype))
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  if ((md = r_msg_digest_new (mdtype)) == NULL)
     return R_TLS_ERROR_OOM;
   dlen = r_msg_digest_size (md);
   ok = r_msg_digest_update (md, tbs, tbslen) &&
@@ -2150,7 +2154,7 @@ r_tls_server_sign_certificate_verify13 (RTLSServer * server,
 
   if (server->cv_scheme == R_TLS_SIGN_SCHEME_RSA_PSS_SHA256)
     r_rsa_priv_key_set_padding (server->privkey, R_RSA_PADDING_PKCS1_V21);
-  if (r_crypto_key_sign (server->privkey, server->prng, R_MSG_DIGEST_TYPE_SHA256,
+  if (r_crypto_key_sign (server->privkey, server->prng, mdtype,
         digest, dlen, sig, siglen) != R_CRYPTO_OK)
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
 

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -994,7 +994,7 @@ r_tls_server_write_key_exchange (RTLSServer * server)
   RBuffer * buf;
   RTLSError ret;
   RMemMapInfo info;
-  ruint8 point[65];                     /* SEC 1 uncompressed P-256; x25519 is 32 */
+  ruint8 point[R_TLS_ECDHE_POINT_MAX];  /* SEC 1 uncompressed, up to P-521 */
   ruint8 tbs[2 * R_TLS_HELLO_RANDOM_BYTES + 4 + sizeof (point)];
   ruint8 hash[64];
   ruint8 sig[512];
@@ -2163,7 +2163,7 @@ r_tls_server_sign_certificate_verify13 (RTLSServer * server,
 static RTLSError
 r_tls_server_write_flight13 (RTLSServer * server)
 {
-  ruint8 ecdhe[64], th[R_TLS13_SECRET_MAX];
+  ruint8 ecdhe[R_TLS_ECDHE_SECRET_MAX], th[R_TLS13_SECRET_MAX];
   ruint8 sig[512], finkey[R_TLS13_SECRET_MAX], vd[R_TLS13_SECRET_MAX];
   ruint8 body[4096];
   rsize ecdhelen = 0, siglen = sizeof (sig), bodylen = 0;
@@ -2758,7 +2758,7 @@ r_tls_server_parse_certificate_verify (RTLSServer * server, const RTLSParser * p
 
 static RTLSError
 r_tls_server_parse_client_key_exchange (RTLSServer * server,
-    const RTLSParser * parser, ruint8 pms[48], rsize * pmslen)
+    const RTLSParser * parser, ruint8 pms[R_TLS_ECDHE_SECRET_MAX], rsize * pmslen)
 {
   const ruint8 * encpms;
   rsize size;
@@ -2779,7 +2779,7 @@ r_tls_server_parse_client_key_exchange (RTLSServer * server,
      * zero secrets; the shared secret is the variable-length premaster. */
     if ((peer = r_tls_ecdhe_point_read (server->ecdhe_curve, point, pointlen)) == NULL)
       return R_TLS_ERROR_HANDSHAKE_FAILURE;
-    ok = r_tls_ecdhe_compute (server->ecdhe_key, peer, pms, 48, pmslen);
+    ok = r_tls_ecdhe_compute (server->ecdhe_key, peer, pms, R_TLS_ECDHE_SECRET_MAX, pmslen);
     r_crypto_key_unref (peer);
     return ok ? R_TLS_ERROR_OK : R_TLS_ERROR_HANDSHAKE_FAILURE;
   }
@@ -3355,7 +3355,7 @@ static RTLSError
 r_tls_server_state_key_exchange (RTLSServer * server, const RTLSParser * parser)
 {
   RTLSError err;
-  ruint8 pms[48];
+  ruint8 pms[R_TLS_ECDHE_SECRET_MAX];
   rsize pmslen = sizeof (pms);
 
   if ((err = r_tls_server_parse_client_key_exchange (server, parser, pms, &pmslen)) == R_TLS_ERROR_OK)

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -77,6 +77,56 @@ static const rchar testpkpem_ecdsa[] =
   "Np4My2vJp9DCvlHhpADjI99HT50XfWNpou8qVaNctGgG/xyWBf6us+KY\n"
   "-----END PRIVATE KEY-----\n";
 
+/* Self-signed P-384 / P-521 ECDSA test certificates + PKCS#8 keys, for the 1.3
+ * CertificateVerify schemes ecdsa_secp384r1_sha384 / ecdsa_secp521r1_sha512.
+ * Same generation constraints as testcertpem_ecdsa (small serial, pre-2050). */
+static const rchar testcertpem_ecdsa384[] =
+  "-----BEGIN CERTIFICATE-----\n"
+  "MIIBrzCCATWgAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDDA1ybGliLWVj\n"
+  "ZHNhMzg0MB4XDTI2MDcyNzIwNDgyMVoXDTQ4MDYyMTIwNDgyMVowGDEWMBQGA1UE\n"
+  "AwwNcmxpYi1lY2RzYTM4NDB2MBAGByqGSM49AgEGBSuBBAAiA2IABHfcO62ibiQU\n"
+  "glYrb6sPqvtMNBx9hQ8PaSN0tjtDT6j06PCMz723JL6M/fqXtFFfEp7fsc9l/qWt\n"
+  "ebpFUXmSGfae7V9gUcYUn0ymDmCMbhJtbhz04Yq1Yu94g4B1dYMaZaNTMFEwHQYD\n"
+  "VR0OBBYEFAXcoxN3AXnLfJVUpwLdMJkCvPfkMB8GA1UdIwQYMBaAFAXcoxN3AXnL\n"
+  "fJVUpwLdMJkCvPfkMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDaAAwZQIw\n"
+  "el4HTsofk/B7Cp/FJWXqivsbMBj7LFB3/Kom3vjmZ6OJll+utXhd7lElP4mhSq3e\n"
+  "AjEAxUsip5CG6drgL5x89Q9XcZz5hEg1UG9OZ0TnxvyKy2IqujOKcYu0KpqafmyD\n"
+  "fidy\n"
+  "-----END CERTIFICATE-----\n";
+
+static const rchar testpkpem_ecdsa384[] =
+  "-----BEGIN PRIVATE KEY-----\n"
+  "MIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDDCbWZwdlCAU6sPeKSD\n"
+  "BRf4heZXVNP6ly9a2A/wlmO6RErkq//ezyhEV3PgqJwAUtqhZANiAAR33Dutom4k\n"
+  "FIJWK2+rD6r7TDQcfYUPD2kjdLY7Q0+o9OjwjM+9tyS+jP36l7RRXxKe37HPZf6l\n"
+  "rXm6RVF5khn2nu1fYFHGFJ9Mpg5gjG4SbW4c9OGKtWLveIOAdXWDGmU=\n"
+  "-----END PRIVATE KEY-----\n";
+
+static const rchar testcertpem_ecdsa521[] =
+  "-----BEGIN CERTIFICATE-----\n"
+  "MIIB+TCCAVugAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDDA1ybGliLWVj\n"
+  "ZHNhNTIxMB4XDTI2MDcyNzIwNDgyMVoXDTQ4MDYyMTIwNDgyMVowGDEWMBQGA1UE\n"
+  "AwwNcmxpYi1lY2RzYTUyMTCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAXM0f8y9\n"
+  "YmTfGEsdGKWUljQ/BpOmgPsHtgrlPrsL5CmpL6JsEMZL1Td7g5tlwKfLh8bB3r8V\n"
+  "oS2Z7Rmbt1JFhsOCAIa5xsoVl42QpunyaIYMFi4TSara6eoZDJXQXV0Q2q9mY/Qk\n"
+  "erTFmxh4V8vRl2+BFnNDAQ15LglOnRFvVKNnfuY6o1MwUTAdBgNVHQ4EFgQUjgHe\n"
+  "cUiLJUWqs95CAU2QI7hnECswHwYDVR0jBBgwFoAUjgHecUiLJUWqs95CAU2QI7hn\n"
+  "ECswDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgOBiwAwgYcCQgHGr2XEchte\n"
+  "EwLZC2sD13k14Q59MbySYcBefHSm+Yw1VgM3eEgKyYP6ncLqJepTxhKiVCxTjNRS\n"
+  "1Pa08NMrrl1+jAJBJ/KZxMUz/jGseAq+OSN6cF6irVc5y/yQi06ZAviKikaqRcyx\n"
+  "s5z6FC1GXtKu3yjbdOk8pMJ/3XMmvIKC6iG54TI=\n"
+  "-----END CERTIFICATE-----\n";
+
+static const rchar testpkpem_ecdsa521[] =
+  "-----BEGIN PRIVATE KEY-----\n"
+  "MIHuAgEAMBAGByqGSM49AgEGBSuBBAAjBIHWMIHTAgEBBEIAgpoilaQNti83T+zw\n"
+  "0wJL9Y3m0WLkPAmG7bb3cFi26R1Q+XLIF2t/GKwirvWSAD+v7D5OzTMxKF434kLB\n"
+  "xpV5HSuhgYkDgYYABAFzNH/MvWJk3xhLHRillJY0PwaTpoD7B7YK5T67C+QpqS+i\n"
+  "bBDGS9U3e4ObZcCny4fGwd6/FaEtme0Zm7dSRYbDggCGucbKFZeNkKbp8miGDBYu\n"
+  "E0mq2unqGQyV0F1dENqvZmP0JHq0xZsYeFfL0ZdvgRZzQwENeS4JTp0Rb1SjZ37m\n"
+  "Og==\n"
+  "-----END PRIVATE KEY-----\n";
+
 RTEST_FIXTURE_STRUCT (rtlsclient)
 {
   RTLSServer * server;
@@ -541,6 +591,40 @@ RTEST_F (rtlsclient, tls13_loopback_ecdsa, RTEST_FAST)
 
   r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (testcertpem_ecdsa, -1)), !=, NULL);
   r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem_ecdsa, -1, NULL, 0)), !=, NULL);
+  r_assert_cmpint (r_tls_server_set_cert (fixture->server, cert, pk), ==, R_TLS_ERROR_OK);
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+
+  r_test_tls13_loopback (fixture);
+}
+RTEST_END;
+
+/* P-384 / P-521 ECDSA server certificates: the 1.3 CertificateVerify uses
+ * ecdsa_secp384r1_sha384 / ecdsa_secp521r1_sha512, so the server signs and the
+ * client verifies with SHA-384 / SHA-512 -- the handshake completing exercises
+ * the curve-matched scheme selection and digest on both sides. */
+RTEST_F (rtlsclient, tls13_loopback_ecdsa_secp384r1, RTEST_FAST)
+{
+  RCryptoCert * cert;
+  RCryptoKey * pk;
+
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (testcertpem_ecdsa384, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem_ecdsa384, -1, NULL, 0)), !=, NULL);
+  r_assert_cmpint (r_tls_server_set_cert (fixture->server, cert, pk), ==, R_TLS_ERROR_OK);
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+
+  r_test_tls13_loopback (fixture);
+}
+RTEST_END;
+
+RTEST_F (rtlsclient, tls13_loopback_ecdsa_secp521r1, RTEST_FAST)
+{
+  RCryptoCert * cert;
+  RCryptoKey * pk;
+
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (testcertpem_ecdsa521, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem_ecdsa521, -1, NULL, 0)), !=, NULL);
   r_assert_cmpint (r_tls_server_set_cert (fixture->server, cert, pk), ==, R_TLS_ERROR_OK);
   r_crypto_key_unref (pk);
   r_crypto_cert_unref (cert);

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -715,6 +715,35 @@ RTEST_F (rtlsclient, tls13_loopback_hrr, RTEST_FAST)
 }
 RTEST_END;
 
+/* The client offers a key_share for x25519 but lists the other supported groups
+ * too; pinning the server to each in turn forces a HelloRetryRequest and drives
+ * the client's retry with that group's key_share. The handshake completing
+ * exercises keygen / point / ECDH shared-secret for the group end to end -- the
+ * secp521r1 case in particular covers the 66-byte secret / 133-byte point. */
+RTEST_F (rtlsclient, tls13_loopback_group_secp384r1, RTEST_FAST)
+{
+  r_assert_cmpint (r_tls_server_set_key_share_group (fixture->server,
+        R_TLS_SUPPORTED_GROUP_SECP384R1), ==, R_TLS_ERROR_OK);
+  r_test_tls13_loopback (fixture);
+}
+RTEST_END;
+
+RTEST_F (rtlsclient, tls13_loopback_group_secp521r1, RTEST_FAST)
+{
+  r_assert_cmpint (r_tls_server_set_key_share_group (fixture->server,
+        R_TLS_SUPPORTED_GROUP_SECP521R1), ==, R_TLS_ERROR_OK);
+  r_test_tls13_loopback (fixture);
+}
+RTEST_END;
+
+RTEST_F (rtlsclient, tls13_loopback_group_x448, RTEST_FAST)
+{
+  r_assert_cmpint (r_tls_server_set_key_share_group (fixture->server,
+        R_TLS_SUPPORTED_GROUP_X448), ==, R_TLS_ERROR_OK);
+  r_test_tls13_loopback (fixture);
+}
+RTEST_END;
+
 /* Drive CH1 -> HelloRetryRequest with a server that requires secp256r1 while
  * the client first offers x25519. Returns the (still-owned) HRR record and
  * leaves the client having consumed nothing yet. */

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -828,6 +828,27 @@ RTEST_F (rtlsclient, tls13_loopback_group_x448, RTEST_FAST)
 }
 RTEST_END;
 
+/* Finite-field (ffdhe, RFC 7919) key exchange: pinning the server to an ffdhe
+ * group forces a HelloRetryRequest and the client retries with an ffdhe
+ * key_share. The handshake completing exercises the DH keygen / public-value
+ * encoding / shared secret. ffdhe8192 (the 1024-byte value / secret) is in the
+ * heavy tier because its modular exponentiations are expensive. */
+RTEST_F (rtlsclient, tls13_loopback_group_ffdhe2048, RTEST_FAST)
+{
+  r_assert_cmpint (r_tls_server_set_key_share_group (fixture->server,
+        R_TLS_SUPPORTED_GROUP_FFDHE2048), ==, R_TLS_ERROR_OK);
+  r_test_tls13_loopback (fixture);
+}
+RTEST_END;
+
+HEAVY_RTEST_F (rtlsclient, tls13_loopback_group_ffdhe8192, RTEST_SLOW)
+{
+  r_assert_cmpint (r_tls_server_set_key_share_group (fixture->server,
+        R_TLS_SUPPORTED_GROUP_FFDHE8192), ==, R_TLS_ERROR_OK);
+  r_test_tls13_loopback (fixture);
+}
+RTEST_END;
+
 /* Drive CH1 -> HelloRetryRequest with a server that requires secp256r1 while
  * the client first offers x25519. Returns the (still-owned) HRR record and
  * leaves the client having consumed nothing yet. */


### PR DESCRIPTION
Broadens TLS 1.3 key-exchange and signature-scheme support (#386). The crypto
primitives already shipped; this is TLS-layer wiring plus the buffer sizing the
larger groups demand.

## Named groups
Adds secp384r1, secp521r1 and x448 as (EC)DHE groups, and ffdhe2048/3072/4096/
6144/8192 as finite-field key_share groups. The 1.3 key_share sites go through
a dispatch layer (`r_tls_ke_*`) keyed on the supported_group: EC groups keep
the existing ecdhe path, ffdhe groups use the RFC 7919 finite-field DH
primitives. key_share value / shared-secret buffers on the 1.3 path are sized
to the largest group (ffdhe8192: 1024-byte value and secret), and the key_share
length is a uint16. The ffdhe groups rank below the EC groups, so only a peer
that selects ffdhe drives the finite-field path; the `<=1.2` ECDHE path is
untouched apart from P-521-safe buffer sizing.

## Signature schemes
Generalises the CertificateVerify handling that was hardcoded to SHA-256:
ECDSA now binds the certificate's curve to its digest (secp256r1/384r1/521r1 ->
SHA-256/384/512) and RSA-PSS is offered/accepted at SHA-256/384/512. The server
signs and the client verifies with the negotiated scheme's digest; the client
offers the full set and accepts every ECDSA / RSA-PSS 1.3 CertificateVerify
scheme (PKCS#1 v1.5 stays rejected).

## Tests
1.3 HRR-driven handshakes to each new group (secp384r1, secp521r1, x448,
ffdhe2048; ffdhe8192 in the heavy tier -- its modexps are expensive), and 1.3
handshakes with P-384 / P-521 ECDSA server certificates verifying the
CertificateVerify under SHA-384 / SHA-512.

Built clean under `-Werror` across the linux/asan/ubsan/mingw tiers; the TLS
suites and full linux suite pass.

Closes #386