### PR TITLE
net/tls: Ed25519 TLS 1.3 signature schemes

### DIFF
--- a/include/rlib/format/roid.h
+++ b/include/rlib/format/roid.h
@@ -343,6 +343,13 @@ R_API rboolean r_asn1_oid_has_dot_prefix (const ruint32 * oid, rsize oidlen,
 #define R_ECDSA_OID_SHA384                      R_X9_62_OID_SIG"\x03\x03"
 #define R_ECDSA_OID_SHA512                      R_X9_62_OID_SIG"\x03\x04"
 
+/* RFC 8410 Edwards-curve algorithm identifiers (1.3.101.{110..113}). */
+#define R_RFC8410_OID                           R_ASN1_OID_ISO_ID_ORG"\x65"
+#define R_RFC8410_OID_X25519                    R_RFC8410_OID"\x6e"
+#define R_RFC8410_OID_X448                      R_RFC8410_OID"\x6f"
+#define R_RFC8410_OID_ED25519                   R_RFC8410_OID"\x70"
+#define R_RFC8410_OID_ED448                     R_RFC8410_OID"\x71"
+
 /** @} */
 
 R_END_DECLS

--- a/rlib/crypto/rcert.c
+++ b/rlib/crypto/rcert.c
@@ -26,6 +26,7 @@ r_crypto_cert_destroy (RCryptoCert * cert)
     r_crypto_key_unref (cert->pk);
   if (cert->certdata != NULL)
     r_buffer_unref (cert->certdata);
+  r_free (cert->tbs);
   r_free (cert->sign);
 }
 

--- a/rlib/crypto/rcrypto-private.h
+++ b/rlib/crypto/rcrypto-private.h
@@ -73,6 +73,8 @@ struct RCryptoCert {
 
   RMsgDigestType signalgo;
   ruint8 signhash[64];
+  ruint8 * tbs;           /* raw TBSCertificate; kept only for PureEdDSA (no pre-hash) */
+  rsize tbssize;
   ruint8 * sign;
   rsize signbits;
 

--- a/rlib/crypto/rkey.c
+++ b/rlib/crypto/rkey.c
@@ -23,6 +23,7 @@
 #include <rlib/crypto/rdsa.h>
 #include <rlib/crypto/recc.h>
 #include <rlib/crypto/recurve.h>
+#include <rlib/crypto/red25519.h>
 #include <rlib/crypto/rrsa.h>
 
 #include <rlib/format/roid.h>
@@ -361,6 +362,14 @@ r_crypto_key_from_asn1_public_key (RAsn1BinDecoder * dec, RAsn1BinTLV * tlv)
         } else {
           r_asn1_bin_decoder_out (dec, tlv);
         }
+      } else if (r_asn1_oid_bin_equals (tlv->value, tlv->len, R_RFC8410_OID_ED25519)) {
+        /* RFC 8410: the AlgorithmIdentifier has no parameters, so the
+         * subjectPublicKey BIT STRING is the OID's next sibling -- one octet
+         * of unused-bits padding then the 32-byte public key. */
+        r_asn1_bin_decoder_out (dec, tlv);
+        if (R_ASN1_BIN_TLV_ID_IS_TAG (tlv, R_ASN1_ID_BIT_STRING) &&
+            tlv->len == R_ED25519_PUB_KEY_SIZE + 1 && tlv->value[0] == 0)
+          ret = r_ed25519_pub_key_new (tlv->value + 1, tlv->len - 1);
       } else {
         r_asn1_bin_decoder_out (dec, tlv);
       }
@@ -450,6 +459,16 @@ r_crypto_key_from_asn1_private_key (RAsn1BinDecoder * dec, RAsn1BinTLV * tlv)
             ret = r_ecc_priv_key_new_from_asn1 (dec, tlv, curve, is_ecdh);
             r_asn1_bin_decoder_out (dec, tlv);
           }
