### PR TITLE
net/tls: Ed448 TLS 1.3 signature schemes

### DIFF
--- a/rlib/crypto/rkey.c
+++ b/rlib/crypto/rkey.c
@@ -24,6 +24,7 @@
 #include <rlib/crypto/recc.h>
 #include <rlib/crypto/recurve.h>
 #include <rlib/crypto/red25519.h>
+#include <rlib/crypto/red448.h>
 #include <rlib/crypto/rrsa.h>
 
 #include <rlib/format/roid.h>
@@ -370,6 +371,14 @@ r_crypto_key_from_asn1_public_key (RAsn1BinDecoder * dec, RAsn1BinTLV * tlv)
         if (R_ASN1_BIN_TLV_ID_IS_TAG (tlv, R_ASN1_ID_BIT_STRING) &&
             tlv->len == R_ED25519_PUB_KEY_SIZE + 1 && tlv->value[0] == 0)
           ret = r_ed25519_pub_key_new (tlv->value + 1, tlv->len - 1);
+      } else if (r_asn1_oid_bin_equals (tlv->value, tlv->len, R_RFC8410_OID_ED448)) {
+        /* RFC 8410: the AlgorithmIdentifier has no parameters, so the
+         * subjectPublicKey BIT STRING is the OID's next sibling -- one octet
+         * of unused-bits padding then the 57-byte public key. */
+        r_asn1_bin_decoder_out (dec, tlv);
+        if (R_ASN1_BIN_TLV_ID_IS_TAG (tlv, R_ASN1_ID_BIT_STRING) &&
+            tlv->len == R_ED448_PUB_KEY_SIZE + 1 && tlv->value[0] == 0)
+          ret = r_ed448_pub_key_new (tlv->value + 1, tlv->len - 1);
       } else {
         r_asn1_bin_decoder_out (dec, tlv);
       }
@@ -468,6 +477,16 @@ r_crypto_key_from_asn1_private_key (RAsn1BinDecoder * dec, RAsn1BinTLV * tlv)
           if (R_ASN1_BIN_TLV_ID_IS_TAG (tlv, R_ASN1_ID_OCTET_STRING) &&
               tlv->len == R_ED25519_SEED_SIZE)
             ret = r_ed25519_priv_key_new (tlv->value, tlv->len);
+          r_asn1_bin_decoder_out (dec, tlv);
+        }
+      } else if (r_asn1_oid_bin_equals (tlv->value, tlv->len, R_RFC8410_OID_ED448)) {
+        /* RFC 8410 / RFC 5958: the privateKey OCTET STRING wraps a nested
+         * OCTET STRING holding the 57-byte seed. */
+        if (r_asn1_bin_decoder_out (dec, tlv) == R_ASN1_DECODER_OK &&
+            r_asn1_bin_decoder_into (dec, tlv) == R_ASN1_DECODER_OK) {
+          if (R_ASN1_BIN_TLV_ID_IS_TAG (tlv, R_ASN1_ID_OCTET_STRING) &&
+              tlv->len == R_ED448_SEED_SIZE)
+            ret = r_ed448_priv_key_new (tlv->value, tlv->len);
           r_asn1_bin_decoder_out (dec, tlv);
         }
       }

--- a/rlib/crypto/rx509.c
+++ b/rlib/crypto/rx509.c
@@ -697,10 +697,11 @@ r_crypto_x509_cert_init (RCryptoX509Cert * cert, RAsn1BinDecoder * dec)
     /* signatureAlgorithm */
     if (r_asn1_bin_decoder_into (dec, &tlv) != R_ASN1_DECODER_OK)
       goto beach;
-    /* PureEdDSA (Ed25519) signs the TBSCertificate directly; there is no
-     * digest OID and no pre-hash, so keep a copy of the raw TBS for
+    /* PureEdDSA (Ed25519 / Ed448) signs the TBSCertificate directly; there is
+     * no digest OID and no pre-hash, so keep a copy of the raw TBS for
      * verification instead of the signhash the hashed schemes precompute. */
