### PR TITLE
net/tls: optional TLS 1.3 extensions (record_size_limit, OCSP stapling, SCT)

### DIFF
--- a/include/rlib/net/proto/rtls.h
+++ b/include/rlib/net/proto/rtls.h
@@ -71,6 +71,7 @@ R_BEGIN_DECLS
 #define R_DTLS_RECORD_HDR_SIZE            (R_TLS_RECORD_HDR_SIZE + R_TLS_RECORD_EXTRA_DTLS_SIZE) /**< @brief DTLS record header size in bytes. */
 #define R_DTLS_HS_HDR_SIZE                (R_TLS_HS_HDR_SIZE + R_TLS_HS_EXTRA_DTLS_SIZE) /**< @brief DTLS handshake header size in bytes. */
 #define R_TLS_SESSION_TICKET_LIFETIME     7200 /**< @brief Default session-ticket lifetime hint, in seconds. */
+#define R_TLS_MAX_PLAINTEXT               16384 /**< @brief Maximum protected-record plaintext (2^14), the default record_size_limit (RFC 8449). */
 /** @} */
 
 /** @brief TLS / DTLS protocol version (the 16-bit version field; DTLS uses 0xfe**). */
@@ -220,6 +221,7 @@ typedef enum {
   R_TLS_EXT_TYPE_EXTENDED_MASTER_SECRET                 = 0x0017, /* [RFC7627] */
   R_TLS_EXT_TYPE_TOKEN_BINDING                          = 0x0018, /* (TEMPORARY - registered 2016-02-04, expires 2017-02-04) [draft-ietf-tokbind-negotiation] */
   R_TLS_EXT_TYPE_CACHED_INFO                            = 0x0019, /* [RFC7924] */
+  R_TLS_EXT_TYPE_RECORD_SIZE_LIMIT                      = 0x001c, /* [RFC8449] */
   R_TLS_EXT_TYPE_SESSION_TICKET                         = 0x0023, /* [RFC4507] */
   R_TLS_EXT_TYPE_PRE_SHARED_KEY                         = 0x0029, /* [RFC8446] */
   R_TLS_EXT_TYPE_EARLY_DATA                             = 0x002a, /* [RFC8446] */

--- a/include/rlib/net/proto/rtls.h
+++ b/include/rlib/net/proto/rtls.h
@@ -463,9 +463,11 @@ typedef struct {
   const ruint8 * start;    /**< @brief First octet of the entry (its length field). */
   ruint32 len;             /**< @brief Certificate length in bytes. */
   const ruint8 * cert;     /**< @brief Pointer to the DER-encoded certificate. */
+  const ruint8 * ext;      /**< @brief TLS 1.3 per-entry Extension list, or @c NULL (1.2). */
+  ruint16 extlen;          /**< @brief Length of @c ext in bytes. */
 } RTLSCertificate;
 /** @brief Static initialiser for an empty @ref RTLSCertificate. */
-#define R_TLS_CERTIFICATE_INIT              { NULL, 0, NULL }
+#define R_TLS_CERTIFICATE_INIT              { NULL, 0, NULL, NULL, 0 }
 
 /** @brief Parsed CertificateRequest message, pointing into the record buffer. */
 typedef struct {
@@ -1191,18 +1193,20 @@ R_API RTLSError r_tls_write_hs_encrypted_extensions (rpointer buf, rsize size,
  * @brief Write a TLS 1.3 Certificate handshake-message body (RFC 8446, 4.4.2).
  *
  * Emits an empty @c certificate_request_context and a @c certificate_list of a
- * single end-entity @p der entry with an empty @c Extension list (or an empty
- * list when @p der is @c NULL). Distinct from the 1.2
- * @ref r_tls_write_hs_certificate, which has neither the context nor per-entry
- * extensions.
+ * single end-entity @p der entry, carrying @p leafexts as the entry's
+ * @c Extension list (an empty list when @p leafexts is @c NULL, or when @p der
+ * is @c NULL). Distinct from the 1.2 @ref r_tls_write_hs_certificate, which has
+ * neither the context nor per-entry extensions.
  * @param buf Destination buffer.
  * @param size Capacity of @p buf in bytes.
  * @param out Out: bytes written.
  * @param der DER-encoded certificate, or @c NULL for an empty Certificate.
  * @param dersize Length of @p der in bytes.
+ * @param leafexts Serialized Extension list for the leaf entry, or @c NULL.
+ * @param leafextslen Length of @p leafexts in bytes.
  */
 R_API RTLSError r_tls_write_hs_certificate13 (rpointer buf, rsize size, rsize * out,
-    const ruint8 * der, rsize dersize);
+    const ruint8 * der, rsize dersize, const ruint8 * leafexts, ruint16 leafextslen);
 
 /**
  * @brief Write a Finished handshake-message body (RFC 8446, 4.4.4).

--- a/include/rlib/net/rtlsclient.h
+++ b/include/rlib/net/rtlsclient.h
@@ -139,6 +139,27 @@ R_API RTLSError r_tls_client_set_alpn_protocols (RTLSClient * client,
 R_API RTLSError r_tls_client_set_record_size_limit (RTLSClient * client,
     ruint16 limit);
 /**
+ * @brief Offer the @c status_request extension to request a stapled OCSP
+ * response (RFC 6066 / RFC 8446 4.4.2.1).
+ *
+ * With @p request @c TRUE the ClientHello asks the server to staple an OCSP
+ * response for its certificate; if the server does, it is available after the
+ * handshake via @ref r_tls_client_get_ocsp_response. The staple is delivered
+ * as-is -- the library does not validate it. Off by default; must be called
+ * before @ref r_tls_client_start. Applies to TLS 1.3 only.
+ */
+R_API RTLSError r_tls_client_request_ocsp (RTLSClient * client, rboolean request);
+/**
+ * @brief The OCSP response the server stapled to its certificate, or @c NULL.
+ *
+ * Valid once the handshake has completed when @ref r_tls_client_request_ocsp was
+ * set and the server stapled one (RFC 6066). The bytes are the DER
+ * @c OCSPResponse, borrowed (owned by the session); @p len, when non-@c NULL,
+ * receives the length. The library does not validate the response.
+ */
+R_API const ruint8 * r_tls_client_get_ocsp_response (const RTLSClient * client,
+    rsize * len);
+/**
  * @brief Constrain the TLS versions the client offers.
  *
  * Both bounds lie in the window @c R_TLS_VERSION_TLS_1_2 ..

--- a/include/rlib/net/rtlsclient.h
+++ b/include/rlib/net/rtlsclient.h
@@ -160,6 +160,28 @@ R_API RTLSError r_tls_client_request_ocsp (RTLSClient * client, rboolean request
 R_API const ruint8 * r_tls_client_get_ocsp_response (const RTLSClient * client,
     rsize * len);
 /**
+ * @brief Offer the @c signed_certificate_timestamp extension to request SCTs
+ * (RFC 6962).
+ *
+ * With @p request @c TRUE the ClientHello asks the server for Signed Certificate
+ * Timestamps evidencing certificate-transparency log inclusion; if the server
+ * carries them, the serialized @c SignedCertificateTimestampList is available
+ * after the handshake via @ref r_tls_client_get_sct_list. The list is delivered
+ * as-is -- the library does not validate it. Off by default; must be called
+ * before @ref r_tls_client_start. Applies to TLS 1.3 only.
+ */
+R_API RTLSError r_tls_client_request_sct (RTLSClient * client, rboolean request);
+/**
+ * @brief The Signed Certificate Timestamps the server sent, or @c NULL.
+ *
+ * Valid once the handshake has completed when @ref r_tls_client_request_sct was
+ * set and the server carried them (RFC 6962). The bytes are the serialized
+ * @c SignedCertificateTimestampList, borrowed (owned by the session); @p len,
+ * when non-@c NULL, receives the length. The library does not validate them.
+ */
+R_API const ruint8 * r_tls_client_get_sct_list (const RTLSClient * client,
+    rsize * len);
+/**
  * @brief Constrain the TLS versions the client offers.
  *
  * Both bounds lie in the window @c R_TLS_VERSION_TLS_1_2 ..

--- a/include/rlib/net/rtlsclient.h
+++ b/include/rlib/net/rtlsclient.h
@@ -122,6 +122,23 @@ R_API RTLSError r_tls_client_set_server_name (RTLSClient * client,
 R_API RTLSError r_tls_client_set_alpn_protocols (RTLSClient * client,
     const rchar * const * protocols, rsize count);
 /**
+ * @brief Advertise a TLS 1.3 @c record_size_limit (RFC 8449).
+ *
+ * @p limit is the largest protected-record plaintext -- counting the inner
+ * content-type byte -- the client is willing to @e receive, in the range
+ * 64 .. @ref R_TLS_MAX_PLAINTEXT (16384); an inbound record whose plaintext
+ * exceeds it aborts the session with a @c record_overflow alert. The value is
+ * offered in the ClientHello, and the server's echoed limit is honoured,
+ * capping the plaintext of each record the client emits. With @p limit 0 (the
+ * default) the client neither offers the extension nor enforces an inbound cap.
+ * The cap governs post-handshake traffic (application data and post-handshake
+ * messages); the handshake flight itself is exempt. Applies to TLS 1.3 only;
+ * must be called before @ref r_tls_client_start. Returns @c R_TLS_ERROR_INVAL
+ * for a non-zero @p limit below 64 or above @ref R_TLS_MAX_PLAINTEXT.
+ */
+R_API RTLSError r_tls_client_set_record_size_limit (RTLSClient * client,
+    ruint16 limit);
+/**
  * @brief Constrain the TLS versions the client offers.
  *
  * Both bounds lie in the window @c R_TLS_VERSION_TLS_1_2 ..

--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -312,6 +312,19 @@ R_API RTLSError r_tls_server_set_record_size_limit (RTLSServer * server,
  */
 R_API RTLSError r_tls_server_set_ocsp_response (RTLSServer * server,
     const ruint8 * der, rsize len);
+/**
+ * @brief Attach Signed Certificate Timestamps to the certificate (RFC 6962).
+ *
+ * When a TLS 1.3 client offers the @c signed_certificate_timestamp extension,
+ * the server carries @p der -- a serialized @c SignedCertificateTimestampList,
+ * @p len bytes, copied -- verbatim in the leaf @c CertificateEntry extensions,
+ * evidencing certificate-transparency log inclusion. With none configured (the
+ * default), or when the client did not ask, no SCTs are sent. Must be set before
+ * the handshake starts; pass @c NULL / @p len 0 to clear. Applies to TLS 1.3
+ * only.
+ */
+R_API RTLSError r_tls_server_set_sct_list (RTLSServer * server,
+    const ruint8 * der, rsize len);
 /** @brief Override the server-random (testing / determinism). */
 R_API RTLSError r_tls_server_set_random (RTLSServer * server,
     const ruint8 servrandom[R_TLS_HELLO_RANDOM_BYTES]);

--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -299,6 +299,19 @@ R_API RTLSError r_tls_server_set_alpn_protocols (RTLSServer * server,
  */
 R_API RTLSError r_tls_server_set_record_size_limit (RTLSServer * server,
     ruint16 limit);
+/**
+ * @brief Staple a DER-encoded OCSP response to the certificate (RFC 6066 /
+ * RFC 8446 4.4.2.1).
+ *
+ * When a TLS 1.3 client offers the @c status_request extension, the server
+ * carries @p der (a complete @c OCSPResponse, @p len bytes, copied) as a
+ * @c CertificateStatus in the leaf @c CertificateEntry extensions, saving the
+ * client a separate OCSP round-trip. With none configured (the default), or when
+ * the client did not ask, no status is stapled. Must be set before the handshake
+ * starts; pass @c NULL / @p len 0 to clear. Applies to TLS 1.3 only.
+ */
+R_API RTLSError r_tls_server_set_ocsp_response (RTLSServer * server,
+    const ruint8 * der, rsize len);
 /** @brief Override the server-random (testing / determinism). */
 R_API RTLSError r_tls_server_set_random (RTLSServer * server,
     const ruint8 servrandom[R_TLS_HELLO_RANDOM_BYTES]);

--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -280,6 +280,25 @@ R_API RTLSError r_tls_server_set_key_share_group (RTLSServer * server,
  */
 R_API RTLSError r_tls_server_set_alpn_protocols (RTLSServer * server,
     const rchar * const * protocols, rsize count);
+/**
+ * @brief Advertise a TLS 1.3 @c record_size_limit (RFC 8449).
+ *
+ * @p limit is the largest protected-record plaintext -- counting the inner
+ * content-type byte -- the server is willing to @e receive, in the range
+ * 64 .. @ref R_TLS_MAX_PLAINTEXT (16384); an inbound record whose plaintext
+ * exceeds it aborts the session with a @c record_overflow alert. The value is
+ * offered in the server's EncryptedExtensions only when the client also offered
+ * the extension, and independently constrains what the peer sends this way.
+ * A peer's advertised limit is likewise honoured, capping the plaintext of each
+ * record the server emits. With @p limit 0 (the default) the server neither
+ * advertises the extension nor enforces an inbound cap. The cap governs
+ * post-handshake traffic (application data and post-handshake messages); the
+ * handshake flight itself is exempt. Applies to TLS 1.3 only; must be set before
+ * the handshake starts. Returns @c R_TLS_ERROR_INVAL for a non-zero @p limit
+ * below 64 or above @ref R_TLS_MAX_PLAINTEXT.
+ */
+R_API RTLSError r_tls_server_set_record_size_limit (RTLSServer * server,
+    ruint16 limit);
 /** @brief Override the server-random (testing / determinism). */
 R_API RTLSError r_tls_server_set_random (RTLSServer * server,
     const ruint8 servrandom[R_TLS_HELLO_RANDOM_BYTES]);

--- a/rlib/net/proto/rtls.c
+++ b/rlib/net/proto/rtls.c
@@ -1391,6 +1391,13 @@ r_tls_certificate13_walk (const RTLSParser * parser, RTLSCertificate * cert,
         RPOINTER_TO_SIZE (end)))
     return R_TLS_ERROR_CORRUPT_RECORD;
 
+  /* The entry's Extension list follows the certificate (RFC 8446 4.4.2). */
+  cert->extlen = r_load_be16 (cert->cert + cert->len);
+  cert->ext = cert->cert + cert->len + sizeof (ruint16);
+  if (R_UNLIKELY (RPOINTER_TO_SIZE (cert->ext + cert->extlen) >
+        RPOINTER_TO_SIZE (end)))
+    return R_TLS_ERROR_CORRUPT_RECORD;
+
   return R_TLS_ERROR_OK;
 }
 
@@ -2383,11 +2390,12 @@ r_tls_write_hs_encrypted_extensions (rpointer data, rsize size, rsize * out,
 
 RTLSError
 r_tls_write_hs_certificate13 (rpointer data, rsize size, rsize * out,
-    const ruint8 * der, rsize dersize)
+    const ruint8 * der, rsize dersize, const ruint8 * leafexts, ruint16 leafextslen)
 {
   ruint8 * p = data;
+  rsize extslen = (leafexts != NULL) ? leafextslen : 0;
   /* One CertificateEntry = cert_data<3> | cert | extensions<2>. */
-  rsize entrylen = (der != NULL && dersize > 0) ? (3 + dersize + 2) : 0;
+  rsize entrylen = (der != NULL && dersize > 0) ? (3 + dersize + 2 + extslen) : 0;
   rsize need = 1 + 3 + entrylen;   /* context<1>=0 | certificate_list<3> | entries */
 
   if (R_UNLIKELY (data == NULL)) return R_TLS_ERROR_INVAL;
@@ -2404,7 +2412,10 @@ r_tls_write_hs_certificate13 (rpointer data, rsize size, rsize * out,
     *p++ = (ruint8)((dersize >>  8) & 0xff);
     *p++ = (ruint8)((dersize      ) & 0xff);
     r_memcpy (p, der, dersize); p += dersize;
-    r_store_be16 (p, 0);   /* extensions<0..2^16-1>: empty */
+    r_store_be16 (p, (ruint16) extslen); p += sizeof (ruint16);   /* extensions<0..2^16-1> */
+    if (extslen > 0) {
+      r_memcpy (p, leafexts, extslen); p += extslen;
+    }
   }
 
   if (out != NULL)

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -110,6 +110,9 @@ struct RTLSClient {
   const rchar * alpn_selected; /* negotiated protocol, points into alpn_protocols */
   rsize alpn_selected_len;
 
+  ruint16 record_size_limit;      /* our advertised record_size_limit (RFC 8449), 0 = off */
+  ruint16 peer_record_size_limit; /* server's echoed limit, caps our send; 0 = none */
+
   rboolean ecdhe;                  /* an ECDHE suite was negotiated */
   REcurveID ecdhe_curve;           /* the server-selected named group */
   RCryptoKey * ecdhe_key;          /* client ephemeral ECDH private key */
@@ -421,6 +424,18 @@ r_tls_client_set_version_range (RTLSClient * client,
   client->min_version = min;
   client->max_version = max;
   client->version_range_set = TRUE;
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_client_set_record_size_limit (RTLSClient * client, ruint16 limit)
+{
+  if (R_UNLIKELY (client == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (client->state != R_TLS_CLIENT_INITIAL)) return R_TLS_ERROR_WRONG_STATE;
+  if (R_UNLIKELY (limit != 0 && (limit < 64 || limit > R_TLS_MAX_PLAINTEXT)))
+    return R_TLS_ERROR_INVAL;
+
+  client->record_size_limit = limit;
   return R_TLS_ERROR_OK;
 }
 
@@ -838,6 +853,17 @@ r_tls_client_write_hs_ext_early_data (ruint8 * ptr)
   return 4;
 }
 
+/* record_size_limit: the max plaintext (incl. content-type byte) we will
+ * receive (RFC 8449). */
+static ruint16
+r_tls_client_write_hs_ext_record_size_limit (ruint8 * ptr, ruint16 limit)
+{
+  r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_RECORD_SIZE_LIMIT);
+  r_store_be16 (&ptr[2], sizeof (ruint16));
+  r_store_be16 (&ptr[4], limit);
+  return 6;
+}
+
 /* Whether an EncryptedExtensions handshake message (a full message: 4-byte
  * header then a uint16-prefixed extension list) carries an early_data
  * extension, i.e. the server accepted 0-RTT. */
@@ -892,6 +918,41 @@ r_tls_client_ee_apply_alpn (RTLSClient * client, const ruint8 * msg, rsize msgle
       return;
     if (etype == R_TLS_EXT_TYPE_APPLICATION_LAYER_PROTOCOL_NEGOTIATION) {
       r_tls_client_alpn_apply_selection (client, p, elen);
+      return;
+    }
+    p += elen;
+  }
+}
+
+/* Walk an EncryptedExtensions message for the server's record_size_limit and,
+ * when present and valid, record it as the cap on our outgoing plaintext
+ * (RFC 8449). */
+static void
+r_tls_client_ee_apply_record_size_limit (RTLSClient * client,
+    const ruint8 * msg, rsize msglen)
+{
+  const ruint8 * p, * end;
+  ruint16 extslen;
+
+  if (msglen < R_TLS_HS_HDR_SIZE + sizeof (ruint16))
+    return;
+  p = msg + R_TLS_HS_HDR_SIZE;
+  extslen = r_load_be16 (p);
+  p += sizeof (ruint16);
+  end = p + extslen;
+  if (RPOINTER_TO_SIZE (end) > RPOINTER_TO_SIZE (msg + msglen))
+    return;
+  while (p + 2 * sizeof (ruint16) <= end) {
+    ruint16 etype = r_load_be16 (p);
+    ruint16 elen = r_load_be16 (p + sizeof (ruint16));
+    p += 2 * sizeof (ruint16);
+    if (p + elen > end)
+      return;
+    if (etype == R_TLS_EXT_TYPE_RECORD_SIZE_LIMIT && elen == sizeof (ruint16)) {
+      ruint16 limit = r_load_be16 (p);
+      if (limit >= 64)
+        client->peer_record_size_limit =
+            limit > R_TLS_MAX_PLAINTEXT ? R_TLS_MAX_PLAINTEXT : limit;
       return;
     }
     p += elen;
@@ -1085,6 +1146,9 @@ r_tls_client_send_hello (RTLSClient * client, rboolean retry)
         extsize += r_tls_client_write_hs_ext_server_name (ptr + 2 + extsize, client->server_name);
       if (client->alpn_count > 0)
         extsize += r_tls_client_write_hs_ext_alpn (client, ptr + 2 + extsize);
+      if (client->record_size_limit != 0)
+        extsize += r_tls_client_write_hs_ext_record_size_limit (
+            ptr + 2 + extsize, client->record_size_limit);
       /* Advertise (EC)DHE resumption support so the server issues tickets. */
       extsize += r_tls_client_write_hs_ext_psk_key_exchange_modes (ptr + 2 + extsize);
       /* early_data (0-RTT) sits before pre_shared_key, which stays last. */
@@ -1236,9 +1300,9 @@ r_tls_client_install_keys13 (RTLSClient * client, RTLS13RecordKeys * rk,
 }
 
 /* AEAD-protect @plain[@plainlen] (real content type @ct) under the current
- * write key and queue the application_data record. */
+ * write key and queue one application_data record. */
 static RTLSError
-r_tls_client_protect_record13 (RTLSClient * client, RTLSContentType ct,
+r_tls_client_protect_record13_one (RTLSClient * client, RTLSContentType ct,
     const ruint8 * plain, rsize plainlen)
 {
   RBuffer * rec;
@@ -1276,6 +1340,35 @@ r_tls_client_protect_record13 (RTLSClient * client, RTLSContentType ct,
   if (rec != NULL)
     r_buffer_unref (rec);
   return ret;
+}
+
+/* Protect @plain[@plainlen], fragmenting into records whose inner plaintext --
+ * content-type byte included -- honours a negotiated record_size_limit
+ * (RFC 8449); with none negotiated a single record up to 2^14 is emitted. The
+ * cap is applied only to post-handshake traffic: the handshake flight is exempt,
+ * since a message split across records is not reassembled by the simple
+ * one-message-per-record handshake reader. */
+static RTLSError
+r_tls_client_protect_record13 (RTLSClient * client, RTLSContentType ct,
+    const ruint8 * plain, rsize plainlen)
+{
+  rsize max = (client->peer_record_size_limit != 0 &&
+      client->state == R_TLS_CLIENT_APPDATA) ?
+      (rsize) client->peer_record_size_limit - 1 : R_TLS_MAX_PLAINTEXT;
+  rsize off = 0;
+
+  do {
+    rsize chunk = plainlen - off;
+    RTLSError ret;
+    if (chunk > max)
+      chunk = max;
+    if ((ret = r_tls_client_protect_record13_one (client, ct,
+            plain + off, chunk)) != R_TLS_ERROR_OK)
+      return ret;
+    off += chunk;
+  } while (off < plainlen);
+
+  return R_TLS_ERROR_OK;
 }
 
 /* Derive the client early-traffic secret (bound to the just-built ClientHello)
@@ -1679,6 +1772,9 @@ r_tls_client_flight13 (RTLSClient * client, const RTLSParser * parser)
         }
       }
       r_tls_client_ee_apply_alpn (client, parser->fragment.data, parser->fragment.size);
+      if (client->record_size_limit != 0)
+        r_tls_client_ee_apply_record_size_limit (client,
+            parser->fragment.data, parser->fragment.size);
       /* A resumed handshake authenticates via the PSK, so no Certificate /
        * CertificateVerify follow: jump straight to the server Finished. */
       client->flight13_step = client->resumed13 ? 3 : 1;
@@ -2935,6 +3031,18 @@ r_tls_client_incoming_data (RTLSClient * client, RBuffer * buffer)
     }
 
     client->server.seqno++;
+
+    /* Honour a negotiated record_size_limit (RFC 8449): a post-handshake record
+     * whose plaintext -- content-type byte included -- exceeds the limit we
+     * advertised is a fatal record_overflow. The handshake flight is exempt (see
+     * r_tls_client_protect_record13). */
+    if (client->tls13 && client->state == R_TLS_CLIENT_APPDATA &&
+        client->record_size_limit != 0 && client->peer_record_size_limit != 0 &&
+        parser.fragment.size + 1 > (rsize) client->record_size_limit) {
+      r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_RECORD_OVERFLOW);
+      err = R_TLS_ERROR_RECORD_OVERFLOW;
+      break;
+    }
 
     if (parser.content == R_TLS_CONTENT_TYPE_ALERT) {
       RTLSAlertLevel alevel;

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -117,6 +117,10 @@ struct RTLSClient {
   ruint8 * ocsp_response;         /* stapled OCSPResponse the server sent (owned), or NULL */
   rsize ocsp_len;
 
+  rboolean request_sct;           /* offer signed_certificate_timestamp (RFC 6962) */
+  ruint8 * sct_list;              /* SignedCertificateTimestampList the server sent (owned), or NULL */
+  rsize sct_len;
+
   rboolean ecdhe;                  /* an ECDHE suite was negotiated */
   REcurveID ecdhe_curve;           /* the server-selected named group */
   RCryptoKey * ecdhe_key;          /* client ephemeral ECDH private key */
@@ -211,6 +215,7 @@ r_tls_client_free (RTLSClient * client)
     r_crypto_key_unref (client->privkey);
   r_free (client->server_name);
   r_free (client->ocsp_response);
+  r_free (client->sct_list);
   if (client->alpn_protocols != NULL) {
     rsize i;
     for (i = 0; i < client->alpn_count; i++)
@@ -464,6 +469,28 @@ r_tls_client_get_ocsp_response (const RTLSClient * client, rsize * len)
   if (len != NULL)
     *len = client->ocsp_len;
   return client->ocsp_response;
+}
+
+RTLSError
+r_tls_client_request_sct (RTLSClient * client, rboolean request)
+{
+  if (R_UNLIKELY (client == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (client->state != R_TLS_CLIENT_INITIAL)) return R_TLS_ERROR_WRONG_STATE;
+
+  client->request_sct = request;
+  return R_TLS_ERROR_OK;
+}
+
+const ruint8 *
+r_tls_client_get_sct_list (const RTLSClient * client, rsize * len)
+{
+  if (R_UNLIKELY (client == NULL)) {
+    if (len != NULL) *len = 0;
+    return NULL;
+  }
+  if (len != NULL)
+    *len = client->sct_len;
+  return client->sct_list;
 }
 
 RTLSError
@@ -904,6 +931,16 @@ r_tls_client_write_hs_ext_status_request (ruint8 * ptr)
   return 9;
 }
 
+/* signed_certificate_timestamp: request SCTs (RFC 6962). Empty in a
+ * ClientHello. */
+static ruint16
+r_tls_client_write_hs_ext_sct (ruint8 * ptr)
+{
+  r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_SIGNED_CERTIFICATE_TIMESTAMP);
+  r_store_be16 (&ptr[2], 0);
+  return 4;
+}
+
 /* Whether an EncryptedExtensions handshake message (a full message: 4-byte
  * header then a uint16-prefixed extension list) carries an early_data
  * extension, i.e. the server accepted 0-RTT. */
@@ -999,11 +1036,13 @@ r_tls_client_ee_apply_record_size_limit (RTLSClient * client,
   }
 }
 
-/* Extract a stapled OCSP response from a leaf CertificateEntry Extension list
- * (status_request, RFC 8446 4.4.2.1): CertificateStatus{ status_type=ocsp(1);
- * OCSPResponse<1..2^24-1> }. Stores a copy on the client. */
+/* Extract the per-entry extensions carried in a leaf CertificateEntry
+ * (RFC 8446 4.4.2.1): a stapled OCSP response (status_request,
+ * CertificateStatus{ status_type=ocsp(1); OCSPResponse }) and/or Signed
+ * Certificate Timestamps (signed_certificate_timestamp, RFC 6962). Stores copies
+ * of the ones the client asked for. */
 static void
-r_tls_client_apply_cert_status (RTLSClient * client,
+r_tls_client_apply_cert_exts (RTLSClient * client,
     const ruint8 * ext, ruint16 extlen)
 {
   const ruint8 * p = ext, * end = ext + extlen;
@@ -1014,14 +1053,19 @@ r_tls_client_apply_cert_status (RTLSClient * client,
     p += 4;
     if (p + elen > end)
       return;
-    if (etype == R_TLS_EXT_TYPE_STATUS_REQUEST && elen >= 4 && p[0] == 1 /* ocsp */) {
+    if (client->request_ocsp && etype == R_TLS_EXT_TYPE_STATUS_REQUEST &&
+        elen >= 4 && p[0] == 1 /* ocsp */) {
       rsize rlen = ((rsize) p[1] << 16) | ((rsize) p[2] << 8) | p[3];
       if (4 + rlen <= (rsize) elen && rlen > 0) {
         r_free (client->ocsp_response);
         client->ocsp_response = r_memdup (p + 4, rlen);
         client->ocsp_len = (client->ocsp_response != NULL) ? rlen : 0;
       }
-      return;
+    } else if (client->request_sct &&
+        etype == R_TLS_EXT_TYPE_SIGNED_CERTIFICATE_TIMESTAMP && elen > 0) {
+      r_free (client->sct_list);
+      client->sct_list = r_memdup (p, elen);
+      client->sct_len = (client->sct_list != NULL) ? elen : 0;
     }
     p += elen;
   }
@@ -1219,6 +1263,8 @@ r_tls_client_send_hello (RTLSClient * client, rboolean retry)
             ptr + 2 + extsize, client->record_size_limit);
       if (client->request_ocsp)
         extsize += r_tls_client_write_hs_ext_status_request (ptr + 2 + extsize);
+      if (client->request_sct)
+        extsize += r_tls_client_write_hs_ext_sct (ptr + 2 + extsize);
       /* Advertise (EC)DHE resumption support so the server issues tickets. */
       extsize += r_tls_client_write_hs_ext_psk_key_exchange_modes (ptr + 2 + extsize);
       /* early_data (0-RTT) sits before pre_shared_key, which stays last. */
@@ -1876,8 +1922,9 @@ r_tls_client_flight13 (RTLSClient * client, const RTLSParser * parser)
         err = R_TLS_ERROR_CORRUPT_CERTIFICATE;
       else {
         client->peer_cert = r_crypto_cert_ref (chain[0]);
-        if (client->request_ocsp && leafext != NULL && leafextlen > 0)
-          r_tls_client_apply_cert_status (client, leafext, leafextlen);
+        if ((client->request_ocsp || client->request_sct) &&
+            leafext != NULL && leafextlen > 0)
+          r_tls_client_apply_cert_exts (client, leafext, leafextlen);
         err = R_TLS_ERROR_OK;
       }
       for (i = 0; i < n; i++)

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -113,6 +113,10 @@ struct RTLSClient {
   ruint16 record_size_limit;      /* our advertised record_size_limit (RFC 8449), 0 = off */
   ruint16 peer_record_size_limit; /* server's echoed limit, caps our send; 0 = none */
 
+  rboolean request_ocsp;          /* offer status_request in the ClientHello (RFC 6066) */
+  ruint8 * ocsp_response;         /* stapled OCSPResponse the server sent (owned), or NULL */
+  rsize ocsp_len;
+
   rboolean ecdhe;                  /* an ECDHE suite was negotiated */
   REcurveID ecdhe_curve;           /* the server-selected named group */
   RCryptoKey * ecdhe_key;          /* client ephemeral ECDH private key */
@@ -206,6 +210,7 @@ r_tls_client_free (RTLSClient * client)
   if (client->privkey != NULL)
     r_crypto_key_unref (client->privkey);
   r_free (client->server_name);
+  r_free (client->ocsp_response);
   if (client->alpn_protocols != NULL) {
     rsize i;
     for (i = 0; i < client->alpn_count; i++)
@@ -437,6 +442,28 @@ r_tls_client_set_record_size_limit (RTLSClient * client, ruint16 limit)
 
   client->record_size_limit = limit;
   return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_client_request_ocsp (RTLSClient * client, rboolean request)
+{
+  if (R_UNLIKELY (client == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (client->state != R_TLS_CLIENT_INITIAL)) return R_TLS_ERROR_WRONG_STATE;
+
+  client->request_ocsp = request;
+  return R_TLS_ERROR_OK;
+}
+
+const ruint8 *
+r_tls_client_get_ocsp_response (const RTLSClient * client, rsize * len)
+{
+  if (R_UNLIKELY (client == NULL)) {
+    if (len != NULL) *len = 0;
+    return NULL;
+  }
+  if (len != NULL)
+    *len = client->ocsp_len;
+  return client->ocsp_response;
 }
 
 RTLSError
@@ -864,6 +891,19 @@ r_tls_client_write_hs_ext_record_size_limit (ruint8 * ptr, ruint16 limit)
   return 6;
 }
 
+/* status_request: request an OCSP staple (RFC 6066). CertificateStatusRequest
+ * with status_type=ocsp and empty responder_id_list / request_extensions. */
+static ruint16
+r_tls_client_write_hs_ext_status_request (ruint8 * ptr)
+{
+  r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_STATUS_REQUEST);
+  r_store_be16 (&ptr[2], 5);       /* status_type(1) + 2 empty <0..2^16-1> lists */
+  ptr[4] = 1;                      /* status_type = ocsp */
+  r_store_be16 (&ptr[5], 0);       /* responder_id_list<0>: empty */
+  r_store_be16 (&ptr[7], 0);       /* request_extensions<0>: empty */
+  return 9;
+}
+
 /* Whether an EncryptedExtensions handshake message (a full message: 4-byte
  * header then a uint16-prefixed extension list) carries an early_data
  * extension, i.e. the server accepted 0-RTT. */
@@ -953,6 +993,34 @@ r_tls_client_ee_apply_record_size_limit (RTLSClient * client,
       if (limit >= 64)
         client->peer_record_size_limit =
             limit > R_TLS_MAX_PLAINTEXT ? R_TLS_MAX_PLAINTEXT : limit;
+      return;
+    }
+    p += elen;
+  }
+}
+
+/* Extract a stapled OCSP response from a leaf CertificateEntry Extension list
+ * (status_request, RFC 8446 4.4.2.1): CertificateStatus{ status_type=ocsp(1);
+ * OCSPResponse<1..2^24-1> }. Stores a copy on the client. */
+static void
+r_tls_client_apply_cert_status (RTLSClient * client,
+    const ruint8 * ext, ruint16 extlen)
+{
+  const ruint8 * p = ext, * end = ext + extlen;
+
+  while (p + 4 <= end) {
+    ruint16 etype = r_load_be16 (p);
+    ruint16 elen = r_load_be16 (p + 2);
+    p += 4;
+    if (p + elen > end)
+      return;
+    if (etype == R_TLS_EXT_TYPE_STATUS_REQUEST && elen >= 4 && p[0] == 1 /* ocsp */) {
+      rsize rlen = ((rsize) p[1] << 16) | ((rsize) p[2] << 8) | p[3];
+      if (4 + rlen <= (rsize) elen && rlen > 0) {
+        r_free (client->ocsp_response);
+        client->ocsp_response = r_memdup (p + 4, rlen);
+        client->ocsp_len = (client->ocsp_response != NULL) ? rlen : 0;
+      }
       return;
     }
     p += elen;
@@ -1149,6 +1217,8 @@ r_tls_client_send_hello (RTLSClient * client, rboolean retry)
       if (client->record_size_limit != 0)
         extsize += r_tls_client_write_hs_ext_record_size_limit (
             ptr + 2 + extsize, client->record_size_limit);
+      if (client->request_ocsp)
+        extsize += r_tls_client_write_hs_ext_status_request (ptr + 2 + extsize);
       /* Advertise (EC)DHE resumption support so the server issues tickets. */
       extsize += r_tls_client_write_hs_ext_psk_key_exchange_modes (ptr + 2 + extsize);
       /* early_data (0-RTT) sits before pre_shared_key, which stays last. */
@@ -1783,11 +1853,17 @@ r_tls_client_flight13 (RTLSClient * client, const RTLSParser * parser)
     case 1: {
       RTLSCertificate tlscert = R_TLS_CERTIFICATE_INIT;
       RCryptoCert * chain[R_TLS_CLIENT_MAX_CHAIN];
+      const ruint8 * leafext = NULL;
+      ruint16 leafextlen = 0;
       ruint n = 0, i;
 
       if (type != R_TLS_HANDSHAKE_TYPE_CERTIFICATE)
         return R_TLS_ERROR_WRONG_TYPE;
       err = r_tls_parser_parse_certificate13_first (parser, &tlscert);
+      if (err == R_TLS_ERROR_OK) {
+        leafext = tlscert.ext;         /* leaf entry's extensions (OCSP staple etc.) */
+        leafextlen = tlscert.extlen;
+      }
       while (n < R_TLS_CLIENT_MAX_CHAIN && err == R_TLS_ERROR_OK) {
         if ((chain[n] = r_tls_certificate_get_cert (&tlscert)) != NULL)
           n++;
@@ -1800,6 +1876,8 @@ r_tls_client_flight13 (RTLSClient * client, const RTLSParser * parser)
         err = R_TLS_ERROR_CORRUPT_CERTIFICATE;
       else {
         client->peer_cert = r_crypto_cert_ref (chain[0]);
+        if (client->request_ocsp && leafext != NULL && leafextlen > 0)
+          r_tls_client_apply_cert_status (client, leafext, leafextlen);
         err = R_TLS_ERROR_OK;
       }
       for (i = 0; i < n; i++)

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -101,6 +101,9 @@ struct RTLSServer {
   ruint8 max_fragment;                  /* negotiated max_fragment_length (RFC 6066): 0 none, else 1..4 */
   ruint16 record_size_limit;            /* our advertised record_size_limit (RFC 8449), 0 = off */
   ruint16 peer_record_size_limit;       /* client's offered limit, caps our send; 0 = none */
+  ruint8 * ocsp_response;               /* DER OCSPResponse to staple (RFC 6066), owned; NULL = none */
+  rsize ocsp_len;
+  rboolean status_request_offered;      /* client sent status_request in its ClientHello */
   ruint8 * ticket;
   ruint16 ticketsize;
   RTLSSessionTicketKeys * ticket_keys;  /* shared STEK store; NULL disables tickets */
@@ -239,6 +242,7 @@ r_tls_server_free (RTLSServer * server)
   r_msg_digest_free (server->hshash);
 
   r_free (server->ticket);
+  r_free (server->ocsp_response);
   if (server->ticket_keys != NULL)
     r_tls_session_ticket_keys_unref (server->ticket_keys);
   r_queue_clear (&server->qsend, r_buffer_unref);
@@ -467,6 +471,27 @@ r_tls_server_set_record_size_limit (RTLSServer * server, ruint16 limit)
     return R_TLS_ERROR_INVAL;
 
   server->record_size_limit = limit;
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_server_set_ocsp_response (RTLSServer * server, const ruint8 * der, rsize len)
+{
+  ruint8 * copy = NULL;
+
+  if (R_UNLIKELY (server == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (server->state > R_TLS_SERVER_HELLO)) return R_TLS_ERROR_WRONG_STATE;
+  if (R_UNLIKELY ((der == NULL) != (len == 0))) return R_TLS_ERROR_INVAL;
+  /* The status_request entry (type + len + CertificateStatus) rides the leaf's
+   * 16-bit CertificateEntry extensions list: 8 + len must fit a uint16. */
+  if (R_UNLIKELY (len > 0xffffu - 8)) return R_TLS_ERROR_INVAL;
+
+  if (len > 0 && (copy = r_memdup (der, len)) == NULL)
+    return R_TLS_ERROR_OOM;
+
+  r_free (server->ocsp_response);
+  server->ocsp_response = copy;
+  server->ocsp_len = len;
   return R_TLS_ERROR_OK;
 }
 
@@ -1883,6 +1908,14 @@ r_tls_server_nego_hello13 (RTLSServer * server)
     }
   }
 
+  /* status_request (RFC 6066): note the OCSP-staple request so the leaf
+   * CertificateEntry can carry a CertificateStatus (RFC 8446 4.4.2.1). */
+  {
+    RTLSHelloExt sr = R_TLS_HELLO_EXT_INIT;
+    server->status_request_offered =
+        r_tls_server_find_ext (server, R_TLS_EXT_TYPE_STATUS_REQUEST, &sr);
+  }
+
   server->comp = R_TLS_COMPRESSION_NULL;
   server->version = R_TLS_VERSION_TLS_1_3;
   server->tls13 = TRUE;
@@ -2243,6 +2276,42 @@ r_tls_server_sign_certificate_verify13 (RTLSServer * server,
   return R_TLS_ERROR_OK;
 }
 
+/* Build the leaf CertificateEntry Extension list (RFC 8446 4.4.2.1): an OCSP
+ * staple (status_request, RFC 6066) when the client asked and one is configured.
+ * Returns a newly allocated blob (caller frees) and its length via @out, or
+ * @c NULL / 0 for an empty list. */
+static ruint8 *
+r_tls_server_build_leaf_cert_exts (RTLSServer * server, ruint16 * out)
+{
+  rboolean staple = server->status_request_offered && server->ocsp_response != NULL;
+  ruint8 * exts, * p;
+  rsize need = 0;
+
+  *out = 0;
+  if (staple)
+    need += 2 + 2 + 1 + 3 + server->ocsp_len;   /* status_request entry */
+  if (need == 0)
+    return NULL;
+  if ((exts = r_malloc (need)) == NULL)
+    return NULL;
+
+  p = exts;
+  if (staple) {
+    /* status_request = CertificateStatus{ status_type=ocsp(1); OCSPResponse }. */
+    rsize dlen = 1 + 3 + server->ocsp_len;
+    r_store_be16 (p, (ruint16) R_TLS_EXT_TYPE_STATUS_REQUEST); p += 2;
+    r_store_be16 (p, (ruint16) dlen); p += 2;
+    *p++ = 1;                                   /* status_type = ocsp */
+    *p++ = (ruint8)((server->ocsp_len >> 16) & 0xff);
+    *p++ = (ruint8)((server->ocsp_len >>  8) & 0xff);
+    *p++ = (ruint8)((server->ocsp_len      ) & 0xff);
+    r_memcpy (p, server->ocsp_response, server->ocsp_len); p += server->ocsp_len;
+  }
+
+  *out = (ruint16) need;
+  return exts;
+}
+
 /* Send the encrypted server flight (EncryptedExtensions, Certificate,
  * CertificateVerify, Finished) and derive the application secrets. The
  * ServerHello goes out in the clear first. */
@@ -2330,21 +2399,36 @@ r_tls_server_write_flight13 (RTLSServer * server)
   /* 5. + 6. Certificate and CertificateVerify: authenticated by the PSK on a
    * resumed handshake, so both are skipped (RFC 8446 2.2). */
   if (!server->resumed13) {
-    /* Certificate (single leaf). */
+    /* Certificate (single leaf), possibly carrying a stapled OCSP response in
+     * the leaf entry's extensions. The message can outgrow the stack scratch
+     * buffer, so build it on the heap sized to the certificate plus staple. */
+    ruint8 * leafexts, * certbody;
+    ruint16 leafextslen;
+    rsize certbodylen = 0;
+
     if ((certbuf = r_crypto_cert_get_data_buffer (server->cert)) == NULL)
       return R_TLS_ERROR_NO_CERTIFICATE;
     if (!r_buffer_map (certbuf, &certinfo, R_MEM_MAP_READ)) {
       r_buffer_unref (certbuf);
       return R_TLS_ERROR_OOM;
     }
-    ret = r_tls_write_hs_certificate13 (body, sizeof (body), &bodylen,
-        certinfo.data, certinfo.size);
+    leafexts = r_tls_server_build_leaf_cert_exts (server, &leafextslen);
+    /* context<1> | certificate_list<3> | cert_data<3> | cert | extensions<2>. */
+    if ((certbody = r_malloc (1 + 3 + 3 + certinfo.size + 2 + leafextslen)) == NULL) {
+      ret = R_TLS_ERROR_OOM;
+    } else {
+      ret = r_tls_write_hs_certificate13 (certbody,
+          1 + 3 + 3 + certinfo.size + 2 + leafextslen, &certbodylen,
+          certinfo.data, certinfo.size, leafexts, leafextslen);
+    }
     r_buffer_unmap (certbuf, &certinfo);
     r_buffer_unref (certbuf);
+    r_free (leafexts);
+    if (ret == R_TLS_ERROR_OK)
+      ret = r_tls_server_send_hs13 (server,
+          R_TLS_HANDSHAKE_TYPE_CERTIFICATE, certbody, certbodylen);
+    r_free (certbody);
     if (ret != R_TLS_ERROR_OK)
-      return ret;
-    if ((ret = r_tls_server_send_hs13 (server,
-            R_TLS_HANDSHAKE_TYPE_CERTIFICATE, body, bodylen)) != R_TLS_ERROR_OK)
       return ret;
 
     /* CertificateVerify over Transcript-Hash(ClientHello..Certificate). */

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -104,6 +104,9 @@ struct RTLSServer {
   ruint8 * ocsp_response;               /* DER OCSPResponse to staple (RFC 6066), owned; NULL = none */
   rsize ocsp_len;
   rboolean status_request_offered;      /* client sent status_request in its ClientHello */
+  ruint8 * sct_list;                    /* SignedCertificateTimestampList (RFC 6962), owned; NULL = none */
+  rsize sct_len;
+  rboolean sct_offered;                 /* client sent signed_certificate_timestamp */
   ruint8 * ticket;
   ruint16 ticketsize;
   RTLSSessionTicketKeys * ticket_keys;  /* shared STEK store; NULL disables tickets */
@@ -243,6 +246,7 @@ r_tls_server_free (RTLSServer * server)
 
   r_free (server->ticket);
   r_free (server->ocsp_response);
+  r_free (server->sct_list);
   if (server->ticket_keys != NULL)
     r_tls_session_ticket_keys_unref (server->ticket_keys);
   r_queue_clear (&server->qsend, r_buffer_unref);
@@ -492,6 +496,27 @@ r_tls_server_set_ocsp_response (RTLSServer * server, const ruint8 * der, rsize l
   r_free (server->ocsp_response);
   server->ocsp_response = copy;
   server->ocsp_len = len;
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_server_set_sct_list (RTLSServer * server, const ruint8 * der, rsize len)
+{
+  ruint8 * copy = NULL;
+
+  if (R_UNLIKELY (server == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (server->state > R_TLS_SERVER_HELLO)) return R_TLS_ERROR_WRONG_STATE;
+  if (R_UNLIKELY ((der == NULL) != (len == 0))) return R_TLS_ERROR_INVAL;
+  /* The SCT entry (type + len + list) rides the leaf's 16-bit CertificateEntry
+   * extensions list: 4 + len must fit a uint16. */
+  if (R_UNLIKELY (len > 0xffffu - 4)) return R_TLS_ERROR_INVAL;
+
+  if (len > 0 && (copy = r_memdup (der, len)) == NULL)
+    return R_TLS_ERROR_OOM;
+
+  r_free (server->sct_list);
+  server->sct_list = copy;
+  server->sct_len = len;
   return R_TLS_ERROR_OK;
 }
 
@@ -1916,6 +1941,14 @@ r_tls_server_nego_hello13 (RTLSServer * server)
         r_tls_server_find_ext (server, R_TLS_EXT_TYPE_STATUS_REQUEST, &sr);
   }
 
+  /* signed_certificate_timestamp (RFC 6962): note the SCT request so the leaf
+   * CertificateEntry can carry the SignedCertificateTimestampList. */
+  {
+    RTLSHelloExt sct = R_TLS_HELLO_EXT_INIT;
+    server->sct_offered =
+        r_tls_server_find_ext (server, R_TLS_EXT_TYPE_SIGNED_CERTIFICATE_TIMESTAMP, &sct);
+  }
+
   server->comp = R_TLS_COMPRESSION_NULL;
   server->version = R_TLS_VERSION_TLS_1_3;
   server->tls13 = TRUE;
@@ -2277,20 +2310,25 @@ r_tls_server_sign_certificate_verify13 (RTLSServer * server,
 }
 
 /* Build the leaf CertificateEntry Extension list (RFC 8446 4.4.2.1): an OCSP
- * staple (status_request, RFC 6066) when the client asked and one is configured.
- * Returns a newly allocated blob (caller frees) and its length via @out, or
- * @c NULL / 0 for an empty list. */
+ * staple (status_request, RFC 6066) and/or Signed Certificate Timestamps
+ * (signed_certificate_timestamp, RFC 6962), each included when the client asked
+ * and one is configured. Returns a newly allocated blob (caller frees) and its
+ * length via @out, or @c NULL / 0 for an empty list. */
 static ruint8 *
 r_tls_server_build_leaf_cert_exts (RTLSServer * server, ruint16 * out)
 {
   rboolean staple = server->status_request_offered && server->ocsp_response != NULL;
+  rboolean sct = server->sct_offered && server->sct_list != NULL;
   ruint8 * exts, * p;
   rsize need = 0;
 
   *out = 0;
   if (staple)
     need += 2 + 2 + 1 + 3 + server->ocsp_len;   /* status_request entry */
-  if (need == 0)
+  if (sct)
+    need += 2 + 2 + server->sct_len;            /* signed_certificate_timestamp entry */
+  /* The whole list rides a 16-bit CertificateEntry extensions length. */
+  if (need == 0 || need > 0xffff)
     return NULL;
   if ((exts = r_malloc (need)) == NULL)
     return NULL;
@@ -2306,6 +2344,12 @@ r_tls_server_build_leaf_cert_exts (RTLSServer * server, ruint16 * out)
     *p++ = (ruint8)((server->ocsp_len >>  8) & 0xff);
     *p++ = (ruint8)((server->ocsp_len      ) & 0xff);
     r_memcpy (p, server->ocsp_response, server->ocsp_len); p += server->ocsp_len;
+  }
+  if (sct) {
+    /* extension_data is the SignedCertificateTimestampList, carried verbatim. */
+    r_store_be16 (p, (ruint16) R_TLS_EXT_TYPE_SIGNED_CERTIFICATE_TIMESTAMP); p += 2;
+    r_store_be16 (p, (ruint16) server->sct_len); p += 2;
+    r_memcpy (p, server->sct_list, server->sct_len); p += server->sct_len;
   }
 
   *out = (ruint16) need;

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -99,6 +99,8 @@ struct RTLSServer {
   rchar * sni;                          /* SNI host_name from the ClientHello (owned), or NULL */
   RTLSServerNameCb server_name_cb;      /* picks cert/policy for the SNI host; may be NULL */
   ruint8 max_fragment;                  /* negotiated max_fragment_length (RFC 6066): 0 none, else 1..4 */
+  ruint16 record_size_limit;            /* our advertised record_size_limit (RFC 8449), 0 = off */
+  ruint16 peer_record_size_limit;       /* client's offered limit, caps our send; 0 = none */
   ruint8 * ticket;
   ruint16 ticketsize;
   RTLSSessionTicketKeys * ticket_keys;  /* shared STEK store; NULL disables tickets */
@@ -457,6 +459,18 @@ r_tls_server_set_alpn_protocols (RTLSServer * server,
 }
 
 RTLSError
+r_tls_server_set_record_size_limit (RTLSServer * server, ruint16 limit)
+{
+  if (R_UNLIKELY (server == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (server->state > R_TLS_SERVER_HELLO)) return R_TLS_ERROR_WRONG_STATE;
+  if (R_UNLIKELY (limit != 0 && (limit < 64 || limit > R_TLS_MAX_PLAINTEXT)))
+    return R_TLS_ERROR_INVAL;
+
+  server->record_size_limit = limit;
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
 r_tls_server_set_random (RTLSServer * server,
     const ruint8 servrandom[R_TLS_HELLO_RANDOM_BYTES])
 {
@@ -782,6 +796,21 @@ r_tls_server_write_hs_ext_max_fragment_length (const RTLSServer * server, ruint8
   ptr[4] = server->max_fragment;        /* echo the negotiated value (1..4) */
 
   return 5;
+}
+
+/* record_size_limit (RFC 8449) for EncryptedExtensions: advertise our own
+ * receive limit, but only in answer to a client that offered the extension. */
+static ruint16
+r_tls_server_write_hs_ext_record_size_limit (const RTLSServer * server, ruint8 * ptr)
+{
+  if (server->record_size_limit == 0 || server->peer_record_size_limit == 0)
+    return 0;
+
+  r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_RECORD_SIZE_LIMIT);
+  r_store_be16 (&ptr[2], sizeof (ruint16));
+  r_store_be16 (&ptr[4], server->record_size_limit);
+
+  return 6;
 }
 
 static RTLSError
@@ -1840,6 +1869,20 @@ r_tls_server_nego_hello13 (RTLSServer * server)
     }
   }
 
+  /* record_size_limit (RFC 8449): the client's value caps the plaintext we send;
+   * we advertise our own in EncryptedExtensions. */
+  {
+    RTLSHelloExt rsl = R_TLS_HELLO_EXT_INIT;
+    server->peer_record_size_limit = 0;
+    if (r_tls_server_find_ext (server, R_TLS_EXT_TYPE_RECORD_SIZE_LIMIT, &rsl)) {
+      ruint16 limit;
+      if (rsl.len != sizeof (ruint16) || (limit = r_load_be16 (rsl.data)) < 64)
+        return R_TLS_ERROR_ILLEGAL_PARAMETER;
+      server->peer_record_size_limit =
+          limit > R_TLS_MAX_PLAINTEXT ? R_TLS_MAX_PLAINTEXT : limit;
+    }
+  }
+
   server->comp = R_TLS_COMPRESSION_NULL;
   server->version = R_TLS_VERSION_TLS_1_3;
   server->tls13 = TRUE;
@@ -2046,9 +2089,9 @@ r_tls_server_write_hello13 (RTLSServer * server)
 }
 
 /* AEAD-protect @plain[@plainlen] (real content type @ct) under the current
- * write key and queue the application_data record. */
+ * write key and queue one application_data record. */
 static RTLSError
-r_tls_server_protect_record13 (RTLSServer * server, RTLSContentType ct,
+r_tls_server_protect_record13_one (RTLSServer * server, RTLSContentType ct,
     const ruint8 * plain, rsize plainlen)
 {
   RBuffer * rec;
@@ -2086,6 +2129,35 @@ r_tls_server_protect_record13 (RTLSServer * server, RTLSContentType ct,
   if (rec != NULL)
     r_buffer_unref (rec);
   return ret;
+}
+
+/* Protect @plain[@plainlen], fragmenting into records whose inner plaintext --
+ * content-type byte included -- honours a negotiated record_size_limit
+ * (RFC 8449); with none negotiated a single record up to 2^14 is emitted. The
+ * cap is applied only to post-handshake traffic: the handshake flight is exempt,
+ * since a message split across records is not reassembled by the simple
+ * one-message-per-record handshake reader. */
+static RTLSError
+r_tls_server_protect_record13 (RTLSServer * server, RTLSContentType ct,
+    const ruint8 * plain, rsize plainlen)
+{
+  rsize max = (server->peer_record_size_limit != 0 &&
+      server->state == R_TLS_SERVER_APPDATA) ?
+      (rsize) server->peer_record_size_limit - 1 : R_TLS_MAX_PLAINTEXT;
+  rsize off = 0;
+
+  do {
+    rsize chunk = plainlen - off;
+    RTLSError ret;
+    if (chunk > max)
+      chunk = max;
+    if ((ret = r_tls_server_protect_record13_one (server, ct,
+            plain + off, chunk)) != R_TLS_ERROR_OK)
+      return ret;
+    off += chunk;
+  } while (off < plainlen);
+
+  return R_TLS_ERROR_OK;
 }
 
 /* Frame @body[@bodylen] as a handshake message, fold it into the transcript,
@@ -2238,7 +2310,7 @@ r_tls_server_write_flight13 (RTLSServer * server)
    * acceptance (empty extension) and the negotiated ALPN protocol -- otherwise
    * an empty list. */
   {
-    ruint8 ee[4 + 7 + 255];   /* early_data(4) + ALPN(7 + name<=255>) */
+    ruint8 ee[4 + 7 + 255 + 6]; /* early_data(4) + ALPN(7 + name<=255>) + record_size_limit(6) */
     ruint16 eelen = 0;
     if (server->early13_accepted) {
       r_store_be16 (ee, (ruint16)R_TLS_EXT_TYPE_EARLY_DATA);
@@ -2246,6 +2318,7 @@ r_tls_server_write_flight13 (RTLSServer * server)
       eelen = 4;
     }
     eelen += r_tls_server_write_hs_ext_alpn (server, ee + eelen);
+    eelen += r_tls_server_write_hs_ext_record_size_limit (server, ee + eelen);
     if ((ret = r_tls_write_hs_encrypted_extensions (body, sizeof (body),
             &bodylen, eelen ? ee : NULL, eelen)) != R_TLS_ERROR_OK)
       return ret;
@@ -3750,6 +3823,18 @@ r_tls_server_incoming_data (RTLSServer * server, RBuffer * buffer)
      * the cap is a fatal record_overflow (RFC 6066). */
     if (server->max_fragment != 0 &&
         parser.fragment.size > ((rsize) 1u << (8 + server->max_fragment))) {
+      r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_RECORD_OVERFLOW);
+      err = R_TLS_ERROR_RECORD_OVERFLOW;
+      break;
+    }
+
+    /* Honour a negotiated record_size_limit (RFC 8449): a post-handshake record
+     * whose plaintext -- content-type byte included -- exceeds the limit we
+     * advertised is a fatal record_overflow. The handshake flight is exempt (see
+     * r_tls_server_protect_record13). */
+    if (server->tls13 && server->state == R_TLS_SERVER_APPDATA &&
+        server->record_size_limit != 0 && server->peer_record_size_limit != 0 &&
+        parser.fragment.size + 1 > (rsize) server->record_size_limit) {
       r_tls_server_send_alert (server, R_TLS_ALERT_TYPE_RECORD_OVERFLOW);
       err = R_TLS_ERROR_RECORD_OVERFLOW;
       break;

--- a/test/rtls.c
+++ b/test/rtls.c
@@ -339,7 +339,7 @@ RTEST (rtls, write_parse_certificate13_roundtrip, RTEST_FAST)
   r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_write_handshake (rec, sizeof (rec),
         &hssize, R_TLS_VERSION_TLS_1_3, R_TLS_HANDSHAKE_TYPE_CERTIFICATE, 0));
   r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_write_hs_certificate13 (
-        rec + hssize, sizeof (rec) - hssize, &bodylen, der, sizeof (der)));
+        rec + hssize, sizeof (rec) - hssize, &bodylen, der, sizeof (der), NULL, 0));
   /* context(1) + list<3> + entry{ cert<3> + der + ext<2> }. */
   r_assert_cmpuint (bodylen, ==, 1 + 3 + (3 + sizeof (der) + 2));
   r_assert_cmpint (R_TLS_ERROR_OK, ==,
@@ -353,6 +353,7 @@ RTEST (rtls, write_parse_certificate13_roundtrip, RTEST_FAST)
       r_tls_parser_parse_certificate13_first (&parser, &tlscert));
   r_assert_cmpuint (tlscert.len, ==, sizeof (der));
   r_assert_cmpmem (tlscert.cert, ==, der, sizeof (der));
+  r_assert_cmpuint (tlscert.extlen, ==, 0);
   /* Only one entry: the next walk reports end-of-buffer. */
   r_assert_cmpint (R_TLS_ERROR_EOB, ==,
       r_tls_parser_parse_certificate13_next (&parser, &tlscert));

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -1068,6 +1068,124 @@ RTEST_F (rtlsclient, tls13_record_size_limit_invalid, RTEST_FAST)
 }
 RTEST_END;
 
+/* OCSP stapling (status_request, RFC 6066 / RFC 8446 4.4.2.1): the client offers
+ * status_request and the server, with a response configured, staples it in the
+ * leaf CertificateEntry; the client retrieves the identical bytes. @staplelen
+ * spans small and multi-KB responses (the latter outgrows the certificate scratch
+ * buffer, exercising the heap-built Certificate message). */
+static void
+r_test_tls13_ocsp_staple (RTEST_FIXTURE_STRUCT (rtlsclient) * fixture, rsize staplelen)
+{
+  ruint8 * staple;
+  const ruint8 * got;
+  rsize gotlen = 0, i;
+
+  r_assert_cmpptr ((staple = r_malloc (staplelen)), !=, NULL);
+  for (i = 0; i < staplelen; i++)
+    staple[i] = (ruint8) ((i * 7 + 3) & 0xff);
+
+  r_assert_cmpint (r_tls_client_request_ocsp (fixture->client, TRUE),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_set_ocsp_response (fixture->server, staple, staplelen),
+      ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->cli_hs_done);
+  r_assert (fixture->srv_hs_done);
+  r_assert (!fixture->cli_error);
+  r_assert (!fixture->srv_error);
+
+  got = r_tls_client_get_ocsp_response (fixture->client, &gotlen);
+  r_assert_cmpptr (got, !=, NULL);
+  r_assert_cmpuint (gotlen, ==, staplelen);
+  r_assert_cmpmem (got, ==, staple, staplelen);
+
+  r_free (staple);
+}
+
+RTEST_F (rtlsclient, tls13_ocsp_staple, RTEST_FAST)
+{
+  r_test_tls13_ocsp_staple (fixture, 128);
+}
+RTEST_END;
+
+/* A multi-KB staple forces the Certificate message past the stack scratch buffer. */
+RTEST_F (rtlsclient, tls13_ocsp_staple_large, RTEST_FAST)
+{
+  r_test_tls13_ocsp_staple (fixture, 6000);
+}
+RTEST_END;
+
+/* No staple is delivered when the client did not ask, even if the server has one
+ * configured; and none when the client asks but the server has none. Either way
+ * the handshake completes. */
+RTEST_F (rtlsclient, tls13_ocsp_not_delivered, RTEST_FAST)
+{
+  static const ruint8 staple[] = { 0x30, 0x03, 0x0a, 0x01, 0x00 };
+  const ruint8 * got;
+  rsize gotlen = 1;
+
+  /* Server has a response, but the client never offers status_request. */
+  r_assert_cmpint (r_tls_server_set_ocsp_response (fixture->server, staple,
+        sizeof (staple)), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->cli_hs_done);
+  r_assert (!fixture->cli_error);
+
+  got = r_tls_client_get_ocsp_response (fixture->client, &gotlen);
+  r_assert_cmpptr (got, ==, NULL);
+  r_assert_cmpuint (gotlen, ==, 0);
+}
+RTEST_END;
+
+/* status_request offered, but the server stapled nothing: no OCSP delivered. */
+RTEST_F (rtlsclient, tls13_ocsp_requested_server_none, RTEST_FAST)
+{
+  const ruint8 * got;
+  rsize gotlen = 1;
+
+  r_assert_cmpint (r_tls_client_request_ocsp (fixture->client, TRUE),
+      ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->cli_hs_done);
+  r_assert (!fixture->cli_error);
+
+  got = r_tls_client_get_ocsp_response (fixture->client, &gotlen);
+  r_assert_cmpptr (got, ==, NULL);
+  r_assert_cmpuint (gotlen, ==, 0);
+}
+RTEST_END;
+
+/* set_ocsp_response validates its arguments. */
+RTEST_F (rtlsclient, tls13_ocsp_set_validation, RTEST_FAST)
+{
+  static const ruint8 der[] = { 0x30, 0x03, 0x0a, 0x01, 0x00 };
+
+  r_assert_cmpint (r_tls_server_set_ocsp_response (fixture->server, der, 0),
+      ==, R_TLS_ERROR_INVAL);          /* non-NULL der, zero len */
+  r_assert_cmpint (r_tls_server_set_ocsp_response (fixture->server, NULL, 5),
+      ==, R_TLS_ERROR_INVAL);          /* NULL der, non-zero len */
+  r_assert_cmpint (r_tls_server_set_ocsp_response (fixture->server, der, sizeof (der)),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_set_ocsp_response (fixture->server, NULL, 0),
+      ==, R_TLS_ERROR_OK);             /* clear */
+}
+RTEST_END;
+
 /* Drive CH1 -> HelloRetryRequest with a server that requires secp256r1 while
  * the client first offers x25519. Returns the (still-owned) HRR record and
  * leaves the client having consumed nothing yet. */

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -925,6 +925,149 @@ HEAVY_RTEST_F (rtlsclient, tls13_loopback_group_ffdhe8192, RTEST_SLOW)
 }
 RTEST_END;
 
+/* Drain @from, asserting every record's ciphertext fits a @limit-byte plaintext
+ * cap (RFC 8449: header + inner plaintext<=limit + AEAD tag), feed each into the
+ * server (@to_server) or client, and return the record count. */
+static ruint
+r_test_tls_relay_capped (RQueue * from, ruint16 limit,
+    rboolean to_server, RTEST_FIXTURE_STRUCT (rtlsclient) * fixture)
+{
+  RBuffer * rec;
+  RMemMapInfo info = R_MEM_MAP_INFO_INIT;
+  ruint n = 0;
+
+  while ((rec = r_queue_pop (from)) != NULL) {
+    r_assert (r_buffer_map (rec, &info, R_MEM_MAP_READ));
+    r_assert_cmpuint (info.size, <=,
+        R_TLS_RECORD_HDR_SIZE + (rsize) limit + R_TLS13_AEAD_TAG_SIZE);
+    r_buffer_unmap (rec, &info);
+    if (to_server)
+      r_tls_server_incoming_data (fixture->server, rec);
+    else
+      r_tls_client_incoming_data (fixture->client, rec);
+    r_buffer_unref (rec);
+    n++;
+  }
+  return n;
+}
+
+/* record_size_limit (RFC 8449): both endpoints advertise a small receive limit;
+ * the handshake completes and each direction honours the peer's cap, fragmenting
+ * larger application data into multiple records that reassemble to the original.
+ * The client sends toward @srv_limit (the server's advertised value), the server
+ * toward @cli_limit. */
+static void
+r_test_tls13_record_size_limit (RTEST_FIXTURE_STRUCT (rtlsclient) * fixture,
+    ruint16 cli_limit, ruint16 srv_limit)
+{
+  ruint8 payload[1000];
+  RBuffer * app;
+  rsize i;
+
+  for (i = 0; i < sizeof (payload); i++)
+    payload[i] = (ruint8) (i & 0xff);
+
+  r_assert_cmpint (r_tls_client_set_record_size_limit (fixture->client, cli_limit),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_set_record_size_limit (fixture->server, srv_limit),
+      ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->cli_hs_done);
+  r_assert (fixture->srv_hs_done);
+  r_assert (!fixture->cli_error);
+  r_assert (!fixture->srv_error);
+
+  /* Client -> server: the client caps each record at the server's limit. */
+  r_assert_cmpptr ((app = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          payload, sizeof (payload), sizeof (payload), 0, NULL, NULL)), !=, NULL);
+  r_assert (r_tls_client_send_appdata (fixture->client, app));
+  r_buffer_unref (app);
+  r_assert_cmpuint (r_test_tls_relay_capped (&fixture->cli_out, srv_limit, TRUE, fixture),
+      >, 1);
+  r_test_tls_assert_appdata (&fixture->srv_app, payload, sizeof (payload));
+
+  /* Server -> client: symmetrically capped at the client's limit. */
+  r_assert_cmpptr ((app = r_buffer_new_wrapped (R_MEM_FLAG_NONE,
+          payload, sizeof (payload), sizeof (payload), 0, NULL, NULL)), !=, NULL);
+  r_assert (r_tls_server_send_appdata (fixture->server, app));
+  r_buffer_unref (app);
+  r_assert_cmpuint (r_test_tls_relay_capped (&fixture->srv_out, cli_limit, FALSE, fixture),
+      >, 1);
+  r_test_tls_assert_appdata (&fixture->cli_app, payload, sizeof (payload));
+
+  r_assert (!fixture->cli_error);
+  r_assert (!fixture->srv_error);
+}
+
+RTEST_F (rtlsclient, tls13_record_size_limit, RTEST_FAST)
+{
+  r_test_tls13_record_size_limit (fixture, 64, 100);
+}
+RTEST_END;
+
+/* An incoming record whose plaintext exceeds the limit we advertised is a fatal
+ * record_overflow (RFC 8449). Post-handshake application_data is AEAD-protected
+ * and would fail decryption before the size guard, so a plaintext handshake-type
+ * record -- which skips decryption -- exercises the guard directly. */
+RTEST_F (rtlsclient, tls13_record_size_limit_incoming_overflow, RTEST_FAST)
+{
+  ruint8 big[R_TLS_RECORD_HDR_SIZE + 200];
+  RBuffer * rec;
+
+  r_assert_cmpint (r_tls_client_set_record_size_limit (fixture->client, 64),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_set_record_size_limit (fixture->server, 64),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->cli_hs_done);
+  r_assert (!fixture->cli_error);
+
+  r_memclear (big, sizeof (big));
+  big[0] = R_TLS_CONTENT_TYPE_HANDSHAKE;
+  r_store_be16 (&big[1], R_TLS_VERSION_TLS_1_2);
+  r_store_be16 (&big[3], 200);                /* fragment length 200 > 64 */
+  r_assert_cmpptr ((rec = r_buffer_new_wrapped (R_MEM_FLAG_NONE, big,
+          sizeof (big), sizeof (big), 0, NULL, NULL)), !=, NULL);
+  r_tls_client_incoming_data (fixture->client, rec);
+  r_buffer_unref (rec);
+
+  r_assert (fixture->cli_error);
+  r_assert_cmpuint (fixture->cli_alert, ==, R_TLS_ALERT_TYPE_RECORD_OVERFLOW);
+}
+RTEST_END;
+
+/* The limit must lie in 64 .. 2^14; 0 disables the extension. */
+RTEST_F (rtlsclient, tls13_record_size_limit_invalid, RTEST_FAST)
+{
+  r_assert_cmpint (r_tls_client_set_record_size_limit (fixture->client, 63),
+      ==, R_TLS_ERROR_INVAL);
+  r_assert_cmpint (r_tls_client_set_record_size_limit (fixture->client,
+        R_TLS_MAX_PLAINTEXT + 1), ==, R_TLS_ERROR_INVAL);
+  r_assert_cmpint (r_tls_client_set_record_size_limit (fixture->client, 0),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_set_record_size_limit (fixture->client, 64),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_set_record_size_limit (fixture->client,
+        R_TLS_MAX_PLAINTEXT), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_set_record_size_limit (fixture->server, 63),
+      ==, R_TLS_ERROR_INVAL);
+  r_assert_cmpint (r_tls_server_set_record_size_limit (fixture->server,
+        R_TLS_MAX_PLAINTEXT + 1), ==, R_TLS_ERROR_INVAL);
+  r_assert_cmpint (r_tls_server_set_record_size_limit (fixture->server, 64),
+      ==, R_TLS_ERROR_OK);
+}
+RTEST_END;
+
 /* Drive CH1 -> HelloRetryRequest with a server that requires secp256r1 while
  * the client first offers x25519. Returns the (still-owned) HRR record and
  * leaves the client having consumed nothing yet. */

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -1186,6 +1186,116 @@ RTEST_F (rtlsclient, tls13_ocsp_set_validation, RTEST_FAST)
 }
 RTEST_END;
 
+/* signed_certificate_timestamp (RFC 6962): the client offers the extension and
+ * the server carries the SignedCertificateTimestampList verbatim in the leaf
+ * CertificateEntry; the client retrieves the identical bytes. */
+RTEST_F (rtlsclient, tls13_sct, RTEST_FAST)
+{
+  static const ruint8 scts[] = {
+    0x00, 0x12, 0x00, 0x10, 0xde, 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03, 0x04,
+    0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c };
+  const ruint8 * got;
+  rsize gotlen = 0;
+
+  r_assert_cmpint (r_tls_client_request_sct (fixture->client, TRUE),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_set_sct_list (fixture->server, scts, sizeof (scts)),
+      ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->cli_hs_done);
+  r_assert (fixture->srv_hs_done);
+  r_assert (!fixture->cli_error);
+
+  got = r_tls_client_get_sct_list (fixture->client, &gotlen);
+  r_assert_cmpptr (got, !=, NULL);
+  r_assert_cmpuint (gotlen, ==, sizeof (scts));
+  r_assert_cmpmem (got, ==, scts, sizeof (scts));
+}
+RTEST_END;
+
+/* OCSP staple and SCTs ride the same leaf CertificateEntry: both are delivered
+ * when both are requested and configured. */
+RTEST_F (rtlsclient, tls13_ocsp_and_sct, RTEST_FAST)
+{
+  static const ruint8 ocsp[] = { 0x30, 0x05, 0x0a, 0x01, 0x00, 0x02, 0x00 };
+  static const ruint8 scts[] = { 0x00, 0x06, 0x00, 0x04, 0xaa, 0xbb, 0xcc, 0xdd };
+  const ruint8 * got;
+  rsize gotlen = 0;
+
+  r_assert_cmpint (r_tls_client_request_ocsp (fixture->client, TRUE),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_request_sct (fixture->client, TRUE),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_set_ocsp_response (fixture->server, ocsp, sizeof (ocsp)),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_set_sct_list (fixture->server, scts, sizeof (scts)),
+      ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->cli_hs_done);
+  r_assert (!fixture->cli_error);
+
+  got = r_tls_client_get_ocsp_response (fixture->client, &gotlen);
+  r_assert_cmpptr (got, !=, NULL);
+  r_assert_cmpuint (gotlen, ==, sizeof (ocsp));
+  r_assert_cmpmem (got, ==, ocsp, sizeof (ocsp));
+
+  got = r_tls_client_get_sct_list (fixture->client, &gotlen);
+  r_assert_cmpptr (got, !=, NULL);
+  r_assert_cmpuint (gotlen, ==, sizeof (scts));
+  r_assert_cmpmem (got, ==, scts, sizeof (scts));
+}
+RTEST_END;
+
+/* No SCTs are delivered when the client did not ask, even with some configured. */
+RTEST_F (rtlsclient, tls13_sct_not_delivered, RTEST_FAST)
+{
+  static const ruint8 scts[] = { 0x00, 0x06, 0x00, 0x04, 0xaa, 0xbb, 0xcc, 0xdd };
+  const ruint8 * got;
+  rsize gotlen = 1;
+
+  r_assert_cmpint (r_tls_server_set_sct_list (fixture->server, scts, sizeof (scts)),
+      ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->cli_hs_done);
+  r_assert (!fixture->cli_error);
+
+  got = r_tls_client_get_sct_list (fixture->client, &gotlen);
+  r_assert_cmpptr (got, ==, NULL);
+  r_assert_cmpuint (gotlen, ==, 0);
+}
+RTEST_END;
+
+/* set_sct_list validates its arguments. */
+RTEST_F (rtlsclient, tls13_sct_set_validation, RTEST_FAST)
+{
+  static const ruint8 scts[] = { 0x00, 0x06, 0x00, 0x04, 0xaa, 0xbb, 0xcc, 0xdd };
+
+  r_assert_cmpint (r_tls_server_set_sct_list (fixture->server, scts, 0),
+      ==, R_TLS_ERROR_INVAL);
+  r_assert_cmpint (r_tls_server_set_sct_list (fixture->server, NULL, 5),
+      ==, R_TLS_ERROR_INVAL);
+  r_assert_cmpint (r_tls_server_set_sct_list (fixture->server, scts, sizeof (scts)),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_set_sct_list (fixture->server, NULL, 0),
+      ==, R_TLS_ERROR_OK);
+}
+RTEST_END;
+
 /* Drive CH1 -> HelloRetryRequest with a server that requires secp256r1 while
  * the client first offers x25519. Returns the (still-owned) HRR record and
  * leaves the client having consumed nothing yet. */


### PR DESCRIPTION
Implements the three optional TLS 1.3 extensions from #387, each as an isolated per-feature commit. All are optional and none are required for RFC 8446 conformance.

## record_size_limit (RFC 8449)
Bidirectional negotiation of a smaller protected-record plaintext limit than the 2^14 default. The client offers `record_size_limit` in the ClientHello; the server echoes its own in EncryptedExtensions when the client offered it. A peer's advertised limit caps the plaintext of each record we emit (fragmenting larger payloads), and an inbound record over our advertised limit is a fatal `record_overflow`. New `r_tls_{client,server}_set_record_size_limit`.

The cap governs post-handshake traffic only — the handshake flight is exempt, because a handshake message split across records is not reassembled by the one-message-per-record handshake reader. Documented on the API.

## OCSP stapling (status_request, RFC 6066 / RFC 8446 4.4.2.1)
The client offers `status_request` (`r_tls_client_request_ocsp`) and reads the delivered response (`r_tls_client_get_ocsp_response`); the server supplies the DER `OCSPResponse` (`r_tls_server_set_ocsp_response`) and, when asked, emits it as a `CertificateStatus` in the leaf CertificateEntry extensions. Delivered as-is; not validated.

This commit introduces the shared per-entry extension plumbing: `r_tls_write_hs_certificate13` takes a leaf Extension list, `RTLSCertificate` exposes the parsed per-entry extensions, and the server builds the Certificate message on the heap since a staple can outgrow the stack scratch buffer.

## signed_certificate_timestamp (SCT, RFC 6962)
The client offers the extension (`r_tls_client_request_sct`) and reads the list (`r_tls_client_get_sct_list`); the server carries a serialized `SignedCertificateTimestampList` (`r_tls_server_set_sct_list`) verbatim in the leaf entry, alongside any OCSP staple. Delivered as-is; not validated.

## Verification
Full suite green on the Linux, ASan, and mingw tiers; each commit builds in isolation. New tests cover bidirectional negotiation and fragmentation, inbound `record_overflow`, OCSP/SCT round-trips (including a combined-in-one-handshake case and a multi-KB staple exercising the heap Certificate path), and setter validation. Every new `R_API` symbol has full Doxygen.

Closes #387