+        }
+      } else if (r_asn1_oid_bin_equals (tlv->value, tlv->len, R_RFC8410_OID_ED25519)) {
+        /* RFC 8410 / RFC 5958: the privateKey OCTET STRING wraps a nested
+         * OCTET STRING holding the 32-byte seed. */
+        if (r_asn1_bin_decoder_out (dec, tlv) == R_ASN1_DECODER_OK &&
+            r_asn1_bin_decoder_into (dec, tlv) == R_ASN1_DECODER_OK) {
+          if (R_ASN1_BIN_TLV_ID_IS_TAG (tlv, R_ASN1_ID_OCTET_STRING) &&
+              tlv->len == R_ED25519_SEED_SIZE)
+            ret = r_ed25519_priv_key_new (tlv->value, tlv->len);
+          r_asn1_bin_decoder_out (dec, tlv);
         }
       }
     }

--- a/rlib/crypto/rx509.c
+++ b/rlib/crypto/rx509.c
@@ -617,6 +617,7 @@ r_crypto_x509_cert_init (RCryptoX509Cert * cert, RAsn1BinDecoder * dec)
     const ruint8 * tbs = tlv.start;
     rsize tbssize = RPOINTER_TO_SIZE (tlv.value - tlv.start) + tlv.len;
     RMsgDigest * md;
+    rboolean is_eddsa;
 
     /* TBSCertificate */
     if (r_asn1_bin_decoder_into (dec, &tlv) == R_ASN1_DECODER_OK) {
@@ -694,13 +695,23 @@ r_crypto_x509_cert_init (RCryptoX509Cert * cert, RAsn1BinDecoder * dec)
     } else goto beach;
 
     /* signatureAlgorithm */