-    is_eddsa = r_asn1_oid_bin_equals (tlv.value, tlv.len, R_RFC8410_OID_ED25519);
+    is_eddsa = r_asn1_oid_bin_equals (tlv.value, tlv.len, R_RFC8410_OID_ED25519) ||
+        r_asn1_oid_bin_equals (tlv.value, tlv.len, R_RFC8410_OID_ED448);
     if (r_asn1_bin_tlv_parse_oid_to_msg_digest_type (&tlv, &cert->cert.signalgo) != R_ASN1_DECODER_OK ||
         r_asn1_bin_decoder_out (dec, &tlv) != R_ASN1_DECODER_OK) {
       goto beach;

--- a/rlib/net/proto/rtls.c
+++ b/rlib/net/proto/rtls.c
@@ -62,6 +62,7 @@ r_tls_sign_scheme_to_md (RTLSSignatureScheme scheme, RMsgDigestType * md)
       *md = R_MSG_DIGEST_TYPE_SHA512;
       return TRUE;
     case R_TLS_SIGN_SCHEME_ED25519:
+    case R_TLS_SIGN_SCHEME_ED448:
       /* PureEdDSA signs the content directly (RFC 8446 4.2.3); no pre-hash. */
       *md = R_MSG_DIGEST_TYPE_NONE;
       return TRUE;
@@ -83,6 +84,8 @@ r_tls_sign_scheme_for_key (const RCryptoKey * key)
       }
     case R_CRYPTO_ALGO_ED25519:
       return R_TLS_SIGN_SCHEME_ED25519;
+    case R_CRYPTO_ALGO_ED448:
+      return R_TLS_SIGN_SCHEME_ED448;
     default:
       return R_TLS_SIGN_SCHEME_RSA_PKCS1_SHA256;
   }

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -740,7 +740,7 @@ r_tls_client_default_cipher_suites (rpointer ctx, RTLSVersion ver,
 }
 
 /* signature_algorithms for 1.3: offer the ECDSA (secp256r1/384r1/521r1),
- * ed25519 and RSA-PSS (SHA-256/384/512) schemes valid for a 1.3
+ * ed25519 / ed448 and RSA-PSS (SHA-256/384/512) schemes valid for a 1.3
  * CertificateVerify, plus rsa_pkcs1_sha256 for certificate signatures. */
 static ruint16
 r_tls_client_write_hs_ext_signature_algorithms13 (ruint8 * ptr)
@@ -750,6 +750,7 @@ r_tls_client_write_hs_ext_signature_algorithms13 (ruint8 * ptr)
     R_TLS_SIGN_SCHEME_ECDSA_SECP384R1_SHA384,
     R_TLS_SIGN_SCHEME_ECDSA_SECP521R1_SHA512,
     R_TLS_SIGN_SCHEME_ED25519,
+    R_TLS_SIGN_SCHEME_ED448,
     R_TLS_SIGN_SCHEME_RSA_PSS_SHA256,
     R_TLS_SIGN_SCHEME_RSA_PSS_SHA384,
     R_TLS_SIGN_SCHEME_RSA_PSS_SHA512,
