### PR TITLE
net/tls: TLS 1.3 post-handshake client authentication (RFC 8446 4.6.2)

### DIFF
--- a/include/rlib/net/proto/rtls.h
+++ b/include/rlib/net/proto/rtls.h
@@ -479,6 +479,16 @@ typedef struct {
   const ruint8 * ca;          /**< @brief Distinguished names of accepted CAs. */
 } RTLSCertReq;
 
+/** @brief Parsed TLS 1.3 CertificateRequest (RFC 8446, 4.3.2), pointing into
+ * the record buffer. The context is echoed by the responding Certificate and,
+ * for post-handshake authentication, ties the flight to the request. */
+typedef struct {
+  ruint8 contextlen;          /**< @brief Length of @c context in bytes. */
+  const ruint8 * context;     /**< @brief certificate_request_context to echo. */
+  ruint16 signschemecount;    /**< @brief Number of accepted signature schemes. */
+  const ruint8 * signscheme;  /**< @brief Accepted signature schemes (@ref RTLSSignatureScheme). */
+} RTLSCertReq13;
+
 /** @brief Peek the protocol version of the record in @p buf without full parsing; @c R_TLS_VERSION_UNKNOWN if not a record. */
 R_API RTLSVersion r_tls_parse_data_shallow (rconstpointer buf, rsize size);
 