-    if (r_asn1_bin_decoder_into (dec, &tlv) != R_ASN1_DECODER_OK ||
-        r_asn1_bin_tlv_parse_oid_to_msg_digest_type (&tlv, &cert->cert.signalgo) != R_ASN1_DECODER_OK ||
+    if (r_asn1_bin_decoder_into (dec, &tlv) != R_ASN1_DECODER_OK)
+      goto beach;
+    /* PureEdDSA (Ed25519) signs the TBSCertificate directly; there is no
+     * digest OID and no pre-hash, so keep a copy of the raw TBS for
+     * verification instead of the signhash the hashed schemes precompute. */
+    is_eddsa = r_asn1_oid_bin_equals (tlv.value, tlv.len, R_RFC8410_OID_ED25519);
+    if (r_asn1_bin_tlv_parse_oid_to_msg_digest_type (&tlv, &cert->cert.signalgo) != R_ASN1_DECODER_OK ||
         r_asn1_bin_decoder_out (dec, &tlv) != R_ASN1_DECODER_OK) {
       goto beach;
     }
 
-    if ((md = r_msg_digest_new (cert->cert.signalgo)) != NULL) {
+    if (is_eddsa) {
+      cert->cert.signalgo = R_MSG_DIGEST_TYPE_NONE;
+      if ((cert->cert.tbs = r_memdup (tbs, tbssize)) == NULL)
+        goto beach;
+      cert->cert.tbssize = tbssize;
+    } else if ((md = r_msg_digest_new (cert->cert.signalgo)) != NULL) {
       if (!r_msg_digest_update (md, tbs, tbssize) ||
           !r_msg_digest_get_data (md, cert->cert.signhash, sizeof (cert->cert.signhash), NULL)) {
         r_msg_digest_free (md);
@@ -1804,6 +1815,14 @@ RCryptoResult
 r_crypto_x509_cert_verify_signature (const RCryptoCert * cert, const RCryptoCert * parent)
 {
   if (R_UNLIKELY (parent->pk == NULL)) return R_CRYPTO_NOT_AVAILABLE;
+
+  /* PureEdDSA verifies over the raw TBSCertificate (kept at parse time),
+   * not a pre-hash; signalgo is NONE for it. */
+  if (cert->signalgo == R_MSG_DIGEST_TYPE_NONE) {
+    if (R_UNLIKELY (cert->tbs == NULL)) return R_CRYPTO_NOT_AVAILABLE;
+    return r_crypto_key_verify (parent->pk, R_MSG_DIGEST_TYPE_NONE,
+        cert->tbs, cert->tbssize, cert->sign, cert->signbits / 8);
+  }
 
   return r_crypto_key_verify (parent->pk, cert->signalgo, cert->signhash,
       r_msg_digest_type_size (cert->signalgo), cert->sign, cert->signbits / 8);

--- a/rlib/net/proto/rtls.c
+++ b/rlib/net/proto/rtls.c
@@ -61,6 +61,10 @@ r_tls_sign_scheme_to_md (RTLSSignatureScheme scheme, RMsgDigestType * md)
     case R_TLS_SIGN_SCHEME_RSA_PSS_SHA512:
       *md = R_MSG_DIGEST_TYPE_SHA512;
       return TRUE;
+    case R_TLS_SIGN_SCHEME_ED25519:
+      /* PureEdDSA signs the content directly (RFC 8446 4.2.3); no pre-hash. */
+      *md = R_MSG_DIGEST_TYPE_NONE;
+      return TRUE;
     default:
       return FALSE;
   }
@@ -69,15 +73,19 @@ r_tls_sign_scheme_to_md (RTLSSignatureScheme scheme, RMsgDigestType * md)
 RTLSSignatureScheme
 r_tls_sign_scheme_for_key (const RCryptoKey * key)
 {
-  if (r_crypto_key_get_algo (key) == R_CRYPTO_ALGO_ECDSA) {
-    /* The ECDSA schemes bind the curve to a digest (RFC 8446 4.2.3). */
-    switch (r_ecc_key_get_curve (key)) {
-      case R_ECURVE_ID_SECP384R1: return R_TLS_SIGN_SCHEME_ECDSA_SECP384R1_SHA384;
-      case R_ECURVE_ID_SECP521R1: return R_TLS_SIGN_SCHEME_ECDSA_SECP521R1_SHA512;
-      default:                    return R_TLS_SIGN_SCHEME_ECDSA_SECP256R1_SHA256;
-    }
+  switch (r_crypto_key_get_algo (key)) {
+    case R_CRYPTO_ALGO_ECDSA:
+      /* The ECDSA schemes bind the curve to a digest (RFC 8446 4.2.3). */
+      switch (r_ecc_key_get_curve (key)) {
+        case R_ECURVE_ID_SECP384R1: return R_TLS_SIGN_SCHEME_ECDSA_SECP384R1_SHA384;
+        case R_ECURVE_ID_SECP521R1: return R_TLS_SIGN_SCHEME_ECDSA_SECP521R1_SHA512;
+        default:                    return R_TLS_SIGN_SCHEME_ECDSA_SECP256R1_SHA256;
+      }
+    case R_CRYPTO_ALGO_ED25519:
+      return R_TLS_SIGN_SCHEME_ED25519;
+    default:
+      return R_TLS_SIGN_SCHEME_RSA_PKCS1_SHA256;
   }
-  return R_TLS_SIGN_SCHEME_RSA_PKCS1_SHA256;
 }
 
 rboolean

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -739,9 +739,9 @@ r_tls_client_default_cipher_suites (rpointer ctx, RTLSVersion ver,
   return TRUE;
 }
 
-/* signature_algorithms for 1.3: offer the ECDSA (secp256r1/384r1/521r1) and
- * RSA-PSS (SHA-256/384/512) schemes valid for a 1.3 CertificateVerify, plus
- * rsa_pkcs1_sha256 for certificate signatures. */
+/* signature_algorithms for 1.3: offer the ECDSA (secp256r1/384r1/521r1),
+ * ed25519 and RSA-PSS (SHA-256/384/512) schemes valid for a 1.3
+ * CertificateVerify, plus rsa_pkcs1_sha256 for certificate signatures. */
 static ruint16
 r_tls_client_write_hs_ext_signature_algorithms13 (ruint8 * ptr)
 {
@@ -749,6 +749,7 @@ r_tls_client_write_hs_ext_signature_algorithms13 (ruint8 * ptr)
     R_TLS_SIGN_SCHEME_ECDSA_SECP256R1_SHA256,
     R_TLS_SIGN_SCHEME_ECDSA_SECP384R1_SHA384,
     R_TLS_SIGN_SCHEME_ECDSA_SECP521R1_SHA512,
+    R_TLS_SIGN_SCHEME_ED25519,
     R_TLS_SIGN_SCHEME_RSA_PSS_SHA256,
     R_TLS_SIGN_SCHEME_RSA_PSS_SHA384,
     R_TLS_SIGN_SCHEME_RSA_PSS_SHA512,
@@ -1582,12 +1583,13 @@ r_tls_client_verify_certificate_verify13 (RTLSClient * client,
   RTLSError err;
 
   /* The schemes valid for a 1.3 CertificateVerify that we can verify: ECDSA
-   * (secp256r1/384r1/521r1) and RSA-PSS (SHA-256/384/512). PKCS#1 v1.5 is
-   * forbidden in 1.3; other schemes are rejected. */
+   * (secp256r1/384r1/521r1), RSA-PSS (SHA-256/384/512) and ed25519. PKCS#1
+   * v1.5 is forbidden in 1.3; other schemes are rejected. */
   switch (scheme) {
     case R_TLS_SIGN_SCHEME_ECDSA_SECP256R1_SHA256:
     case R_TLS_SIGN_SCHEME_ECDSA_SECP384R1_SHA384:
     case R_TLS_SIGN_SCHEME_ECDSA_SECP521R1_SHA512:
+    case R_TLS_SIGN_SCHEME_ED25519:
       pss = FALSE;
       break;
     case R_TLS_SIGN_SCHEME_RSA_PSS_SHA256:
@@ -1606,17 +1608,31 @@ r_tls_client_verify_certificate_verify13 (RTLSClient * client,
       !r_tls13_cert_verify_tbs (TRUE, th, hlen, tbs, sizeof (tbs), &tbslen))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
 
-  if ((md = r_msg_digest_new (mdtype)) == NULL)
+  if ((pub = r_crypto_cert_get_public_key (client->peer_cert)) == NULL)
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
+  if (mdtype == R_MSG_DIGEST_TYPE_NONE) {
+    /* PureEdDSA verifies over the content directly, without a pre-hash. */
+    err = (r_crypto_key_verify (pub, mdtype, tbs, tbslen,
+              sig, sigsize) == R_CRYPTO_OK) ?
+        R_TLS_ERROR_OK : R_TLS_ERROR_HS_VERIFICATION_FAILED;
+    r_crypto_key_unref (pub);
+    return err;
+  }
+
+  if ((md = r_msg_digest_new (mdtype)) == NULL) {
+    r_crypto_key_unref (pub);
     return R_TLS_ERROR_OOM;
+  }
   dlen = r_msg_digest_size (md);
   ok = r_msg_digest_update (md, tbs, tbslen) &&
        r_msg_digest_get_data (md, digest, dlen, NULL);
   r_msg_digest_free (md);
-  if (!ok)
+  if (!ok) {
+    r_crypto_key_unref (pub);
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  }
 
-  if ((pub = r_crypto_cert_get_public_key (client->peer_cert)) == NULL)
-    return R_TLS_ERROR_HANDSHAKE_FAILURE;
   if (pss)
     r_rsa_pub_key_set_padding (pub, R_RSA_PADDING_PKCS1_V21);
   err = (r_crypto_key_verify (pub, mdtype, digest, dlen,

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -1770,9 +1770,10 @@ r_tls_server_nego_hello13 (RTLSServer * server)
   }
 
   /* CertificateVerify scheme follows the certificate key: ECDSA binds the curve
-   * to its digest (secp256r1/384r1/521r1), RSA uses rsa_pss_rsae_sha256. */
+   * to its digest (secp256r1/384r1/521r1), ed25519 is PureEdDSA, RSA uses
+   * rsa_pss_rsae_sha256. */
   certalgo = r_crypto_key_get_algo (server->privkey);
-  if (certalgo == R_CRYPTO_ALGO_ECDSA)
+  if (certalgo == R_CRYPTO_ALGO_ECDSA || certalgo == R_CRYPTO_ALGO_ED25519)
     server->cv_scheme = r_tls_sign_scheme_for_key (server->privkey);
   else if (certalgo == R_CRYPTO_ALGO_RSA)
     server->cv_scheme = R_TLS_SIGN_SCHEME_RSA_PSS_SHA256;
@@ -2142,6 +2143,15 @@ r_tls_server_sign_certificate_verify13 (RTLSServer * server,
    * ecdsa_secp384r1_sha384), independent of the cipher-suite hash. */
   if (!r_tls_sign_scheme_to_md (server->cv_scheme, &mdtype))
     return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
+  if (mdtype == R_MSG_DIGEST_TYPE_NONE) {
+    /* PureEdDSA signs the content directly, without a pre-hash. */
+    if (r_crypto_key_sign (server->privkey, server->prng, mdtype,
+          tbs, tbslen, sig, siglen) != R_CRYPTO_OK)
+      return R_TLS_ERROR_HANDSHAKE_FAILURE;
+    return R_TLS_ERROR_OK;
+  }
+
   if ((md = r_msg_digest_new (mdtype)) == NULL)
     return R_TLS_ERROR_OOM;
   dlen = r_msg_digest_size (md);

--- a/test/rcryptocert.c
+++ b/test/rcryptocert.c
@@ -804,6 +804,37 @@ RTEST (rcryptocert, large_serial_number, RTEST_FAST)
 }
 RTEST_END;
 
+/* A self-signed Ed25519 certificate (RFC 8410): the subjectPublicKeyInfo and
+ * the signatureAlgorithm are both ed25519. PureEdDSA signs the TBSCertificate
+ * directly, so verify_signature checks the raw content rather than a pre-hash. */
+RTEST (rcryptocert, self_signed_ed25519, RTEST_FAST)
+{
+  static const rchar pem[] =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIBLzCB4qADAgECAgEBMAUGAytlcDAXMRUwEwYDVQQDDAxybGliLWVkMjU1MTkw\n"
+    "HhcNMjYwNzI3MjIwNzU4WhcNNDgwNjIxMjIwNzU4WjAXMRUwEwYDVQQDDAxybGli\n"
+    "LWVkMjU1MTkwKjAFBgMrZXADIQCraKuX/GZ695ZdM5IWppcYyHKCHa0bsPum1mxl\n"
+    "7Su9C6NTMFEwHQYDVR0OBBYEFEejUEmkmH4KhOFQbwqykULLE34rMB8GA1UdIwQY\n"
+    "MBaAFEejUEmkmH4KhOFQbwqykULLE34rMA8GA1UdEwEB/wQFMAMBAf8wBQYDK2Vw\n"
+    "A0EA+pW3yQXXbirkFdrSS/h4ks261980uyvLB38wOrxsg8y9C2EljrtAcTWOLFQH\n"
+    "2Fvt0wDLNP+pQlXYPoqsZL3vDw==\n"
+    "-----END CERTIFICATE-----\n";
+  RCryptoCert * cert;
+  RCryptoKey * pk;
+
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (pem, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_crypto_cert_get_public_key (cert)), !=, NULL);
+  r_assert_cmpint (r_crypto_key_get_algo (pk), ==, R_CRYPTO_ALGO_ED25519);
+  r_crypto_key_unref (pk);
+
+  r_assert (r_crypto_x509_cert_is_self_issued (cert));
+  r_assert (r_crypto_x509_cert_is_self_signed (cert));
+  r_assert_cmpuint (r_crypto_x509_cert_verify_signature (cert, cert), ==, R_CRYPTO_OK);
+
+  r_crypto_cert_unref (cert);
+}
+RTEST_END;
+
 /* r_crypto_x509_cert_verify_host: RFC 6125 SAN matching (DNS + IP, wildcard),
  * exercised directly on the certificate. */
 RTEST (rcryptocert, x509_verify_host_dns, RTEST_FAST)

--- a/test/rcryptopem.c
+++ b/test/rcryptopem.c
@@ -1043,6 +1043,75 @@ RTEST (rcryptopem, ec_p256_pkcs8_private_key, RTEST_FAST)
 }
 RTEST_END;
 
+static const rchar pem_ed25519_pkcs8[] =
+  "-----BEGIN PRIVATE KEY-----\n"
+  "MC4CAQAwBQYDK2VwBCIEIHt7K2fM0GArAkMamRMg/Y18t/UCIUwZJdaW4QqWSIOY\n"
+  "-----END PRIVATE KEY-----\n";
+static const rchar pem_ed25519_spki[] =
+  "-----BEGIN PUBLIC KEY-----\n"
+  "MCowBQYDK2VwAyEAgjHFjqoJ7PWTP+zwNxlCxaphvg9bJy232B2czSre8tY=\n"
+  "-----END PUBLIC KEY-----\n";
+static const ruint8 ed25519_pub[] = {
+  0x82, 0x31, 0xc5, 0x8e, 0xaa, 0x09, 0xec, 0xf5, 0x93, 0x3f, 0xec, 0xf0,
+  0x37, 0x19, 0x42, 0xc5, 0xaa, 0x61, 0xbe, 0x0f, 0x5b, 0x27, 0x2d, 0xb7,
+  0xd8, 0x1d, 0x9c, 0xcd, 0x2a, 0xde, 0xf2, 0xd6
+};
+
+RTEST (rcryptopem, ed25519_pkcs8_private_key, RTEST_FAST)
+{
+  RPemParser * parser;
+  RPemBlock * block;
+  RCryptoKey * key;
+  const ruint8 * pub = NULL;
+  rsize pubsize = 0;
+
+  r_assert_cmpptr (
+      (parser = r_pem_parser_new (pem_ed25519_pkcs8, sizeof (pem_ed25519_pkcs8))),
+      !=, NULL);
+  r_assert_cmpptr ((block = r_pem_parser_next_block (parser)), !=, NULL);
+
+  r_assert_cmpptr ((key = r_pem_block_get_key (block, NULL, 0)), !=, NULL);
+  r_assert_cmpint (r_crypto_key_get_type (key), ==, R_CRYPTO_PRIVATE_KEY);
+  r_assert_cmpint (r_crypto_key_get_algo (key), ==, R_CRYPTO_ALGO_ED25519);
+
+  /* The seed derives the public key -- check it matches the known pair. */
+  r_assert (r_ed25519_key_get_pub (key, &pub, &pubsize));
+  r_assert_cmpuint (pubsize, ==, sizeof (ed25519_pub));
+  r_assert_cmpmem (pub, ==, ed25519_pub, pubsize);
+
+  r_crypto_key_unref (key);
+  r_pem_block_unref (block);
+  r_pem_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rcryptopem, ed25519_spki_public_key, RTEST_FAST)
+{
+  RPemParser * parser;
+  RPemBlock * block;
+  RCryptoKey * key;
+  const ruint8 * pub = NULL;
+  rsize pubsize = 0;
+
+  r_assert_cmpptr (
+      (parser = r_pem_parser_new (pem_ed25519_spki, sizeof (pem_ed25519_spki))),
+      !=, NULL);
+  r_assert_cmpptr ((block = r_pem_parser_next_block (parser)), !=, NULL);
+
+  r_assert_cmpptr ((key = r_pem_block_get_key (block, NULL, 0)), !=, NULL);
+  r_assert_cmpint (r_crypto_key_get_type (key), ==, R_CRYPTO_PUBLIC_KEY);
+  r_assert_cmpint (r_crypto_key_get_algo (key), ==, R_CRYPTO_ALGO_ED25519);
+
+  r_assert (r_ed25519_key_get_pub (key, &pub, &pubsize));
+  r_assert_cmpuint (pubsize, ==, sizeof (ed25519_pub));
+  r_assert_cmpmem (pub, ==, ed25519_pub, pubsize);
+
+  r_crypto_key_unref (key);
+  r_pem_block_unref (block);
+  r_pem_parser_unref (parser);
+}
+RTEST_END;
+
 /* Round-trip the given key through r_pem_write_private_key_dup +
  * r_pem_parser_new, returning the decoded key. Caller owns it. */
 static RCryptoKey *

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -127,6 +127,25 @@ static const rchar testpkpem_ecdsa521[] =
   "Og==\n"
   "-----END PRIVATE KEY-----\n";
 
+/* Self-signed Ed25519 certificate + matching PKCS#8 key (CN=rlib-ed25519), for
+ * the 1.3 CertificateVerify ed25519 scheme. Same generation constraints as
+ * testcertpem_ecdsa (small serial, pre-2050). */
+static const rchar testcertpem_ed25519[] =
+  "-----BEGIN CERTIFICATE-----\n"
+  "MIIBLzCB4qADAgECAgEBMAUGAytlcDAXMRUwEwYDVQQDDAxybGliLWVkMjU1MTkw\n"
+  "HhcNMjYwNzI3MjIwNzU4WhcNNDgwNjIxMjIwNzU4WjAXMRUwEwYDVQQDDAxybGli\n"
+  "LWVkMjU1MTkwKjAFBgMrZXADIQCraKuX/GZ695ZdM5IWppcYyHKCHa0bsPum1mxl\n"
+  "7Su9C6NTMFEwHQYDVR0OBBYEFEejUEmkmH4KhOFQbwqykULLE34rMB8GA1UdIwQY\n"
+  "MBaAFEejUEmkmH4KhOFQbwqykULLE34rMA8GA1UdEwEB/wQFMAMBAf8wBQYDK2Vw\n"
+  "A0EA+pW3yQXXbirkFdrSS/h4ks261980uyvLB38wOrxsg8y9C2EljrtAcTWOLFQH\n"
+  "2Fvt0wDLNP+pQlXYPoqsZL3vDw==\n"
+  "-----END CERTIFICATE-----\n";
+
+static const rchar testpkpem_ed25519[] =
+  "-----BEGIN PRIVATE KEY-----\n"
+  "MC4CAQAwBQYDK2VwBCIEIJKdC2hLiSupxcBfuOHOJo21Xs4uo1DHngILAzCzFb3D\n"
+  "-----END PRIVATE KEY-----\n";
+
 RTEST_FIXTURE_STRUCT (rtlsclient)
 {
   RTLSServer * server;
@@ -625,6 +644,24 @@ RTEST_F (rtlsclient, tls13_loopback_ecdsa_secp521r1, RTEST_FAST)
 
   r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (testcertpem_ecdsa521, -1)), !=, NULL);
   r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem_ecdsa521, -1, NULL, 0)), !=, NULL);
+  r_assert_cmpint (r_tls_server_set_cert (fixture->server, cert, pk), ==, R_TLS_ERROR_OK);
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+
+  r_test_tls13_loopback (fixture);
+}
+RTEST_END;
+
+/* Ed25519 server certificate: the 1.3 CertificateVerify uses the ed25519 scheme,
+ * so the server signs and the client verifies over the content directly (no
+ * pre-hash). The handshake completing exercises the PureEdDSA sign/verify path. */
+RTEST_F (rtlsclient, tls13_loopback_ed25519, RTEST_FAST)
+{
+  RCryptoCert * cert;
+  RCryptoKey * pk;
+
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (testcertpem_ed25519, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem_ed25519, -1, NULL, 0)), !=, NULL);
   r_assert_cmpint (r_tls_server_set_cert (fixture->server, cert, pk), ==, R_TLS_ERROR_OK);
   r_crypto_key_unref (pk);
   r_crypto_cert_unref (cert);