@@ -1583,13 +1584,14 @@ r_tls_client_verify_certificate_verify13 (RTLSClient * client,
   RTLSError err;
 
   /* The schemes valid for a 1.3 CertificateVerify that we can verify: ECDSA
-   * (secp256r1/384r1/521r1), RSA-PSS (SHA-256/384/512) and ed25519. PKCS#1
-   * v1.5 is forbidden in 1.3; other schemes are rejected. */
+   * (secp256r1/384r1/521r1), RSA-PSS (SHA-256/384/512) and ed25519 / ed448.
+   * PKCS#1 v1.5 is forbidden in 1.3; other schemes are rejected. */
   switch (scheme) {
     case R_TLS_SIGN_SCHEME_ECDSA_SECP256R1_SHA256:
     case R_TLS_SIGN_SCHEME_ECDSA_SECP384R1_SHA384:
     case R_TLS_SIGN_SCHEME_ECDSA_SECP521R1_SHA512:
     case R_TLS_SIGN_SCHEME_ED25519:
+    case R_TLS_SIGN_SCHEME_ED448:
       pss = FALSE;
       break;
     case R_TLS_SIGN_SCHEME_RSA_PSS_SHA256:

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -1770,10 +1770,11 @@ r_tls_server_nego_hello13 (RTLSServer * server)
   }
 
   /* CertificateVerify scheme follows the certificate key: ECDSA binds the curve
-   * to its digest (secp256r1/384r1/521r1), ed25519 is PureEdDSA, RSA uses
-   * rsa_pss_rsae_sha256. */
+   * to its digest (secp256r1/384r1/521r1), ed25519 / ed448 are PureEdDSA, RSA
+   * uses rsa_pss_rsae_sha256. */
   certalgo = r_crypto_key_get_algo (server->privkey);
-  if (certalgo == R_CRYPTO_ALGO_ECDSA || certalgo == R_CRYPTO_ALGO_ED25519)
+  if (certalgo == R_CRYPTO_ALGO_ECDSA || certalgo == R_CRYPTO_ALGO_ED25519 ||
+      certalgo == R_CRYPTO_ALGO_ED448)
     server->cv_scheme = r_tls_sign_scheme_for_key (server->privkey);
   else if (certalgo == R_CRYPTO_ALGO_RSA)
     server->cv_scheme = R_TLS_SIGN_SCHEME_RSA_PSS_SHA256;

--- a/test/gen-rtlstestcerts.sh
+++ b/test/gen-rtlstestcerts.sh
@@ -69,6 +69,32 @@ issue leaf_sub      subinter      "basicConstraints=critical,CA:FALSE
 extendedKeyUsage=serverAuth
 subjectAltName=DNS:localhost,IP:127.0.0.1"                               "localhost"
 
+# A parallel Ed448 chain (root/intermediate/leaf), for PureEdDSA chain
+# verification. issue_ed448 mirrors issue but with an Ed448 key and no external
+# digest (EdDSA signs the content directly).
+issue_ed448 () {
+  openssl genpkey -algorithm ed448 -out "$1.key" 2>/dev/null
+  openssl req -new -key "$1.key" -out "$1.csr" -subj "/CN=$4" 2>/dev/null
+  printf '%s\n' "$3" > "$1.ext"
+  openssl x509 -req -in "$1.csr" -CA "$2.crt" -CAkey "$2.key" -CAcreateserial \
+    -out "$1.crt" -not_before "$NOT_BEFORE" -not_after "$NOT_AFTER" \
+    -extfile "$1.ext" 2>/dev/null
+}
+
+openssl genpkey -algorithm ed448 -out ed448_root.key 2>/dev/null
+openssl req -new -x509 -key ed448_root.key -out ed448_root.crt \
+  -not_before "$NOT_BEFORE" -not_after "$NOT_AFTER" \
+  -subj "/CN=rlib Test Ed448 Root CA" \
+  -addext "basicConstraints=critical,CA:TRUE,pathlen:1" \
+  -addext "keyUsage=critical,keyCertSign,cRLSign" 2>/dev/null
+
+issue_ed448 ed448_inter ed448_root "basicConstraints=critical,CA:TRUE,pathlen:0
+keyUsage=critical,keyCertSign,cRLSign"                                   "rlib Test Ed448 Intermediate CA"
+issue_ed448 ed448_leaf  ed448_inter "basicConstraints=critical,CA:FALSE
+keyUsage=critical,digitalSignature
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1"                               "localhost"
+
 emit () {  # emit <c-name> <pem-file>
   printf 'static const rchar %s[] =\n' "$1"
   while IFS= read -r line; do printf '  "%s\\r\\n"\n' "$line"; done < "$2"
@@ -84,7 +110,8 @@ emit () {  # emit <c-name> <pem-file>
  * validity window (independent of the build host's clock). Leaves carry SAN
  * DNS:localhost + IP:127.0.0.1 and extendedKeyUsage serverAuth unless their name
  * says otherwise; leaf_clientauth is the client (CN=rlib Test Client, clientAuth).
- * Regenerate via test/gen-rtlstestcerts.sh.
+ * A parallel Ed448 root/intermediate/leaf chain exercises PureEdDSA chain
+ * verification. Regenerate via test/gen-rtlstestcerts.sh.
  */
 #ifndef __R_TEST_TLS_TEST_CERTS_H__
 #define __R_TEST_TLS_TEST_CERTS_H__
@@ -105,6 +132,9 @@ HDR
   emit rtest_leaf_wild_pem     leaf_wild.crt
   emit rtest_leaf_clientauth_pem     leaf_clientauth.crt
   emit rtest_leaf_clientauth_key_pem leaf_clientauth.key
+  emit rtest_ed448_root_pem          ed448_root.crt
+  emit rtest_ed448_inter_pem         ed448_inter.crt
+  emit rtest_ed448_leaf_pem          ed448_leaf.crt
   echo "#endif /* __R_TEST_TLS_TEST_CERTS_H__ */"
 } > "$OUT"
 

--- a/test/rcryptocert.c
+++ b/test/rcryptocert.c
@@ -835,6 +835,38 @@ RTEST (rcryptocert, self_signed_ed25519, RTEST_FAST)
 }
 RTEST_END;
 
+/* A self-signed Ed448 certificate (RFC 8410): the subjectPublicKeyInfo and
+ * the signatureAlgorithm are both ed448. PureEdDSA signs the TBSCertificate
+ * directly, so verify_signature checks the raw content rather than a pre-hash. */
+RTEST (rcryptocert, self_signed_ed448, RTEST_FAST)
+{
+  static const rchar pem[] =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIBdjCB96ADAgECAgEBMAUGAytlcTAVMRMwEQYDVQQDDApybGliLWVkNDQ4MB4X\n"
+    "DTI2MDcyNzIyMzgzNVoXDTQ4MDYyMTIyMzgzNVowFTETMBEGA1UEAwwKcmxpYi1l\n"
+    "ZDQ0ODBDMAUGAytlcQM6ALsYJKLhoYrpXLc0/NT4FTHn3ufPTYqN9cNqHoO4G+/n\n"
+    "byz7tDfnc0wUY60oV9W+ld4IuPiDnFh+gKNTMFEwHQYDVR0OBBYEFI+7lKgPHo4r\n"
+    "16us3Oy20G7dAsKAMB8GA1UdIwQYMBaAFI+7lKgPHo4r16us3Oy20G7dAsKAMA8G\n"
+    "A1UdEwEB/wQFMAMBAf8wBQYDK2VxA3MAw/4wBzJpHCJX9A9gGQTJ3kWNtR5q35Nu\n"
+    "wC4AAgcxa3P1YVGA7WNyH4HMJkIeCXeQj2/1P9938r4AzHws10Sew1lxXLfnq+/t\n"
+    "0zq0Q0xz1qzYfW0Ct/03IBoCDoHfhDx1qMdSEL4q3lRlGnE+kCFlLQ8A\n"
+    "-----END CERTIFICATE-----\n";
+  RCryptoCert * cert;
+  RCryptoKey * pk;
+
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (pem, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_crypto_cert_get_public_key (cert)), !=, NULL);
+  r_assert_cmpint (r_crypto_key_get_algo (pk), ==, R_CRYPTO_ALGO_ED448);
+  r_crypto_key_unref (pk);
+
+  r_assert (r_crypto_x509_cert_is_self_issued (cert));
+  r_assert (r_crypto_x509_cert_is_self_signed (cert));
+  r_assert_cmpuint (r_crypto_x509_cert_verify_signature (cert, cert), ==, R_CRYPTO_OK);
+
+  r_crypto_cert_unref (cert);
+}
+RTEST_END;
+
 /* r_crypto_x509_cert_verify_host: RFC 6125 SAN matching (DNS + IP, wildcard),
  * exercised directly on the certificate. */
 RTEST (rcryptocert, x509_verify_host_dns, RTEST_FAST)

--- a/test/rcryptopem.c
+++ b/test/rcryptopem.c
@@ -1112,6 +1112,79 @@ RTEST (rcryptopem, ed25519_spki_public_key, RTEST_FAST)
 }
 RTEST_END;
 