@@ -572,8 +582,27 @@ R_API RTLSError r_tls_parser_parse_certificate13_first (const RTLSParser * parse
  * current entry's extensions. @see r_tls_parser_parse_certificate13_first */
 R_API RTLSError r_tls_parser_parse_certificate13_next (const RTLSParser * parser,
     RTLSCertificate * cert);
+/**
+ * @brief Read the @c certificate_request_context of a TLS 1.3 Certificate.
+ *
+ * The context is empty in the handshake and non-empty for a post-handshake
+ * authentication answer, where it echoes the CertificateRequest (RFC 8446
+ * 4.6.2). @p ctx points into the record buffer (@c NULL when empty).
+ */
+R_API RTLSError r_tls_parser_parse_certificate13_context (const RTLSParser * parser,
+    const ruint8 ** ctx, ruint8 * ctxlen);
 /** @brief Parse the current record as a CertificateRequest into @p req. */
 R_API RTLSError r_tls_parser_parse_certificate_request (const RTLSParser * parser, RTLSCertReq * req);
+/**
+ * @brief Parse the current record as a TLS 1.3 CertificateRequest into @p req.
+ *
+ * The 1.3 message (RFC 8446, 4.3.2) replaces the 1.2 certificate-type and CA
+ * fields with a @c certificate_request_context and an extension list, so the
+ * 1.2 @ref r_tls_parser_parse_certificate_request would misparse it. Exposes the
+ * context to echo and the accepted signature schemes; @p req points into the
+ * record buffer.
+ */
+R_API RTLSError r_tls_parser_parse_certificate_request13 (const RTLSParser * parser, RTLSCertReq13 * req);
 /**
  * @brief Parse the current record as a NewSessionTicket.
  * @param parser Parser positioned on the message.
@@ -941,6 +970,9 @@ static inline RTLSClientCertificateType r_tls_cert_req_cert_type (const RTLSCert
 /** @brief Return the @p n th accepted signature scheme in @p req. */
 static inline RTLSSignatureScheme r_tls_cert_req_sign_scheme (const RTLSCertReq * req, int n)
 { return (RTLSSignatureScheme) r_load_be16 (req->signscheme + n * sizeof (ruint16)); }
+/** @brief Return the @p n th accepted signature scheme in a TLS 1.3 @p req. */
+static inline RTLSSignatureScheme r_tls_cert_req13_sign_scheme (const RTLSCertReq13 * req, int n)
+{ return (RTLSSignatureScheme) r_load_be16 (req->signscheme + n * sizeof (ruint16)); }
 /** @} */
 
 
@@ -1151,6 +1183,24 @@ R_API RTLSError r_tls_write_hs_certificate_request (rpointer buf, rsize size, rs
 #define r_dtls_write_hs_certificate_request r_tls_write_hs_certificate_request
 
 /**
+ * @brief Write a TLS 1.3 CertificateRequest body (RFC 8446, 4.3.2) into @p buf.
+ *
+ * Emits @p ctx as the @c certificate_request_context (non-empty for
+ * post-handshake authentication) followed by an extension list holding the
+ * mandatory @c signature_algorithms with @p signschemes.
+ * @param buf Destination buffer.
+ * @param size Capacity of @p buf in bytes.
+ * @param out Out: bytes written.
+ * @param ctx certificate_request_context bytes, or @c NULL when @p ctxlen is 0.
+ * @param ctxlen Length of @p ctx in bytes.
+ * @param signschemes Accepted signature schemes (@ref RTLSSignatureScheme).
+ * @param nsignschemes Number of signature schemes.
+ */
+R_API RTLSError r_tls_write_hs_certificate_request13 (rpointer buf, rsize size, rsize * out,
+    const ruint8 * ctx, ruint8 ctxlen,
+    const RTLSSignatureScheme * signschemes, ruint16 nsignschemes);
+
+/**
  * @brief Write a CertificateVerify handshake-message body into @p buf.
  * @param buf Destination buffer.
  * @param size Capacity of @p buf in bytes.
@@ -1192,20 +1242,24 @@ R_API RTLSError r_tls_write_hs_encrypted_extensions (rpointer buf, rsize size,
 /**
  * @brief Write a TLS 1.3 Certificate handshake-message body (RFC 8446, 4.4.2).
  *
- * Emits an empty @c certificate_request_context and a @c certificate_list of a
- * single end-entity @p der entry, carrying @p leafexts as the entry's
- * @c Extension list (an empty list when @p leafexts is @c NULL, or when @p der
- * is @c NULL). Distinct from the 1.2 @ref r_tls_write_hs_certificate, which has
- * neither the context nor per-entry extensions.
+ * Emits @p ctx as the @c certificate_request_context (empty in the handshake,
+ * echoed from the CertificateRequest for post-handshake authentication) and a
+ * @c certificate_list of a single end-entity @p der entry, carrying @p leafexts
+ * as the entry's @c Extension list (an empty list when @p leafexts is @c NULL,
+ * or when @p der is @c NULL). Distinct from the 1.2 @ref r_tls_write_hs_certificate,
+ * which has neither the context nor per-entry extensions.
  * @param buf Destination buffer.
  * @param size Capacity of @p buf in bytes.
  * @param out Out: bytes written.
+ * @param ctx certificate_request_context bytes, or @c NULL when @p ctxlen is 0.
+ * @param ctxlen Length of @p ctx in bytes.
  * @param der DER-encoded certificate, or @c NULL for an empty Certificate.
  * @param dersize Length of @p der in bytes.
  * @param leafexts Serialized Extension list for the leaf entry, or @c NULL.
  * @param leafextslen Length of @p leafexts in bytes.
  */
 R_API RTLSError r_tls_write_hs_certificate13 (rpointer buf, rsize size, rsize * out,
+    const ruint8 * ctx, ruint8 ctxlen,
     const ruint8 * der, rsize dersize, const ruint8 * leafexts, ruint16 leafextslen);
 
 /**

--- a/include/rlib/net/rtlsclient.h
+++ b/include/rlib/net/rtlsclient.h
@@ -98,6 +98,18 @@ R_API RTLSClient * r_tls_client_new (const RTLSCallbacks * cb,
 R_API RTLSError r_tls_client_set_cert (RTLSClient * client,
     RCryptoCert * cert, RCryptoKey * privkey);
 /**
+ * @brief Offer post-handshake client authentication (RFC 8446, 4.6.2; TLS 1.3).
+ *
+ * When @p enable is @c TRUE the client advertises the @c post_handshake_auth
+ * extension in its ClientHello, permitting the server to send a
+ * @c CertificateRequest after the handshake. The client answers with the
+ * certificate configured via @ref r_tls_client_set_cert (or an empty
+ * Certificate when none is set). Off by default; must be set before
+ * @ref r_tls_client_start and has no effect on TLS 1.2 / DTLS.
+ */
+R_API RTLSError r_tls_client_set_post_handshake_auth (RTLSClient * client,
+    rboolean enable);
+/**
  * @brief Offer @p host in the ClientHello @c server_name (SNI) extension.
  *
  * Lets the server select a certificate (and policy) for the requested name --

--- a/include/rlib/net/rtlsserver.h
+++ b/include/rlib/net/rtlsserver.h
@@ -134,6 +134,21 @@ typedef void (*RTLSClosedCb) (rpointer ctx, rpointer session);
  */
 typedef RTLSError (*RTLSServerNameCb) (rpointer ctx, const rchar * name, rpointer session);
 
+/**
+ * @brief Callback fired when a post-handshake client authentication exchange
+ * completes (server only; RFC 8446, 4.6.2).
+ *
+ * Invoked once a @ref r_tls_server_request_post_handshake_auth flight completes
+ * cleanly: @p ok is @c TRUE when the client authenticated with a verified
+ * certificate (the leaf is then available via @ref r_tls_server_get_peer_cert)
+ * and @c FALSE when it declined with an empty certificate (permitted only under
+ * @ref R_TLS_CLIENT_CERT_MODE_REQUEST). A malformed or unverifiable flight, or
+ * an empty certificate under @ref R_TLS_CLIENT_CERT_MODE_REQUIRE, aborts the
+ * session with a fatal alert (@ref RTLSErrorCb) instead of firing this callback.
+ * May be @c NULL. @p session is the @ref RTLSServer.
+ */
+typedef void (*RTLSPostHandshakeAuthCb) (rpointer ctx, rboolean ok, rpointer session);
+
 /** @brief Callback bundle wiring a session to its transport and policy. */
 typedef struct {
   RTLSPreferredCipherSuitesCb   preferred_cipher_suites; /**< Choose cipher suites; may be @c NULL for defaults. */
@@ -143,6 +158,7 @@ typedef struct {
   RTLSErrorCb                   error;                   /**< Fired on a fatal alert; may be @c NULL. */
   RTLSCertVerifyCb              verify_cert;             /**< Verify the peer certificate chain; may be @c NULL. */
   RTLSClosedCb                  closed;                  /**< Fired on a peer close_notify; may be @c NULL. */
+  RTLSPostHandshakeAuthCb       post_handshake_auth;     /**< Post-handshake auth result (server); may be @c NULL. */
 } RTLSCallbacks;
 
 /** @brief Create a TLS server with the given callbacks and user context. */
@@ -202,6 +218,20 @@ R_API RTLSError r_tls_server_set_client_cert_mode (RTLSServer * server,
  */
 R_API RTLSError r_tls_server_set_server_name_cb (RTLSServer * server,
     RTLSServerNameCb cb);
+/**
+ * @brief Request post-handshake client authentication (RFC 8446, 4.6.2).
+ *
+ * Sends a @c CertificateRequest after the handshake, prompting the client to
+ * present a certificate flight; the result is delivered to the
+ * @ref RTLSPostHandshakeAuthCb and the verified leaf via
+ * @ref r_tls_server_get_peer_cert. Requires a completed TLS 1.3 handshake in
+ * which the client offered the @c post_handshake_auth extension (see
+ * @ref r_tls_client_set_post_handshake_auth) and no prior request still
+ * outstanding; returns @ref R_TLS_ERROR_WRONG_STATE otherwise. Trust and the
+ * empty-certificate policy follow @ref r_tls_server_set_client_cert_mode as in
+ * the handshake.
+ */
+R_API RTLSError r_tls_server_request_post_handshake_auth (RTLSServer * server);
 /**
  * @brief The peer (client) leaf certificate presented during a mutual-TLS
  * handshake, or @c NULL if none was presented. The reference is borrowed

--- a/rlib/net/proto/rtls.c
+++ b/rlib/net/proto/rtls.c
@@ -1418,6 +1418,30 @@ r_tls_parser_parse_certificate13_next (const RTLSParser * parser,
 }
 
 RTLSError
+r_tls_parser_parse_certificate13_context (const RTLSParser * parser,
+    const ruint8 ** ctx, ruint8 * ctxlen)
+{
+  RTLSHandshakeType type;
+  const ruint8 * ptr, * end;
+  RTLSError ret;
+
+  if (R_UNLIKELY (ctx == NULL || ctxlen == NULL)) return R_TLS_ERROR_INVAL;
+
+  ret = r_tls_parser_parse_handshake_internal (parser, &type, &ptr, &end);
+  if (R_UNLIKELY (ret != R_TLS_ERROR_OK)) return ret;
+  if (R_UNLIKELY (type != R_TLS_HANDSHAKE_TYPE_CERTIFICATE))
+    return R_TLS_ERROR_WRONG_TYPE;
+
+  if (R_UNLIKELY (RPOINTER_TO_SIZE (ptr + sizeof (ruint8)) > RPOINTER_TO_SIZE (end)))
+    return R_TLS_ERROR_CORRUPT_RECORD;
+  *ctxlen = *ptr++;
+  if (R_UNLIKELY (RPOINTER_TO_SIZE (ptr + *ctxlen) > RPOINTER_TO_SIZE (end)))
+    return R_TLS_ERROR_CORRUPT_RECORD;
+  *ctx = *ctxlen > 0 ? ptr : NULL;
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
 r_tls_parser_parse_certificate_request (const RTLSParser * parser,
     RTLSCertReq * req)
 {
@@ -1455,6 +1479,59 @@ r_tls_parser_parse_certificate_request (const RTLSParser * parser,
     return R_TLS_ERROR_CORRUPT_RECORD;
   else
     return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_parser_parse_certificate_request13 (const RTLSParser * parser,
+    RTLSCertReq13 * req)
+{
+  RTLSHandshakeType type;
+  const ruint8 * ptr, * end, * ext, * extend;
+  ruint16 extslen;
+  RTLSError ret;
+
+  if (R_UNLIKELY (req == NULL)) return R_TLS_ERROR_INVAL;
+
+  ret = r_tls_parser_parse_handshake_internal (parser, &type, &ptr, &end);
+  if (R_UNLIKELY (ret != R_TLS_ERROR_OK)) return ret;
+  if (R_UNLIKELY (type != R_TLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST))
+    return R_TLS_ERROR_WRONG_TYPE;
+
+  /* certificate_request_context<0..2^8-1> */
+  if (R_UNLIKELY (RPOINTER_TO_SIZE (ptr + sizeof (ruint8)) > RPOINTER_TO_SIZE (end)))
+    return R_TLS_ERROR_CORRUPT_RECORD;
+  req->contextlen = *ptr++;
+  req->context = ptr;
+  ptr += req->contextlen;
+
+  /* extensions<2..2^16-1> */
+  if (R_UNLIKELY (RPOINTER_TO_SIZE (ptr + sizeof (ruint16)) > RPOINTER_TO_SIZE (end)))
+    return R_TLS_ERROR_CORRUPT_RECORD;
+  extslen = r_load_be16 (ptr); ptr += sizeof (ruint16);
+  if (R_UNLIKELY (RPOINTER_TO_SIZE (ptr + extslen) > RPOINTER_TO_SIZE (end)))
+    return R_TLS_ERROR_CORRUPT_RECORD;
+
+  /* Walk the extensions for signature_algorithms (mandatory, RFC 8446 4.3.2). */
+  req->signschemecount = 0;
+  req->signscheme = NULL;
+  for (ext = ptr, extend = ptr + extslen;
+      RPOINTER_TO_SIZE (ext + 2 * sizeof (ruint16)) <= RPOINTER_TO_SIZE (extend); ) {
+    ruint16 etype = r_load_be16 (ext); ext += sizeof (ruint16);
+    ruint16 elen = r_load_be16 (ext); ext += sizeof (ruint16);
+    if (R_UNLIKELY (RPOINTER_TO_SIZE (ext + elen) > RPOINTER_TO_SIZE (extend)))
+      return R_TLS_ERROR_CORRUPT_RECORD;
+    if (etype == R_TLS_EXT_TYPE_SIGNATURE_ALGORITHMS &&
+        elen >= sizeof (ruint16)) {
+      ruint16 listlen = r_load_be16 (ext);
+      if (R_UNLIKELY ((rsize) listlen + sizeof (ruint16) > elen))
+        return R_TLS_ERROR_CORRUPT_RECORD;
+      req->signschemecount = listlen / sizeof (ruint16);
+      req->signscheme = ext + sizeof (ruint16);
+    }
+    ext += elen;
+  }
+
+  return R_TLS_ERROR_OK;
 }
 
 RTLSError
@@ -2320,6 +2397,42 @@ r_tls_write_hs_certificate_request (rpointer data, rsize size, rsize * out,
 }
 
 RTLSError
+r_tls_write_hs_certificate_request13 (rpointer data, rsize size, rsize * out,
+    const ruint8 * ctx, ruint8 ctxlen,
+    const RTLSSignatureScheme * signschemes, ruint16 nsignschemes)
+{
+  ruint8 * p = data;
+  /* signature_algorithms extension: type<2> | ext_len<2> | list_len<2> | schemes. */
+  rsize schemebytes = (rsize)nsignschemes * sizeof (ruint16);
+  rsize sigext = sizeof (ruint16) + sizeof (ruint16) + sizeof (ruint16) + schemebytes;
+  rsize need = sizeof (ruint8) + (rsize)ctxlen + sizeof (ruint16) + sigext;
+  ruint16 i;
+
+  if (R_UNLIKELY (data == NULL || (ctxlen > 0 && ctx == NULL) ||
+        (nsignschemes > 0 && signschemes == NULL)))
+    return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (size < need)) return R_TLS_ERROR_BUF_TOO_SMALL;
+
+  /* certificate_request_context<0..2^8-1> */
+  *p++ = ctxlen;
+  if (ctxlen > 0) { r_memcpy (p, ctx, ctxlen); p += ctxlen; }
+
+  /* extensions<2..2^16-1>: a lone signature_algorithms (mandatory, RFC 8446 4.3.2). */
+  r_store_be16 (p, (ruint16) sigext); p += sizeof (ruint16);
+  r_store_be16 (p, (ruint16) R_TLS_EXT_TYPE_SIGNATURE_ALGORITHMS); p += sizeof (ruint16);
+  r_store_be16 (p, (ruint16) (sizeof (ruint16) + schemebytes)); p += sizeof (ruint16);
+  r_store_be16 (p, (ruint16) schemebytes); p += sizeof (ruint16);
+  for (i = 0; i < nsignschemes; i++) {
+    r_store_be16 (p, (ruint16) signschemes[i]); p += sizeof (ruint16);
+  }
+
+  if (out != NULL)
+    *out = need;
+
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
 r_tls_write_hs_certificate_verify (rpointer data, rsize size, rsize * out,
     RTLSSignatureScheme sigscheme, const ruint8 * sig, ruint16 sigsize)
 {
@@ -2390,18 +2503,22 @@ r_tls_write_hs_encrypted_extensions (rpointer data, rsize size, rsize * out,
 
 RTLSError
 r_tls_write_hs_certificate13 (rpointer data, rsize size, rsize * out,
+    const ruint8 * ctx, ruint8 ctxlen,
     const ruint8 * der, rsize dersize, const ruint8 * leafexts, ruint16 leafextslen)
 {
   ruint8 * p = data;
   rsize extslen = (leafexts != NULL) ? leafextslen : 0;
   /* One CertificateEntry = cert_data<3> | cert | extensions<2>. */
   rsize entrylen = (der != NULL && dersize > 0) ? (3 + dersize + 2 + extslen) : 0;
-  rsize need = 1 + 3 + entrylen;   /* context<1>=0 | certificate_list<3> | entries */
+  rsize need = 1 + (rsize)ctxlen + 3 + entrylen;   /* context<1> | certificate_list<3> | entries */
 
-  if (R_UNLIKELY (data == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (data == NULL || (ctxlen > 0 && ctx == NULL))) return R_TLS_ERROR_INVAL;
   if (R_UNLIKELY (size < need)) return R_TLS_ERROR_BUF_TOO_SMALL;
 
-  *p++ = 0x00;   /* certificate_request_context<0..2^8-1>: empty */
+  /* certificate_request_context<0..2^8-1>: empty in the handshake, echoed from
+   * the CertificateRequest for post-handshake authentication (RFC 8446 4.6.2). */
+  *p++ = ctxlen;
+  if (ctxlen > 0) { r_memcpy (p, ctx, ctxlen); p += ctxlen; }
 
   /* certificate_list<0..2^24-1> */
   *p++ = (ruint8)((entrylen >> 16) & 0xff);

--- a/rlib/net/rhttpclient.c
+++ b/rlib/net/rhttpclient.c
@@ -419,6 +419,7 @@ static const RTLSCallbacks g__r_http_client_tls_callbacks = {
   r_http_client_tls_error,               /* error */
   r_http_client_tls_verify,              /* verify_cert */
   r_http_client_tls_closed,              /* closed */
+  NULL,                                  /* post_handshake_auth */
 };
 
 static RHttpClientConn *

--- a/rlib/net/rhttpserver.c
+++ b/rlib/net/rhttpserver.c
@@ -788,6 +788,7 @@ static const RTLSCallbacks g__r_http_tls_callbacks = {
   r_http_client_ctx_tls_error,       /* error */
   r_http_client_ctx_tls_verify_peer, /* verify_cert (mutual TLS) */
   r_http_client_ctx_tls_closed,      /* closed */
+  NULL,                              /* post_handshake_auth */
 };
 
 static void

--- a/rlib/net/rtlsclient.c
+++ b/rlib/net/rtlsclient.c
@@ -102,6 +102,7 @@ struct RTLSClient {
   RCryptoCert * cert;          /* own certificate for mTLS, or NULL */
   RCryptoKey * privkey;        /* own private key for mTLS, or NULL */
   rboolean cert_requested;     /* server sent a CertificateRequest */
+  rboolean post_handshake_auth; /* offer post_handshake_auth (RFC 8446 4.6.2, TLS 1.3) */
 
   rchar * server_name;         /* SNI host to offer in the ClientHello, or NULL */
 
@@ -456,6 +457,16 @@ r_tls_client_request_ocsp (RTLSClient * client, rboolean request)
   if (R_UNLIKELY (client->state != R_TLS_CLIENT_INITIAL)) return R_TLS_ERROR_WRONG_STATE;
 
   client->request_ocsp = request;
+  return R_TLS_ERROR_OK;
+}
+
+RTLSError
+r_tls_client_set_post_handshake_auth (RTLSClient * client, rboolean enable)
+{
+  if (R_UNLIKELY (client == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (client->state != R_TLS_CLIENT_INITIAL)) return R_TLS_ERROR_WRONG_STATE;
+
+  client->post_handshake_auth = enable;
   return R_TLS_ERROR_OK;
 }
 
@@ -941,6 +952,16 @@ r_tls_client_write_hs_ext_sct (ruint8 * ptr)
   return 4;
 }
 
+/* post_handshake_auth: offer to answer a post-handshake CertificateRequest
+ * (RFC 8446 4.6.2). Empty; TLS 1.3 only. */
+static ruint16
+r_tls_client_write_hs_ext_post_handshake_auth (ruint8 * ptr)
+{
+  r_store_be16 (&ptr[0], (ruint16)R_TLS_EXT_TYPE_POST_HANDSHAKE_AUTH);
+  r_store_be16 (&ptr[2], 0);
+  return 4;
+}
+
 /* Whether an EncryptedExtensions handshake message (a full message: 4-byte
  * header then a uint16-prefixed extension list) carries an early_data
  * extension, i.e. the server accepted 0-RTT. */
@@ -1265,6 +1286,8 @@ r_tls_client_send_hello (RTLSClient * client, rboolean retry)
         extsize += r_tls_client_write_hs_ext_status_request (ptr + 2 + extsize);
       if (client->request_sct)
         extsize += r_tls_client_write_hs_ext_sct (ptr + 2 + extsize);
+      if (client->post_handshake_auth)
+        extsize += r_tls_client_write_hs_ext_post_handshake_auth (ptr + 2 + extsize);
       /* Advertise (EC)DHE resumption support so the server issues tickets. */
       extsize += r_tls_client_write_hs_ext_psk_key_exchange_modes (ptr + 2 + extsize);
       /* early_data (0-RTT) sits before pre_shared_key, which stays last. */
@@ -2704,8 +2727,13 @@ r_tls_client_state_certificate (RTLSClient * client, const RTLSParser * parser)
     err = r_tls_client_flight13 (client, parser);
     if (err == R_TLS_ERROR_OK && client->flight13_step >= 4) {
       err = r_tls_client_change_state (client, R_TLS_CLIENT_APPDATA);
-      r_msg_digest_free (client->hshash);
-      client->hshash = NULL;
+      /* Keep the transcript alive for post-handshake authentication: a later
+       * CertificateRequest and our answering flight extend it (RFC 8446 4.6.2).
+       * Otherwise drop it now that the handshake is done. */
+      if (!client->post_handshake_auth) {
+        r_msg_digest_free (client->hshash);
+        client->hshash = NULL;
+      }
       /* Deliver the 0-RTT payload as ordinary application data when the server
        * did not accept it (declined 0-RTT, or the session never permitted it),
        * so it is sent either way. */
@@ -3060,6 +3088,159 @@ r_tls_client_recv_key_update13 (RTLSClient * client, const RTLSParser * parser)
   return R_TLS_ERROR_OK;
 }
 
+/* Sign the post-handshake CertificateVerify transcript hash @th with the client
+ * certificate key. Mirrors the server's handshake CertificateVerify (RFC 8446
+ * 4.4.3): ECDSA binds the curve to its digest, ed25519 / ed448 are PureEdDSA,
+ * RSA uses rsa_pss_rsae_sha256. The chosen scheme is returned via @scheme. */
+static RTLSError
+r_tls_client_sign_certificate_verify13 (RTLSClient * client, const ruint8 * th,
+    rsize hlen, RTLSSignatureScheme * scheme, ruint8 * sig, rsize * siglen)
+{
+  ruint8 tbs[R_TLS13_CERT_VERIFY_TBS_MAX], digest[64];
+  rsize tbslen = 0, dlen;
+  RMsgDigestType mdtype;
+  RMsgDigest * md;
+  RCryptoAlgorithm algo = r_crypto_key_get_algo (client->privkey);
+  rboolean ok;
+
+  if (algo == R_CRYPTO_ALGO_ECDSA || algo == R_CRYPTO_ALGO_ED25519 ||
+      algo == R_CRYPTO_ALGO_ED448)
+    *scheme = r_tls_sign_scheme_for_key (client->privkey);
+  else if (algo == R_CRYPTO_ALGO_RSA)
+    *scheme = R_TLS_SIGN_SCHEME_RSA_PSS_SHA256;
+  else
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
+  if (!r_tls13_cert_verify_tbs (FALSE, th, hlen, tbs, sizeof (tbs), &tbslen) ||
+      !r_tls_sign_scheme_to_md (*scheme, &mdtype))
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
+  if (mdtype == R_MSG_DIGEST_TYPE_NONE) {
+    if (r_crypto_key_sign (client->privkey, client->prng, mdtype,
+          tbs, tbslen, sig, siglen) != R_CRYPTO_OK)
+      return R_TLS_ERROR_HANDSHAKE_FAILURE;
+    return R_TLS_ERROR_OK;
+  }
+
+  if ((md = r_msg_digest_new (mdtype)) == NULL)
+    return R_TLS_ERROR_OOM;
+  dlen = r_msg_digest_size (md);
+  ok = r_msg_digest_update (md, tbs, tbslen) &&
+       r_msg_digest_get_data (md, digest, dlen, NULL);
+  r_msg_digest_free (md);
+  if (!ok)
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
+  if (*scheme == R_TLS_SIGN_SCHEME_RSA_PSS_SHA256)
+    r_rsa_priv_key_set_padding (client->privkey, R_RSA_PADDING_PKCS1_V21);
+  if (r_crypto_key_sign (client->privkey, client->prng, mdtype,
+        digest, dlen, sig, siglen) != R_CRYPTO_OK)
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
+  return R_TLS_ERROR_OK;
+}
+
+/* Answer a post-handshake CertificateRequest (RFC 8446 4.6.2): send Certificate
+ * echoing the request context, a CertificateVerify when we hold a certificate,
+ * and a Finished keyed from the client application-traffic secret. The whole
+ * flight extends the transcript kept alive since the handshake. */
+static RTLSError
+r_tls_client_recv_certificate_request13 (RTLSClient * client, const RTLSParser * parser)
+{
+  RTLSCertReq13 req = { 0, NULL, 0, NULL };
+  RTLSError err;
+  ruint8 th[R_TLS13_SECRET_MAX], finkey[R_TLS13_SECRET_MAX], cvd[R_TLS13_SECRET_MAX];
+  rsize hlen = r_msg_digest_type_size (client->cs13_hash);
+  RBuffer * certder = NULL;
+  RMemMapInfo dinfo = R_MEM_MAP_INFO_INIT;
+  const ruint8 * der = NULL;
+  rsize dersize = 0;
+  ruint8 * body;
+  rsize bodylen = 0;
+
+  if (R_UNLIKELY (client->hshash == NULL))
+    return R_TLS_ERROR_WRONG_STATE;
+  if (r_tls_parser_parse_certificate_request13 (parser, &req) != R_TLS_ERROR_OK ||
+      req.contextlen == 0) {
+    /* The post-handshake context is server-chosen and non-empty (RFC 8446 4.6.2). */
+    r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_ILLEGAL_PARAMETER);
+    return R_TLS_ERROR_ILLEGAL_PARAMETER;
+  }
+
+  /* Fold the CertificateRequest; our answering flight signs over it. */
+  r_msg_digest_update (client->hshash, parser->fragment.data, parser->fragment.size);
+
+  if (client->cert != NULL) {
+    if ((certder = r_crypto_cert_get_data_buffer (client->cert)) == NULL)
+      return R_TLS_ERROR_NO_CERTIFICATE;
+    if (!r_buffer_map (certder, &dinfo, R_MEM_MAP_READ)) {
+      r_buffer_unref (certder);
+      return R_TLS_ERROR_OOM;
+    }
+    der = dinfo.data;
+    dersize = dinfo.size;
+  }
+
+  /* Certificate: context<1> | list<3> | entry{ cert<3> | der | ext<2> }. */
+  if ((body = r_malloc (1 + req.contextlen + 3 +
+          ((der != NULL) ? (3 + dersize + 2) : 0))) == NULL) {
+    err = R_TLS_ERROR_OOM;
+    goto beach;
+  }
+  if ((err = r_tls_write_hs_certificate13 (body,
+          1 + req.contextlen + 3 + ((der != NULL) ? (3 + dersize + 2) : 0), &bodylen,
+          req.context, req.contextlen, der, dersize, NULL, 0)) == R_TLS_ERROR_OK)
+    err = r_tls_client_send_hs13 (client, R_TLS_HANDSHAKE_TYPE_CERTIFICATE, body, bodylen);
+  r_free (body);
+  if (err != R_TLS_ERROR_OK)
+    goto beach;
+
+  /* CertificateVerify over Transcript-Hash(..Certificate), only when we have a
+   * key to prove possession; an empty Certificate carries no CertificateVerify. */
+  if (client->cert != NULL && client->privkey != NULL) {
+    ruint8 sig[512], cvbody[4 + sizeof (sig)];
+    rsize sigsize = sizeof (sig), cvlen = 0;
+    RTLSSignatureScheme scheme;
+
+    if (!r_msg_digest_get_data (client->hshash, th, hlen, NULL)) {
+      err = R_TLS_ERROR_HANDSHAKE_FAILURE;
+      goto beach;
+    }
+    if ((err = r_tls_client_sign_certificate_verify13 (client, th, hlen,
+            &scheme, sig, &sigsize)) != R_TLS_ERROR_OK)
+      goto beach;
+    if ((err = r_tls_write_hs_certificate_verify (cvbody, sizeof (cvbody), &cvlen,
+            scheme, sig, (ruint16) sigsize)) == R_TLS_ERROR_OK)
+      err = r_tls_client_send_hs13 (client,
+          R_TLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY, cvbody, cvlen);
+    if (err != R_TLS_ERROR_OK)
+      goto beach;
+  }
+
+  /* Finished over Transcript-Hash(..CertificateVerify), keyed from the client
+   * application-traffic secret (RFC 8446 4.4.4 / 4.6.2). */
+  {
+    ruint8 finbody[4 + R_TLS13_SECRET_MAX];
+    rsize finlen = 0;
+
+    if (!r_msg_digest_get_data (client->hshash, th, hlen, NULL) ||
+        !r_tls13_finished_key (client->cs13_hash, client->sched13.cap, finkey) ||
+        !r_tls13_verify_data (client->cs13_hash, finkey, th, cvd)) {
+      err = R_TLS_ERROR_HANDSHAKE_FAILURE;
+      goto beach;
+    }
+    if ((err = r_tls_write_hs_finished (finbody, sizeof (finbody), &finlen,
+            cvd, hlen)) == R_TLS_ERROR_OK)
+      err = r_tls_client_send_hs13 (client, R_TLS_HANDSHAKE_TYPE_FINISHED, finbody, finlen);
+  }
+
+beach:
+  if (certder != NULL) { r_buffer_unmap (certder, &dinfo); r_buffer_unref (certder); }
+  if (err != R_TLS_ERROR_OK)
+    r_tls_client_send_alert (client, R_TLS_ALERT_TYPE_INTERNAL_ERROR);
+  return err;
+}
+
 static RTLSError
 r_tls_client_state_appdata (RTLSClient * client, const RTLSParser * parser)
 {
@@ -3072,7 +3253,8 @@ r_tls_client_state_appdata (RTLSClient * client, const RTLSParser * parser)
     }
   } else if (parser->content == R_TLS_CONTENT_TYPE_HANDSHAKE) {
     /* Post-handshake messages (1.3): store a NewSessionTicket for resumption,
-     * rekey on a KeyUpdate, ignore the rest. */
+     * rekey on a KeyUpdate, answer a CertificateRequest (RFC 8446 4.6.2) when we
+     * offered post_handshake_auth, ignore the rest. */
     RTLSHandshakeType type;
     if (client->tls13 &&
         r_tls_parser_parse_handshake_peek_type (parser, &type) == R_TLS_ERROR_OK) {
@@ -3080,6 +3262,9 @@ r_tls_client_state_appdata (RTLSClient * client, const RTLSParser * parser)
         r_tls_client_store_ticket13 (client, parser);
       else if (type == R_TLS_HANDSHAKE_TYPE_KEY_UPDATE)
         return r_tls_client_recv_key_update13 (client, parser);
+      else if (type == R_TLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST &&
+          client->post_handshake_auth)
+        return r_tls_client_recv_certificate_request13 (client, parser);
     }
   } else {
     R_LOG_WARNING ("Received non-app-data record");

--- a/rlib/net/rtlsserver.c
+++ b/rlib/net/rtlsserver.c
@@ -159,6 +159,13 @@ struct RTLSServer {
   rsize early13_skipped;                /* bytes of rejected early data discarded so far */
   rsize early13_received;               /* bytes of accepted early data delivered so far */
 
+  /* Post-handshake client authentication (RFC 8446 4.6.2, TLS 1.3). */
+  rboolean peer_post_handshake_auth;    /* client offered post_handshake_auth */
+  rboolean ph_auth_pending;             /* a CertificateRequest is outstanding */
+  ruint8 ph_step;                       /* 0 Certificate, 1 CertificateVerify, 2 Finished */
+  ruint8 ph_ctx[32];                    /* certificate_request_context we sent */
+  ruint8 ph_ctxlen;
+
   RBuffer * inbuf;
   RQueue qsend;
 };
@@ -1949,6 +1956,14 @@ r_tls_server_nego_hello13 (RTLSServer * server)
         r_tls_server_find_ext (server, R_TLS_EXT_TYPE_SIGNED_CERTIFICATE_TIMESTAMP, &sct);
   }
 
+  /* post_handshake_auth (RFC 8446 4.6.2): note the client's willingness so
+   * r_tls_server_request_post_handshake_auth may later prompt for a cert. */
+  {
+    RTLSHelloExt pha = R_TLS_HELLO_EXT_INIT;
+    server->peer_post_handshake_auth =
+        r_tls_server_find_ext (server, R_TLS_EXT_TYPE_POST_HANDSHAKE_AUTH, &pha);
+  }
+
   server->comp = R_TLS_COMPRESSION_NULL;
   server->version = R_TLS_VERSION_TLS_1_3;
   server->tls13 = TRUE;
@@ -2463,7 +2478,7 @@ r_tls_server_write_flight13 (RTLSServer * server)
     } else {
       ret = r_tls_write_hs_certificate13 (certbody,
           1 + 3 + 3 + certinfo.size + 2 + leafextslen, &certbodylen,
-          certinfo.data, certinfo.size, leafexts, leafextslen);
+          NULL, 0, certinfo.data, certinfo.size, leafexts, leafextslen);
     }
     r_buffer_unmap (certbuf, &certinfo);
     r_buffer_unref (certbuf);
@@ -3701,8 +3716,13 @@ r_tls_server_state_finished (RTLSServer * server, const RTLSParser * parser)
     if ((err = r_tls_server_finished13 (server, parser)) == R_TLS_ERROR_OK)
       err = r_tls_server_change_state (server, R_TLS_SERVER_APPDATA);
     if (err == R_TLS_ERROR_OK) {
-      r_msg_digest_free (server->hshash);
-      server->hshash = NULL;
+      /* Keep the transcript alive when the client offered post_handshake_auth: a
+       * later CertificateRequest and the client's answer extend it (RFC 8446
+       * 4.6.2). Otherwise release it now that the handshake is done. */
+      if (!server->peer_post_handshake_auth) {
+        r_msg_digest_free (server->hshash);
+        server->hshash = NULL;
+      }
       /* Offer a resumption ticket now that the handshake (and the resumption
        * master secret) is complete. A failure here does not fail the session. */
       r_tls_server_write_new_session_ticket13 (server);
@@ -3804,6 +3824,271 @@ r_tls_server_recv_key_update13 (RTLSServer * server, const RTLSParser * parser)
   return R_TLS_ERROR_OK;
 }
 
+/* Send a post-handshake CertificateRequest (RFC 8446 4.6.2) carrying a fresh,
+ * non-empty certificate_request_context that binds the client's answering
+ * flight to this request. Framed, folded into the transcript kept alive since
+ * the handshake, and protected under the current application key. */
+static RTLSError
+r_tls_server_send_certificate_request13 (RTLSServer * server)
+{
+  static const RTLSSignatureScheme schemes[] = {
+    R_TLS_SIGN_SCHEME_ECDSA_SECP256R1_SHA256,
+    R_TLS_SIGN_SCHEME_ECDSA_SECP384R1_SHA384,
+    R_TLS_SIGN_SCHEME_ED25519,
+    R_TLS_SIGN_SCHEME_ED448,
+    R_TLS_SIGN_SCHEME_RSA_PSS_SHA256,
+  };
+  ruint8 msg[R_TLS_HS_HDR_SIZE + 1 + sizeof (server->ph_ctx) + 64];
+  rsize bodylen = 0;
+  RTLSError ret;
+
+  server->ph_ctxlen = (ruint8) sizeof (server->ph_ctx);
+  if (!r_prng_fill (server->prng, server->ph_ctx, server->ph_ctxlen))
+    return R_TLS_ERROR_ENCRYPTION_FAILED;
+
+  if ((ret = r_tls_write_hs_certificate_request13 (msg + R_TLS_HS_HDR_SIZE,
+          sizeof (msg) - R_TLS_HS_HDR_SIZE, &bodylen, server->ph_ctx, server->ph_ctxlen,
+          schemes, R_N_ELEMENTS (schemes))) != R_TLS_ERROR_OK)
+    return ret;
+
+  msg[0] = (ruint8) R_TLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST;
+  _r_write_u24 (msg + 1, (ruint32) bodylen);
+
+  r_msg_digest_update (server->hshash, msg, R_TLS_HS_HDR_SIZE + bodylen);
+  return r_tls_server_protect_record13 (server, R_TLS_CONTENT_TYPE_HANDSHAKE,
+      msg, R_TLS_HS_HDR_SIZE + bodylen);
+}
+
+RTLSError
+r_tls_server_request_post_handshake_auth (RTLSServer * server)
+{
+  RTLSError ret;
+
+  if (R_UNLIKELY (server == NULL)) return R_TLS_ERROR_INVAL;
+  if (R_UNLIKELY (!server->tls13 || server->state != R_TLS_SERVER_APPDATA ||
+        !server->peer_post_handshake_auth || server->ph_auth_pending ||
+        server->hshash == NULL))
+    return R_TLS_ERROR_WRONG_STATE;
+
+  if ((ret = r_tls_server_send_certificate_request13 (server)) != R_TLS_ERROR_OK)
+    return ret;
+
+  /* Await the client's Certificate / CertificateVerify / Finished flight; a
+   * stale leaf from a prior authentication is dropped so get_peer_cert reflects
+   * only the outcome of this exchange. */
+  server->ph_auth_pending = TRUE;
+  server->ph_step = 0;
+  server->client_cert_received = FALSE;
+  if (server->peer_cert != NULL) {
+    r_crypto_cert_unref (server->peer_cert);
+    server->peer_cert = NULL;
+  }
+  if (server->peer_pubkey != NULL) {
+    r_crypto_key_unref (server->peer_pubkey);
+    server->peer_pubkey = NULL;
+  }
+
+  r_tls_server_send_out (server);
+  return R_TLS_ERROR_OK;
+}
+
+/* Parse the client's post-handshake Certificate (RFC 8446 4.4.2 / 4.6.2): the
+ * echoed context must match our request, then the leaf is trust-checked via the
+ * verify_cert callback and kept for the CertificateVerify. */
+static RTLSError
+r_tls_server_parse_client_certificate13 (RTLSServer * server, const RTLSParser * parser)
+{
+  RCryptoCert * chain[16];
+  RTLSCertificate tlscert = R_TLS_CERTIFICATE_INIT;
+  const ruint8 * ctx = NULL;
+  ruint8 ctxlen = 0;
+  ruint n = 0, i;
+  RTLSError err = R_TLS_ERROR_OK;
+
+  if (r_tls_parser_parse_certificate13_context (parser, &ctx, &ctxlen) != R_TLS_ERROR_OK ||
+      ctxlen != server->ph_ctxlen || r_memcmp (ctx, server->ph_ctx, ctxlen) != 0)
+    return R_TLS_ERROR_ILLEGAL_PARAMETER;
+
+  if (r_tls_parser_parse_certificate13_first (parser, &tlscert) == R_TLS_ERROR_OK) {
+    do {
+      if ((chain[n] = r_tls_certificate_get_cert (&tlscert)) != NULL)
+        n++;
+    } while (n < R_N_ELEMENTS (chain) &&
+        r_tls_parser_parse_certificate13_next (parser, &tlscert) == R_TLS_ERROR_OK);
+  }
+
+  if (n == 0) {
+    if (server->client_cert_mode == R_TLS_CLIENT_CERT_MODE_REQUIRE)
+      return R_TLS_ERROR_NO_CERTIFICATE;
+    server->client_cert_received = FALSE;
+    return R_TLS_ERROR_OK;
+  }
+
+  if (server->cb.verify_cert != NULL &&
+      !server->cb.verify_cert (server->userdata, chain, n)) {
+    err = R_TLS_ERROR_CORRUPT_CERTIFICATE;
+  } else if ((server->peer_pubkey = r_crypto_cert_get_public_key (chain[0])) == NULL) {
+    err = R_TLS_ERROR_CORRUPT_CERTIFICATE;
+  } else {
+    server->peer_cert = r_crypto_cert_ref (chain[0]);
+    server->client_cert_received = TRUE;
+  }
+
+  for (i = 0; i < n; i++)
+    r_crypto_cert_unref (chain[i]);
+
+  return err;
+}
+
+/* Verify the client's post-handshake CertificateVerify: its signature covers the
+ * content over Transcript-Hash(..Certificate) with the client context string.
+ * PKCS#1 v1.5 is forbidden in 1.3; other schemes are rejected. */
+static RTLSError
+r_tls_server_verify_certificate_verify13 (RTLSServer * server, const RTLSParser * parser)
+{
+  RTLSSignatureScheme scheme;
+  const ruint8 * sig;
+  ruint16 sigsize;
+  ruint8 th[R_TLS13_SECRET_MAX], tbs[R_TLS13_CERT_VERIFY_TBS_MAX], digest[64];
+  rsize hlen = r_msg_digest_type_size (server->cs13_hash), tbslen = 0, dlen;
+  RMsgDigestType mdtype;
+  RMsgDigest * md;
+  rboolean pss, ok;
+  RTLSError err;
+
+  if (R_UNLIKELY (server->peer_pubkey == NULL))
+    return R_TLS_ERROR_WRONG_STATE;
+  if ((err = r_tls_parser_parse_certificate_verify (parser, &scheme, &sig, &sigsize))
+        != R_TLS_ERROR_OK)
+    return err;
+
+  switch (scheme) {
+    case R_TLS_SIGN_SCHEME_ECDSA_SECP256R1_SHA256:
+    case R_TLS_SIGN_SCHEME_ECDSA_SECP384R1_SHA384:
+    case R_TLS_SIGN_SCHEME_ECDSA_SECP521R1_SHA512:
+    case R_TLS_SIGN_SCHEME_ED25519:
+    case R_TLS_SIGN_SCHEME_ED448:
+      pss = FALSE;
+      break;
+    case R_TLS_SIGN_SCHEME_RSA_PSS_SHA256:
+    case R_TLS_SIGN_SCHEME_RSA_PSS_SHA384:
+    case R_TLS_SIGN_SCHEME_RSA_PSS_SHA512:
+      pss = TRUE;
+      break;
+    default:
+      return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  }
+  if (!r_tls_sign_scheme_to_md (scheme, &mdtype))
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
+  if (!r_msg_digest_get_data (server->hshash, th, hlen, NULL) ||
+      !r_tls13_cert_verify_tbs (FALSE, th, hlen, tbs, sizeof (tbs), &tbslen))
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
+  if (mdtype == R_MSG_DIGEST_TYPE_NONE)
+    return (r_crypto_key_verify (server->peer_pubkey, mdtype, tbs, tbslen,
+              sig, sigsize) == R_CRYPTO_OK) ?
+        R_TLS_ERROR_OK : R_TLS_ERROR_HS_VERIFICATION_FAILED;
+
+  if ((md = r_msg_digest_new (mdtype)) == NULL)
+    return R_TLS_ERROR_OOM;
+  dlen = r_msg_digest_size (md);
+  ok = r_msg_digest_update (md, tbs, tbslen) &&
+       r_msg_digest_get_data (md, digest, dlen, NULL);
+  r_msg_digest_free (md);
+  if (!ok)
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+
+  if (pss)
+    r_rsa_pub_key_set_padding (server->peer_pubkey, R_RSA_PADDING_PKCS1_V21);
+  return (r_crypto_key_verify (server->peer_pubkey, mdtype, digest, dlen,
+            sig, sigsize) == R_CRYPTO_OK) ?
+      R_TLS_ERROR_OK : R_TLS_ERROR_HS_VERIFICATION_FAILED;
+}
+
+/* Verify the client's post-handshake Finished: verify_data keyed from the client
+ * application-traffic secret over Transcript-Hash(..CertificateVerify). */
+static RTLSError
+r_tls_server_ph_finished13 (RTLSServer * server, const RTLSParser * parser)
+{
+  const ruint8 * vd;
+  rsize vdsize;
+  ruint8 th[R_TLS13_SECRET_MAX], finkey[R_TLS13_SECRET_MAX], expect[R_TLS13_SECRET_MAX];
+  rsize hlen = r_msg_digest_type_size (server->cs13_hash);
+  RTLSError err;
+
+  if ((err = r_tls_parser_parse_finished (parser, &vd, &vdsize)) != R_TLS_ERROR_OK)
+    return err;
+  if (!r_msg_digest_get_data (server->hshash, th, hlen, NULL) ||
+      !r_tls13_finished_key (server->cs13_hash, server->sched13.cap, finkey) ||
+      !r_tls13_verify_data (server->cs13_hash, finkey, th, expect))
+    return R_TLS_ERROR_HANDSHAKE_FAILURE;
+  if (vdsize != hlen || r_memcmp_ct (vd, expect, hlen) != 0)
+    return R_TLS_ERROR_HS_VERIFICATION_FAILED;
+  return R_TLS_ERROR_OK;
+}
+
+/* Drive the client's post-handshake authentication flight (RFC 8446 4.6.2):
+ * Certificate, an optional CertificateVerify, then Finished. Each message is
+ * folded into the transcript; a failure alerts and ends the exchange. */
+static RTLSError
+r_tls_server_recv_post_handshake_auth13 (RTLSServer * server,
+    const RTLSParser * parser, RTLSHandshakeType hstype)
+{
+  RTLSError err;
+
+  switch (server->ph_step) {
+    case 0:
+      if (hstype != R_TLS_HANDSHAKE_TYPE_CERTIFICATE) { err = R_TLS_ERROR_WRONG_TYPE; break; }
+      err = r_tls_server_parse_client_certificate13 (server, parser);
+      if (err == R_TLS_ERROR_OK) {
+        r_msg_digest_update (server->hshash, parser->fragment.data, parser->fragment.size);
+        /* An empty Certificate (no leaf) carries no CertificateVerify. */
+        server->ph_step = server->client_cert_received ? 1 : 2;
+      }
+      break;
+    case 1:
+      if (hstype != R_TLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY) { err = R_TLS_ERROR_WRONG_TYPE; break; }
+      err = r_tls_server_verify_certificate_verify13 (server, parser);
+      if (err == R_TLS_ERROR_OK) {
+        r_msg_digest_update (server->hshash, parser->fragment.data, parser->fragment.size);
+        server->ph_step = 2;
+      }
+      break;
+    default:
+      if (hstype != R_TLS_HANDSHAKE_TYPE_FINISHED) { err = R_TLS_ERROR_WRONG_TYPE; break; }
+      if ((err = r_tls_server_ph_finished13 (server, parser)) == R_TLS_ERROR_OK) {
+        r_msg_digest_update (server->hshash, parser->fragment.data, parser->fragment.size);
+        /* Clean completion: report whether a certificate was authenticated (an
+         * empty answer under REQUEST authenticates no one). Verification and
+         * policy failures instead abort below via the error path. */
+        server->ph_auth_pending = FALSE;
+        if (server->cb.post_handshake_auth != NULL)
+          server->cb.post_handshake_auth (server->userdata,
+              server->client_cert_received, server);
+      }
+      break;
+  }
+
+  if (err != R_TLS_ERROR_OK) {
+    server->ph_auth_pending = FALSE;
+    /* Drop any leaf accepted before the proof-of-possession failed, so a failed
+     * exchange never leaves an unverified certificate visible via
+     * r_tls_server_get_peer_cert. */
+    server->client_cert_received = FALSE;
+    if (server->peer_cert != NULL) {
+      r_crypto_cert_unref (server->peer_cert);
+      server->peer_cert = NULL;
+    }
+    if (server->peer_pubkey != NULL) {
+      r_crypto_key_unref (server->peer_pubkey);
+      server->peer_pubkey = NULL;
+    }
+    r_tls_server_send_alert (server, r_tls_server_alert_for_error (err));
+  }
+  return err;
+}
+
 static RTLSError
 r_tls_server_state_appdata (RTLSServer * server, const RTLSParser * parser)
 {
@@ -3823,6 +4108,8 @@ r_tls_server_state_appdata (RTLSServer * server, const RTLSParser * parser)
       R_LOG_WARNING ("Received non-app-data record");
     else if (server->tls13 && hstype == R_TLS_HANDSHAKE_TYPE_KEY_UPDATE)
       return r_tls_server_recv_key_update13 (server, parser);
+    else if (server->tls13 && server->ph_auth_pending)
+      return r_tls_server_recv_post_handshake_auth13 (server, parser, hstype);
     else if (hstype == R_TLS_HANDSHAKE_TYPE_CLIENT_HELLO)
       /* A post-handshake ClientHello is a renegotiation attempt. We do not
        * renegotiate; decline with a warning and keep the session running

--- a/rlib/rtc/rrtcdtlstransport.c
+++ b/rlib/rtc/rrtcdtlstransport.c
@@ -220,6 +220,7 @@ r_rtc_crypto_transport_new_dtls (RRtcIceTransport * ice, RPrng * prng,
     NULL,
     NULL,
     NULL,
+    NULL,
   };
 
   if (R_UNLIKELY (ice == NULL)) return NULL;

--- a/test/rhttpserver.c
+++ b/test/rhttpserver.c
@@ -346,7 +346,7 @@ r_test_tls_client_appdata (rpointer data, RBuffer * buf, rpointer session)
 
 static const RTLSCallbacks g_test_tls_client_cbs = {
   NULL, r_test_tls_client_hs_done, r_test_tls_client_out,
-  r_test_tls_client_appdata, NULL, NULL, NULL,
+  r_test_tls_client_appdata, NULL, NULL, NULL, NULL,
 };
 
 static void

--- a/test/rtls.c
+++ b/test/rtls.c
@@ -339,7 +339,7 @@ RTEST (rtls, write_parse_certificate13_roundtrip, RTEST_FAST)
   r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_write_handshake (rec, sizeof (rec),
         &hssize, R_TLS_VERSION_TLS_1_3, R_TLS_HANDSHAKE_TYPE_CERTIFICATE, 0));
   r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_write_hs_certificate13 (
-        rec + hssize, sizeof (rec) - hssize, &bodylen, der, sizeof (der), NULL, 0));
+        rec + hssize, sizeof (rec) - hssize, &bodylen, NULL, 0, der, sizeof (der), NULL, 0));
   /* context(1) + list<3> + entry{ cert<3> + der + ext<2> }. */
   r_assert_cmpuint (bodylen, ==, 1 + 3 + (3 + sizeof (der) + 2));
   r_assert_cmpint (R_TLS_ERROR_OK, ==,
@@ -357,6 +357,77 @@ RTEST (rtls, write_parse_certificate13_roundtrip, RTEST_FAST)
   /* Only one entry: the next walk reports end-of-buffer. */
   r_assert_cmpint (R_TLS_ERROR_EOB, ==,
       r_tls_parser_parse_certificate13_next (&parser, &tlscert));
+
+  r_tls_parser_clear (&parser);
+}
+RTEST_END;
+
+RTEST (rtls, write_parse_certificate_request13_roundtrip, RTEST_FAST)
+{
+  /* Build a TLS 1.3 CertificateRequest with a non-empty context and a
+   * signature_algorithms list, then read the context and schemes back. */
+  static const ruint8 ctx[] = { 0xa1, 0xb2, 0xc3, 0xd4 };
+  static const RTLSSignatureScheme schemes[] = {
+    R_TLS_SIGN_SCHEME_ECDSA_SECP256R1_SHA256, R_TLS_SIGN_SCHEME_RSA_PSS_SHA256 };
+  ruint8 rec[64];
+  rsize hssize = 0, bodylen = 0;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSCertReq13 req = { 0, NULL, 0, NULL };
+
+  r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_write_handshake (rec, sizeof (rec),
+        &hssize, R_TLS_VERSION_TLS_1_3, R_TLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST, 0));
+  r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_write_hs_certificate_request13 (
+        rec + hssize, sizeof (rec) - hssize, &bodylen, ctx, sizeof (ctx),
+        schemes, R_N_ELEMENTS (schemes)));
+  r_assert_cmpint (R_TLS_ERROR_OK, ==,
+      r_tls_update_handshake_len (rec, sizeof (rec), (ruint16) bodylen));
+
+  r_assert_cmpint (R_TLS_ERROR_OK, ==,
+      r_tls_parser_init (&parser, rec, hssize + bodylen));
+  r_assert_cmpint (R_TLS_ERROR_OK, ==,
+      r_tls_parser_parse_certificate_request13 (&parser, &req));
+  r_assert_cmpuint (req.contextlen, ==, sizeof (ctx));
+  r_assert_cmpmem (req.context, ==, ctx, sizeof (ctx));
+  r_assert_cmpuint (req.signschemecount, ==, R_N_ELEMENTS (schemes));
+  r_assert_cmpuint (r_tls_cert_req13_sign_scheme (&req, 0), ==, schemes[0]);
+  r_assert_cmpuint (r_tls_cert_req13_sign_scheme (&req, 1), ==, schemes[1]);
+
+  r_tls_parser_clear (&parser);
+}
+RTEST_END;
+
+RTEST (rtls, write_parse_certificate13_context_roundtrip, RTEST_FAST)
+{
+  /* A post-handshake Certificate echoes a non-empty context; the context reader
+   * returns it and the entry walker still finds the leaf past it. */
+  static const ruint8 ctx[] = { 0x11, 0x22, 0x33 };
+  static const ruint8 der[] = { 0x30, 0x82, 0x01, 0x0a, 0xde, 0xad, 0xbe, 0xef };
+  ruint8 rec[64];
+  rsize hssize = 0, bodylen = 0;
+  RTLSParser parser = R_TLS_PARSER_INIT;
+  RTLSCertificate tlscert = R_TLS_CERTIFICATE_INIT;
+  const ruint8 * rctx = NULL;
+  ruint8 rctxlen = 0;
+
+  r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_write_handshake (rec, sizeof (rec),
+        &hssize, R_TLS_VERSION_TLS_1_3, R_TLS_HANDSHAKE_TYPE_CERTIFICATE, 0));
+  r_assert_cmpint (R_TLS_ERROR_OK, ==, r_tls_write_hs_certificate13 (
+        rec + hssize, sizeof (rec) - hssize, &bodylen, ctx, sizeof (ctx),
+        der, sizeof (der), NULL, 0));
+  r_assert_cmpuint (bodylen, ==, 1 + sizeof (ctx) + 3 + (3 + sizeof (der) + 2));
+  r_assert_cmpint (R_TLS_ERROR_OK, ==,
+      r_tls_update_handshake_len (rec, sizeof (rec), (ruint16) bodylen));
+
+  r_assert_cmpint (R_TLS_ERROR_OK, ==,
+      r_tls_parser_init (&parser, rec, hssize + bodylen));
+  r_assert_cmpint (R_TLS_ERROR_OK, ==,
+      r_tls_parser_parse_certificate13_context (&parser, &rctx, &rctxlen));
+  r_assert_cmpuint (rctxlen, ==, sizeof (ctx));
+  r_assert_cmpmem (rctx, ==, ctx, sizeof (ctx));
+  r_assert_cmpint (R_TLS_ERROR_OK, ==,
+      r_tls_parser_parse_certificate13_first (&parser, &tlscert));
+  r_assert_cmpuint (tlscert.len, ==, sizeof (der));
+  r_assert_cmpmem (tlscert.cert, ==, der, sizeof (der));
 
   r_tls_parser_clear (&parser);
 }

--- a/test/rtlsclient.c
+++ b/test/rtlsclient.c
@@ -176,6 +176,8 @@ RTEST_FIXTURE_STRUCT (rtlsclient)
   rboolean srv_error, cli_error;
   RTLSAlertType srv_alert, cli_alert;   /* alert each side raised at its error */
   rboolean srv_closed, cli_closed;
+  rboolean srv_ph_auth_called;          /* server post_handshake_auth cb fired */
+  rboolean srv_ph_auth_ok;              /* its result flag */
   ruint verify_calls;
   rboolean verify_result;
   RTLSCipherSuite force_suite;   /* pin both endpoints to one suite; NONE = defaults */
@@ -312,6 +314,15 @@ r_tlsclient_test_sni (rpointer ctx, const rchar * name, rpointer session)
   return R_TLS_ERROR_OK;
 }
 