### PR DESCRIPTION
Adds Ed25519 support to the TLS 1.3 CertificateVerify path (sign on the server, verify and offer on the client), plus the certificate/key plumbing it depends on. Ed448 is out of scope — the EdDSA primitives for it don't exist yet.

## Layers
- **`crypto/rkey`** — RFC 8410 key parsing. The ASN.1 key dispatch knew only RSA/DH/DSA/EC OIDs; add the `1.3.101.112` OID and decode Ed25519 from both a SubjectPublicKeyInfo `BIT STRING` and a PKCS#8 nested `OCTET STRING` seed.
- **`crypto/x509`** — verify Ed25519 (PureEdDSA) certificate signatures. An Ed25519-signed certificate previously failed to parse because the parser tried to pre-hash the TBSCertificate under a digest the algorithm doesn't have. PureEdDSA signs the content directly, so the raw TBSCertificate is retained and verified over. Gated on the explicit ed25519 OID, so genuinely unknown algorithms still fail to load as before.
- **`net/tls`** — wire ed25519 into the 1.3 signature-scheme mapping (`R_MSG_DIGEST_TYPE_NONE`, no pre-hash), server scheme selection and signing, and the client verify allowlist and `signature_algorithms` offer.

## Tests
- Ed25519 SPKI + PKCS#8 key parsing round-trips against a known pair.
- A self-signed Ed25519 certificate loads and self-verifies its signature.
- A 1.3 loopback handshake completes with a self-signed Ed25519 server certificate.

Full suite passes; the new code is warning-clean and leak-free under the ASan tier.

Closes #391