+static const rchar pem_ed448_pkcs8[] =
+  "-----BEGIN PRIVATE KEY-----\n"
+  "MEcCAQAwBQYDK2VxBDsEORtAq9iHLGotJ4Nctu8X08dMYN9OVyGG7L7/uhFDrJ7q\n"
+  "dLpCuWG+OY9CEHXZFz+l0DOgJkvQiK+drg==\n"
+  "-----END PRIVATE KEY-----\n";
+static const rchar pem_ed448_spki[] =
+  "-----BEGIN PUBLIC KEY-----\n"
+  "MEMwBQYDK2VxAzoAuxgkouGhiulctzT81PgVMefe589Nio31w2oeg7gb7+dvLPu0\n"
+  "N+dzTBRjrShX1b6V3gi4+IOcWH6A\n"
+  "-----END PUBLIC KEY-----\n";
+static const ruint8 ed448_pub[] = {
+  0xbb, 0x18, 0x24, 0xa2, 0xe1, 0xa1, 0x8a, 0xe9, 0x5c, 0xb7, 0x34, 0xfc,
+  0xd4, 0xf8, 0x15, 0x31, 0xe7, 0xde, 0xe7, 0xcf, 0x4d, 0x8a, 0x8d, 0xf5,
+  0xc3, 0x6a, 0x1e, 0x83, 0xb8, 0x1b, 0xef, 0xe7, 0x6f, 0x2c, 0xfb, 0xb4,
+  0x37, 0xe7, 0x73, 0x4c, 0x14, 0x63, 0xad, 0x28, 0x57, 0xd5, 0xbe, 0x95,
+  0xde, 0x08, 0xb8, 0xf8, 0x83, 0x9c, 0x58, 0x7e, 0x80
+};
+
+RTEST (rcryptopem, ed448_pkcs8_private_key, RTEST_FAST)
+{
+  RPemParser * parser;
+  RPemBlock * block;
+  RCryptoKey * key;
+  const ruint8 * pub = NULL;
+  rsize pubsize = 0;
+
+  r_assert_cmpptr (
+      (parser = r_pem_parser_new (pem_ed448_pkcs8, sizeof (pem_ed448_pkcs8))),
+      !=, NULL);
+  r_assert_cmpptr ((block = r_pem_parser_next_block (parser)), !=, NULL);
+
+  r_assert_cmpptr ((key = r_pem_block_get_key (block, NULL, 0)), !=, NULL);
+  r_assert_cmpint (r_crypto_key_get_type (key), ==, R_CRYPTO_PRIVATE_KEY);
+  r_assert_cmpint (r_crypto_key_get_algo (key), ==, R_CRYPTO_ALGO_ED448);
+
+  /* The seed derives the public key -- check it matches the known pair. */
+  r_assert (r_ed448_key_get_pub (key, &pub, &pubsize));
+  r_assert_cmpuint (pubsize, ==, sizeof (ed448_pub));
+  r_assert_cmpmem (pub, ==, ed448_pub, pubsize);
+
+  r_crypto_key_unref (key);
+  r_pem_block_unref (block);
+  r_pem_parser_unref (parser);
+}
+RTEST_END;
+
+RTEST (rcryptopem, ed448_spki_public_key, RTEST_FAST)
+{
+  RPemParser * parser;
+  RPemBlock * block;
+  RCryptoKey * key;
+  const ruint8 * pub = NULL;
+  rsize pubsize = 0;
+
+  r_assert_cmpptr (
+      (parser = r_pem_parser_new (pem_ed448_spki, sizeof (pem_ed448_spki))),
+      !=, NULL);
+  r_assert_cmpptr ((block = r_pem_parser_next_block (parser)), !=, NULL);
+
+  r_assert_cmpptr ((key = r_pem_block_get_key (block, NULL, 0)), !=, NULL);
+  r_assert_cmpint (r_crypto_key_get_type (key), ==, R_CRYPTO_PUBLIC_KEY);
+  r_assert_cmpint (r_crypto_key_get_algo (key), ==, R_CRYPTO_ALGO_ED448);
+
+  r_assert (r_ed448_key_get_pub (key, &pub, &pubsize));
+  r_assert_cmpuint (pubsize, ==, sizeof (ed448_pub));
+  r_assert_cmpmem (pub, ==, ed448_pub, pubsize);
+
+  r_crypto_key_unref (key);
+  r_pem_block_unref (block);
+  r_pem_parser_unref (parser);
+}
+RTEST_END;
+
 /* Round-trip the given key through r_pem_write_private_key_dup +
  * r_pem_parser_new, returning the decoded key. Caller owns it. */
 static RCryptoKey *

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -146,6 +146,27 @@ static const rchar testpkpem_ed25519[] =
   "MC4CAQAwBQYDK2VwBCIEIJKdC2hLiSupxcBfuOHOJo21Xs4uo1DHngILAzCzFb3D\n"
   "-----END PRIVATE KEY-----\n";
 