+static void
+r_tlsclient_test_srv_ph_auth (rpointer ctx, rboolean ok, rpointer session)
+{
+  RTEST_FIXTURE_STRUCT (rtlsclient) * fixture = ctx;
+  (void) session;
+  fixture->srv_ph_auth_called = TRUE;
+  fixture->srv_ph_auth_ok = ok;
+}
+
 static const RTLSCallbacks srvcbs = {
   r_tlsclient_test_prefer_ecdhe,
   r_tlsclient_test_srv_hs_done,
@@ -320,6 +331,7 @@ static const RTLSCallbacks srvcbs = {
   r_tlsclient_test_srv_error,
   NULL,
   r_tlsclient_test_srv_closed,
+  r_tlsclient_test_srv_ph_auth,
 };
 static const RTLSCallbacks clicbs = {
   r_tlsclient_test_prefer_ecdhe,
@@ -329,6 +341,7 @@ static const RTLSCallbacks clicbs = {
   r_tlsclient_test_cli_error,
   r_tlsclient_test_verify_cert,
   r_tlsclient_test_cli_closed,
+  NULL,
 };
 
 RTEST_FIXTURE_SETUP (rtlsclient)
@@ -344,6 +357,7 @@ RTEST_FIXTURE_SETUP (rtlsclient)
   fixture->srv_error = fixture->cli_error = FALSE;
   fixture->srv_alert = fixture->cli_alert = R_TLS_ALERT_TYPE_CLOSE_NOTIFY;
   fixture->srv_closed = fixture->cli_closed = FALSE;
+  fixture->srv_ph_auth_called = fixture->srv_ph_auth_ok = FALSE;
   fixture->verify_calls = 0;
   fixture->verify_result = TRUE;
   fixture->force_suite = R_TLS_CS_NONE;
@@ -2876,5 +2890,141 @@ RTEST_F (rtlsclient, tls_ecdsa_mutual, RTEST_FAST)
   r_assert (!fixture->srv_error);
   r_assert_cmpptr (r_tls_server_get_peer_cert (fixture->server), !=, NULL);
   r_assert_cmpptr (r_tls_client_get_peer_cert (fixture->client), !=, NULL);
+}
+RTEST_END;
+
+/* Post-handshake client authentication (RFC 8446 4.6.2): run a TLS 1.3 handshake
+ * in which the client offered post_handshake_auth, confirm no client cert was
+ * requested during it, then have the server request one and drive the client's
+ * answering Certificate / CertificateVerify / Finished flight. */
+static void
+r_test_tls13_post_handshake_auth (RTEST_FIXTURE_STRUCT (rtlsclient) * fixture,
+    RTLSClientCertMode mode)
+{
+  r_assert_cmpint (r_tls_client_set_post_handshake_auth (fixture->client, TRUE),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_set_client_cert_mode (fixture->server, mode),
+      ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->cli_hs_done);
+  r_assert (fixture->srv_hs_done);
+  r_assert (!fixture->cli_error);
+  r_assert (!fixture->srv_error);
+  r_assert_cmpptr (r_tls_server_get_peer_cert (fixture->server), ==, NULL);
+
+  r_assert_cmpint (r_tls_server_request_post_handshake_auth (fixture->server),
+      ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+}
+
+/* RSA client certificate: the server requests it after the handshake and the
+ * flight verifies, exposing the leaf and reporting success. */
+RTEST_F (rtlsclient, tls13_post_handshake_auth, RTEST_FAST)
+{
+  RCryptoCert * cert;
+  RCryptoKey * pk;
+
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (testcertpem, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem, -1, NULL, 0)), !=, NULL);
+  r_assert_cmpint (r_tls_client_set_cert (fixture->client, cert, pk), ==, R_TLS_ERROR_OK);
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+
+  r_test_tls13_post_handshake_auth (fixture, R_TLS_CLIENT_CERT_MODE_REQUIRE);
+
+  r_assert (!fixture->cli_error);
+  r_assert (!fixture->srv_error);
+  r_assert (fixture->srv_ph_auth_called);
+  r_assert (fixture->srv_ph_auth_ok);
+  r_assert_cmpptr (r_tls_server_get_peer_cert (fixture->server), !=, NULL);
+}
+RTEST_END;
+
+/* ECDSA client certificate: exercises the ECDSA CertificateVerify sign (client)
+ * and verify (server) on the post-handshake path. */
+RTEST_F (rtlsclient, tls13_post_handshake_auth_ecdsa, RTEST_FAST)
+{
+  RCryptoCert * cert;
+  RCryptoKey * pk;
+
+  r_test_tls_use_ecdsa_server_cert (fixture);
+
+  r_assert_cmpptr ((cert = r_pem_parse_cert_from_data (testcertpem_ecdsa, -1)), !=, NULL);
+  r_assert_cmpptr ((pk = r_pem_parse_key_from_data (testpkpem_ecdsa, -1, NULL, 0)), !=, NULL);
+  r_assert_cmpint (r_tls_client_set_cert (fixture->client, cert, pk), ==, R_TLS_ERROR_OK);
+  r_crypto_key_unref (pk);
+  r_crypto_cert_unref (cert);
+
+  r_test_tls13_post_handshake_auth (fixture, R_TLS_CLIENT_CERT_MODE_REQUIRE);
+
+  r_assert (!fixture->cli_error);
+  r_assert (!fixture->srv_error);
+  r_assert (fixture->srv_ph_auth_called);
+  r_assert (fixture->srv_ph_auth_ok);
+  r_assert_cmpptr (r_tls_server_get_peer_cert (fixture->server), !=, NULL);
+}
+RTEST_END;
+
+/* Client offered post_handshake_auth but holds no certificate: under REQUEST it
+ * answers with an empty Certificate, so the flight completes but authenticates
+ * no one -- the result is reported as failure and no peer cert is exposed. */
+RTEST_F (rtlsclient, tls13_post_handshake_auth_no_cert, RTEST_FAST)
+{
+  r_test_tls13_post_handshake_auth (fixture, R_TLS_CLIENT_CERT_MODE_REQUEST);
+
+  r_assert (!fixture->srv_error);
+  r_assert (fixture->srv_ph_auth_called);
+  r_assert (!fixture->srv_ph_auth_ok);
+  r_assert_cmpptr (r_tls_server_get_peer_cert (fixture->server), ==, NULL);
+}
+RTEST_END;
+
+/* Client offered post_handshake_auth but holds no certificate, and the server
+ * requires one: the empty answer aborts the session with a fatal alert and the
+ * completion callback does not fire. */
+RTEST_F (rtlsclient, tls13_post_handshake_auth_require_no_cert, RTEST_FAST)
+{
+  r_assert_cmpint (r_tls_client_set_post_handshake_auth (fixture->client, TRUE),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_server_set_client_cert_mode (fixture->server,
+        R_TLS_CLIENT_CERT_MODE_REQUIRE), ==, R_TLS_ERROR_OK);
+
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->srv_hs_done);
+
+  r_assert_cmpint (r_tls_server_request_post_handshake_auth (fixture->server),
+      ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+
+  r_assert (fixture->srv_error);
+  r_assert (!fixture->srv_ph_auth_called);
+  r_assert_cmpptr (r_tls_server_get_peer_cert (fixture->server), ==, NULL);
+}
+RTEST_END;
+
+/* The client never offered post_handshake_auth: the server cannot request a
+ * post-handshake certificate and the trigger is rejected. */
+RTEST_F (rtlsclient, tls13_post_handshake_auth_not_offered, RTEST_FAST)
+{
+  r_assert_cmpint (r_tls_server_start (fixture->server, fixture->evloop, fixture->prng),
+      ==, R_TLS_ERROR_OK);
+  r_assert_cmpint (r_tls_client_start (fixture->client, fixture->evloop, fixture->prng,
+        R_TLS_VERSION_TLS_1_3), ==, R_TLS_ERROR_OK);
+  r_test_tls_loopback_pump (fixture);
+  r_assert (fixture->srv_hs_done);
+
+  r_assert_cmpint (r_tls_server_request_post_handshake_auth (fixture->server),
+      ==, R_TLS_ERROR_WRONG_STATE);
+  r_assert (!fixture->srv_ph_auth_called);
 }
 RTEST_END;