+/* Self-signed Ed448 certificate + matching PKCS#8 key (CN=rlib-ed448), for the
+ * 1.3 CertificateVerify ed448 scheme. Same generation constraints as
+ * testcertpem_ecdsa (small serial, pre-2050). */
+static const rchar testcertpem_ed448[] =
+  "-----BEGIN CERTIFICATE-----\n"
+  "MIIBdjCB96ADAgECAgEBMAUGAytlcTAVMRMwEQYDVQQDDApybGliLWVkNDQ4MB4X\n"
+  "DTI2MDcyNzIyMzgzNVoXDTQ4MDYyMTIyMzgzNVowFTETMBEGA1UEAwwKcmxpYi1l\n"
+  "ZDQ0ODBDMAUGAytlcQM6ALsYJKLhoYrpXLc0/NT4FTHn3ufPTYqN9cNqHoO4G+/n\n"
+  "byz7tDfnc0wUY60oV9W+ld4IuPiDnFh+gKNTMFEwHQYDVR0OBBYEFI+7lKgPHo4r\n"
+  "16us3Oy20G7dAsKAMB8GA1UdIwQYMBaAFI+7lKgPHo4r16us3Oy20G7dAsKAMA8G\n"
+  "A1UdEwEB/wQFMAMBAf8wBQYDK2VxA3MAw/4wBzJpHCJX9A9gGQTJ3kWNtR5q35Nu\n"
+  "wC4AAgcxa3P1YVGA7WNyH4HMJkIeCXeQj2/1P9938r4AzHws10Sew1lxXLfnq+/t\n"
+  "0zq0Q0xz1qzYfW0Ct/03IBoCDoHfhDx1qMdSEL4q3lRlGnE+kCFlLQ8A\n"
+  "-----END CERTIFICATE-----\n";
+
+static const rchar testpkpem_ed448[] =
+  "-----BEGIN PRIVATE KEY-----\n"
+  "MEcCAQAwBQYDK2VxBDsEORtAq9iHLGotJ4Nctu8X08dMYN9OVyGG7L7/uhFDrJ7q\n"
+  "dLpCuWG+OY9CEHXZFz+l0DOgJkvQiK+drg==\n"
+  "-----END PRIVATE KEY-----\n";
+
 RTEST_FIXTURE_STRUCT (rtlsclient)
 {
   RTLSServer * server;
@@ -662,6 +683,24 @@ RTEST_F (rtlsclient, tls13_loopback_ed25519, RTEST_FAST)
 
   r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (testcertpem_ed25519, -1)), !=, NULL);
   r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem_ed25519, -1, NULL, 0)), !=, NULL);
+  r_assert_cmpint (r_tls_server_set_cert (fixture->server, cert, pk), ==, R_TLS_ERROR_OK);
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+
+  r_test_tls13_loopback (fixture);
+}
+RTEST_END;
+
+/* Ed448 server certificate: the 1.3 CertificateVerify uses the ed448 scheme,
+ * so the server signs and the client verifies over the content directly (no
+ * pre-hash). The handshake completing exercises the PureEdDSA sign/verify path. */
+RTEST_F (rtlsclient, tls13_loopback_ed448, RTEST_FAST)
+{
+  RCryptoCert * cert;
+  RCryptoKey * pk;
+
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (testcertpem_ed448, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem_ed448, -1, NULL, 0)), !=, NULL);
   r_assert_cmpint (r_tls_server_set_cert (fixture->server, cert, pk), ==, R_TLS_ERROR_OK);
   r_crypto_key_unref (pk);
   r_crypto_cert_unref (cert);

--- a/test/rtlstestcerts.h
+++ b/test/rtlstestcerts.h
@@ -5,7 +5,8 @@
  * validity window (independent of the build host's clock). Leaves carry SAN
  * DNS:localhost + IP:127.0.0.1 and extendedKeyUsage serverAuth unless their name
  * says otherwise; leaf_clientauth is the client (CN=rlib Test Client, clientAuth).
- * Regenerate via test/gen-rtlstestcerts.sh.
+ * A parallel Ed448 root/intermediate/leaf chain exercises PureEdDSA chain
+ * verification. Regenerate via test/gen-rtlstestcerts.sh.
  */
 #ifndef __R_TEST_TLS_TEST_CERTS_H__
 #define __R_TEST_TLS_TEST_CERTS_H__
@@ -369,6 +370,52 @@ static const rchar rtest_leaf_clientauth_key_pem[] =
   "y31Xo4pN9Mnw13sxxcQ4BlZsFyxkrynL/u4SE1zf/eKoDjettm/T6qctLLeDp2bW\r\n"
   "w1DB9mABK7t9AtCvgLtbNjM=\r\n"
   "-----END PRIVATE KEY-----\r\n"
+;
+
+static const rchar rtest_ed448_root_pem[] =
+  "-----BEGIN CERTIFICATE-----\r\n"
+  "MIIBuTCCATmgAwIBAgIURJdDX2UoF5MbgomZfOeREg0ZTl4wBQYDK2VxMCIxIDAe\r\n"
+  "BgNVBAMMF3JsaWIgVGVzdCBFZDQ0OCBSb290IENBMCAXDTE1MDEwMTAwMDAwMFoY\r\n"
+  "DzIxMjUwMTAxMDAwMDAwWjAiMSAwHgYDVQQDDBdybGliIFRlc3QgRWQ0NDggUm9v\r\n"
+  "dCBDQTBDMAUGAytlcQM6AFOLEGeqwiVsOv3S6FgiqfPHL6SaqWCLQUz5/J0SQ5da\r\n"
+  "hhgLYFqV2pSC+AXeyl7Ipeih+BYH06ysAKNmMGQwHQYDVR0OBBYEFNmXKlZOCGWs\r\n"
+  "sm+tuxSebXjPk+d1MB8GA1UdIwQYMBaAFNmXKlZOCGWssm+tuxSebXjPk+d1MBIG\r\n"
+  "A1UdEwEB/wQIMAYBAf8CAQEwDgYDVR0PAQH/BAQDAgEGMAUGAytlcQNzANSxbwqe\r\n"
+  "hcUvFLCOW0iR59rXB5x9/AJYw4dL6eFx0NomeItCXAye6KsEOb41P42av3OdNnDe\r\n"
+  "4Q7cgEoCQ3LSbKQpzqRQkpRFFVZZPT2PxQd4DcVM0vS1CE9p3VnMEllye/bOXbXd\r\n"
+  "hSBUxMXXYv164e82AA==\r\n"
+  "-----END CERTIFICATE-----\r\n"
+;
+
+static const rchar rtest_ed448_inter_pem[] =
+  "-----BEGIN CERTIFICATE-----\r\n"
+  "MIIBwTCCAUGgAwIBAgIUGuvbiFIeioaiDLpchvcxYMC8XlUwBQYDK2VxMCIxIDAe\r\n"
+  "BgNVBAMMF3JsaWIgVGVzdCBFZDQ0OCBSb290IENBMCAXDTE1MDEwMTAwMDAwMFoY\r\n"
+  "DzIxMjUwMTAxMDAwMDAwWjAqMSgwJgYDVQQDDB9ybGliIFRlc3QgRWQ0NDggSW50\r\n"
+  "ZXJtZWRpYXRlIENBMEMwBQYDK2VxAzoA4ajQYESZ7RPA+esQiViGKzsScRyyWkb8\r\n"
+  "X4NDNSsESlyJfXUarQXKU5CcgJvcqN/QK1J7nBpX/FqAo2YwZDASBgNVHRMBAf8E\r\n"
+  "CDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUP1knkBwfWlCcoJSp\r\n"
+  "d/cZBpjHncgwHwYDVR0jBBgwFoAU2ZcqVk4IZayyb627FJ5teM+T53UwBQYDK2Vx\r\n"
+  "A3MAzdRZsEpREg6wFchsHO0YVpYdS/B22zSnjNqXnKiaIkrkKbtWuSnnREV+IBN7\r\n"
+  "GqRnQmblpHwitCMAIBlDR4jx+zvDR9g/SEloVcfR7pXVefnvVR3je8yZhRCvz0DL\r\n"
+  "mqiGh0W05/Qt+QbQFwJNtjmyKzAA\r\n"
+  "-----END CERTIFICATE-----\r\n"
+;
+
+static const rchar rtest_ed448_leaf_pem[] =
+  "-----BEGIN CERTIFICATE-----\r\n"
+  "MIIB4DCCAWCgAwIBAgIUWOCMOfk+0aesoNo9kdSRJb/nl0kwBQYDK2VxMCoxKDAm\r\n"
+  "BgNVBAMMH3JsaWIgVGVzdCBFZDQ0OCBJbnRlcm1lZGlhdGUgQ0EwIBcNMTUwMTAx\r\n"
+  "MDAwMDAwWhgPMjEyNTAxMDEwMDAwMDBaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDBD\r\n"
+  "MAUGAytlcQM6ADaLHUXVBD2Q0GVn+AJsXWMmsp8bin3mpZFnW0lT03eDspg1cBIp\r\n"
+  "aKudAihIXZwMTvDKZGr0QICOgKOBkjCBjzAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB\r\n"
+  "/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDATAaBgNVHREEEzARgglsb2NhbGhv\r\n"
+  "c3SHBH8AAAEwHQYDVR0OBBYEFDuOwXkcARkQN+Y+75VgM0J93nY0MB8GA1UdIwQY\r\n"
+  "MBaAFD9ZJ5AcH1pQnKCUqXf3GQaYx53IMAUGAytlcQNzAHwwdAscwR9EboRBr43v\r\n"
+  "pBZzepP3Z0cZGIJPh3QEufMYtO2XwBHmYsZq15q2R58deqhOibzsZu90AI5y5QYt\r\n"
+  "Ef0ahwpt1Ui6AxzyA6qK2NFK3Rs/pKY3j1R1T9EhiQKa9gQ/FB3HtkQ5mCVrDZoD\r\n"
+  "UrUIAA==\r\n"
+  "-----END CERTIFICATE-----\r\n"
 ;
 
 #endif /* __R_TEST_TLS_TEST_CERTS_H__ */

--- a/test/rtruststore.c
+++ b/test/rtruststore.c
@@ -76,6 +76,32 @@ RTEST (rtruststore, trust_three_level, RTEST_FAST)
 }
 RTEST_END;
 