--- a/test/rtlsserver.c
+++ b/test/rtlsserver.c
@@ -150,6 +150,7 @@ RTEST_FIXTURE_SETUP (rtlsserver)
     r_tlsserver_test_error,
     r_tlsserver_test_verify_cert,
     r_tlsserver_test_closed,
+    NULL,
   };
   RCryptoCert * cert;
   RCryptoKey * pk;
@@ -2193,7 +2194,7 @@ r_test_tls_server_new_cfg (rpointer ctx)
 {
   static const RTLSCallbacks cbs = {
     NULL, r_tlsserver_test_hs_done, r_tlsserver_test_buffer_out,
-    r_tlsserver_test_buffer_appdata, r_tlsserver_test_error, NULL, NULL,
+    r_tlsserver_test_buffer_appdata, r_tlsserver_test_error, NULL, NULL, NULL,
   };
   RTLSServer * srv;
   RCryptoCert * cert;


### PR DESCRIPTION
Implements TLS 1.3 post-handshake client authentication (RFC 8446 §4.6.2), the optional follow-up to the TLS 1.3 work in #329.

## Behaviour
- **Client** opts in with `r_tls_client_set_post_handshake_auth()`, which offers the empty `post_handshake_auth` extension in its ClientHello. When negotiated, both peers keep the handshake transcript alive past completion.
- **Server** may then call `r_tls_server_request_post_handshake_auth()` to send a `CertificateRequest` carrying a fresh random `certificate_request_context`.
- **Client** answers with `Certificate` (echoing the context), `CertificateVerify` over the extended transcript with the `"TLS 1.3, client CertificateVerify"` context, and a `Finished` keyed from the client application-traffic secret — or an empty `Certificate` when it holds none.
- **Server** verifies the flight and reports the outcome through a new `RTLSPostHandshakeAuthCb`; the verified leaf is exposed via `r_tls_server_get_peer_cert`. A malformed/unverifiable flight, or an empty certificate under `REQUIRE`, aborts with a fatal alert and leaves no unverified certificate visible.

The sign/verify paths reuse the existing mutual-TLS machinery. `NewSessionTicket` and `KeyUpdate` are kept out of the preserved transcript, which is released at teardown. The proto layer gains a 1.3 `CertificateRequest` writer/parser and a `certificate_request_context` argument on the 1.3 `Certificate` writer.

## Testing
- `-Werror` clean on the default and ASan build tiers; ASan leak-free.
- Loopback coverage: RSA and ECDSA success, empty certificate under `REQUEST`, abort under `REQUIRE`, and rejection when the client never offered the extension; plus proto-level round-trips for the new wire format.
- Correctness and adversarial security reviews (both-peers-malicious threat model) found no memory-safety, DoS-amplification, context-bypass, verification-bypass, or state-confusion issues.

Closes #384