+/* A full Ed448 chain: leaf <- intermediate (in chain) <- root (anchor). Both
+ * hops are PureEdDSA signatures, so completing the chain exercises Ed448
+ * certificate-signature verification across issuers, not just self-signed. */
+RTEST (rtruststore, trust_three_level_ed448, RTEST_FAST)
+{
+  RTrustStore * store = r_test_store_with (rtest_ed448_root_pem);
+  r_assert_cmpint (r_test_verify (store, RTEST_NOW,
+        R_X509_EXT_KEY_USAGE_SERVER_AUTH, rtest_ed448_leaf_pem,
+        rtest_ed448_inter_pem, NULL),
+      ==, R_TRUST_OK);
+  r_trust_store_unref (store);
+}
+RTEST_END;
+
+/* The same Ed448 leaf does not chain to the wrong (RSA root) anchor. */
+RTEST (rtruststore, untrusted_wrong_anchor_ed448, RTEST_FAST)
+{
+  RTrustStore * store = r_test_store_with (rtest_root_pem);
+  r_assert_cmpint (r_test_verify (store, RTEST_NOW,
+        R_X509_EXT_KEY_USAGE_SERVER_AUTH, rtest_ed448_leaf_pem,
+        rtest_ed448_inter_pem, NULL),
+      ==, R_TRUST_UNTRUSTED);
+  r_trust_store_unref (store);
+}
+RTEST_END;
+
 RTEST (rtruststore, trust_anchor_is_intermediate, RTEST_FAST)
 {
   RTrustStore * store = r_test_store_with (rtest_inter_pem);


### PR DESCRIPTION
Adds Ed448 support to the TLS 1.3 CertificateVerify path (sign on the server, verify and offer on the client), plus the certificate/key plumbing it depends on. This completes the EdDSA scheme pair started with Ed25519 (#392). The Ed448 EdDSA primitives (SHAKE256, dom4 domain separation, 57-byte keys, 114-byte signatures) already exist; this is the parsing, verification, and TLS wiring on top.

## Layers
- **`crypto/rkey`** — RFC 8410 key parsing. Decode Ed448 from a SubjectPublicKeyInfo `BIT STRING` (57-byte public key) and from a PKCS#8 `privateKey` OCTET STRING wrapping a nested OCTET STRING (57-byte seed), dispatching on the `1.3.101.113` OID.
- **`crypto/x509`** — verify Ed448 (PureEdDSA) certificate signatures. Extend the existing raw-TBS-retention path to the Ed448 signatureAlgorithm, keyed off `signalgo` NONE — like Ed25519 there is no digest OID and no pre-hash.
- **`net/tls`** — wire ed448 into the 1.3 signature-scheme mapping (`R_MSG_DIGEST_TYPE_NONE`), server scheme selection, and the client verify allowlist and `signature_algorithms` offer. The server sign and client verify paths already branch on the no-pre-hash case, so they cover Ed448 unchanged.

## Tests
- Ed448 SPKI + PKCS#8 key parsing round-trips against a known pair.
- A self-signed Ed448 certificate loads and self-verifies its signature.
- A 1.3 loopback handshake completes with a self-signed Ed448 server certificate.
- A full Ed448 trust-store chain (leaf ← intermediate ← root) verifies across issuers, with a negative test that the Ed448 leaf does not chain to the RSA root. The test PKI is generated by `test/gen-rtlstestcerts.sh`.

Full suite passes; the new code is warning-clean and leak-free under the ASan tier.